### PR TITLE
[3006.x][BACKPORT] fixes saltstack/salt#65501 file.comment ignore_missing not working with multiline char

### DIFF
--- a/changelog/65501.fixed.md
+++ b/changelog/65501.fixed.md
@@ -1,0 +1,1 @@
+Fix file.comment ignore_missing not working with multiline char

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -439,7 +439,7 @@ def _gen_recurse_managed_files(
     exclude_pat=None,
     maxdepth=None,
     include_empty=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Generate the list of files managed by a recurse state
@@ -1342,7 +1342,7 @@ def hardlink(
     user=None,
     group=None,
     dir_mode=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Create a hard link
@@ -1548,7 +1548,7 @@ def symlink(
     atomic=False,
     disallow_copy_and_unlink=False,
     inherit_user_and_group=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Create a symbolic link (symlink, soft link)
@@ -1986,7 +1986,7 @@ def tidied(
     age_size_logical_operator="OR",
     age_size_only=None,
     rmlinks=True,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionchanged:: 3005,3006.0
@@ -2305,7 +2305,7 @@ def managed(
     win_perms_reset=False,
     verify_ssl=True,
     use_etag=False,
-    **kwargs
+    **kwargs,
 ):
     r"""
     Manage a given file, this function allows for a file to be downloaded from
@@ -3207,7 +3207,7 @@ def managed(
                     serange=serange,
                     verify_ssl=verify_ssl,
                     follow_symlinks=follow_symlinks,
-                    **kwargs
+                    **kwargs,
                 )
 
                 if salt.utils.platform.is_windows():
@@ -3270,7 +3270,7 @@ def managed(
             skip_verify,
             verify_ssl=verify_ssl,
             use_etag=use_etag,
-            **kwargs
+            **kwargs,
         )
     except Exception as exc:  # pylint: disable=broad-except
         ret["changes"] = {}
@@ -3325,7 +3325,7 @@ def managed(
                 setype=setype,
                 serange=serange,
                 use_etag=use_etag,
-                **kwargs
+                **kwargs,
             )
         except Exception as exc:  # pylint: disable=broad-except
             ret["changes"] = {}
@@ -3404,7 +3404,7 @@ def managed(
                 setype=setype,
                 serange=serange,
                 use_etag=use_etag,
-                **kwargs
+                **kwargs,
             )
         except Exception as exc:  # pylint: disable=broad-except
             ret["changes"] = {}
@@ -3492,7 +3492,7 @@ def directory(
     win_deny_perms=None,
     win_inheritance=True,
     win_perms_reset=False,
-    **kwargs
+    **kwargs,
 ):
     r"""
     Ensure that a named directory is present and has the right perms
@@ -4206,7 +4206,7 @@ def recurse(
     win_perms=None,
     win_deny_perms=None,
     win_inheritance=True,
-    **kwargs
+    **kwargs,
 ):
     """
     Recurse through a subdirectory on the master and copy said subdirectory
@@ -4577,7 +4577,7 @@ def recurse(
             context=context,
             defaults=defaults,
             backup=backup,
-            **pass_kwargs
+            **pass_kwargs,
         )
         merge_ret(path, _ret)
 
@@ -6158,7 +6158,7 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     # remove (?i)-like flags, ^ and $
     unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
-    uncomment_regex = r"^(?!\s*{}).*".format(char) + unanchor_regex
+    uncomment_regex = rf"^(?!\s*{char})\s*" + unanchor_regex
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing
@@ -6902,7 +6902,7 @@ def patch(
     reject_file=None,
     strip=None,
     saltenv=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Ensure that a patch has been applied to the specified file or directory
@@ -7400,7 +7400,7 @@ def copy_(
     mode=None,
     dir_mode=None,
     subdir=False,
-    **kwargs
+    **kwargs,
 ):
     """
     If the file defined by the ``source`` option exists on the minion, copy it
@@ -7842,7 +7842,7 @@ def serialize(
     serializer=None,
     serializer_opts=None,
     deserializer_opts=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Serializes dataset and store it into managed file. Useful for sharing
@@ -8178,7 +8178,7 @@ def serialize(
             saltenv=__env__,
             contents=contents,
             skip_verify=False,
-            **kwargs
+            **kwargs,
         )
 
         if ret["changes"]:
@@ -8559,7 +8559,7 @@ def shortcut(
     backupname=None,
     makedirs=False,
     user=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Create a Windows shortcut

--- a/tests/pytests/functional/states/file/test_comment.py
+++ b/tests/pytests/functional/states/file/test_comment.py
@@ -106,7 +106,7 @@ def test_issue_2401_file_comment(modules, tmp_path):
     tmp_file.write_text("hello\nworld\n")
     # create the sls template
     template_lines = [
-        "{}:".format(tmp_file),
+        f"{tmp_file}:",
         "  file.comment:",
         "    - regex: ^world",
     ]
@@ -122,3 +122,16 @@ def test_issue_2401_file_comment(modules, tmp_path):
     for state_run in ret:
         assert state_run.result is True
         assert "Pattern already commented" in state_run.comment
+
+
+def test_issue_65501(file, tmp_path):
+    tmp_file = tmp_path / "issue-65501.txt"
+    tmp_file.write_text("first\n#PermitRootLogin prohibit-password\nlast")
+    ret = file.comment(
+        name=str(tmp_file),
+        regex="^PermitRootLogin[ \t]+.*$",
+        char="# NEXT LINE COMMENT SALTSTACK openssh-server_comment_permitrootlogin_sshd_config\n# ",
+        ignore_missing=True,
+    )
+    assert ret.result is True
+    assert ret.comment == "Pattern not found and ignore_missing set to True"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [fixes saltstack/salt#65501 file.comment ignore_missing not working with multiline char](https://github.com/saltstack/salt/pull/65552)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)