### PR TITLE
[3006.x] Salt Cloud: Put cleanup in a try/except block

### DIFF
--- a/changelog/65584.fixed.md
+++ b/changelog/65584.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue where Salt Cloud would fail if it could not delete lingering
+PAexec binaries

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -63,7 +63,7 @@ try:
     from pypsexec.client import Client as PsExecClient
     from pypsexec.exceptions import SCMRException
     from pypsexec.scmr import Service as ScmrService
-    from smbprotocol.exceptions import SMBResponseException
+    from smbprotocol.exceptions import CannotDelete, SMBResponseException
     from smbprotocol.tree import TreeConnect
 
     logging.getLogger("smbprotocol").setLevel(logging.WARNING)
@@ -910,7 +910,12 @@ class Client:
         return self._client.connect()
 
     def disconnect(self):
-        self._client.cleanup()  # This removes the lingering PAExec binary
+        try:
+            # This removes any lingering PAExec binaries
+            self._client.cleanup()
+        except CannotDelete as exc:
+            # We shouldn't hard crash here, so just log the error
+            log.debug("Exception cleaning up PAexec: %r", exc)
         return self._client.disconnect()
 
     def create_service(self):


### PR DESCRIPTION
### What does this PR do?
In a previous attempt to have PSExec clean up after itself (https://github.com/saltstack/salt/pull/63031), we started calling the cleanup command. This doesn't always work and will raise an exception. This shouldn't be a blocker to a successful installation of Salt, so this PR puts that command in a Try/Except block. If it fails to cleanup the PAexec binaries, it should still continue.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65584

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes