### PR TITLE
[3006.x] update photon paths to use their $releasever string

### DIFF
--- a/tests/pytests/pkg/download/test_pkg_download.py
+++ b/tests/pytests/pkg/download/test_pkg_download.py
@@ -256,6 +256,9 @@ def setup_redhat_family(
 ):
     arch = os.environ.get("SALT_REPO_ARCH") or "x86_64"
 
+    if os_name == "photon":
+        os_version = f"{os_version}.0"
+
     if repo_subpath == "minor":
         repo_url_base = (
             f"{root_url}/{os_name}/{os_version}/{arch}/{repo_subpath}/{salt_release}"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -380,6 +380,9 @@ def rpm(
         assert incoming is not None
         assert repo_path is not None
         assert key_id is not None
+
+    if distro == "photon":
+        distro_version = f"{distro_version}.0"
     display_name = f"{distro.capitalize()} {distro_version}"
     if distro_version not in _rpm_distro_info[distro]:
         ctx.error(f"Support for {display_name} is missing.")


### PR DESCRIPTION
### What does this PR do?
fix photon3/4/5 repo paths