### PR TITLE
[3006.x] Add more loader dunders to cp module.

### DIFF
--- a/salt/loader/context.py
+++ b/salt/loader/context.py
@@ -43,6 +43,9 @@ class NamedLoaderContext(collections.abc.MutableMapping):
         self.loader_context = loader_context
         self.default = default
 
+    def with_default(self, default):
+        return NamedLoaderContext(self.name, self.loader_context, default=default)
+
     def loader(self):
         """
         The LazyLoader in the current context. This will return None if there

--- a/salt/loader/context.py
+++ b/salt/loader/context.py
@@ -68,9 +68,19 @@ class NamedLoaderContext(collections.abc.MutableMapping):
         loader = self.loader()
         if loader is None:
             return self.default
-        if self.name == "__context__":
+        elif self.name == "__context__":
             return loader.pack[self.name]
-        if self.name == loader.pack_self:
+        elif self.name == "__opts__":
+            # XXX: This behaviour tires to mimick what the loader does when
+            # __opts__ was not imported from dunder. It would be nice to just
+            # pass the value of __opts__ here. However, un-winding this
+            # behavior will be tricky.
+            opts = {}
+            if self.default:
+                opts.update(copy.deepcopy(self.default))
+            opts.update(copy.deepcopy(loader.opts))
+            return opts
+        elif self.name == loader.pack_self:
             return loader
         try:
             return loader.pack[self.name]

--- a/salt/loader/dunder.py
+++ b/salt/loader/dunder.py
@@ -8,3 +8,6 @@ loader_context = salt.loader.context.LoaderContext()
 
 
 __file_client__ = loader_context.named_context("__file_client__", default=None)
+__context__ = loader_context.named_context("__context__")
+__pillar__ = loader_context.named_context("__pillar__")
+__grains__ = loader_context.named_context("__grains__")

--- a/salt/loader/dunder.py
+++ b/salt/loader/dunder.py
@@ -8,6 +8,7 @@ loader_context = salt.loader.context.LoaderContext()
 
 
 __file_client__ = loader_context.named_context("__file_client__", default=None)
+__opts__ = loader_context.named_context("__opts__")
 __context__ = loader_context.named_context("__context__")
 __pillar__ = loader_context.named_context("__pillar__")
 __grains__ = loader_context.named_context("__grains__")

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -1257,7 +1257,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self.parent_loader = current_loader
         token = salt.loader.context.loader_ctxvar.set(self)
         try:
-            return _func_or_method(*args, **kwargs)
+            ret = _func_or_method(*args, **kwargs)
+            if isinstance(ret, salt.loader.context.NamedLoaderContext):
+                return ret.value()
+            return ret
         finally:
             self.parent_loader = None
             salt.loader.context.loader_ctxvar.reset(token)

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -20,7 +20,7 @@ import salt.utils.path
 import salt.utils.templates
 import salt.utils.url
 from salt.exceptions import CommandExecutionError
-from salt.loader.dunder import __file_client__
+from salt.loader.dunder import __context__, __file_client__, __grains__, __pillar__
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -20,7 +20,13 @@ import salt.utils.path
 import salt.utils.templates
 import salt.utils.url
 from salt.exceptions import CommandExecutionError
-from salt.loader.dunder import __context__, __file_client__, __grains__, __pillar__, __opts__
+from salt.loader.dunder import (
+    __context__,
+    __file_client__,
+    __grains__,
+    __opts__,
+    __pillar__,
+)
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +173,7 @@ def _client():
     """
     if __file_client__:
         return __file_client__.value()
-    return salt.fileclient.get_file_client(__opts__)
+    return salt.fileclient.get_file_client(__opts__.value())
 
 
 def _render_filenames(path, dest, saltenv, template, **kw):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -20,7 +20,7 @@ import salt.utils.path
 import salt.utils.templates
 import salt.utils.url
 from salt.exceptions import CommandExecutionError
-from salt.loader.dunder import __context__, __file_client__, __grains__, __pillar__
+from salt.loader.dunder import __context__, __file_client__, __grains__, __pillar__, __opts__
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/functional/loader/test_dunder.py
+++ b/tests/pytests/functional/loader/test_dunder.py
@@ -6,7 +6,7 @@ import salt.utils.files
 import tests.support.helpers
 
 
-def test_opts_dunder_opts_without_import(tempdir):
+def xtest_opts_dunder_opts_without_import(tempdir):
     """
     Test __opts__ without being imported.
 
@@ -19,12 +19,12 @@ def test_opts_dunder_opts_without_import(tempdir):
             tests.support.helpers.dedent(
                 """
             def mymethod():
-                return type(__opts__)
+                return __opts__
             """
             )
         )
     loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
-    assert loader["mymod.mymethod"]() == dict
+    assert type(loader["mymod.mymethod"]()) == dict
 
 
 def test_opts_dunder_opts_with_import(tempdir):
@@ -40,10 +40,13 @@ def test_opts_dunder_opts_with_import(tempdir):
             tests.support.helpers.dedent(
                 """
             from salt.loader.dunder import __opts__
-            def mymethod():
+            def optstype():
                 return type(__opts__)
+            def opts():
+                return __opts__
             """
             )
         )
     loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
-    assert loader["mymod.mymethod"]() == salt.loader.context.NamedLoaderContext
+    assert loader["mymod.optstype"]() == salt.loader.context.NamedLoaderContext
+    assert loader["mymod.opts"]() == opts

--- a/tests/pytests/functional/loader/test_dunder.py
+++ b/tests/pytests/functional/loader/test_dunder.py
@@ -1,12 +1,10 @@
-import pathlib
-
 import salt.loader.context
 import salt.loader.lazy
 import salt.utils.files
 import tests.support.helpers
 
 
-def xtest_opts_dunder_opts_without_import(tempdir):
+def test_opts_dunder_opts_without_import(tmp_path):
     """
     Test __opts__ without being imported.
 
@@ -14,7 +12,7 @@ def xtest_opts_dunder_opts_without_import(tempdir):
     salt.loader.dunder the __opts__ object will be a dictionary.
     """
     opts = {"optimization_order": [0, 1, 2]}
-    with salt.utils.files.fopen(pathlib.Path(tempdir.tempdir) / "mymod.py", "w") as fp:
+    with salt.utils.files.fopen(tmp_path / "mymod.py", "w") as fp:
         fp.write(
             tests.support.helpers.dedent(
                 """
@@ -23,11 +21,11 @@ def xtest_opts_dunder_opts_without_import(tempdir):
             """
             )
         )
-    loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
+    loader = salt.loader.lazy.LazyLoader([tmp_path], opts)
     assert type(loader["mymod.mymethod"]()) == dict
 
 
-def test_opts_dunder_opts_with_import(tempdir):
+def test_opts_dunder_opts_with_import(tmp_path):
     """
     Test __opts__ when imported.
 
@@ -35,7 +33,7 @@ def test_opts_dunder_opts_with_import(tempdir):
     salt.loader.dunder the __opts__ object will be a NamedLoaderContext.
     """
     opts = {"optimization_order": [0, 1, 2]}
-    with salt.utils.files.fopen(pathlib.Path(tempdir.tempdir) / "mymod.py", "w") as fp:
+    with salt.utils.files.fopen(tmp_path / "mymod.py", "w") as fp:
         fp.write(
             tests.support.helpers.dedent(
                 """
@@ -47,6 +45,6 @@ def test_opts_dunder_opts_with_import(tempdir):
             """
             )
         )
-    loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
+    loader = salt.loader.lazy.LazyLoader([tmp_path], opts)
     assert loader["mymod.optstype"]() == salt.loader.context.NamedLoaderContext
     assert loader["mymod.opts"]() == opts

--- a/tests/pytests/functional/loader/test_dunder.py
+++ b/tests/pytests/functional/loader/test_dunder.py
@@ -1,0 +1,49 @@
+import pathlib
+
+import salt.loader.context
+import salt.loader.lazy
+import salt.utils.files
+import tests.support.helpers
+
+
+def test_opts_dunder_opts_without_import(tempdir):
+    """
+    Test __opts__ without being imported.
+
+    When a loaded module uses __opts__ but does not import it from
+    salt.loader.dunder the __opts__ object will be a dictionary.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    with salt.utils.files.fopen(pathlib.Path(tempdir.tempdir) / "mymod.py", "w") as fp:
+        fp.write(
+            tests.support.helpers.dedent(
+                """
+            def mymethod():
+                return type(__opts__)
+            """
+            )
+        )
+    loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
+    assert loader["mymod.mymethod"]() == dict
+
+
+def test_opts_dunder_opts_with_import(tempdir):
+    """
+    Test __opts__ when imported.
+
+    When a loaded module uses __opts__ by importing it from
+    salt.loader.dunder the __opts__ object will be a NamedLoaderContext.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    with salt.utils.files.fopen(pathlib.Path(tempdir.tempdir) / "mymod.py", "w") as fp:
+        fp.write(
+            tests.support.helpers.dedent(
+                """
+            from salt.loader.dunder import __opts__
+            def mymethod():
+                return type(__opts__)
+            """
+            )
+        )
+    loader = salt.loader.lazy.LazyLoader([tempdir.tempdir], opts)
+    assert loader["mymod.mymethod"]() == salt.loader.context.NamedLoaderContext

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -13,6 +13,7 @@ import salt.modules.file as file
 import salt.modules.gpg as gpg
 import salt.utils.files
 import salt.utils.stringutils
+from salt.loader.dunder import __opts__
 from tests.support.mock import Mock, patch
 
 pytestmark = [
@@ -76,7 +77,7 @@ def configure_loader_modules(minion_opts):
         },
         gpg: {},
         cp: {
-            "__opts__": minion_opts,
+            "__opts__": __opts__.with_default(minion_opts),
         },
         config: {
             "__opts__": minion_opts,

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -6,6 +6,7 @@ import logging
 
 import pytest
 
+import salt.loader.dunder
 import salt.modules.config as config
 import salt.modules.cp as cp
 import salt.modules.pkg_resource as pkg_resource
@@ -57,7 +58,7 @@ def configure_loader_modules(minion_opts):
     opts = minion_opts
     opts["master_uri"] = "localhost"
     return {
-        cp: {"__opts__": opts},
+        cp: {"__opts__": salt.loader.dunder.__opts__.with_default(opts)},
         win_pkg: {
             "_get_latest_package_version": MagicMock(return_value="3.03"),
             "_get_package_info": MagicMock(return_value=pkg_info),

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -11,6 +11,7 @@ import salt.modules.yumpkg as yumpkg
 import salt.states.beacon as beaconstate
 import salt.states.pkg as pkg
 import salt.utils.state as state_utils
+from salt.loader.dunder import __opts__
 from salt.utils.event import SaltEvent
 from tests.support.mock import MagicMock, patch
 
@@ -21,7 +22,7 @@ log = logging.getLogger(__name__)
 def configure_loader_modules(minion_opts):
     return {
         cp: {
-            "__opts__": minion_opts,
+            "__opts__": __opts__.with_default(minion_opts),
         },
         pkg: {
             "__env__": "base",


### PR DESCRIPTION
Using cp module to dip our feet into more explicit loader dunders. Most all of the existing dunders can be imported already. The one outlier being used by the cp module is __opts__.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
