### PR TITLE
[3006.x] Skip flakey blackout tests on windows

### DIFF
--- a/tests/pytests/scenarios/blackout/test_minion_blackout.py
+++ b/tests/pytests/scenarios/blackout/test_minion_blackout.py
@@ -11,7 +11,11 @@ log = logging.getLogger(__name__)
 
 
 def _check_skip(grains):
-    if grains["os"] == "Windows" and grains["osrelease"] == "2016Server":
+    """
+    Skip on windows because these tests are flaky, we need to spend some time to
+    debug why.
+    """
+    if grains["os"] == "Windows":
         return True
     return False
 


### PR DESCRIPTION
### What does this PR do?

This change was merge to master but really should land on `3006.x` and be merged forward.
