### PR TITLE
[master] Add acme support for manual plugin hooks

### DIFF
--- a/changelog/65744.added.md
+++ b/changelog/65744.added.md
@@ -1,0 +1,1 @@
+Add acme support for manual plugin hooks

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -132,6 +132,8 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    manual_auth_hook=None,
+    manual_cleanup_hook=None,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -168,6 +170,8 @@ def cert(
         the specified DNS plugin
     :param dns_plugin_propagate_seconds: Number of seconds to wait for DNS propogations
         before asking ACME servers to verify the DNS record. (default 10)
+    :param manual_auth_hook: Path to the manual authentication hook script.
+    :param manual_cleanup_hook: Path to the manual cleanup or post-authentication hook script.
     :rtype: dict
     :return: Dictionary with 'result' True/False/None, 'comment' and certificate's
         expiry date ('not_after')
@@ -221,6 +225,11 @@ def cert(
                 "result": False,
                 "comment": f"DNS plugin '{dns_plugin}' is not supported",
             }
+    elif manual_auth_hook:
+        cmd.append("--manual")
+        cmd.append(f"--manual-auth-hook '{manual_auth_hook}'")
+        if manual_cleanup_hook:
+            cmd.append(f"--manual-cleanup-hook '{manual_cleanup_hook}'")
     else:
         cmd.append("--authenticator standalone")
 

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -61,6 +61,8 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    manual_auth_hook=None,
+    manual_cleanup_hook=None,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -91,6 +93,8 @@ def cert(
     :param https_01_address: The address the server listens to during http-01 challenge.
     :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare')
     :param dns_plugin_credentials: Path to the credentials file if required by the specified DNS plugin
+    :param manual_auth_hook: Path to the authentication hook script.
+    :param manual_cleanup_hook: Path to the cleanup or post-authentication hook script.
     """
 
     if certname is None:
@@ -138,6 +142,8 @@ def cert(
                 http_01_address=http_01_address,
                 dns_plugin=dns_plugin,
                 dns_plugin_credentials=dns_plugin_credentials,
+                manual_auth_hook=manual_auth_hook,
+                manual_cleanup_hook=manual_cleanup_hook,
             )
             ret["result"] = res["result"]
             ret["comment"].append(res["comment"])


### PR DESCRIPTION
### What does this PR do?
Add acme support for manual plugin hooks

### What issues does this PR fix or reference?
Fixes: #65744

### Previous Behavior
The `manual` plugin was not supported

### New Behavior
The `manual` plugin is supported by allowing the ability use provided `--manual-auth-hook` and `--manual-cleanup-hook` arguments.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
