### PR TITLE
[3006.x] Bump to `cryptography==41.0.7` due to https://github.com/advisories/GHSA-jfhm-5ghh-2f97

### DIFF
--- a/changelog/65643.security.md
+++ b/changelog/65643.security.md
@@ -1,0 +1,1 @@
+Bump to `cryptography==41.0.7` due to https://github.com/advisories/GHSA-jfhm-5ghh-2f97

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -124,7 +124,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -90,7 +90,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -87,7 +87,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -135,7 +135,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -96,7 +96,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -81,7 +81,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -120,7 +120,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -86,7 +86,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -85,7 +85,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -131,7 +131,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -94,7 +94,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -79,7 +79,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -120,7 +120,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -86,7 +86,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -85,7 +85,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -131,7 +131,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -94,7 +94,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -79,7 +79,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -138,7 +138,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -97,7 +97,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -157,7 +157,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -108,7 +108,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -88,7 +88,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -133,7 +133,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -92,7 +92,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -148,7 +148,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -103,7 +103,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -83,7 +83,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -133,7 +133,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -95,7 +95,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -92,7 +92,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -144,7 +144,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -101,7 +101,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -83,7 +83,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.6
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements/windows.txt
     #   pyopenssl


### PR DESCRIPTION
### What does this PR do?
Bump to `cryptography==41.0.7` due to https://github.com/advisories/GHSA-jfhm-5ghh-2f97
