### PR TITLE
[master] Fix salt-cloud `get_cloud_config_value` for list objects

### DIFF
--- a/changelog/65789.fixed.md
+++ b/changelog/65789.fixed.md
@@ -1,0 +1,1 @@
+Fix salt-cloud get_cloud_config_value for list objects

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3248,7 +3248,9 @@ def get_cloud_config_value(name, vm_, opts, default=None, search_global=True):
         # Let's get the value from the profile, if present
         if "profile" in vm_ and vm_["profile"] is not None:
             if name in opts["profiles"][vm_["profile"]]:
-                if isinstance(value, dict):
+                if isinstance(value, dict) and isinstance(
+                    opts["profiles"][vm_["profile"]][name], dict
+                ):
                     value.update(opts["profiles"][vm_["profile"]][name].copy())
                 else:
                     value = deepcopy(opts["profiles"][vm_["profile"]][name])

--- a/tests/pytests/unit/cloud/test_cloud.py
+++ b/tests/pytests/unit/cloud/test_cloud.py
@@ -1,6 +1,7 @@
 import pytest
 
 from salt.cloud import Cloud
+from salt.config import get_cloud_config_value
 from salt.exceptions import SaltCloudSystemExit
 from tests.support.mock import MagicMock, patch
 
@@ -194,7 +195,6 @@ def test_vm_config_merger_nooverridevalue():
 
 @pytest.mark.skip_on_fips_enabled_platform
 def test_cloud_run_profile_create_returns_boolean(master_config):
-
     master_config["profiles"] = {"test_profile": {"provider": "test_provider:saltify"}}
     master_config["providers"] = {
         "test_provider": {
@@ -213,3 +213,50 @@ def test_cloud_run_profile_create_returns_boolean(master_config):
         with pytest.raises(SaltCloudSystemExit):
             ret = cloud.run_profile("test_profile", ["test_vm"])
             assert ret == {"test_vm": False}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [{"key1": "value1"}, {"key1": "value1", "key2": "value2"}],
+        ["a", "b"],
+        [1, 2, 4],
+        {"key1": "value1", "key2": 123},
+        "some text",
+        1234,
+    ],
+)
+def test_get_cloud_config_value(value):
+    value_name = "test_value_name"
+    opts = {
+        "providers": {
+            "my-cool-cloud-provider": {
+                "cool-cloud": {
+                    "driver": "cool-cloud",
+                    "profiles": {
+                        "my-cool-cloud-profile": {
+                            "provider": "my-cool-cloud-provider:cool-cloud",
+                            value_name: value,
+                            "profile": "my-cool-cloud-profile",
+                        }
+                    },
+                }
+            }
+        },
+        "profiles": {
+            "my-cool-cloud-profile": {
+                "provider": "my-cool-cloud-provider:cool-cloud",
+                value_name: value,
+                "profile": "my-cool-cloud-profile",
+            }
+        },
+        "profile": "my-cool-cloud-profile",
+    }
+    vm_ = {
+        value_name: value,
+        "profile": "my-cool-cloud-profile",
+        "driver": "cool-cloud",
+    }
+
+    result = get_cloud_config_value(value_name, vm_, opts)
+    assert result == value


### PR DESCRIPTION
This is to fix an issue that updating a non-dict object into a dict and causes an error. See details in the issue.

### What issues does this PR fix or reference?
Fixes: #65789 

### Previous Behavior
The config `value` `dict` is always updated with the new value found, whether the new `value` is a `dict` or not.

### New Behavior
The config `value` `dict` is only updated with the new value found if the new `value` is also a `dict`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

~~Tests are hard to implement because there isn't an existent test to directly test the modified function, `get_cloud_config_value`. But this function is widely used so existing tests may be sufficient to cover it.~~

I managed to implement the test, and many other existent tests can also cover this change.

### Commits signed with GPG?
Yes
