### PR TITLE
[master] Handle None/empty and numeric SLS modules listed in include declarations

### DIFF
--- a/changelog/56253.fixed.md
+++ b/changelog/56253.fixed.md
@@ -1,0 +1,1 @@
+Handle None/empty and numeric SLS modules listed in include declarations

--- a/salt/state.py
+++ b/salt/state.py
@@ -4289,6 +4289,18 @@ class BaseHighState:
                         errors.append(msg)
                         continue
 
+                    if not hasattr(inc_sls, "startswith"):
+                        if inc_sls is None:
+                            msg = (
+                                "Empty include found in include "
+                                "in SLS '{}:{}'".format(saltenv, sls)
+                            )
+                            log.error(msg)
+                            errors.append(msg)
+                            continue
+                        else:
+                            inc_sls = str(inc_sls)
+
                     if inc_sls.startswith("."):
                         match = re.match(r"^(\.+)(.*)$", inc_sls)
                         if match:

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1251,3 +1251,41 @@ def test_state_requires_missing(state, state_tree):
             assert "Referenced state does not exist" in err_str
             assert "onchanges" in err_str
             # Note: onchanges_any might be there too if it reached it
+
+
+def test_issue_56253_empty_include(state, state_tree):
+    """
+    Verify that a None/empty item in an include list produces a friendly error
+    rather than an AttributeError traceback.
+    """
+    sls_contents = """
+include:
+  - ~
+
+a_state:
+  test.nop: []
+"""
+    expected_error = "Empty include found in include in SLS 'base:issue-56253-empty'"
+    with pytest.helpers.temp_file("issue-56253-empty.sls", sls_contents, state_tree):
+        ret = state.sls("issue-56253-empty")
+        assert ret.failed
+        assert expected_error in ret.errors
+
+
+def test_issue_56253_numeric_include(state, state_tree):
+    """
+    Verify that a numeric item in an include list is handled without an
+    AttributeError traceback.  The numeric value is converted to str and
+    results in the normal "Unknown include" error rather than a crash.
+    """
+    sls_contents = """
+include:
+  - 42
+
+a_state:
+  test.nop: []
+"""
+    with pytest.helpers.temp_file("issue-56253-numeric.sls", sls_contents, state_tree):
+        ret = state.sls("issue-56253-numeric")
+        assert ret.failed
+        assert any("42" in err for err in ret.errors)


### PR DESCRIPTION
### What does this PR do?
Handle `None`/empty and numeric SLS modules listed in include declarations

### What issues does this PR fix or reference?
Fixes: #56253

### Previous Behavior
Unfriendly stacktrace displayed due to unhandled condition of include declaration having an empty list item or numeric SLS name.

### New Behavior
Handle empty include list items with a formatted error message and convert other values explicitly to `str` if they do not have `startswith` attribute (e.g. `int`).

```
minion:
    Data failed to compile:
----------
    Empty include found in include in SLS 'base:test.empty_include'
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
