### PR TITLE
[master] Handle regular expressions which do not not use grouping

### DIFF
--- a/changelog/65722.fixed.md
+++ b/changelog/65722.fixed.md
@@ -1,0 +1,1 @@
+Handle regular expressions which do not not use grouping

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -468,6 +468,9 @@ def regex_search(txt, rgx, ignorecase=False, multiline=False):
     obj = re.search(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 
@@ -495,6 +498,9 @@ def regex_match(txt, rgx, ignorecase=False, multiline=False):
     obj = re.match(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 

--- a/tests/pytests/functional/modules/state/test_jinja_filters.py
+++ b/tests/pytests/functional/modules/state/test_jinja_filters.py
@@ -613,6 +613,17 @@ def _filter_id(value):
             """,
         ),
         Filter(
+            name="regex_match_ungrouped",
+            expected={"ret": "('1.abc',)"},
+            sls="""
+            {% set result = '1.abc' | regex_match('^1.abc$') %}
+            test:
+              module.run:
+                - name: test.echo
+                - text: {{ result }}
+            """,
+        ),
+        Filter(
             name="regex_match_no_match",
             expected={"ret": "None"},
             sls="""
@@ -694,6 +705,17 @@ def _filter_id(value):
             expected={"ret": "('a', 'd')"},
             sls="""
             {% set result = 'abcd' | regex_search('^(.*)bc(.*)$') %}
+            test:
+              module.run:
+                - name: test.echo
+                - text: {{ result }}
+            """,
+        ),
+        Filter(
+            name="regex_search_ungrouped",
+            expected={"ret": "('1.abc',)"},
+            sls="""
+            {% set result = '1.abc' | regex_search('^1.abc$') %}
             test:
               module.run:
                 - name: test.echo


### PR DESCRIPTION
### What does this PR do?

Handle regular expressions which do not not use grouping in `regex_search` and `regex_match`


### Previous Behavior

```
FAILED tests/pytests/functional/modules/state/test_jinja_filters.py::test_filter[regex_match_ungrouped0] - assert {'ret': '()'} == {'ret': "('1.abc',)"}
FAILED tests/pytests/functional/modules/state/test_jinja_filters.py::test_filter[regex_match_ungrouped1] - assert {'ret': '()'} == {'ret': "('1.abc',)"}
```

### New Behavior

Entire match is returned as a tuple.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes