### PR TITLE
[WIP] [3006.x] Initial re-do of changes for _sync_grains only affecting masterless minions

### DIFF
--- a/changelog/65027.fixed.md
+++ b/changelog/65027.fixed.md
@@ -1,0 +1,1 @@
+Ensure sync from _grains occurs before attempting pillar compilation in case custom grain used in pillar file and salt-minion in masterless mode

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -46,12 +46,15 @@ log = logging.getLogger(__name__)
 MAX_FILENAME_LENGTH = 255
 
 
-def get_file_client(opts, pillar=False):
+def get_file_client(opts, pillar=False, force_local=False):
     """
     Read in the ``file_client`` option and return the correct type of file
     server
     """
-    client = opts.get("file_client", "remote")
+    if force_local:
+        client = "local"
+    else:
+        client = opts.get("file_client", "remote")
 
     if pillar and client == "local":
         client = "pillar"

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -113,6 +113,24 @@ log = logging.getLogger(__name__)
 # 6. Handle publications
 
 
+def _sync_grains(opts):
+    # if local client (masterless minion), need sync of custom grains
+    # as they may be used in pillar compilation
+    # in addition, with masterless minion some opts may not be filled
+    # at this point of syncing,for example sometimes does not contain
+    # extmod_whitelist and extmod_blacklist hence set those to defaults,
+    # empty dict, if not part of opts, as ref'd in
+    # salt.utils.extmod sync function
+    if "local" == opts.get("file_client", "remote"):
+        if opts.get("extmod_whitelist", None) is None:
+            opts["extmod_whitelist"] = {}
+
+        if opts.get("extmod_blacklist", None) is None:
+            opts["extmod_blacklist"] = {}
+
+        salt.utils.extmods.sync(opts, "grains", force_local=True)
+
+
 def resolve_dns(opts, fallback=True):
     """
     Resolves the master_ip and master_uri options

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -938,6 +938,7 @@ class SMinion(MinionBase):
         # Late setup of the opts grains, so we can log from the grains module
         import salt.loader
 
+        _sync_grains(opts)
         opts["grains"] = salt.loader.grains(opts)
         super().__init__(opts)
 

--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -83,7 +83,6 @@ def sync(
                         "Cannot create cache module directory %s. Check permissions.",
                         mod_dir,
                     )
-            ## DGM with salt.fileclient.get_file_client(opts) as fileclient:
             with salt.fileclient.get_file_client(
                 opts, pillar=False, force_local=force_local
             ) as fileclient:

--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -39,6 +39,7 @@ def sync(
     saltenv=None,
     extmod_whitelist=None,
     extmod_blacklist=None,
+    force_local=False,
 ):
     """
     Sync custom modules into the extension_modules directory
@@ -82,7 +83,10 @@ def sync(
                         "Cannot create cache module directory %s. Check permissions.",
                         mod_dir,
                     )
-            with salt.fileclient.get_file_client(opts) as fileclient:
+            ## DGM with salt.fileclient.get_file_client(opts) as fileclient:
+            with salt.fileclient.get_file_client(
+                opts, pillar=False, force_local=force_local
+            ) as fileclient:
                 for sub_env in saltenv:
                     log.info("Syncing %s for environment '%s'", form, sub_env)
                     cache = []

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -468,7 +468,6 @@ def test_state_highstate_custom_grains_masterless_mode(
         return {'custom_grain': 'test_value'}
     """
 
-    ## DGM TBD need to get masterless mode
     assert salt_master.is_running()
     with salt_minion_factory.started():
         salt_minion = salt_minion_factory
@@ -484,7 +483,8 @@ def test_state_highstate_custom_grains_masterless_mode(
         ), salt_minion.state_tree.base.temp_file(
             "_grains/custom_grain.py", salt_custom_grains_py
         ):
-            ret = salt_call_cli.run("state.highstate")
+            ## need to try masterless mode
+            ret = salt_call_cli.run("--local", "state.highstate")
             assert ret.returncode == 0
             ret = salt_call_cli.run("pillar.items")
             assert ret.returncode == 0
@@ -493,55 +493,7 @@ def test_state_highstate_custom_grains_masterless_mode(
             assert "mypillar" in pillar_items
             assert pillar_items["mypillar"] == "test_value"
 
-
-def test_state_highstate_custom_grains_master_mode(salt_master, salt_minion_factory):
-    """
-    This test ensure that custom grains in salt://_grains are loaded before pillar compilation
-    to ensure that any use of custom grains in pillar files are unaffected by changes for
-    sync custom grains for the salt-minion in masterless mode,
-    """
-    pillar_top_sls = """
-    base:
-      '*':
-        - defaults
-        """
-
-    pillar_defaults_sls = """
-    mypillar: "{{ grains['custom_grain'] }}"
-    """
-
-    salt_top_sls = """
-    base:
-      '*':
-        - test
-        """
-
-    salt_test_sls = """
-    "donothing":
-      test.nop: []
-    """
-
-    salt_custom_grains_py = """
-    def main():
-        return {'custom_grain': 'test_value'}
-    """
-
-    ## DGM TBD need to ensure master mode
-    assert salt_master.is_running()
-    with salt_minion_factory.started():
-        salt_minion = salt_minion_factory
-        salt_call_cli = salt_minion_factory.salt_call_cli()
-        with salt_minion.pillar_tree.base.temp_file(
-            "top.sls", pillar_top_sls
-        ), salt_minion.pillar_tree.base.temp_file(
-            "defaults.sls", pillar_defaults_sls
-        ), salt_minion.state_tree.base.temp_file(
-            "top.sls", salt_top_sls
-        ), salt_minion.state_tree.base.temp_file(
-            "test.sls", salt_test_sls
-        ), salt_minion.state_tree.base.temp_file(
-            "_grains/custom_grain.py", salt_custom_grains_py
-        ):
+            ## need to try with master mode
             ret = salt_call_cli.run("state.highstate")
             assert ret.returncode == 0
             ret = salt_call_cli.run("pillar.items")

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -429,3 +429,134 @@ def test_local_salt_call_no_function_no_retcode(salt_call_cli):
     assert "test" in ret.data
     assert ret.data["test"] == "'test' is not available."
     assert "test.echo" in ret.data
+
+
+def test_state_highstate_custom_grains_masterless_mode(
+    salt_master, salt_minion_factory
+):
+    """
+    This test ensure that custom grains in salt://_grains are loaded before pillar compilation
+    to ensure that any use of custom grains in pillar files are available when in masterless mode,
+    this implies that a sync of grains occurs before loading the regular
+    /etc/salt/grains or configuration file grains, as well as the usual grains.
+    Note: cannot use salt_minion and salt_call_cli, since these will be loaded before
+    the pillar and custom_grains files are written, hence using salt_minion_factory.
+    """
+    pillar_top_sls = """
+    base:
+      '*':
+        - defaults
+        """
+
+    pillar_defaults_sls = """
+    mypillar: "{{ grains['custom_grain'] }}"
+    """
+
+    salt_top_sls = """
+    base:
+      '*':
+        - test
+        """
+
+    salt_test_sls = """
+    "donothing":
+      test.nop: []
+    """
+
+    salt_custom_grains_py = """
+    def main():
+        return {'custom_grain': 'test_value'}
+    """
+
+    ## DGM TBD need to get masterless mode
+    assert salt_master.is_running()
+    with salt_minion_factory.started():
+        salt_minion = salt_minion_factory
+        salt_call_cli = salt_minion_factory.salt_call_cli()
+        with salt_minion.pillar_tree.base.temp_file(
+            "top.sls", pillar_top_sls
+        ), salt_minion.pillar_tree.base.temp_file(
+            "defaults.sls", pillar_defaults_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "top.sls", salt_top_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "test.sls", salt_test_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "_grains/custom_grain.py", salt_custom_grains_py
+        ):
+            ret = salt_call_cli.run("state.highstate")
+            assert ret.returncode == 0
+            ret = salt_call_cli.run("pillar.items")
+            assert ret.returncode == 0
+            assert ret.data
+            pillar_items = ret.data
+            assert "mypillar" in pillar_items
+            assert pillar_items["mypillar"] == "test_value"
+
+
+def test_state_highstate_custom_grains_master_mode(salt_master, salt_minion_factory):
+    """
+    This test ensure that custom grains in salt://_grains are loaded before pillar compilation
+    to ensure that any use of custom grains in pillar files are unaffected by changes for
+    sync custom grains for the salt-minion in masterless mode,
+    """
+    pillar_top_sls = """
+    base:
+      '*':
+        - defaults
+        """
+
+    pillar_defaults_sls = """
+    mypillar: "{{ grains['custom_grain'] }}"
+    """
+
+    salt_top_sls = """
+    base:
+      '*':
+        - test
+        """
+
+    salt_test_sls = """
+    "donothing":
+      test.nop: []
+    """
+
+    salt_custom_grains_py = """
+    def main():
+        return {'custom_grain': 'test_value'}
+    """
+
+    ## DGM TBD need to ensure master mode
+    assert salt_master.is_running()
+    with salt_minion_factory.started():
+        salt_minion = salt_minion_factory
+        salt_call_cli = salt_minion_factory.salt_call_cli()
+        with salt_minion.pillar_tree.base.temp_file(
+            "top.sls", pillar_top_sls
+        ), salt_minion.pillar_tree.base.temp_file(
+            "defaults.sls", pillar_defaults_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "top.sls", salt_top_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "test.sls", salt_test_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "_grains/custom_grain.py", salt_custom_grains_py
+        ):
+            ret = salt_call_cli.run("state.highstate")
+            assert ret.returncode == 0
+            ret = salt_call_cli.run("pillar.items")
+            assert ret.returncode == 0
+            assert ret.data
+            pillar_items = ret.data
+            assert "mypillar" not in pillar_items
+
+
+def test_salt_call_versions(salt_call_cli, caplog):
+    """
+    Call test.versions without '--local' to test grains
+    are sync'd without any missing keys in opts
+    """
+    with caplog.at_level(logging.DEBUG):
+        ret = salt_call_cli.run("test.versions")
+        assert ret.returncode == 0
+        assert "Failed to sync grains module: 'master_uri'" not in caplog.messages


### PR DESCRIPTION
### What does this PR do?
Ensures that grains are sync'd before loading grains and then compiling pillar, since there could be custom grains used in pillar files, which will throw rendering errors if not found, when in masterless mode on a salt-minion

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65027

### Previous Behavior
Would throw rendering errors if custom grains in salt://_grains were used in pillar files, salt-minion in masterless mode.

### New Behavior
No rendering errors thrown if custom grains in salt://_grains were used in pillar files, and custom grains values available in pillar, and salt-minion in masterless mode.

Additional tests to be written ensuring use with a salt-master is unaffected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
