### PR TITLE
[master] skip_during_range as dict

### DIFF
--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -97,8 +97,8 @@ options found in the xmpp_state_run section.
             test: True
         - hours: 1
         - skip_during_range:
-            - start: 2pm
-            - end: 3pm
+            start: 2pm
+            end: 3pm
         - run_after_skip_range: True
 
 This will schedule the command: state.sls httpd test=True at 5pm on Monday,


### PR DESCRIPTION
[salt.utils.schedule:1257][ERROR   ][18861] schedule.handle_func: Invalid, range must be specified as a dictionary

### What does this PR do?
Change documentation in schedulepy => skip_during_range
### What issues does this PR fix or reference?
Fixes:
Timeframe is no given as dict in documentation example

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
