### PR TITLE
[master] fix: add deprecation notice for elasticsearch module/states

### DIFF
--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -55,6 +55,15 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
+__deprecated__ = (
+    3009,
+    "elasticsearch",
+    "https://github.com/cesan3/salt-ext-elasticsearch",  # This is the repo with the issues tracker for this module
+    # and the one that will be used to submit PRs, for now, until
+    # PR actions are enabled in
+    # http://salt-extensions/saltext-elasticsearch repo
+)
+
 try:
     import elasticsearch
 

--- a/salt/states/elasticsearch.py
+++ b/salt/states/elasticsearch.py
@@ -11,6 +11,15 @@ import salt.utils.json
 
 log = logging.getLogger(__name__)
 
+__deprecated__ = (
+    3009,
+    "elasticsearch",
+    "https://github.com/cesan3/salt-ext-elasticsearch",  # This is the repo with the issues tracker for this module
+    # and the one that will be used to submit PRs, for now, until
+    # PR actions are enabled in
+    # http://salt-extensions/saltext-elasticsearch repo
+)
+
 
 def index_absent(name):
     """
@@ -26,20 +35,20 @@ def index_absent(name):
         index = __salt__["elasticsearch.index_get"](index=name)
         if index and name in index:
             if __opts__["test"]:
-                ret["comment"] = "Index {} will be removed".format(name)
+                ret["comment"] = f"Index {name} will be removed"
                 ret["changes"]["old"] = index[name]
                 ret["result"] = None
             else:
                 ret["result"] = __salt__["elasticsearch.index_delete"](index=name)
                 if ret["result"]:
-                    ret["comment"] = "Successfully removed index {}".format(name)
+                    ret["comment"] = f"Successfully removed index {name}"
                     ret["changes"]["old"] = index[name]
                 else:
                     ret[
                         "comment"
-                    ] = "Failed to remove index {} for unknown reasons".format(name)
+                    ] = f"Failed to remove index {name} for unknown reasons"
         else:
-            ret["comment"] = "Index {} is already absent".format(name)
+            ret["comment"] = f"Index {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -89,15 +98,15 @@ def index_present(name, definition=None):
                     index=name, body=definition
                 )
                 if output:
-                    ret["comment"] = "Successfully created index {}".format(name)
+                    ret["comment"] = f"Successfully created index {name}"
                     ret["changes"] = {
                         "new": __salt__["elasticsearch.index_get"](index=name)[name]
                     }
                 else:
                     ret["result"] = False
-                    ret["comment"] = "Cannot create index {}, {}".format(name, output)
+                    ret["comment"] = f"Cannot create index {name}, {output}"
         else:
-            ret["comment"] = "Index {} is already present".format(name)
+            ret["comment"] = f"Index {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -138,7 +147,7 @@ def alias_absent(name, index):
                 if ret["result"]:
                     ret[
                         "comment"
-                    ] = "Successfully removed alias {} for index {}".format(name, index)
+                    ] = f"Successfully removed alias {name} for index {index}"
                     ret["changes"]["old"] = (
                         alias.get(index, {}).get("aliases", {}).get(name, {})
                     )
@@ -257,7 +266,7 @@ def index_template_absent(name):
         index_template = __salt__["elasticsearch.index_template_get"](name=name)
         if index_template and name in index_template:
             if __opts__["test"]:
-                ret["comment"] = "Index template {} will be removed".format(name)
+                ret["comment"] = f"Index template {name} will be removed"
                 ret["changes"]["old"] = index_template[name]
                 ret["result"] = None
             else:
@@ -276,7 +285,7 @@ def index_template_absent(name):
                         name
                     )
         else:
-            ret["comment"] = "Index template {} is already absent".format(name)
+            ret["comment"] = f"Index template {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -318,7 +327,7 @@ def index_template_present(name, definition, check_definition=False):
             if __opts__["test"]:
                 ret[
                     "comment"
-                ] = "Index template {} does not exist and will be created".format(name)
+                ] = f"Index template {name} does not exist and will be created"
                 ret["changes"] = {"new": definition}
                 ret["result"] = None
             else:
@@ -371,7 +380,7 @@ def index_template_present(name, definition, check_definition=False):
                         if output:
                             ret[
                                 "comment"
-                            ] = "Successfully updated index template {}".format(name)
+                            ] = f"Successfully updated index template {name}"
                             ret["changes"] = diff
                         else:
                             ret["result"] = False
@@ -387,7 +396,7 @@ def index_template_present(name, definition, check_definition=False):
                         name
                     )
             else:
-                ret["comment"] = "Index template {} is already present".format(name)
+                ret["comment"] = f"Index template {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -409,20 +418,20 @@ def pipeline_absent(name):
         pipeline = __salt__["elasticsearch.pipeline_get"](id=name)
         if pipeline and name in pipeline:
             if __opts__["test"]:
-                ret["comment"] = "Pipeline {} will be removed".format(name)
+                ret["comment"] = f"Pipeline {name} will be removed"
                 ret["changes"]["old"] = pipeline[name]
                 ret["result"] = None
             else:
                 ret["result"] = __salt__["elasticsearch.pipeline_delete"](id=name)
                 if ret["result"]:
-                    ret["comment"] = "Successfully removed pipeline {}".format(name)
+                    ret["comment"] = f"Successfully removed pipeline {name}"
                     ret["changes"]["old"] = pipeline[name]
                 else:
                     ret[
                         "comment"
-                    ] = "Failed to remove pipeline {} for unknown reasons".format(name)
+                    ] = f"Failed to remove pipeline {name} for unknown reasons"
         else:
-            ret["comment"] = "Pipeline {} is already absent".format(name)
+            ret["comment"] = f"Pipeline {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -467,7 +476,7 @@ def pipeline_present(name, definition):
                 if not pipeline:
                     ret[
                         "comment"
-                    ] = "Pipeline {} does not exist and will be created".format(name)
+                    ] = f"Pipeline {name} does not exist and will be created"
                 else:
                     ret["comment"] = (
                         "Pipeline {} exists with wrong configuration and will be"
@@ -481,7 +490,7 @@ def pipeline_present(name, definition):
                 )
                 if output:
                     if not pipeline:
-                        ret["comment"] = "Successfully created pipeline {}".format(name)
+                        ret["comment"] = f"Successfully created pipeline {name}"
                     else:
                         ret["comment"] = "Successfully replaced pipeline {}".format(
                             name
@@ -492,7 +501,7 @@ def pipeline_present(name, definition):
                         name, output
                     )
         else:
-            ret["comment"] = "Pipeline {} is already present".format(name)
+            ret["comment"] = f"Pipeline {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -514,7 +523,7 @@ def search_template_absent(name):
         template = __salt__["elasticsearch.search_template_get"](id=name)
         if template:
             if __opts__["test"]:
-                ret["comment"] = "Search template {} will be removed".format(name)
+                ret["comment"] = f"Search template {name} will be removed"
                 ret["changes"]["old"] = salt.utils.json.loads(template["template"])
                 ret["result"] = None
             else:
@@ -533,7 +542,7 @@ def search_template_absent(name):
                         name
                     )
         else:
-            ret["comment"] = "Search template {} is already absent".format(name)
+            ret["comment"] = f"Search template {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -593,20 +602,16 @@ def search_template_present(name, definition):
                 )
                 if output:
                     if not template:
-                        ret[
-                            "comment"
-                        ] = "Successfully created search template {}".format(name)
+                        ret["comment"] = f"Successfully created search template {name}"
                     else:
-                        ret[
-                            "comment"
-                        ] = "Successfully replaced search template {}".format(name)
+                        ret["comment"] = f"Successfully replaced search template {name}"
                 else:
                     ret["result"] = False
                     ret["comment"] = "Cannot create search template {}, {}".format(
                         name, output
                     )
         else:
-            ret["comment"] = "Search template {} is already present".format(name)
+            ret["comment"] = f"Search template {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)

--- a/salt/states/elasticsearch_index.py
+++ b/salt/states/elasticsearch_index.py
@@ -11,6 +11,15 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__deprecated__ = (
+    3009,
+    "elasticsearch",
+    "https://github.com/cesan3/salt-ext-elasticsearch",  # This is the repo with the issues tracker for this module
+    # and the one that will be used to submit PRs, for now, until
+    # PR actions are enabled in
+    # http://salt-extensions/saltext-elasticsearch repo
+)
+
 
 def absent(name):
     """
@@ -26,20 +35,20 @@ def absent(name):
         index = __salt__["elasticsearch.index_get"](index=name)
         if index and name in index:
             if __opts__["test"]:
-                ret["comment"] = "Index {} will be removed".format(name)
+                ret["comment"] = f"Index {name} will be removed"
                 ret["changes"]["old"] = index[name]
                 ret["result"] = None
             else:
                 ret["result"] = __salt__["elasticsearch.index_delete"](index=name)
                 if ret["result"]:
-                    ret["comment"] = "Successfully removed index {}".format(name)
+                    ret["comment"] = f"Successfully removed index {name}"
                     ret["changes"]["old"] = index[name]
                 else:
                     ret[
                         "comment"
-                    ] = "Failed to remove index {} for unknown reasons".format(name)
+                    ] = f"Failed to remove index {name} for unknown reasons"
         else:
-            ret["comment"] = "Index {} is already absent".format(name)
+            ret["comment"] = f"Index {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -94,15 +103,15 @@ def present(name, definition=None):
                     index=name, body=definition
                 )
                 if output:
-                    ret["comment"] = "Successfully created index {}".format(name)
+                    ret["comment"] = f"Successfully created index {name}"
                     ret["changes"] = {
                         "new": __salt__["elasticsearch.index_get"](index=name)[name]
                     }
                 else:
                     ret["result"] = False
-                    ret["comment"] = "Cannot create index {}, {}".format(name, output)
+                    ret["comment"] = f"Cannot create index {name}, {output}"
         else:
-            ret["comment"] = "Index {} is already present".format(name)
+            ret["comment"] = f"Index {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)

--- a/salt/states/elasticsearch_index_template.py
+++ b/salt/states/elasticsearch_index_template.py
@@ -11,6 +11,15 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__deprecated__ = (
+    3009,
+    "elasticsearch",
+    "https://github.com/cesan3/salt-ext-elasticsearch",  # This is the repo with the issues tracker for this module
+    # and the one that will be used to submit PRs, for now, until
+    # PR actions are enabled in
+    # http://salt-extensions/saltext-elasticsearch repo
+)
+
 
 def absent(name):
     """
@@ -26,7 +35,7 @@ def absent(name):
         index_template = __salt__["elasticsearch.index_template_get"](name=name)
         if index_template and name in index_template:
             if __opts__["test"]:
-                ret["comment"] = "Index template {} will be removed".format(name)
+                ret["comment"] = f"Index template {name} will be removed"
                 ret["changes"]["old"] = index_template[name]
                 ret["result"] = None
             else:
@@ -45,7 +54,7 @@ def absent(name):
                         name
                     )
         else:
-            ret["comment"] = "Index template {} is already absent".format(name)
+            ret["comment"] = f"Index template {name} is already absent"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)
@@ -90,7 +99,7 @@ def present(name, definition):
             if __opts__["test"]:
                 ret[
                     "comment"
-                ] = "Index template {} does not exist and will be created".format(name)
+                ] = f"Index template {name} does not exist and will be created"
                 ret["changes"] = {"new": definition}
                 ret["result"] = None
             else:
@@ -112,7 +121,7 @@ def present(name, definition):
                         name, output
                     )
         else:
-            ret["comment"] = "Index template {} is already present".format(name)
+            ret["comment"] = f"Index template {name} is already present"
     except Exception as err:  # pylint: disable=broad-except
         ret["result"] = False
         ret["comment"] = str(err)


### PR DESCRIPTION
### What does this PR do?

Adds deprecation warning for the elasticsearch module and states to privilege the use of the extension module located in https://github.com/cesan3/salt-ext-elasticsearch.  temporarily until we set up https://github.com/salt-extensions/saltext-elasticsearch correctly to package/release the extension.

### What issues does this PR fix or reference?
Fixes: Related to https://github.com/salt-extensions/extension_migration/issues/32


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
