### PR TITLE
[master] Add Backup Schedule Setter Function for Linode VMs

### DIFF
--- a/changelog/65713.added.md
+++ b/changelog/65713.added.md
@@ -1,0 +1,1 @@
+Add a backup schedule setter fFunction for Linode VMs

--- a/tests/integration/cloud/clouds/test_linode.py
+++ b/tests/integration/cloud/clouds/test_linode.py
@@ -2,6 +2,7 @@
     :codeauthor: Nicole Thomas <nicole@saltstack.com>
 """
 
+import random
 
 # Create the cloud instance name to be used throughout the tests
 from tests.integration.cloud.helpers.cloud_test_base import TIMEOUT, CloudTest
@@ -15,7 +16,7 @@ class LinodeTest(CloudTest):
     PROVIDER = "linode"
     REQUIRED_PROVIDER_CONFIG_ITEMS = ("apikey", "password")
 
-    def _test_instance(self, profile):
+    def _test_instance(self, profile, destroy=True):
         """
         Test creating an instance on Linode for a given profile.
         """
@@ -25,11 +26,56 @@ class LinodeTest(CloudTest):
         ret_str = self.run_cloud(" ".join(args), timeout=TIMEOUT)
 
         self.assertInstanceExists(ret_str)
-        self.assertDestroyInstance()
+        if destroy:
+            self.assertDestroyInstance()
         return ret_str
 
     def test_instance(self):
         return self._test_instance("linode-test")
 
     def test_instance_with_backup(self):
-        return self._test_instance("linode-test-with-backup")
+        profile = "linode-test-with-backup"
+
+        self._test_instance(profile, False)
+
+        set_backup_func = "set_backup_schedule"
+
+        available_days = [
+            "Sunday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+        ]
+        available_windows = [
+            "W0",
+            "W2",
+            "W4",
+            "W6",
+            "W8",
+            "W10",
+            "W12",
+            "W14",
+            "W16",
+            "W18",
+            "W20",
+            "W22",
+        ]
+
+        args = [
+            "-f",
+            set_backup_func,
+            self.PROVIDER,
+            f"name={self.instance_name}",
+            f"day={random.choice(available_days)}",
+            f"window={random.choice(available_windows)}",
+            "auto_enable=True",
+        ]
+        self.run_cloud(" ".join(args), timeout=TIMEOUT)
+
+        args = ["-f", set_backup_func, self.PROVIDER, f"name={self.instance_name}"]
+        self.run_cloud(" ".join(args), timeout=TIMEOUT)
+
+        self.assertDestroyInstance()


### PR DESCRIPTION
### What does this PR do?
This is for adding a Salt Cloud function that configures auto backup schedule of a Linode VM.

### What issues does this PR fix or reference?
Fixes: #65713

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
