### PR TITLE
[3006.x] Fix credentials encoding for Artifactory

### DIFF
--- a/changelog/63063.fixed.md
+++ b/changelog/63063.fixed.md
@@ -1,0 +1,1 @@
+Corrected encoding of credentials for use with Artifactory

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -79,7 +79,7 @@ def get_latest_snapshot(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encodestring(
+            salt.utils.hashutils.base64_encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -165,7 +165,7 @@ def get_snapshot(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encodestring(
+            salt.utils.hashutils.base64_encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -238,7 +238,7 @@ def get_latest_release(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encodestring(
+            salt.utils.hashutils.base64_encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -320,8 +320,9 @@ def get_release(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encodestring(
+            salt.utils.hashutils.base64_encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
+                ## f"{username.replace("\n", "")}:{password.replace("\n", "")}")
             )
         )
     release_url, file_name = _get_release_url(

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -79,7 +79,7 @@ def get_latest_snapshot(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encode(
+            salt.utils.hashutils.base64_b64encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -165,7 +165,7 @@ def get_snapshot(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encode(
+            salt.utils.hashutils.base64_b64encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -238,7 +238,7 @@ def get_latest_release(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encode(
+            salt.utils.hashutils.base64_b64encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
             )
         )
@@ -320,7 +320,7 @@ def get_release(
     headers = {}
     if username and password:
         headers["Authorization"] = "Basic {}".format(
-            salt.utils.hashutils.base64_encode(
+            salt.utils.hashutils.base64_b64encode(
                 "{}:{}".format(username.replace("\n", ""), password.replace("\n", ""))
                 ## f"{username.replace("\n", "")}:{password.replace("\n", "")}")
             )

--- a/tests/pytests/unit/modules/test_artifactory.py
+++ b/tests/pytests/unit/modules/test_artifactory.py
@@ -278,7 +278,7 @@ def test_get_latest_snapshot_username_password():
         save_artifact_mock.assert_called_with(
             "http://artifactory.example.com/artifactory/snapshot",
             "/path/to/file",
-            {"Authorization": "Basic dXNlcjpwYXNzd29yZA==\n"},
+            {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
         )
 
 
@@ -305,7 +305,7 @@ def test_get_snapshot_username_password():
         save_artifact_mock.assert_called_with(
             "http://artifactory.example.com/artifactory/snapshot",
             "/path/to/file",
-            {"Authorization": "Basic dXNlcjpwYXNzd29yZA==\n"},
+            {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
         )
 
 
@@ -334,7 +334,7 @@ def test_get_latest_release_username_password():
         save_artifact_mock.assert_called_with(
             "http://artifactory.example.com/artifactory/release",
             "/path/to/file",
-            {"Authorization": "Basic dXNlcjpwYXNzd29yZA==\n"},
+            {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
         )
 
 
@@ -361,7 +361,7 @@ def test_get_release_username_password():
         save_artifact_mock.assert_called_with(
             "http://artifactory.example.com/artifactory/release",
             "/path/to/file",
-            {"Authorization": "Basic dXNlcjpwYXNzd29yZA==\n"},
+            {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
         )
 
 


### PR DESCRIPTION
### What does this PR do?
Fix credentials encoding for Artifactory

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63063

### Previous Behavior
Failed credentials to invalid encoding due to use of base64_encodestring, since the terminating '\n' affecting credentials used

### New Behavior
Credentials correctly encoded with base64_b64encode

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
