### PR TITLE
[master] Keep track when an included file only includes sls files but is a requisite

### DIFF
--- a/changelog/65080.fixed.md
+++ b/changelog/65080.fixed.md
@@ -1,0 +1,1 @@
+Keep track when an included file only includes sls files but is a requisite.

--- a/salt/state.py
+++ b/salt/state.py
@@ -107,6 +107,7 @@ STATE_RUNTIME_KEYWORDS = frozenset(
         "__env__",
         "__sls__",
         "__id__",
+        "__sls_included_from__",
         "__orchestration_jid__",
         "__pub_user",
         "__pub_arg",
@@ -1719,6 +1720,8 @@ class State:
                     chunk["__sls__"] = body["__sls__"]
                 if "__env__" in body:
                     chunk["__env__"] = body["__env__"]
+                if "__sls_included_from__" in body:
+                    chunk["__sls_included_from__"] = body["__sls_included_from__"]
                 chunk["__id__"] = name
                 for arg in run:
                     if isinstance(arg, str):
@@ -2928,7 +2931,9 @@ class State:
                     for chunk in chunks:
                         if req_key == "sls":
                             # Allow requisite tracking of entire sls files
-                            if fnmatch.fnmatch(chunk["__sls__"], req_val):
+                            if fnmatch.fnmatch(
+                                chunk["__sls__"], req_val
+                            ) or req_val in chunk.get("__sls_included_from__", []):
                                 found = True
                                 reqs[r_state].append(chunk)
                             continue
@@ -3143,7 +3148,9 @@ class State:
                             continue
                         if req_key == "sls":
                             # Allow requisite tracking of entire sls files
-                            if fnmatch.fnmatch(chunk["__sls__"], req_val):
+                            if fnmatch.fnmatch(
+                                chunk["__sls__"], req_val
+                            ) or req_val in chunk.get("__sls_included_from__", []):
                                 if requisite == "prereq":
                                     chunk["__prereq__"] = True
                                 reqs.append(chunk)
@@ -4486,6 +4493,16 @@ class BaseHighState:
                                     context=context,
                                 )
                                 if nstate:
+                                    for item in nstate:
+                                        # Skip existing state keywords
+                                        if item.startswith("__"):
+                                            continue
+                                        if "__sls_included_from__" not in nstate[item]:
+                                            nstate[item]["__sls_included_from__"] = []
+                                        nstate[item]["__sls_included_from__"].append(
+                                            sls
+                                        )
+
                                     self.merge_included_states(state, nstate, errors)
                                     state.update(nstate)
                                 if err:

--- a/tests/pytests/integration/states/test_include.py
+++ b/tests/pytests/integration/states/test_include.py
@@ -38,3 +38,154 @@ def test_issue_64111(salt_master, salt_minion, salt_call_cli):
             with tf("common/file1.sls", file1_sls):
                 ret = salt_call_cli.run("state.apply", "common")
                 assert ret.returncode == 0
+
+
+@pytest.mark.slow_test
+def test_issue_65080(salt_master, salt_minion, salt_call_cli):
+    """
+    Test scenario when a state includes another state that only includes a third state
+    """
+
+    only_include_sls = """
+include:
+  - includetest.another-include
+    """
+
+    another_include_sls = """
+/tmp/from-test-file.txt:
+  file.managed:
+    - contents: Hello from test-file.sls
+    """
+
+    init_sls = """
+include:
+  - includetest.only-include
+/tmp/from-init.txt:
+  file.managed:
+    - contents: Hello from init.sls
+    - require:
+      - sls: includetest.only-include
+    """
+
+    tf = salt_master.state_tree.base.temp_file
+
+    with tf("includetest/init.sls", init_sls):
+        with tf("includetest/another-include.sls", another_include_sls):
+            with tf("includetest/only-include.sls", only_include_sls):
+                ret = salt_call_cli.run("state.apply", "includetest")
+                assert ret.returncode == 0
+
+                ret = salt_call_cli.run("state.show_low_sls", "includetest")
+                assert "__sls_included_from__" in ret.data[0]
+                assert (
+                    "includetest.only-include" in ret.data[0]["__sls_included_from__"]
+                )
+
+
+@pytest.mark.slow_test
+def test_issue_65080_multiple_includes(salt_master, salt_minion, salt_call_cli):
+    """
+    Test scenario when a state includes another state that only includes a third state
+    """
+
+    only_include_one_sls = """
+include:
+  - includetest.include-one
+    """
+
+    only_include_two_sls = """
+include:
+  - includetest.include-two
+    """
+
+    include_one_sls = """
+/tmp/from-test-file1.txt:
+  file.managed:
+    - contents: Hello from test-file.sls
+    """
+
+    include_two_sls = """
+/tmp/from-test-file2.txt:
+  file.managed:
+    - contents: Hello from test-file.sls
+    """
+
+    init_sls = """
+include:
+  - includetest.only-include-one
+  - includetest.only-include-two
+/tmp/from-init.txt:
+  file.managed:
+    - contents: Hello from init.sls
+    - require:
+      - sls: includetest.only-include-one
+      - sls: includetest.only-include-two
+    """
+
+    tf = salt_master.state_tree.base.temp_file
+
+    with tf("includetest/init.sls", init_sls):
+        with tf("includetest/include-one.sls", include_one_sls), tf(
+            "includetest/include-two.sls", include_two_sls
+        ):
+            with tf("includetest/only-include-one.sls", only_include_one_sls), tf(
+                "includetest/only-include-two.sls", only_include_two_sls
+            ):
+                ret = salt_call_cli.run("state.apply", "includetest")
+                assert ret.returncode == 0
+
+                ret = salt_call_cli.run("state.show_low_sls", "includetest")
+                assert "__sls_included_from__" in ret.data[0]
+                assert (
+                    "includetest.only-include-one"
+                    in ret.data[0]["__sls_included_from__"]
+                )
+
+                assert "__sls_included_from__" in ret.data[1]
+                assert (
+                    "includetest.only-include-two"
+                    in ret.data[1]["__sls_included_from__"]
+                )
+
+
+@pytest.mark.slow_test
+def test_issue_65080_saltenv(salt_master, salt_minion, salt_call_cli):
+    """
+    Test scenario when a state includes another state that only includes a third state
+    """
+
+    only_include_sls = """
+include:
+  - includetest.another-include
+    """
+
+    another_include_sls = """
+/tmp/from-test-file.txt:
+  file.managed:
+    - contents: Hello from test-file.sls
+    """
+
+    init_sls = """
+include:
+  - prod: includetest.only-include
+/tmp/from-init.txt:
+  file.managed:
+    - contents: Hello from init.sls
+    - require:
+      - sls: includetest.only-include
+    """
+
+    base_tf = salt_master.state_tree.base.temp_file
+    prod_tf = salt_master.state_tree.prod.temp_file
+
+    with base_tf("includetest/init.sls", init_sls):
+        with prod_tf("includetest/only-include.sls", only_include_sls):
+            with prod_tf("includetest/another-include.sls", another_include_sls):
+                ret = salt_call_cli.run("state.apply", "includetest")
+                assert ret.returncode == 0
+
+                ret = salt_call_cli.run("state.show_low_sls", "includetest")
+                assert "__sls_included_from__" in ret.data[0]
+                assert (
+                    "includetest.only-include" in ret.data[0]["__sls_included_from__"]
+                )

--- a/tests/pytests/unit/state/test_state_highstate.py
+++ b/tests/pytests/unit/state/test_state_highstate.py
@@ -323,6 +323,7 @@ def test_dont_extend_in_excluded_sls_file(highstate, state_tree_dir):
                             ),
                             ("__sls__", "test2"),
                             ("__env__", "base"),
+                            ("__sls_included_from__", ["test1"]),
                         ]
                     ),
                 ),


### PR DESCRIPTION
### What does this PR do?
Keep track when an included file only includes sls files but is a requisite.

Based on Gareth's PR 65326

### What issues does this PR fix or reference?
Fixes:https://github.com/saltstack/salt/issues/65080

### Previous Behavior
If the contents of an included state file only includes other state files that original state file cannot be used as a requisite.

### New Behavior
Keep track of included files to ensure they can be used as requisites if they only include other state files.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
