### PR TITLE
[3006.x] MacOS packages include `arm64` in their name, not `aarch64`

### DIFF
--- a/pkg/tests/download/test_pkg_download.py
+++ b/pkg/tests/download/test_pkg_download.py
@@ -401,8 +401,6 @@ def setup_macos(
 ):
     arch = os.environ.get("SALT_REPO_ARCH") or "x86_64"
     if package_type == "package":
-        if arch == "aarch64":
-            arch = "arm64"
 
         if packaging.version.parse(salt_release) > packaging.version.parse("3005"):
             mac_pkg = f"salt-{salt_release}-py3-{arch}.pkg"

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -266,8 +266,12 @@ def generate_workflows(ctx: Context):
             continue
         test_salt_pkg_downloads_listing["linux"].append((slug, arch, "onedir"))
     for slug, display_name, arch in build_ci_deps_listing["macos"]:
+        if arch == "aarch64":
+            arch = "arm64"
         test_salt_pkg_downloads_listing["macos"].append((slug, arch, "package"))
     for slug, display_name, arch in build_ci_deps_listing["macos"][-1:]:
+        if arch == "aarch64":
+            arch = "arm64"
         test_salt_pkg_downloads_listing["macos"].append((slug, arch, "onedir"))
     for slug, display_name, arch in build_ci_deps_listing["windows"][-1:]:
         for pkg_type in ("nsis", "msi", "onedir"):


### PR DESCRIPTION
### What does this PR do?
See title