### PR TITLE
[3006.x] maintain user-defined options in apt source definitions

### DIFF
--- a/changelog/64130.fixed.md
+++ b/changelog/64130.fixed.md
@@ -1,0 +1,1 @@
+Made Salt maintain options in Debian package repo definitions

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2932,6 +2932,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
     if "comments" in kwargs:
         kwargs["comments"] = salt.utils.pkg.deb.combine_comments(kwargs["comments"])
 
+    repo_source_entry = SourceEntry(repo)
     if not mod_source:
         mod_source = SourceEntry(repo)
         if "comments" in kwargs:
@@ -2940,12 +2941,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
     elif "comments" in kwargs:
         mod_source.comment = kwargs["comments"]
 
-    if HAS_APT:
-        # workaround until python3-apt supports signedby
-        if str(mod_source) != str(SourceEntry(repo)) and "signed-by" in str(mod_source):
-            rline = SourceEntry(repo)
-            mod_source.line = rline.line
-
+    mod_source.line = repo_source_entry.line
     if not mod_source.line.endswith("\n"):
         mod_source.line = mod_source.line + "\n"
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -203,16 +203,27 @@ if not HAS_APT:
                 repo_line.append("#")
 
             repo_line.append(self.type)
-            opts = []
+            opts = _get_opts(self.line)
             if self.architectures:
-                opts.append("arch={}".format(",".join(self.architectures)))
+                archs = ",".join(self.architectures)
+                opts["arch"]["full"] = "arch={}".format(archs)
+                opts["arch"]["value"] = self.architectures
             if self.signedby:
-                opts.append("signed-by={}".format(self.signedby))
+                opts["signedby"]["full"] = "signed-by={}".format(self.signedby)
+                opts["signedby"]["value"] = self.signedby
 
-            if opts:
-                repo_line.append("[{}]".format(" ".join(opts)))
+            ordered_opts = [
+                opt_type for opt_type, opt in opts.items() if opt["full"] != ""
+            ]
 
-            repo_line = repo_line + [self.uri, self.dist, " ".join(self.comps)]
+            for opt in opts.values():
+                if opt["full"] != "":
+                    ordered_opts[opt["index"]] = opt["full"]
+
+            if ordered_opts:
+                repo_line.append("[{}]".format(" ".join(ordered_opts)))
+
+            repo_line += [self.uri, self.dist, " ".join(self.comps)]
             if self.comment:
                 repo_line.append("#{}".format(self.comment))
             return " ".join(repo_line) + "\n"

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -5,37 +5,33 @@ import pytest
 import salt.utils.files
 
 
+@pytest.mark.parametrize(
+    "options",
+    [
+        "",
+        "  signed-by=/foo/bar  ",
+        "  trusted=yes",
+        "signed-by=/foo/bar arch=amd64,i386",
+        "signed-by=foo/bar trusted=yes arch=amd64",
+    ],
+)
 @pytest.mark.skipif(
     not any([x for x in ["ubuntu", "debian"] if x in platform.platform()]),
     reason="Test only for debian based platforms",
 )
-def test_adding_repo_file(states, tmp_path):
+def test_adding_repo_file_options(states, tmp_path, options):
     """
     test adding a repo file using pkgrepo.managed
+    and maintaining the user-supplied options
     """
     repo_file = str(tmp_path / "stable-binary.list")
-    repo_content = "deb http://www.deb-multimedia.org stable main"
-    ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
-    with salt.utils.files.fopen(repo_file, "r") as fp:
-        file_content = fp.read()
-    assert file_content.strip() == repo_content
-
-
-@pytest.mark.skipif(
-    not any([x for x in ["ubuntu", "debian"] if x in platform.platform()]),
-    reason="Test only for debian based platforms",
-)
-def test_adding_repo_file_arch(states, tmp_path):
-    """
-    test adding a repo file using pkgrepo.managed
-    and setting architecture
-    """
-    repo_file = str(tmp_path / "stable-binary.list")
-    repo_content = "deb [arch=amd64  ] http://www.deb-multimedia.org stable main"
+    option = f"[{options}] " if options != "" else ""
+    expected_option = f"[{options.strip()}] " if options != "" else ""
+    repo_content = f"deb {option}http://www.deb-multimedia.org stable main"
     ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
     with salt.utils.files.fopen(repo_file, "r") as fp:
         file_content = fp.read()
         assert (
             file_content.strip()
-            == "deb [arch=amd64] http://www.deb-multimedia.org stable main"
+            == f"deb {expected_option}http://www.deb-multimedia.org stable main"
         )


### PR DESCRIPTION
### What does this PR do?
Port https://github.com/saltstack/salt/pull/65366 to 3006.x
----
Attempts to maintain all debian source options (not just arch and signed-by) from debian package repo definitions.

NOTE: Through testing it was observed that Salt was also removing options from sources list files that were not even managed by Salt (because it reads all *.list files in known apt locations and re-writes them). This PR doesn't fix the behavior of Salt re-writing all *.list files, but it should prevent Salt from blindly stripping out options in those files.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64130

### Previous Behavior

A pkgrepo definition like this: 
```
test_unsigned_repo:
  pkgrepo.managed:
    - humanname: unsigned_repo
    - name: deb [trusted=yes] http://reposerver.net/ubuntu main
    - file: /etc/apt/sources.list.d/unsigned_repo_test
```

Resulted in a source list file like this (missing [trustred=yes] option):

```
deb http://reposerver.net/ubuntu main
```

### New Behavior

A pkgrepo definition like this: 
```
test_unsigned_repo:
  pkgrepo.managed:
    - humanname: unsigned_repo
    - name: deb [trusted=yes] http://reposerver.net/ubuntu main
    - file: /etc/apt/sources.list.d/unsigned_repo_test
```

Results in a correct source list file like this ([trustred=yes] option is maintained):

```
deb [trusted=yes] http://reposerver.net/ubuntu main
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs- Didn't seem to me like docs needed updated for this change
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
