### PR TITLE
[master] Move configuration index doc

### DIFF
--- a/doc/ref/index.rst
+++ b/doc/ref/index.rst
@@ -12,7 +12,6 @@ This section contains a list of the Python modules that are used to extend the v
     ../ref/beacons/all/index
     ../ref/cache/all/index
     ../ref/clouds/all/index
-    ../ref/configuration/index
     ../ref/engines/all/index
     ../ref/modules/all/index
     ../ref/executors/all/index

--- a/doc/topics/configuration/index.rst
+++ b/doc/topics/configuration/index.rst
@@ -9,6 +9,7 @@ secure and troubleshoot, and how to perform many other administrative tasks.
     :maxdepth: 1
     :glob:
 
+    ../../ref/configuration/index
     ../../ref/configuration/master
     ../../ref/configuration/minion
     ../../ref/configuration/proxy


### PR DESCRIPTION
### What does this PR do?

Fix misplaced doc in the index (was introduced in https://github.com/saltstack/salt/pull/62216#issuecomment-1165932051):

![CleanShot 2023-11-13 at 19 20 11@2x](https://github.com/saltstack/salt/assets/370942/2d4b04c9-2a5f-4489-b60f-5451c5d760b3)


### Merge requirements satisfied?

- [x] Docs

