### PR TITLE
[3006.x] Bump to `paramiko==3.4.0` due to https://github.com/advisories/GHSA-45x7-px36-x8w8

### DIFF
--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -40,7 +40,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
@@ -84,7 +84,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pynacl
 charset-normalizer==3.2.0
@@ -360,7 +359,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
@@ -612,7 +611,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -624,7 +622,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -30,7 +30,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -258,7 +258,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1
+paramiko==3.4.0
     # via
     #   junos-eznc
     #   ncclient

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -27,7 +27,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -250,7 +250,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -48,7 +48,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
@@ -94,7 +94,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
@@ -364,7 +363,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
@@ -593,7 +592,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -605,7 +603,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -33,7 +33,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -261,7 +261,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -19,7 +19,7 @@ attrs==23.1.0
     #   pytest-shell-utilities
     #   pytest-skip-markers
     #   pytest-system-statistics
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -36,7 +36,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
@@ -80,7 +80,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pynacl
 charset-normalizer==3.2.0
@@ -335,7 +334,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
@@ -570,7 +569,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -580,7 +578,6 @@ six==1.16.0
     #   kazoo
     #   kubernetes
     #   more-itertools
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -28,7 +28,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -25,7 +25,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -235,7 +235,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via -r requirements/static/ci/common.in
 passlib==1.7.4
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -44,7 +44,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
@@ -90,7 +90,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
@@ -342,7 +341,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
@@ -554,7 +553,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.11/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -564,7 +562,6 @@ six==1.16.0
     #   kazoo
     #   kubernetes
     #   more-itertools
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -31,7 +31,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -246,7 +246,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via -r requirements/static/ci/common.in
 passlib==1.7.4
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -17,7 +17,7 @@ attrs==23.1.0
     #   pytest-shell-utilities
     #   pytest-skip-markers
     #   pytest-system-statistics
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -36,7 +36,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
@@ -80,7 +80,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pynacl
 charset-normalizer==3.2.0
@@ -335,7 +334,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
@@ -570,7 +569,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -580,7 +578,6 @@ six==1.16.0
     #   kazoo
     #   kubernetes
     #   more-itertools
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -28,7 +28,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -25,7 +25,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -235,7 +235,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via -r requirements/static/ci/common.in
 passlib==1.7.4
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -44,7 +44,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
@@ -90,7 +90,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
@@ -342,7 +341,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
@@ -554,7 +553,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.12/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -564,7 +562,6 @@ six==1.16.0
     #   kazoo
     #   kubernetes
     #   more-itertools
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -31,7 +31,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -246,7 +246,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via -r requirements/static/ci/common.in
 passlib==1.7.4
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -17,7 +17,7 @@ attrs==23.1.0
     #   pytest-shell-utilities
     #   pytest-skip-markers
     #   pytest-system-statistics
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -44,7 +44,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
@@ -88,7 +88,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
@@ -405,7 +404,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
@@ -667,7 +666,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -679,7 +677,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -29,7 +29,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -286,7 +286,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -56,7 +56,7 @@ backports.zoneinfo==0.2.1
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   tzlocal
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
@@ -106,7 +106,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pygit2
@@ -415,7 +414,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
@@ -654,7 +653,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.7/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -666,7 +664,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -37,7 +37,7 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 backports.zoneinfo==0.2.1
     # via tzlocal
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -299,7 +299,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -23,7 +23,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -40,7 +40,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
@@ -84,7 +84,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
@@ -392,7 +391,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
@@ -654,7 +653,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -666,7 +664,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -27,7 +27,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -273,7 +273,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -52,7 +52,7 @@ backports.zoneinfo==0.2.1
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   tzlocal
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
@@ -98,7 +98,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pygit2
@@ -400,7 +399,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
@@ -639,7 +638,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.8/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -651,7 +649,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -35,7 +35,7 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 backports.zoneinfo==0.2.1
     # via tzlocal
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -286,7 +286,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -21,7 +21,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -40,7 +40,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
@@ -84,7 +84,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
@@ -392,7 +391,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
@@ -656,7 +655,6 @@ six==1.16.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -668,7 +666,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   profitbricks
     #   pypsexec
     #   python-dateutil

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -30,7 +30,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -281,7 +281,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1
+paramiko==3.4.0
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -27,7 +27,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -273,7 +273,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -48,7 +48,7 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
@@ -94,7 +94,6 @@ cffi==1.14.6
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-    #   bcrypt
     #   cryptography
     #   napalm
     #   pygit2
@@ -396,7 +395,7 @@ packaging==22.0
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
@@ -637,7 +636,6 @@ six==1.16.0
     #   -c requirements/static/ci/py3.9/linux.txt
     #   apscheduler
     #   astroid
-    #   bcrypt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -649,7 +647,6 @@ six==1.16.0
     #   kubernetes
     #   more-itertools
     #   ncclient
-    #   paramiko
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -33,7 +33,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==3.1.6
+bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
@@ -284,7 +284,7 @@ packaging==22.0
     #   ansible-core
     #   docker
     #   pytest
-paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
+paramiko==3.4.0
     # via
     #   -r requirements/static/ci/common.in
     #   junos-eznc

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -21,7 +21,7 @@ attrs==23.1.0
     #   pytest-system-statistics
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-bcrypt==4.0.1
+bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.21.46
     # via


### PR DESCRIPTION
### What does this PR do?
See title.
A dependency of paramiko also had to be upgraded, `bcrypt==4.1.2`