### PR TITLE
[3006.x] Fix salt-ssh orch/`saltutil.cmd` with `ssh=true`

### DIFF
--- a/changelog/65670.fixed.md
+++ b/changelog/65670.fixed.md
@@ -1,0 +1,1 @@
+Fixed Salt-SSH pillar rendering and state rendering with nested SSH calls when called via saltutil.cmd or in an orchestration

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -39,6 +39,10 @@ class SSHClient:
 
         # Salt API should never offer a custom roster!
         self.opts["__disable_custom_roster"] = disable_custom_roster
+        # Pillar compilation and nested SSH calls require the correct config_dir
+        # in __opts__, otherwise we will use the SSH minion's one later.
+        if "config_dir" not in self.opts:
+            self.opts["config_dir"] = os.path.dirname(c_path)
 
     def sanitize_kwargs(self, kwargs):
         roster_vals = [


### PR DESCRIPTION
### What does this PR do?
Ensures `config_dir` is set in the master opts when an `SSHClient` is instantiated. See issue for more details.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65670

### Previous Behavior
When called via `saltutil.cmd` or in an orchestration with `salt.state` and `ssh=true`:

* GPG renderer broken during pillar rendering
* mine/publish wrappers broken because of broken roster (during state rendering ofc)


### New Behavior
Works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes