### PR TITLE
[3006.x] Handle MacOS's Arch64 architecture when creating the package repository

### DIFF
--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -890,6 +890,8 @@ def _create_onedir_based_repo(
             arch = "x86"
         elif "-aarch64" in dpath.name.lower():
             arch = "aarch64"
+        elif "-arm64" in dpath.name.lower():
+            arch = "arm64"
         else:
             ctx.error(
                 f"Cannot pickup the right architecture from the filename '{dpath.name}'."


### PR DESCRIPTION
### What does this PR do?
See title