### PR TITLE
[3006.x][BACKPORT] Fix bug in pip.installed state when user does not exists

### DIFF
--- a/changelog/65458.fixed.md
+++ b/changelog/65458.fixed.md
@@ -1,0 +1,1 @@
+pip.installed state will now properly fail when a specified user does not exists

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -820,6 +820,13 @@ def installed(
             ret["comment"] = "\n".join(comments)
             return ret
 
+    # If the user does not exist, stop here with error:
+    if user and "user.info" in __salt__ and not __salt__["user.info"](user):
+        # The user does not exists, exit with result set to False
+        ret["result"] = False
+        ret["comment"] = f"User {user} does not exist"
+        return ret
+
     # If a requirements file is specified, only install the contents of the
     # requirements file. Similarly, using the --editable flag with pip should
     # also ignore the "name" and "pkgs" parameters.

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -379,6 +379,24 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
             self.assertSaltTrueReturn({"test": ret})
             self.assertInSaltComment("successfully installed", {"test": ret})
 
+    def test_install_with_specified_user(self):
+        """
+        Check that if `user` parameter is set and the user does not exists
+        it will fail with an error, see #65458
+        """
+        user_info = MagicMock(return_value={})
+        pip_version = MagicMock(return_value="10.0.1")
+        with patch.dict(
+            pip_state.__salt__,
+            {
+                "user.info": user_info,
+                "pip.version": pip_version,
+            },
+        ):
+            ret = pip_state.installed("mypkg", user="fred")
+            self.assertSaltFalseReturn({"test": ret})
+            self.assertInSaltComment("User fred does not exist", {"test": ret})
+
 
 class PipStateUtilsTest(TestCase):
     def test_has_internal_exceptions_mod_function(self):

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -432,7 +432,7 @@ class PipStateInstallationErrorTest(TestCase):
         extra_requirements = []
         for name, version in salt.version.dependency_information():
             if name in ["PyYAML", "packaging", "looseversion"]:
-                extra_requirements.append("{}=={}".format(name, version))
+                extra_requirements.append(f"{name}=={version}")
         failures = {}
         pip_version_requirements = [
             # Latest pip 18
@@ -471,7 +471,7 @@ class PipStateInstallationErrorTest(TestCase):
                 with VirtualEnv() as venv:
                     venv.install(*extra_requirements)
                     if requirement:
-                        venv.install("pip{}".format(requirement))
+                        venv.install(f"pip{requirement}")
                     try:
                         subprocess.check_output([venv.venv_python, "-c", code])
                     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Fix for pip state when user doesn't exist](https://github.com/saltstack/salt/pull/65466)
 - [Add test for fix when user does not exists on pip](https://github.com/saltstack/salt/pull/65466)
 - [Add changelog for #65458](https://github.com/saltstack/salt/pull/65466)
 - [Fix pylint issues in unit test for pip state](https://github.com/saltstack/salt/pull/65466)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)