### PR TITLE
[master] Fix S3 module: config.option returns empty string not None

### DIFF
--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -405,19 +405,19 @@ def _get_key(
     if not service_url:
         service_url = "s3.amazonaws.com"
 
-    if verify_ssl is None and __salt__["config.option"]("s3.verify_ssl") is not None:
+    if verify_ssl is None and __salt__["config.option"]("s3.verify_ssl"):
         verify_ssl = __salt__["config.option"]("s3.verify_ssl")
 
     if verify_ssl is None:
         verify_ssl = True
 
-    if location is None and __salt__["config.option"]("s3.location") is not None:
+    if location is None and __salt__["config.option"]("s3.location"):
         location = __salt__["config.option"]("s3.location")
 
     if role_arn is None and __salt__["config.option"]("s3.role_arn"):
         role_arn = __salt__["config.option"]("s3.role_arn")
 
-    if path_style is None and __salt__["config.option"]("s3.path_style") is not None:
+    if path_style is None and __salt__["config.option"]("s3.path_style"):
         path_style = __salt__["config.option"]("s3.path_style")
 
     if path_style is None:
@@ -425,7 +425,7 @@ def _get_key(
 
     if (
         https_enable is None
-        and __salt__["config.option"]("s3.https_enable") is not None
+        and __salt__["config.option"]("s3.https_enable")
     ):
         https_enable = __salt__["config.option"]("s3.https_enable")
 


### PR DESCRIPTION
This commit revisits #56220, hopefully this time won't take 3 more years. The reasoning of this change is that ``__salt__['config.option']`` can never return ``None``:

```bash
{u'tgt': u''}
```

As a result some statements are never evaluated properly, and this module misbehaving.