### PR TITLE
[master] Add Linode `backups_enabled` Option; Improve Linode Cloud Docs

### DIFF
--- a/changelog/65697.added.md
+++ b/changelog/65697.added.md
@@ -1,0 +1,1 @@
+Allow enabling backup for Linode in Salt Cloud

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -58,12 +58,15 @@ Configuration Options
 
     ``location``
         **(Required)** The location of the VM. This should be a Linode region
-        (e.g. ``us-east``). See `listing locations <#listing-locations>`_ for
-        more options.
+        (e.g. ``us-east``). See `the list of locations <https://api.linode.com/v4/regions>`_ and
+        `the guide to choose a location <https://www.linode.com/docs/products/platform/get-started/guides/choose-a-data-center/>`_
+        for more options.
 
     ``size``
         **(Required)** The size of the VM. This should be a Linode instance type ID
-        (e.g. ``g6-standard-2``). See `listing sizes <#listing-sizes>`_ for more options.
+        (e.g. ``g6-standard-2``). See `the list of sizes <https://api.linode.com/v4/linode/types>`_ and
+        `the guide to choose a size <https://www.linode.com/docs/products/compute/compute-instances/plans/choosing-a-plan/>`_
+        for more options.
 
     ``password`` (overrides provider)
         **(*Required)** The default password for the VM. Must be provided at the profile
@@ -72,15 +75,19 @@ Configuration Options
     ``assign_private_ip``
         .. versionadded:: 2016.3.0
 
-        Whether or not to assign a private key to the VM. Defaults to ``False``.
+        **(optional)** Whether or not to assign a private IP to the VM. Defaults to ``False``.
+
+    ``backups_enabled``
+        **(optional)** Whether or not to enable the backup for this VM. Backup can be
+        configured in your Linode account Defaults to ``False``.
 
     ``cloneform``
-        The name of the Linode to clone from.
+        **(optional)** The name of the Linode to clone from.
 
     ``ssh_interface``
         .. versionadded:: 2016.3.0
 
-        The interface with which to connect over SSH. Valid options are ``private_ips`` or
+        **(optional)** The interface with which to connect over SSH. Valid options are ``private_ips`` or
         ``public_ips``. Defaults to ``public_ips``.
 
         If specifying ``private_ips``, the Linodes must be hosted within the same data center
@@ -93,17 +100,17 @@ Configuration Options
         documentation.
 
     ``ssh_pubkey``
-        The public key to authorize for SSH with the VM.
+        **(optional)** The public key to authorize for SSH with the VM.
 
     ``swap``
-        The amount of disk space to allocate for the swap partition. Defaults to ``256``.
+        **(optional)** The amount of disk space to allocate for the swap partition. Defaults to ``256``.
 
 .. _Linode's Network Helper: https://www.linode.com/docs/platform/network-helper/#what-is-network-helper
 
 Example Configuration
 ---------------------
 
-Set up a profile configuration in ``/etc/salt/cloud.profiles.d/``:
+Set up a profile configuration at ``/etc/salt/cloud.profiles`` or ``/etc/salt/cloud.profiles.d/*.conf``:
 
 .. code-block:: yaml
 

--- a/tests/integration/cloud/clouds/test_linode.py
+++ b/tests/integration/cloud/clouds/test_linode.py
@@ -30,3 +30,6 @@ class LinodeTest(CloudTest):
 
     def test_instance(self):
         return self._test_instance("linode-test")
+
+    def test_instance_with_backup(self):
+        return self._test_instance("linode-test-with-backup")

--- a/tests/integration/files/conf/cloud.profiles.d/linode.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/linode.conf
@@ -1,5 +1,12 @@
 linode-test:
   provider: linode-config
-  size: g6-standard-1
+  size: g6-nanode-1
   image: linode/ubuntu22.04
-  location: us-east
+  location: us-mia
+
+linode-test-with-backup:
+  provider: linode-config
+  size: g6-nanode-1
+  image: linode/ubuntu22.04
+  location: us-mia
+  backups_enabled: True


### PR DESCRIPTION
### What does this PR do?

This PR does:
- improved documentation for Linode module of Salt Cloud
- Add `backups_enabled` option for Linode instance creation

### What issues does this PR fix or reference?
Fixes: #65697

### Previous Behavior
`backups_enabled` option doesn't exist.

### New Behavior
Users can now configure `backups_enabled` in the Linode profile/provider

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
