### PR TITLE
[master] Simplify timezone.compare_zone to primarily rely get_zone()

### DIFF
--- a/changelog/65719.fixed.md
+++ b/changelog/65719.fixed.md
@@ -1,0 +1,1 @@
+Simplify timezone.compare_zone to primarily rely get_zone()


### PR DESCRIPTION
### What does this PR do?
Simplify `timezone.compare_zone()` to primarily rely `get_zone()`

### What issues does this PR fix or reference?
Fixes: #65719

### Previous Behavior
`get_zone()` and `compare_zone()` use different logic to determine the current system timezone and            `compare_zone()` failed on at least new RedHat/AlmaLinux installations.

### New Behavior
`compare_zone()` relies on `get_zone()` and falls back to previous non-OS dependent behavior if there is an exception raised.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
