### PR TITLE
[master] Make Salt-SSH sync custom utils

### DIFF
--- a/changelog/53666.added.md
+++ b/changelog/53666.added.md
@@ -1,0 +1,1 @@
+Made salt-ssh sync custom utils

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1802,6 +1802,7 @@ def mod_data(fsclient):
         "grains",
         "renderers",
         "returners",
+        "utils",
     ]
     ret = {}
     with fsclient:


### PR DESCRIPTION
### What does this PR do?
Includes modules found inside `salt://_utils` in ext_mods.tgz.

Note: This is about making **direct imports** work, **not** `__utils__` (although that's likely a side effect until removed from the loader).

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/53666

### Previous Behavior
Modules relying on custom utils would fail when executed via salt-ssh.

### New Behavior
Custom utils can be imported by custom modules as usual.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes