### PR TITLE
[master] Fix clustered master startup race condition

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -965,10 +965,13 @@ class MasterPubServerChannel:
         with salt.utils.event.get_master_event(
             self.opts, self.opts["sock_dir"], listen=False
         ) as event:
-            event.fire_event(
+            success = event.fire_event(
                 data,
                 salt.utils.event.tagify(self.opts["id"], "peer", "cluster"),
+                timeout=30000,  # 30 second timeout
             )
+            if not success:
+                log.error("Unable to send aes key event")
 
     def __getstate__(self):
         return {

--- a/tests/pytests/scenarios/cluster/test_cluster.py
+++ b/tests/pytests/scenarios/cluster/test_cluster.py
@@ -55,8 +55,6 @@ def test_cluster_key_rotation(
         if time.monotonic() - start > timeout:
             assert False, f"Drop file never removed {dfpath}"
 
-    time.sleep(30)
-
     keys = set()
 
     # Validate the aes session key for all masters match


### PR DESCRIPTION
When starting up a cluster master, sending the initial aes key event needs to wait for the event server to fully start. Prior to this change we'd only try for one second and there was no logging of a failure.
