### PR TITLE
[master] fix file.managed test diff

### DIFF
--- a/changelog/65589.fixed.md
+++ b/changelog/65589.fixed.md
@@ -1,0 +1,1 @@
+fixes file.managed always showing changes in test mode

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5733,11 +5733,14 @@ def check_file_meta(
                 )
             if sfn:
                 try:
-                    changes["diff"] = get_diff(
+                    diff = get_diff(
                         name, sfn, template=True, show_filenames=False
                     )
                 except CommandExecutionError as exc:
-                    changes["diff"] = exc.strerror
+                    diff = exc.strerror
+
+                if diff:
+                    changes["diff"] = diff
             else:
                 changes["sum"] = "Checksum differs"
 


### PR DESCRIPTION
### What does this PR do?

In `file.managed` when test mode is active, if the file is a plain copy of the managed file (i.e. no templating), test mode always shows it as changed with an empty diff.

This turns out to be because it simply assigns the empty diff result to the `changes` dict. In turn, when the `file.managed` function checks for whether any changes would happen to the managed file, it checks if the top-level `changes` dict is empty, which itself is not empty, since it contains the `diff` key (which is empty), so it thinks there are changes.

This fixes this problem by only assigning the `diff` key to the `changes` if the diff is non-empty.

### What issues does this PR fix or reference?

Fixes: #65589

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No