### PR TITLE
[3006.x] Adds workflow for Macos Arm64 builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3714,6 +3714,12 @@ jobs:
           name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-x86_64.tar.xz
           path: artifacts/pkgs/incoming
 
+      - name: Download macOS arm64 Onedir Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-arm64.tar.xz
+          path: artifacts/pkgs/incoming
+
       - name: Download Windows amd64 Onedir Archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3520,6 +3520,12 @@ jobs:
           name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-x86_64.tar.xz
           path: artifacts/pkgs/incoming
 
+      - name: Download macOS arm64 Onedir Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-arm64.tar.xz
+          path: artifacts/pkgs/incoming
+
       - name: Download Windows amd64 Onedir Archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/templates/build-onedir-repo.yml.jinja
+++ b/.github/workflows/templates/build-onedir-repo.yml.jinja
@@ -37,6 +37,12 @@
           name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-x86_64.tar.xz
           path: artifacts/pkgs/incoming
 
+      - name: Download macOS arm64 Onedir Archive
+        uses: actions/download-artifact@v3
+        with:
+          name: salt-${{ needs.prepare-workflow.outputs.salt-version }}-onedir-darwin-arm64.tar.xz
+          path: artifacts/pkgs/incoming
+
       - name: Download Windows amd64 Onedir Archive
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
### What does this PR do?
Adds workflow so that the MacOS Arm64 builds will get uploaded to the repo
