### PR TITLE
[3006.x] Bump to `aiohttp>=3.8.6` due to CVE's

### DIFF
--- a/.github/actions/build-onedir-deps/action.yml
+++ b/.github/actions/build-onedir-deps/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Cache Deps Onedir Package Directory
       id: onedir-pkg-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: artifacts/${{ inputs.package-name }}
         key: >

--- a/.github/actions/build-onedir-salt/action.yml
+++ b/.github/actions/build-onedir-salt/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Download Cached Deps Onedir Package Directory
       id: onedir-bare-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: artifacts/${{ inputs.package-name }}
         key: >

--- a/.github/actions/cached-virtualenv/action.yml
+++ b/.github/actions/cached-virtualenv/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Cache VirtualEnv
       id: cache-virtualenv
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         key: ${{ steps.setup-cache-key.outputs.cache-key }}
         path: ${{ steps.virtualenv-path.outputs.venv-path }}

--- a/.github/actions/setup-actionlint/action.yml
+++ b/.github/actions/setup-actionlint/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
 
     - name: Cache actionlint Binary
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: /usr/local/bin/actionlint
         key: ${{ inputs.cache-seed }}|${{ runner.os }}|${{ runner.arch }}|actionlint|${{ inputs.version }}

--- a/.github/actions/setup-pre-commit/action.yml
+++ b/.github/actions/setup-pre-commit/action.yml
@@ -36,7 +36,7 @@ runs:
         ${{ steps.pre-commit-virtualenv.outputs.python-executable }} -m pip install pre-commit==${{ inputs.version }}
 
     - name: Cache Pre-Commit Hooks
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       id: pre-commit-hooks-cache
       with:
         key: ${{ steps.pre-commit-virtualenv.outputs.cache-key }}|${{ inputs.version }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/actions/setup-python-tools-scripts/action.yml
+++ b/.github/actions/setup-python-tools-scripts/action.yml
@@ -50,7 +50,7 @@ runs:
         cache-seed: tools|${{ steps.venv-hash.outputs.venv-hash }}
 
     - name: Restore Python Tools Virtualenvs Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: ${{ inputs.cwd }}/.tools-venvs
         key: ${{ inputs.cache-prefix }}|${{ steps.venv-hash.outputs.venv-hash }}

--- a/.github/actions/setup-relenv/action.yml
+++ b/.github/actions/setup-relenv/action.yml
@@ -45,7 +45,7 @@ runs:
         python3 -m pip install relenv==${{ inputs.version }}
 
     - name: Cache Relenv Data Directory
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: ${{ github.workspace }}/.relenv
         key: ${{ inputs.cache-seed }}|relenv|${{ inputs.version }}|${{ inputs.python-version }}|${{ inputs.platform }}|${{ inputs.arch }}

--- a/.github/actions/setup-shellcheck/action.yml
+++ b/.github/actions/setup-shellcheck/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
 
     - name: Cache shellcheck Binary
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       with:
         path: /usr/local/bin/shellcheck
         key: ${{ inputs.cache-seed }}|${{ runner.os }}|${{ runner.arch }}|shellcheck|${{ inputs.version }}

--- a/.github/workflows/build-deps-ci-action-macos.yml
+++ b/.github/workflows/build-deps-ci-action-macos.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Cache nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
         id: nox-dependencies-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{

--- a/.github/workflows/build-deps-ci-action.yml
+++ b/.github/workflows/build-deps-ci-action.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Cache nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
         id: nox-dependencies-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{
@@ -102,6 +102,8 @@ jobs:
       - name: Setup Python Tools Scripts
         if: steps.nox-dependencies-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-python-tools-scripts
+        with:
+          cache-prefix: ${{ inputs.cache-prefix }}-build-deps-ci
 
       - name: Get Salt Project GitHub Actions Bot Environment
         if: steps.nox-dependencies-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache Python Tools Docs Virtualenv
         id: tools-venvs-dependencies-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: .tools-venvs/docs
           key: ${{ inputs.cache-seed }}|${{ github.workflow }}|${{ github.job }}|tools-venvs|${{ steps.python-tools-scripts.outputs.version }}|docs|${{ steps.get-python-version.outputs.version }}|${{ hashFiles('requirements/**/docs.txt') }}

--- a/.github/workflows/templates/test-package-downloads-action.yml.jinja
+++ b/.github/workflows/templates/test-package-downloads-action.yml.jinja
@@ -95,7 +95,7 @@ jobs:
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-linux-${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}.tar.xz
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{
@@ -343,7 +343,7 @@ jobs:
           python3 -m pip install 'nox==${{ inputs.nox-version }}'
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{
@@ -546,7 +546,7 @@ jobs:
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-windows-${{ matrix.arch }}.tar.xz
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{

--- a/.github/workflows/test-action-macos.yml
+++ b/.github/workflows/test-action-macos.yml
@@ -146,7 +146,7 @@ jobs:
           brew install tree
 
       - name: Download cached nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.gh-actions-python-version }}|${{

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -156,7 +156,7 @@ jobs:
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-${{ inputs.platform }}-${{ inputs.arch }}.tar.xz
 
       - name: Download cached nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.gh-actions-python-version }}|${{

--- a/.github/workflows/test-package-downloads-action.yml
+++ b/.github/workflows/test-package-downloads-action.yml
@@ -231,7 +231,7 @@ jobs:
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-linux-${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}.tar.xz
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{
@@ -486,7 +486,7 @@ jobs:
           python3 -m pip install 'nox==${{ inputs.nox-version }}'
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{
@@ -693,7 +693,7 @@ jobs:
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-windows-${{ matrix.arch }}.tar.xz
 
       - name: Download cached nox.${{ matrix.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ matrix.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ matrix.arch }}|${{ matrix.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{

--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -155,7 +155,7 @@ jobs:
           python3 -m pip install 'nox==${{ inputs.nox-version }}'
 
       - name: Download cached nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -153,7 +153,7 @@ jobs:
           tree pkg/artifacts
 
       - name: Download cached nox.${{ inputs.distro-slug }}.tar.* for session ${{ inputs.nox-session }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: nox.${{ inputs.distro-slug }}.tar.*
           key: ${{ inputs.cache-prefix }}|testrun-deps|${{ inputs.arch }}|${{ inputs.distro-slug }}|${{ inputs.nox-session }}|${{ inputs.python-version }}|${{

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/cloud.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/cloud.in requirements/static/ci/common.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   etcd3-py
@@ -22,10 +22,6 @@ asn1crypto==1.3.0
     #   -c requirements/static/ci/py3.11/linux.txt
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   aiohttp
 attrs==23.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -91,7 +87,6 @@ charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/darwin.txt requirements/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/darwin.in
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -17,8 +17,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -66,7 +64,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/freebsd.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -14,8 +14,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -65,7 +63,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/lint.txt requirements/base.txt requirements/static/ci/common.in requirements/static/ci/lint.in requirements/static/ci/linux.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   etcd3-py
@@ -35,10 +35,6 @@ asn1crypto==1.3.0
     #   oscrypto
 astroid==2.3.3
     # via pylint
-async-timeout==4.0.2
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   aiohttp
 attrs==23.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -102,7 +98,6 @@ charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/linux.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/linux.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -20,8 +20,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -74,7 +72,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.11/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/windows.in requirements/windows.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.3.1
-    # via aiohttp
-async-timeout==4.0.2
     # via aiohttp
 attrs==23.1.0
     # via
@@ -55,7 +53,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/cloud.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/cloud.in requirements/static/ci/common.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   etcd3-py
@@ -22,10 +22,6 @@ asn1crypto==1.3.0
     #   -c requirements/static/ci/py3.12/linux.txt
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   aiohttp
 attrs==23.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -91,7 +87,6 @@ charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/darwin.txt requirements/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/darwin.in
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -17,8 +17,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -66,7 +64,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/freebsd.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -14,8 +14,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -65,7 +63,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/lint.txt requirements/base.txt requirements/static/ci/common.in requirements/static/ci/lint.in requirements/static/ci/linux.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   etcd3-py
@@ -35,10 +35,6 @@ asn1crypto==1.3.0
     #   oscrypto
 astroid==2.3.3
     # via pylint
-async-timeout==4.0.2
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   aiohttp
 attrs==23.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -102,7 +98,6 @@ charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/linux.txt requirements/base.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/linux.in requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.2.0
     # via aiohttp
@@ -20,8 +20,6 @@ asn1crypto==1.3.0
     # via
     #   certvalidator
     #   oscrypto
-async-timeout==4.0.2
-    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
@@ -74,7 +72,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/ci/py3.12/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/windows.in requirements/windows.txt
 #
-aiohttp==3.8.5
+aiohttp==3.9.0
     # via etcd3-py
 aiosignal==1.3.1
-    # via aiohttp
-async-timeout==4.0.2
     # via aiohttp
 attrs==23.1.0
     # via
@@ -55,7 +53,6 @@ cffi==1.14.6
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
-    #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in


### PR DESCRIPTION
### What does this PR do?
Bump to `aiohttp>=3.8.6` due to CVE's

* https://github.com/advisories/GHSA-pjjw-qhg8-p2p9
* https://github.com/advisories/GHSA-q3qx-c6g2-7pw2