### PR TITLE
[master] deprecate the use of egrep in favor of grep -E

### DIFF
--- a/changelog/65608.deprecated.md
+++ b/changelog/65608.deprecated.md
@@ -1,0 +1,1 @@
+Deprecated the use of egrep in favor of grep -E

--- a/pkg/old/shar/build_shar.sh
+++ b/pkg/old/shar/build_shar.sh
@@ -238,7 +238,7 @@ output=`pip install --upgrade pip`
 _log "$output"
 
 # Check if wheel is supported in current version of pip
-pip help install 2>/dev/null | egrep --quiet '(--)no-use-wheel' && PIP_OPTS='--no-use-wheel' || PIP_OPTS=''
+pip help install 2>/dev/null | grep -E --quiet '(--)no-use-wheel' && PIP_OPTS='--no-use-wheel' || PIP_OPTS=''
 
 # Make sure swig is available
 test -z "$SWIG" && SWIG=`command -v swig`
@@ -310,7 +310,7 @@ for dep in "${deps[@]}"; do
         else
             _display "Bundled ZeroMQ detected"
         fi
-        zeromq_version=`egrep '^Version' "$zeromq_spec" | awk '{print $2}'`
+        zeromq_version=`grep -E '^Version' "$zeromq_spec" | awk '{print $2}'`
         _display "ZeroMQ version: $zeromq_version"
     fi
     _display "Installing $src"

--- a/pkg/old/shar/salt.sh
+++ b/pkg/old/shar/salt.sh
@@ -16,7 +16,7 @@ if test -z "$pyver"; then
     # Detect RHEL 5 and Arch, operating systems for which "/usr/bin/env python"
     # refers to a python version <2.6 or >=3.0.
     if test -f /etc/redhat-release; then
-        osmajor=`egrep -o '[0-9]+\.[0-9]+' /etc/redhat-release | cut -f1 -d.`
+        osmajor=`grep -Eo '[0-9]+\.[0-9]+' /etc/redhat-release | cut -f1 -d.`
         test "$osmajor" -eq 5 && pyver=2.6
     elif test -f /etc/arch-release; then
         python=python2


### PR DESCRIPTION
### What does this PR do?
It changes all uses of `egrep` --> `grep -E`
`egrep` has been deprecated since 2007, so it's about time we adopted the new `grep -E` format. 

Surprisingly, there was only a few places where `egrep` was even used throughout the entire code base.

No need to write a unit test as `egrep` is functionally equivalent to `grep -E`  

### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/65608

### Previous Behavior
The use of `egrep` with Fedora 39 spits out an error message that causes errors with salt states that use it.

### New Behavior
Salt states that use `grep -E` are now functional (on Fedora 39)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes