### PR TITLE
[master] Fix granting of privileges on Postgres functions

### DIFF
--- a/changelog/65839.fixed.md
+++ b/changelog/65839.fixed.md
@@ -1,0 +1,1 @@
+Fix granting of privileges on Postgres functions

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -3576,10 +3576,10 @@ def privileges_revoke(
 
     _grants = ",".join(_privs)
 
-    if object_type in ["table", "sequence"]:
-        on_part = f"{prepend}.{object_name}"
+    if object_type in ["table", "sequence", "function"]:
+        on_part = f'{prepend}."{object_name}"'
     else:
-        on_part = object_name
+        on_part = f'"{object_name}"'
 
     if object_type == "group":
         query = f"REVOKE {object_name} FROM {name}"

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -3424,17 +3424,18 @@ def privileges_grant(
 
     _grants = ",".join(_privs)
 
-    if object_type in ["table", "sequence"]:
+    if object_type in ["table", "sequence", "function"]:
         on_part = f'{prepend}."{object_name}"'
-    elif object_type == "function":
-        on_part = f"{object_name}"
     else:
         on_part = f'"{object_name}"'
 
     if grant_option:
         if object_type == "group":
             query = f'GRANT {object_name} TO "{name}" WITH ADMIN OPTION'
-        elif object_type in ("table", "sequence") and object_name.upper() == "ALL":
+        elif (
+            object_type in ("table", "sequence", "function")
+            and object_name.upper() == "ALL"
+        ):
             query = 'GRANT {} ON ALL {}S IN SCHEMA {} TO "{}" WITH GRANT OPTION'.format(
                 _grants, object_type.upper(), prepend, name
             )
@@ -3445,7 +3446,10 @@ def privileges_grant(
     else:
         if object_type == "group":
             query = f'GRANT {object_name} TO "{name}"'
-        elif object_type in ("table", "sequence") and object_name.upper() == "ALL":
+        elif (
+            object_type in ("table", "sequence", "function")
+            and object_name.upper() == "ALL"
+        ):
             query = 'GRANT {} ON ALL {}S IN SCHEMA {} TO "{}"'.format(
                 _grants, object_type.upper(), prepend, name
             )

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -2264,7 +2264,57 @@ def test_privileges_revoke_table():
             password="testpassword",
         )
 
-        query = "REVOKE ALL ON TABLE public.awl FROM baruwa"
+        query = 'REVOKE ALL ON TABLE public."awl" FROM baruwa'
+
+        postgres._run_psql.assert_called_once_with(
+            [
+                "/usr/bin/pgsql",
+                "--no-align",
+                "--no-readline",
+                "--no-psqlrc",
+                "--no-password",
+                "--username",
+                "testuser",
+                "--host",
+                "testhost",
+                "--port",
+                "testport",
+                "--dbname",
+                "db_name",
+                "-c",
+                query,
+            ],
+            host="testhost",
+            port="testport",
+            password="testpassword",
+            user="testuser",
+            runas="user",
+        )
+
+
+def test_privileges_revoke_function():
+    """
+    Test revoking privileges on function
+    """
+    with patch(
+        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
+        "salt.modules.postgres.has_privileges", Mock(return_value=True)
+    ):
+        ret = postgres.privileges_revoke(
+            "baruwa",
+            "f-awl",
+            "function",
+            "EXECUTE",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+
+        query = 'REVOKE EXECUTE ON FUNCTION public."f-awl" FROM baruwa'
 
         postgres._run_psql.assert_called_once_with(
             [

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -2007,6 +2007,147 @@ def test_privileges_grant_table():
         )
 
 
+def test_privileges_grant_function():
+    """
+    Test granting privileges on function
+    """
+    with patch(
+        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
+        with patch("salt.modules.postgres.has_privileges", Mock(return_value=False)):
+            ret = postgres.privileges_grant(
+                "baruwa",
+                "fawl",
+                "function",
+                "ALL",
+                grant_option=True,
+                maintenance_db="db_name",
+                runas="user",
+                host="testhost",
+                port="testport",
+                user="testuser",
+                password="testpassword",
+            )
+
+            query = 'GRANT ALL ON FUNCTION public."fawl" TO "baruwa" WITH GRANT OPTION'
+
+            postgres._run_psql.assert_called_once_with(
+                [
+                    "/usr/bin/pgsql",
+                    "--no-align",
+                    "--no-readline",
+                    "--no-psqlrc",
+                    "--no-password",
+                    "--username",
+                    "testuser",
+                    "--host",
+                    "testhost",
+                    "--port",
+                    "testport",
+                    "--dbname",
+                    "db_name",
+                    "-c",
+                    query,
+                ],
+                host="testhost",
+                port="testport",
+                password="testpassword",
+                user="testuser",
+                runas="user",
+            )
+
+    with patch(
+        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
+        "salt.modules.postgres.has_privileges", Mock(return_value=False)
+    ):
+        ret = postgres.privileges_grant(
+            "baruwa",
+            "fawl",
+            "function",
+            "ALL",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+
+        query = 'GRANT ALL ON TABLE public."fawl" TO "baruwa"'
+
+        postgres._run_psql.assert_called_once_with(
+            [
+                "/usr/bin/pgsql",
+                "--no-align",
+                "--no-readline",
+                "--no-psqlrc",
+                "--no-password",
+                "--username",
+                "testuser",
+                "--host",
+                "testhost",
+                "--port",
+                "testport",
+                "--dbname",
+                "db_name",
+                "-c",
+                query,
+            ],
+            host="testhost",
+            port="testport",
+            password="testpassword",
+            user="testuser",
+            runas="user",
+        )
+
+    # Test grant on all tables
+    with patch(
+        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
+        "salt.modules.postgres.has_privileges", Mock(return_value=False)
+    ):
+        ret = postgres.privileges_grant(
+            "baruwa",
+            "ALL",
+            "function",
+            "SELECT",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+
+        query = 'GRANT SELECT ON ALL FUNCTIONS IN SCHEMA public TO "baruwa"'
+
+        postgres._run_psql.assert_called_once_with(
+            [
+                "/usr/bin/pgsql",
+                "--no-align",
+                "--no-readline",
+                "--no-psqlrc",
+                "--no-password",
+                "--username",
+                "testuser",
+                "--host",
+                "testhost",
+                "--port",
+                "testport",
+                "--dbname",
+                "db_name",
+                "-c",
+                query,
+            ],
+            host="testhost",
+            port="testport",
+            password="testpassword",
+            user="testuser",
+            runas="user",
+        )
+
+
 def test_privileges_grant_group():
     """
     Test granting privileges on group

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -2074,7 +2074,7 @@ def test_privileges_grant_function():
             password="testpassword",
         )
 
-        query = 'GRANT ALL ON TABLE public."fawl" TO "baruwa"'
+        query = 'GRANT ALL ON FUNCTION public."fawl" TO "baruwa"'
 
         postgres._run_psql.assert_called_once_with(
             [
@@ -2101,7 +2101,7 @@ def test_privileges_grant_function():
             runas="user",
         )
 
-    # Test grant on all tables
+    # Test grant on all functions
     with patch(
         "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
     ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
@@ -2111,7 +2111,7 @@ def test_privileges_grant_function():
             "baruwa",
             "ALL",
             "function",
-            "SELECT",
+            "EXECUTE",
             maintenance_db="db_name",
             runas="user",
             host="testhost",
@@ -2120,7 +2120,7 @@ def test_privileges_grant_function():
             password="testpassword",
         )
 
-        query = 'GRANT SELECT ON ALL FUNCTIONS IN SCHEMA public TO "baruwa"'
+        query = 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "baruwa"'
 
         postgres._run_psql.assert_called_once_with(
             [


### PR DESCRIPTION
### What does this PR do?

The Postgres module code for granting privileges on functions has issues.
This PR adds a test for grants on Postgres functions, and fixes the issue.
It also fixes a minor issue in revoking privileges on tables.

### Previous Behavior
Granting a privilege on ALL functions would run
```
GRANT EXECUTE ON FUNCTION ALL TO "user"
```
Revoking a privilege from a table would run
```
REVOKE SELECT ON TABLE public.badly-named-table FROM ...
```

### New Behavior
```
GRANT EXECUTE ON ALL FUNCTIONS TO "user"
```

```
REVOKE SELECT ON TABLE public."badly-named-table" FROM ...
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs - no change required
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
