### PR TITLE
[master] Fix saltext vault/pushover docs

### DIFF
--- a/changelog/64893.deprecated.md
+++ b/changelog/64893.deprecated.md
@@ -1,1 +1,1 @@
-Deprecate all the Vault modules in favor of the Vault Salt Extension https://github.com/saltstack/saltext-vault. The Vault modules will be removed in Salt core in 3009.0.
+Deprecate all the Vault modules in favor of the Vault Salt Extension https://github.com/salt-extensions/saltext-vault. The Vault modules will be removed in Salt core in 3009.0.

--- a/doc/topics/releases/templates/3007.0.md.template
+++ b/doc/topics/releases/templates/3007.0.md.template
@@ -68,9 +68,8 @@ peer_run:
 Please see the [Vault execution module docs](https://docs.saltproject.io/en/3007.0/ref/modules/all/salt.modules.vault.html) for
 details and setup instructions regarding AppRole issuance.
 
-.. note::
-  The Vault modules are being moved to a [Salt extension](https://github.com/salt-extensions/saltext-vault), but this improvement
-  has still been merged into core for a smoother transition.
+Note: The Vault modules are being moved to a [Salt extension](https://github.com/salt-extensions/saltext-vault),
+but this improvement has still been merged into core for a smoother transition.
 
 <!--
 Do not edit the changelog below.

--- a/salt/modules/pushover_notify.py
+++ b/salt/modules/pushover_notify.py
@@ -28,7 +28,7 @@ __virtualname__ = "pushover"
 __deprecated__ = (
     3009,
     "pushover",
-    "https://github.com/saltstack/saltext-pushover",
+    "https://github.com/salt-extensions/saltext-pushover",
 )
 
 

--- a/salt/returners/pushover_returner.py
+++ b/salt/returners/pushover_returner.py
@@ -94,7 +94,7 @@ __virtualname__ = "pushover"
 __deprecated__ = (
     3009,
     "pushover",
-    "https://github.com/saltstack/saltext-pushover",
+    "https://github.com/salt-extensions/saltext-pushover",
 )
 
 

--- a/salt/states/pushover.py
+++ b/salt/states/pushover.py
@@ -30,7 +30,7 @@ The api key can be specified in the master or minion configuration like below:
 __deprecated__ = (
     3009,
     "pushover",
-    "https://github.com/saltstack/saltext-pushover",
+    "https://github.com/salt-extensions/saltext-pushover",
 )
 
 


### PR DESCRIPTION
### What does this PR do?
* the correct organization is `salt-extensions`, not `saltstack`
* the release file is strict GitHub-flavoured Markdown only

Note that the links for `saltext-docker` return HTTP 404 and it's not in `salt-extensions` as well.

### What issues does this PR fix or reference?
Fixes:

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes