### PR TITLE
[3006.x][BACKPORT] Add `macos-13` to the platforms to run tests on

### DIFF
--- a/.github/actions/setup-actionlint/action.yml
+++ b/.github/actions/setup-actionlint/action.yml
@@ -4,7 +4,7 @@ description: Setup actionlint
 inputs:
   version:
     description: The version of actionlint
-    default: 1.6.24
+    default: 1.6.26
   cache-seed:
     required: true
     type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,6 +695,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  macos-13-ci-deps:
+    name: macOS 13 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-macos
+    uses: ./.github/workflows/build-deps-ci-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   almalinux-8-ci-deps:
     name: Alma Linux 8 Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1796,6 +1813,28 @@ jobs:
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
+  macos-13-pkg-tests:
+    name: macOS 13 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-macos-pkgs-onedir
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-packages-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: macos
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
   windows-2016-nsis-pkg-tests:
     name: Windows 2016 NSIS Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2003,6 +2042,28 @@ jobs:
     uses: ./.github/workflows/test-action-macos.yml
     with:
       distro-slug: macos-12
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      workflow-slug: ci
+      default-timeout: 180
+
+  macos-13:
+    name: macOS 13 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-action-macos.yml
+    with:
+      distro-slug: macos-13
       nox-session: ci-test-onedir
       platform: darwin
       arch: x86_64
@@ -2642,6 +2703,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -2681,6 +2743,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -2838,6 +2901,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -2877,6 +2941,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -2928,6 +2993,7 @@ jobs:
       - ubuntu-2204-pkg-tests
       - ubuntu-2204-arm64-pkg-tests
       - macos-12-pkg-tests
+      - macos-13-pkg-tests
       - windows-2016-nsis-pkg-tests
       - windows-2016-msi-pkg-tests
       - windows-2019-nsis-pkg-tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -756,6 +756,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  macos-13-ci-deps:
+    name: macOS 13 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-macos
+    uses: ./.github/workflows/build-deps-ci-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   almalinux-8-ci-deps:
     name: Alma Linux 8 Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1857,6 +1874,28 @@ jobs:
       skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
+  macos-13-pkg-tests:
+    name: macOS 13 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-macos-pkgs-onedir
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-packages-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: macos
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
   windows-2016-nsis-pkg-tests:
     name: Windows 2016 NSIS Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2064,6 +2103,28 @@ jobs:
     uses: ./.github/workflows/test-action-macos.yml
     with:
       distro-slug: macos-12
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      workflow-slug: nightly
+      default-timeout: 360
+
+  macos-13:
+    name: macOS 13 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-action-macos.yml
+    with:
+      distro-slug: macos-13
       nox-session: ci-test-onedir
       platform: darwin
       arch: x86_64
@@ -2703,6 +2764,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -2742,6 +2804,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -3598,6 +3661,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -3637,6 +3701,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -3749,6 +3814,7 @@ jobs:
       - ubuntu-2204-pkg-tests
       - ubuntu-2204-arm64-pkg-tests
       - macos-12-pkg-tests
+      - macos-13-pkg-tests
       - windows-2016-nsis-pkg-tests
       - windows-2016-msi-pkg-tests
       - windows-2019-nsis-pkg-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,22 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  macos-13-ci-deps:
+    name: macOS 13 Deps
+    needs:
+      - prepare-workflow
+      - download-onedir-artifact
+    uses: ./.github/workflows/build-deps-ci-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   almalinux-8-ci-deps:
     name: Alma Linux 8 Deps
     needs:
@@ -876,6 +892,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - fedora-38-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - photonos-3-arm64-ci-deps
       - photonos-3-ci-deps
       - photonos-4-arm64-ci-deps
@@ -1078,6 +1095,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -729,6 +729,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  macos-13-ci-deps:
+    name: macOS 13 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-macos
+    uses: ./.github/workflows/build-deps-ci-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   almalinux-8-ci-deps:
     name: Alma Linux 8 Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1830,6 +1847,28 @@ jobs:
       skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
+  macos-13-pkg-tests:
+    name: macOS 13 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-macos-pkgs-onedir
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-packages-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: macos
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
   windows-2016-nsis-pkg-tests:
     name: Windows 2016 NSIS Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2037,6 +2076,28 @@ jobs:
     uses: ./.github/workflows/test-action-macos.yml
     with:
       distro-slug: macos-12
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      workflow-slug: scheduled
+      default-timeout: 360
+
+  macos-13:
+    name: macOS 13 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-action-macos.yml
+    with:
+      distro-slug: macos-13
       nox-session: ci-test-onedir
       platform: darwin
       arch: x86_64
@@ -2676,6 +2737,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -2715,6 +2777,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -2874,6 +2937,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -2913,6 +2977,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -2964,6 +3029,7 @@ jobs:
       - ubuntu-2204-pkg-tests
       - ubuntu-2204-arm64-pkg-tests
       - macos-12-pkg-tests
+      - macos-13-pkg-tests
       - windows-2016-nsis-pkg-tests
       - windows-2016-msi-pkg-tests
       - windows-2019-nsis-pkg-tests

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -751,6 +751,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  macos-13-ci-deps:
+    name: macOS 13 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-macos
+    uses: ./.github/workflows/build-deps-ci-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   almalinux-8-ci-deps:
     name: Alma Linux 8 Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1852,6 +1869,28 @@ jobs:
       skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
+  macos-13-pkg-tests:
+    name: macOS 13 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-macos-pkgs-onedir
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-packages-action-macos.yml
+    with:
+      distro-slug: macos-13
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: macos
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
   windows-2016-nsis-pkg-tests:
     name: Windows 2016 NSIS Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2059,6 +2098,28 @@ jobs:
     uses: ./.github/workflows/test-action-macos.yml
     with:
       distro-slug: macos-12
+      nox-session: ci-test-onedir
+      platform: darwin
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      workflow-slug: staging
+      default-timeout: 180
+
+  macos-13:
+    name: macOS 13 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
+    needs:
+      - prepare-workflow
+      - macos-13-ci-deps
+    uses: ./.github/workflows/test-action-macos.yml
+    with:
+      distro-slug: macos-13
       nox-session: ci-test-onedir
       platform: darwin
       arch: x86_64
@@ -3541,6 +3602,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - fedora-38-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - photonos-3-arm64-ci-deps
       - photonos-3-ci-deps
       - photonos-4-arm64-ci-deps
@@ -3577,6 +3639,7 @@ jobs:
       - windows-2019-ci-deps
       - windows-2022-ci-deps
       - macos-12-ci-deps
+      - macos-13-ci-deps
       - almalinux-8-ci-deps
       - almalinux-8-arm64-ci-deps
       - almalinux-9-ci-deps
@@ -3616,6 +3679,7 @@ jobs:
       - windows-2019
       - windows-2022
       - macos-12
+      - macos-13
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
@@ -3667,6 +3731,7 @@ jobs:
       - ubuntu-2204-pkg-tests
       - ubuntu-2204-arm64-pkg-tests
       - macos-12-pkg-tests
+      - macos-13-pkg-tests
       - windows-2016-nsis-pkg-tests
       - windows-2016-msi-pkg-tests
       - windows-2019-nsis-pkg-tests

--- a/.github/workflows/test-package-downloads-action.yml
+++ b/.github/workflows/test-package-downloads-action.yml
@@ -400,7 +400,10 @@ jobs:
           - distro-slug: macos-12
             arch: x86_64
             pkg-type: package
-          - distro-slug: macos-12
+          - distro-slug: macos-13
+            arch: x86_64
+            pkg-type: package
+          - distro-slug: macos-13
             arch: x86_64
             pkg-type: onedir
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -143,7 +143,7 @@ def _get_service(name):
     # so we need to raise that the service could not be found.
     try:
         if not __context__["using_cached_services"]:
-            raise CommandExecutionError("Service not found: {}".format(name))
+            raise CommandExecutionError(f"Service not found: {name}")
     except KeyError:
         pass
 
@@ -151,7 +151,7 @@ def _get_service(name):
     # state then there is no reason to check again.
     # fixes https://github.com/saltstack/salt/issues/57907
     if __context__.get("service.state") == "dead":
-        raise CommandExecutionError("Service not found: {}".format(name))
+        raise CommandExecutionError(f"Service not found: {name}")
 
     # we used a cached version to check, a service could have been made
     # between now and then, we should refresh our available services.
@@ -162,7 +162,7 @@ def _get_service(name):
 
     if not service:
         # Could not find the service after refresh raise.
-        raise CommandExecutionError("Service not found: {}".format(name))
+        raise CommandExecutionError(f"Service not found: {name}")
 
     # found it :)
     return service
@@ -240,7 +240,7 @@ def _get_domain_target(name, service_target=False):
     if "LaunchAgents" in path:
         # Get the console user so we can service in the correct session
         uid = __utils__["mac_utils.console_user"]()
-        domain_target = "gui/{}".format(uid)
+        domain_target = f"gui/{uid}"
 
     # check to see if we need to make it a full service target.
     if service_target is True:
@@ -638,7 +638,8 @@ def disabled(name, runas=None, domain="system"):
             if name != srv_name:
                 pass
             else:
-                return True if "true" in status.lower() else False
+                matches = ["true", "disabled"]
+                return True if any([x in status.lower() for x in matches]) else False
 
     return False
 

--- a/tests/integration/modules/test_mac_sysctl.py
+++ b/tests/integration/modules/test_mac_sysctl.py
@@ -12,7 +12,7 @@ from salt.exceptions import CommandExecutionError
 from tests.support.case import ModuleCase
 
 # Module Variables
-ASSIGN_CMD = "net.inet.icmp.icmplim"
+ASSIGN_CMD = "net.inet.icmp.timestamp"
 CONFIG = "/etc/sysctl.conf"
 
 
@@ -74,7 +74,7 @@ class DarwinSysctlModuleTest(ModuleCase):
             os.remove(CONFIG)
         try:
             self.run_function("sysctl.persist", [ASSIGN_CMD, 10])
-            line = "{}={}".format(ASSIGN_CMD, 10)
+            line = f"{ASSIGN_CMD}={10}"
             found = self.__check_string(CONFIG, line)
             self.assertTrue(found)
         except CommandExecutionError:

--- a/tests/pytests/functional/modules/test_mac_pkgutil.py
+++ b/tests/pytests/functional/modules/test_mac_pkgutil.py
@@ -56,6 +56,8 @@ def macports_package_url(macports_package_filename):
 
 @pytest.fixture(scope="module")
 def pkg_name(grains):
+    if grains["osrelease_info"][0] >= 13:
+        return "com.apple.pkg.CLTools_SDK_macOS13"
     if grains["osrelease_info"][0] >= 12:
         return "com.apple.pkg.XcodeSystemResources"
     if grains["osrelease_info"][0] >= 11:

--- a/tools/pre_commit.py
+++ b/tools/pre_commit.py
@@ -85,7 +85,7 @@ def generate_workflows(ctx: Context):
         },
     }
     test_salt_listing = {
-        "linux": (
+        "linux": [
             ("almalinux-8", "Alma Linux 8", "x86_64"),
             ("almalinux-9", "Alma Linux 9", "x86_64"),
             ("amazonlinux-2", "Amazon Linux 2", "x86_64"),
@@ -114,16 +114,19 @@ def generate_workflows(ctx: Context):
             ("ubuntu-20.04-arm64", "Ubuntu 20.04 Arm64", "aarch64"),
             ("ubuntu-22.04", "Ubuntu 22.04", "x86_64"),
             ("ubuntu-22.04-arm64", "Ubuntu 22.04 Arm64", "aarch64"),
-        ),
-        "macos": (("macos-12", "macOS 12", "x86_64"),),
-        "windows": (
+        ],
+        "macos": [
+            ("macos-12", "macOS 12", "x86_64"),
+            ("macos-13", "macOS 13", "x86_64"),
+        ],
+        "windows": [
             ("windows-2016", "Windows 2016", "amd64"),
             ("windows-2019", "Windows 2019", "amd64"),
             ("windows-2022", "Windows 2022", "amd64"),
-        ),
+        ],
     }
     test_salt_pkg_listing = {
-        "linux": (
+        "linux": [
             ("amazonlinux-2", "Amazon Linux 2", "x86_64", "rpm"),
             ("amazonlinux-2-arm64", "Amazon Linux 2 Arm64", "aarch64", "rpm"),
             ("amazonlinux-2023", "Amazon Linux 2023", "x86_64", "rpm"),
@@ -146,13 +149,16 @@ def generate_workflows(ctx: Context):
             ("ubuntu-20.04-arm64", "Ubuntu 20.04 Arm64", "aarch64", "deb"),
             ("ubuntu-22.04", "Ubuntu 22.04", "x86_64", "deb"),
             ("ubuntu-22.04-arm64", "Ubuntu 22.04 Arm64", "aarch64", "deb"),
-        ),
-        "macos": (("macos-12", "macOS 12", "x86_64"),),
-        "windows": (
+        ],
+        "macos": [
+            ("macos-12", "macOS 12", "x86_64"),
+            ("macos-13", "macOS 13", "x86_64"),
+        ],
+        "windows": [
             ("windows-2016", "Windows 2016", "amd64"),
             ("windows-2019", "Windows 2019", "amd64"),
             ("windows-2022", "Windows 2022", "amd64"),
-        ),
+        ],
     }
     build_ci_deps_listing = {
         "linux": [
@@ -194,6 +200,7 @@ def generate_workflows(ctx: Context):
         ],
         "macos": [
             ("macos-12", "macOS 12", "x86_64"),
+            ("macos-13", "macOS 13", "x86_64"),
         ],
         "windows": [
             ("windows-2016", "Windows 2016", "amd64"),


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Bump to actionlint 1.6.26](https://github.com/saltstack/salt/pull/65532)
 - [Add `macos-13` to the platforms to run tests on](https://github.com/saltstack/salt/pull/65532)
 - [fixes for MacOS X 13](https://github.com/saltstack/salt/pull/65532)
 - [Additional package name for OS X 13.](https://github.com/saltstack/salt/pull/65532)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)