### PR TITLE
[master] Fix unreachable error message with unsupported DNS plugins

### DIFF
--- a/changelog/65739.fixed.md
+++ b/changelog/65739.fixed.md
@@ -1,0 +1,1 @@
+Return an error message when the DNS plugin is not supported

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -212,7 +212,7 @@ def cert(
         cmd.append("--authenticator webroot")
         if webroot is not True:
             cmd.append(f"--webroot-path {webroot}")
-    elif dns_plugin in supported_dns_plugins:
+    elif dns_plugin:
         if dns_plugin == "cloudflare":
             cmd.append("--dns-cloudflare")
             cmd.append(f"--dns-cloudflare-credentials {dns_plugin_credentials}")


### PR DESCRIPTION
### What does this PR do?
Return an error message when the DNS plugin is not supported

### What issues does this PR fix or reference?
Fixes: #65739

### Previous Behavior
Expected error was in unreachable code

### New Behavior
Return error returns properly with the intended message

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
