### PR TITLE
[master] Deprecate `pushover` modules in favor of saltext

### DIFF
--- a/changelog/65567.deprecated.md
+++ b/changelog/65567.deprecated.md
@@ -1,0 +1,1 @@
+Deprecated all Pushover modules in favor of the Salt Extension at https://github.com/salt-extensions/saltext-pushover. The Pushover modules will be removed from Salt core in 3009.0

--- a/salt/modules/pushover_notify.py
+++ b/salt/modules/pushover_notify.py
@@ -25,6 +25,12 @@ from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)
 __virtualname__ = "pushover"
 
+__deprecated__ = (
+    3009,
+    "pushover",
+    "https://github.com/saltstack/saltext-pushover",
+)
+
 
 def __virtual__():
     """

--- a/salt/modules/pushover_notify.py
+++ b/salt/modules/pushover_notify.py
@@ -1,11 +1,6 @@
 """
 Module for sending messages to Pushover (https://www.pushover.net)
 
-.. warning::
-    This module will be removed from Salt in version 3009.0 in favor of
-    the `saltext.pushover Salt Extension
-    <https://github.com/salt-extensions/saltext-pushover>`_
-
 .. versionadded:: 2016.3.0
 
 :configuration: This module can be used by either passing an api key and version

--- a/salt/modules/pushover_notify.py
+++ b/salt/modules/pushover_notify.py
@@ -1,6 +1,11 @@
 """
 Module for sending messages to Pushover (https://www.pushover.net)
 
+.. warning::
+    This module will be removed from Salt in version 3009.0 in favor of
+    the `saltext.pushover Salt Extension
+    <https://github.com/salt-extensions/saltext-pushover>`_
+
 .. versionadded:: 2016.3.0
 
 :configuration: This module can be used by either passing an api key and version

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -1,6 +1,11 @@
 """
 Return salt data via pushover (http://www.pushover.net)
 
+.. warning::
+    This module will be removed from Salt in version 3009.0 in favor of
+    the `saltext.pushover Salt Extension
+    <https://github.com/salt-extensions/saltext-pushover>`_
+
 .. versionadded:: 2016.3.0
 
 The following fields can be set in the minion conf file::

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -1,11 +1,6 @@
 """
 Return salt data via pushover (http://www.pushover.net)
 
-.. warning::
-    This module will be removed from Salt in version 3009.0 in favor of
-    the `saltext.pushover Salt Extension
-    <https://github.com/salt-extensions/saltext-pushover>`_
-
 .. versionadded:: 2016.3.0
 
 The following fields can be set in the minion conf file::
@@ -95,6 +90,12 @@ from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)
 
 __virtualname__ = "pushover"
+
+__deprecated__ = (
+    3009,
+    "pushover",
+    "https://github.com/saltstack/saltext-pushover",
+)
 
 
 def _get_options(ret=None):

--- a/salt/states/pushover.py
+++ b/salt/states/pushover.py
@@ -27,6 +27,12 @@ The api key can be specified in the master or minion configuration like below:
 
 """
 
+__deprecated__ = (
+    3009,
+    "pushover",
+    "https://github.com/saltstack/saltext-pushover",
+)
+
 
 def __virtual__():
     """
@@ -109,11 +115,11 @@ def post_message(
         return ret
 
     if not user:
-        ret["comment"] = "PushOver user is missing: {}".format(user)
+        ret["comment"] = f"PushOver user is missing: {user}"
         return ret
 
     if not message:
-        ret["comment"] = "PushOver message is missing: {}".format(message)
+        ret["comment"] = f"PushOver message is missing: {message}"
         return ret
 
     result = __salt__["pushover.post_message"](
@@ -129,8 +135,8 @@ def post_message(
 
     if result:
         ret["result"] = True
-        ret["comment"] = "Sent message: {}".format(name)
+        ret["comment"] = f"Sent message: {name}"
     else:
-        ret["comment"] = "Failed to send message: {}".format(name)
+        ret["comment"] = f"Failed to send message: {name}"
 
     return ret

--- a/salt/states/pushover.py
+++ b/salt/states/pushover.py
@@ -2,11 +2,6 @@
 Send a message to PushOver
 ==========================
 
-.. warning::
-    This module will be removed from Salt in version 3009.0 in favor of
-    the `saltext.pushover Salt Extension
-    <https://github.com/salt-extensions/saltext-pushover>`_
-
 This state is useful for sending messages to PushOver during state runs.
 
 .. versionadded:: 2015.5.0

--- a/salt/states/pushover.py
+++ b/salt/states/pushover.py
@@ -2,6 +2,11 @@
 Send a message to PushOver
 ==========================
 
+.. warning::
+    This module will be removed from Salt in version 3009.0 in favor of
+    the `saltext.pushover Salt Extension
+    <https://github.com/salt-extensions/saltext-pushover>`_
+
 This state is useful for sending messages to PushOver during state runs.
 
 .. versionadded:: 2015.5.0


### PR DESCRIPTION
### What does this PR do?
Deprecates the `pushover` execution/state/returner module in favor of the Salt Extension found at https://github.com/salt-extensions/saltext-pushover. Removal target is 3009.0.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65567

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes