### PR TITLE
[master] Add `extra_args` Parameter to `pip.uninstall` Module Function

### DIFF
--- a/changelog/65870.added.md
+++ b/changelog/65870.added.md
@@ -1,0 +1,1 @@
+Added extra_args functionality to pip.uninstall module function

--- a/changelog/65870.added.md
+++ b/changelog/65870.added.md
@@ -1,1 +1,0 @@
-Added extra_args functionality to pip.uninstall module function

--- a/changelog/65870.fixed.md
+++ b/changelog/65870.fixed.md
@@ -1,0 +1,1 @@
+Fixed pip.uninstall rejecting the extra_args keyword argument, matching the behavior of pip.install.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1043,6 +1043,7 @@ def uninstall(
     cwd=None,
     saltenv="base",
     use_vt=False,
+    extra_args=None,
 ):
     """
     Uninstall packages individually or from a pip requirements file
@@ -1084,6 +1085,24 @@ def uninstall(
 
     use_vt
         Use VT terminal emulation (see output while installing)
+
+    extra_args
+        pip keyword and positional arguments not yet implemented in salt
+
+        .. code-block:: yaml
+
+            salt '*' pip.install pandas extra_args="[{'--latest-pip-kwarg':'param'}, '--latest-pip-arg']"
+
+        Will be translated into the following pip command:
+
+        .. code-block:: bash
+
+            pip install pandas --latest-pip-kwarg param --latest-pip-arg
+
+        .. warning::
+
+            If unsupported options are passed here that are not supported in a
+            minion's version of pip, a `No such option error` will be thrown.
 
     CLI Example:
 
@@ -1154,6 +1173,24 @@ def uninstall(
                         except ValueError:
                             pass
         cmd.extend(pkgs)
+
+    if extra_args:
+        # These are arguments from the latest version of pip that
+        # have not yet been implemented in salt
+        for arg in extra_args:
+            # It is a keyword argument
+            if isinstance(arg, dict):
+                # There will only ever be one item in this dictionary
+                key, val = arg.popitem()
+                # Don't allow any recursion into keyword arg definitions
+                # Don't allow multiple definitions of a keyword
+                if isinstance(val, (dict, list)):
+                    raise TypeError(f"Too many levels in: {key}")
+                # This is a a normal one-to-one keyword argument
+                cmd.extend([key, val])
+            # It is a positional argument, append it to the list
+            else:
+                cmd.append(arg)
 
     cmd_kwargs = dict(
         python_shell=False, runas=user, cwd=cwd, saltenv=saltenv, use_vt=use_vt

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -1330,6 +1330,52 @@ def test_uninstall_timeout_argument_in_resulting_command(python_binary):
         pytest.raises(ValueError, pip.uninstall, pkg, timeout="a")
 
 
+def test_uninstall_extra_args_arguments_in_resulting_command(python_binary):
+    pkg = "pep8"
+    mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
+    with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
+        pip.uninstall(
+            pkg, extra_args=[{"--latest-pip-kwarg": "param"}, "--latest-pip-arg"]
+        )
+        expected = [
+            *python_binary,
+            "uninstall",
+            "-y",
+            pkg,
+            "--latest-pip-kwarg",
+            "param",
+            "--latest-pip-arg",
+        ]
+        mock.assert_called_with(
+            expected,
+            saltenv="base",
+            cwd=None,
+            runas=None,
+            use_vt=False,
+            python_shell=False,
+        )
+
+
+def test_uninstall_extra_args_arguments_recursion_error():
+    pkg = "pep8"
+    mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
+    with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
+
+        pytest.raises(
+            TypeError,
+            lambda: pip.uninstall(
+                pkg, extra_args=[{"--latest-pip-kwarg": ["param1", "param2"]}]
+            ),
+        )
+
+        pytest.raises(
+            TypeError,
+            lambda: pip.uninstall(
+                pkg, extra_args=[{"--latest-pip-kwarg": [{"--too-deep": dict()}]}]
+            ),
+        )
+
+
 def test_freeze_command(python_binary):
     expected = [*python_binary, "freeze"]
     eggs = [


### PR DESCRIPTION
### What does this PR do?
Adds the existing `extra_args` logic for the `install` function in the `pip` module to the `uninstall` function.

### What issues does this PR fix or reference?
Addresses the issue in #65870

### Previous Behavior
The `pip.uninstall` function did not support the `extra_args` parameter

### New Behavior
The `pip.uninstall` function now supports the `extra_args` parameter

### Merge requirements satisfied?
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
