### PR TITLE
[master] Introduce fibre_channel_host grain

### DIFF
--- a/changelog/65750.added.md
+++ b/changelog/65750.added.md
@@ -1,0 +1,1 @@
+Introduce fibre_channel_host grain

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -28,6 +28,7 @@ import salt.exceptions
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod
+import salt.modules.file as file
 import salt.modules.network
 import salt.modules.smbios
 import salt.utils.args
@@ -3625,3 +3626,13 @@ def kernelparams():
             log.debug("Failed to read /proc/cmdline: %s", exc)
 
         return grains
+
+
+def fibre_channel_host():
+    """
+    Determine whether the minion is a fibre channel host
+    """
+    grains = {"fibre_channel_host": False}
+    if file.directory_exists("/sys/class/fc_host"):
+        grains["fibre_channel_host"] = True
+    return grains

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -5538,3 +5538,32 @@ def test__ps():
             "| awk '{ $7=\"\"; print }'"
         )
     }
+
+
+@pytest.mark.skip_on_windows
+@pytest.mark.parametrize(
+    "status",
+    (
+        False,
+        True,
+    ),
+)
+def test_fibre_channel_host(status):
+    """
+    Test if fibre_channel_host grain is correctly reflecting a fibre channel enabled host.
+    """
+
+    def _dir_side_effect(path):
+        if path == "/sys/class/fc_host":
+            return status
+
+    with patch.object(
+        salt.utils.platform, "is_windows", MagicMock(return_value=False)
+    ), patch.object(
+        os.path,
+        "isdir",
+        MagicMock(side_effect=_dir_side_effect),
+    ):
+        grains = core.fibre_channel_host()
+        assert "fibre_channel_host" in grains
+        assert grains["fibre_channel_host"] is status


### PR DESCRIPTION
New grain to assess whether the minion is a fiber channel host.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65750

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.


Hi,

- Is this fine in core or should I move it to extra?
- What tests could I add for this? I checked tests for other grains in `tests/pytests/unit/grains/test_core.py` but I couldn't find how mocked files under /proc, /sys are created.

Would appreciate any pointers.
