### PR TITLE
[3006.x] Reduce the amount of annotations on workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -527,7 +526,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -550,7 +548,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -573,7 +570,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -596,7 +592,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -619,7 +614,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -642,7 +636,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -665,7 +658,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -688,7 +680,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -711,7 +702,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -734,7 +724,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -757,7 +746,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -780,7 +768,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -803,7 +790,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -826,7 +812,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -849,7 +834,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -873,7 +857,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -897,7 +880,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -921,7 +903,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -945,7 +926,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -968,7 +948,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -991,7 +970,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1014,7 +992,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1037,7 +1014,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1060,7 +1036,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1083,7 +1058,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1106,7 +1080,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1129,7 +1102,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1152,7 +1124,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1175,7 +1146,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1198,7 +1168,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1221,7 +1190,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1243,7 +1211,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1266,7 +1233,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1289,7 +1255,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1312,7 +1277,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1335,7 +1299,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1358,7 +1321,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1381,7 +1343,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1404,7 +1365,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1427,7 +1387,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1450,7 +1409,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1473,7 +1431,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1496,7 +1453,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1519,7 +1475,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1542,7 +1497,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1565,7 +1519,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1588,7 +1541,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1611,7 +1563,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1634,7 +1585,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1657,7 +1607,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1680,7 +1629,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1703,7 +1651,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1726,7 +1673,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1749,7 +1695,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1772,7 +1717,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1795,7 +1739,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1818,7 +1761,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1841,7 +1783,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1865,7 +1806,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1889,7 +1829,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1913,7 +1852,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1937,7 +1875,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1960,7 +1897,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1983,7 +1919,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2006,7 +1941,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
       workflow-slug: ci
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -561,7 +561,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -584,7 +583,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -607,7 +605,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -630,7 +627,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -653,7 +649,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -676,7 +671,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -699,7 +693,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -722,7 +715,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -745,7 +737,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -768,7 +759,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -791,7 +781,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -814,7 +803,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -837,7 +825,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -860,7 +847,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -883,7 +869,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -906,7 +891,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -930,7 +914,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -954,7 +937,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -978,7 +960,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -1002,7 +983,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1025,7 +1005,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1048,7 +1027,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1071,7 +1049,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1094,7 +1071,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1117,7 +1093,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1140,7 +1115,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1163,7 +1137,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1186,7 +1159,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1209,7 +1181,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1232,7 +1203,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1255,7 +1225,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1278,7 +1247,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1300,7 +1268,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1323,7 +1290,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1346,7 +1312,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1369,7 +1334,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1392,7 +1356,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1415,7 +1378,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1438,7 +1400,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1461,7 +1422,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1484,7 +1444,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1507,7 +1466,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1530,7 +1488,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1553,7 +1510,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1576,7 +1532,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1599,7 +1554,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1622,7 +1576,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1645,7 +1598,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1668,7 +1620,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1691,7 +1642,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1714,7 +1664,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1737,7 +1686,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1760,7 +1708,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1783,7 +1730,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1806,7 +1752,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1829,7 +1774,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1852,7 +1796,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1875,7 +1818,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1898,7 +1840,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1922,7 +1863,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1946,7 +1886,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1970,7 +1909,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1994,7 +1932,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2017,7 +1954,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2040,7 +1976,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2063,7 +1998,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: nightly
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -538,7 +538,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -561,7 +560,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -584,7 +582,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -607,7 +604,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -630,7 +626,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -653,7 +648,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -676,7 +670,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -699,7 +692,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -722,7 +714,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -745,7 +736,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -768,7 +758,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -791,7 +780,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -814,7 +802,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -837,7 +824,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -860,7 +846,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -883,7 +868,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -907,7 +891,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -931,7 +914,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -955,7 +937,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -979,7 +960,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1002,7 +982,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1025,7 +1004,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1048,7 +1026,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1071,7 +1048,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1094,7 +1070,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1117,7 +1092,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1140,7 +1114,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1163,7 +1136,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1186,7 +1158,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1209,7 +1180,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1232,7 +1202,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1255,7 +1224,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1277,7 +1245,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1300,7 +1267,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1323,7 +1289,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1346,7 +1311,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1369,7 +1333,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1392,7 +1355,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1415,7 +1377,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1438,7 +1399,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1461,7 +1421,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1484,7 +1443,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1507,7 +1465,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1530,7 +1487,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1553,7 +1509,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1576,7 +1531,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1599,7 +1553,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1622,7 +1575,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1645,7 +1597,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1668,7 +1619,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1691,7 +1641,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1714,7 +1663,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1737,7 +1685,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1760,7 +1707,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1783,7 +1729,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1806,7 +1751,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1829,7 +1773,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1852,7 +1795,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1875,7 +1817,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1899,7 +1840,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1923,7 +1863,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1947,7 +1886,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1971,7 +1909,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1994,7 +1931,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2017,7 +1953,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2040,7 +1975,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
-      skip-junit-reports: false
       workflow-slug: scheduled
       default-timeout: 360
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -551,7 +551,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -574,7 +573,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -597,7 +595,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -620,7 +617,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -643,7 +639,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -666,7 +661,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -689,7 +683,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -712,7 +705,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -735,7 +727,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -758,7 +749,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -781,7 +771,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -804,7 +793,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -827,7 +815,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -850,7 +837,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -873,7 +859,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -896,7 +881,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -920,7 +904,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -944,7 +927,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -968,7 +950,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       fips: true
@@ -992,7 +973,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1015,7 +995,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1038,7 +1017,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1061,7 +1039,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1084,7 +1061,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1107,7 +1083,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1130,7 +1105,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1153,7 +1127,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1176,7 +1149,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1199,7 +1171,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1222,7 +1193,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1245,7 +1215,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1268,7 +1237,6 @@ jobs:
       python-version: "3.10"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -1290,7 +1258,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1313,7 +1280,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1336,7 +1302,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1359,7 +1324,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1382,7 +1346,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1405,7 +1368,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1428,7 +1390,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1451,7 +1412,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1474,7 +1434,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1497,7 +1456,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1520,7 +1478,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1543,7 +1500,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1566,7 +1522,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1589,7 +1544,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1612,7 +1566,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1635,7 +1588,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1658,7 +1610,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1681,7 +1632,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1704,7 +1654,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1727,7 +1676,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1750,7 +1698,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1773,7 +1720,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1796,7 +1742,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1819,7 +1764,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1842,7 +1786,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1865,7 +1808,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1888,7 +1830,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1912,7 +1853,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1936,7 +1876,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1960,7 +1899,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -1984,7 +1922,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2007,7 +1944,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2030,7 +1966,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -2053,7 +1988,6 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
-      skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"

--- a/.github/workflows/templates/layout.yml.jinja
+++ b/.github/workflows/templates/layout.yml.jinja
@@ -6,7 +6,6 @@
 <%- set prepare_workflow_skip_pkg_download_test_suite = prepare_workflow_skip_pkg_download_test_suite|default("") %>
 <%- set prepare_workflow_salt_version_input = prepare_workflow_salt_version_input|default("") %>
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}") %>
-<%- set skip_junit_reports_check = skip_junit_reports_check|default("${{ github.event_name == 'pull_request' }}") %>
 <%- set gpg_key_id = "64CBBC8173D76B3F" %>
 <%- set prepare_actual_release = prepare_actual_release | default(False) %>
 <%- set gh_actions_workflows_python_version = "3.10" %>

--- a/.github/workflows/templates/nightly.yml.jinja
+++ b/.github/workflows/templates/nightly.yml.jinja
@@ -1,6 +1,5 @@
 <%- set gh_environment = gh_environment|default("nightly") %>
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("false") %>
-<%- set skip_junit_reports_check = skip_junit_reports_check|default("false") %>
 <%- set prepare_workflow_skip_test_suite = "${{ inputs.skip-salt-test-suite && ' --skip-tests' || '' }}" %>
 <%- set prepare_workflow_skip_pkg_test_suite = "${{ inputs.skip-salt-pkg-test-suite && ' --skip-pkg-tests' || '' }}" %>
 <%- set prepare_workflow_if_check = prepare_workflow_if_check|default("${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}") %>

--- a/.github/workflows/templates/scheduled.yml.jinja
+++ b/.github/workflows/templates/scheduled.yml.jinja
@@ -1,6 +1,5 @@
 <%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}" %>
 <%- set skip_test_coverage_check = "false" %>
-<%- set skip_junit_reports_check = "false" %>
 <%- extends 'ci.yml.jinja' %>
 
 

--- a/.github/workflows/templates/staging.yml.jinja
+++ b/.github/workflows/templates/staging.yml.jinja
@@ -6,7 +6,6 @@
 <%- set gh_environment = "staging" %>
 <%- set prepare_actual_release = True %>
 <%- set skip_test_coverage_check = "true" %>
-<%- set skip_junit_reports_check = "true" %>
 <%- extends 'nightly.yml.jinja' %>
 
 <%- block name %>

--- a/.github/workflows/templates/test-package-downloads-action.yml.jinja
+++ b/.github/workflows/templates/test-package-downloads-action.yml.jinja
@@ -282,15 +282,6 @@ jobs:
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled' && steps.download-artifacts-from-vm.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
-
 
   macos:
     name: MacOS
@@ -499,15 +490,6 @@ jobs:
             artifacts
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
 
 
   windows:
@@ -728,12 +710,3 @@ jobs:
             artifacts
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled' && steps.download-artifacts-from-vm.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }} ${{ matrix.pkg-type }} )
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true

--- a/.github/workflows/templates/test-salt-pkg.yml.jinja
+++ b/.github/workflows/templates/test-salt-pkg.yml.jinja
@@ -21,7 +21,6 @@
       python-version: "<{ gh_actions_workflows_python_version }>"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
     <%- if fips == "fips" %>
@@ -55,7 +54,6 @@
       python-version: "<{ gh_actions_workflows_python_version }>"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
@@ -86,7 +84,6 @@
       python-version: "<{ gh_actions_workflows_python_version }>"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 

--- a/.github/workflows/templates/test-salt.yml.jinja
+++ b/.github/workflows/templates/test-salt.yml.jinja
@@ -25,7 +25,6 @@
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       workflow-slug: <{ workflow_slug }>
       default-timeout: <{ timeout_value }>
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -54,7 +53,6 @@
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       workflow-slug: <{ workflow_slug }>
       default-timeout: <{ timeout_value }>
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -82,7 +80,6 @@
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|<{ python_version }>
       skip-code-coverage: <{ skip_test_coverage_check }>
-      skip-junit-reports: <{ skip_junit_reports_check }>
       workflow-slug: <{ workflow_slug }>
       default-timeout: <{ timeout_value }>
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"

--- a/.github/workflows/test-action-linux.yml
+++ b/.github/workflows/test-action-linux.yml
@@ -60,11 +60,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
       workflow-slug:
         required: false
         type: string
@@ -324,16 +319,6 @@ jobs:
           name: testrun-log-artifacts-${{ inputs.distro-slug }}-${{ inputs.nox-session }}-${{ matrix.transport }}
           path: |
             artifacts/logs
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false && job.status != 'cancelled'
-        with:
-          check_name: Test Results(${{ inputs.distro-slug }}, transport=${{ matrix.transport }}, tests-chunk=${{ matrix.tests-chunk }}, group=${{ matrix.test-group || '1' }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
-
 
   report:
     name: Test Reports

--- a/.github/workflows/test-action-macos.yml
+++ b/.github/workflows/test-action-macos.yml
@@ -55,11 +55,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
       workflow-slug:
         required: false
         type: string
@@ -371,16 +366,6 @@ jobs:
           name: testrun-log-artifacts-${{ inputs.distro-slug }}-${{ inputs.nox-session }}-${{ matrix.transport }}
           path: |
             artifacts/logs
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false
-        with:
-          check_name: Test Results(${{ inputs.distro-slug }}, transport=${{ matrix.transport }}, tests-chunk=${{ matrix.tests-chunk }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
-
 
   report:
     name: Test Reports

--- a/.github/workflows/test-action-windows.yml
+++ b/.github/workflows/test-action-windows.yml
@@ -60,11 +60,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
       workflow-slug:
         required: false
         type: string
@@ -324,15 +319,6 @@ jobs:
           name: testrun-log-artifacts-${{ inputs.distro-slug }}-${{ inputs.nox-session }}-${{ matrix.transport }}
           path: |
             artifacts/logs
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false && job.status != 'cancelled'
-        with:
-          check_name: Test Results(${{ inputs.distro-slug }}, transport=${{ matrix.transport }}, tests-chunk=${{ matrix.tests-chunk }}, group=${{ matrix.test-group || '1' }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
 
 
   report:

--- a/.github/workflows/test-package-downloads-action.yml
+++ b/.github/workflows/test-package-downloads-action.yml
@@ -427,15 +427,6 @@ jobs:
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled' && steps.download-artifacts-from-vm.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
-
 
   macos:
     name: MacOS
@@ -651,15 +642,6 @@ jobs:
             artifacts
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true
 
 
   windows:
@@ -884,12 +866,3 @@ jobs:
             artifacts
             !artifacts/salt/*
             !artifacts/salt-*.tar.*
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && job.status != 'cancelled' && steps.download-artifacts-from-vm.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ matrix.distro-slug }} ${{ matrix.arch }} ${{ matrix.pkg-type }} )
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true

--- a/.github/workflows/test-packages-action-linux.yml
+++ b/.github/workflows/test-packages-action-linux.yml
@@ -64,11 +64,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
 
 env:
   COLUMNS: 190
@@ -241,7 +236,7 @@ jobs:
   report:
     name: Report
     runs-on: ubuntu-latest
-    if: always() && (inputs.skip-code-coverage == false || inputs.skip-junit-reports == false) && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
+    if: always() && inputs.skip-code-coverage == false && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
     needs:
       - test
       - generate-matrix
@@ -265,12 +260,3 @@ jobs:
         if: always() && steps.download-test-run-artifacts.outcome == 'success'
         run: |
           tree -a artifacts
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false && steps.download-test-run-artifacts.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ inputs.distro-slug }} ${{ matrix.tests-chunk }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true

--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -59,11 +59,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
 
 env:
   COLUMNS: 190
@@ -225,7 +220,7 @@ jobs:
   report:
     name: Report
     runs-on: ubuntu-latest
-    if: always() && (inputs.skip-code-coverage == false || inputs.skip-junit-reports == false) && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
+    if: always() && inputs.skip-code-coverage == false && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
     needs:
       - test
       - generate-matrix
@@ -258,12 +253,3 @@ jobs:
       - name: Install Nox
         run: |
           python3 -m pip install 'nox==${{ inputs.nox-version }}'
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false && steps.download-test-run-artifacts.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ inputs.distro-slug }} ${{ matrix.tests-chunk }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true

--- a/.github/workflows/test-packages-action-windows.yml
+++ b/.github/workflows/test-packages-action-windows.yml
@@ -64,11 +64,6 @@ on:
         type: boolean
         description: Skip code coverage
         default: false
-      skip-junit-reports:
-        required: false
-        type: boolean
-        description: Skip Publishing JUnit Reports
-        default: false
 
 env:
   COLUMNS: 190
@@ -241,7 +236,7 @@ jobs:
   report:
     name: Report
     runs-on: ubuntu-latest
-    if: always() && (inputs.skip-code-coverage == false || inputs.skip-junit-reports == false) && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
+    if: always() && inputs.skip-code-coverage == false && needs.test.result != 'cancelled' && needs.test.result != 'skipped'
     needs:
       - test
       - generate-matrix
@@ -265,12 +260,3 @@ jobs:
         if: always() && steps.download-test-run-artifacts.outcome == 'success'
         run: |
           tree -a artifacts
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        # always run even if the previous steps fails
-        if: always() && inputs.skip-junit-reports == false && steps.download-test-run-artifacts.outcome == 'success'
-        with:
-          check_name: Overall Test Results(${{ inputs.distro-slug }} ${{ matrix.tests-chunk }})
-          report_paths: 'artifacts/xml-unittests-output/*.xml'
-          annotate_only: true


### PR DESCRIPTION
### What does this PR do?
Reduce the amount of annotations on workflows. Suggested by GitHub.
Since our bigger builds always throw 500's by GitHub. We have to refresh a few times before being able to see the workflow.