### PR TITLE
[master] Distribute virtualenv_mod in the windows packages

### DIFF
--- a/pkg/windows/msi/build_pkg.ps1
+++ b/pkg/windows/msi/build_pkg.ps1
@@ -391,7 +391,7 @@ $modules = "acme",
            "uswgi",
            "varnish",
            "vbox",
-           "virt",
+           "virt.py",  # We don't want to remove virtualenv_mod.py
            "xapi",
            "xbpspkg",
            "xfs",

--- a/pkg/windows/nsis/build_pkg.ps1
+++ b/pkg/windows/nsis/build_pkg.ps1
@@ -261,7 +261,7 @@ $modules = "acme",
            "uswgi",
            "varnish",
            "vbox",
-           "virt",
+           "virt.py",  # We don't want to remove virtualenv_mod.py
            "xapi",
            "xbpspkg",
            "xfs",


### PR DESCRIPTION
Due to an oversight the virtualenv_mod module was not distributes with the Windows package anymore.

### What does this PR do?

Add the virtualenv_mod module back in the windows packages

### What issues does this PR fix or reference?
Fixes: In the step of removing the modules that are not compatible with Windows, we want to remove the _virt_ package. The way the code works, it deletes every packages that match the _virt\*_ glob, which also includes _virtualenv\_mod_.

### New Behavior
We specify the file extension so _virtualenv\_mod.py_ is not deleted anymore.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
