### PR TITLE
[master] Use unittest.mock for newer Python versions

### DIFF
--- a/changelog/65644.changed.md
+++ b/changelog/65644.changed.md
@@ -1,0 +1,1 @@
+Use ``unittest.mock`` instead of the external ``mock`` package on Python >= 3.8.

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,4 +1,4 @@
-mock >= 5.2.0
+mock >= 5.2.0; python_version < '3.8'
 # PyTest
 docker >= 7.1.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'

--- a/tests/support/mock.py
+++ b/tests/support/mock.py
@@ -18,37 +18,34 @@
 import copy
 import errno
 import fnmatch
+import importlib
 import sys
 
-# By these days, we should blowup if mock is not available
-import mock  # pylint: disable=blacklisted-external-import
+current_version = (sys.version_info.major, sys.version_info.minor)
 
-# pylint: disable=no-name-in-module,no-member
-from mock import (
-    ANY,
-    DEFAULT,
-    FILTER_DIR,
-    AsyncMock,
-    MagicMock,
-    Mock,
-    NonCallableMagicMock,
-    NonCallableMock,
-    PropertyMock,
-    __version__,
-    call,
-    create_autospec,
-    patch,
-    sentinel,
-)
+# Prefer unittest.mock for Python versions that are sufficient
+if current_version >= (3, 8):
+    mock = importlib.import_module("unittest.mock")
+else:
+    mock = importlib.import_module("mock")
+
+ANY = mock.ANY
+AsyncMock = mock.AsyncMock
+DEFAULT = mock.DEFAULT
+FILTER_DIR = mock.FILTER_DIR
+MagicMock = mock.MagicMock
+Mock = mock.Mock
+NonCallableMagicMock = mock.NonCallableMagicMock
+NonCallableMock = mock.NonCallableMock
+PropertyMock = mock.PropertyMock
+call = mock.call
+create_autospec = mock.create_autospec
+patch = mock.patch
+sentinel = mock.sentinel
 
 import salt.utils.stringutils
 
 # pylint: disable=no-name-in-module,no-member
-
-
-__mock_version = tuple(
-    int(part) for part in mock.__version__.split(".") if part.isdigit()
-)  # pylint: disable=no-member
 
 
 class MockFH:


### PR DESCRIPTION
### What does this PR do?

This PR causes the test suite to use `unittest.mock` instead of `mock` for supported Python versions, so the usage of standard library components is favoured.

To achieve this, the `__version__` variable is removed as it was dropped from Python 3.9  and it's almost not used.

The results of the test suite do not change.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
