### PR TITLE
[master] override test kwarg to be a bool for state.apply and state.highstate 

### DIFF
--- a/salt/engines/slack_bolt_engine.py
+++ b/salt/engines/slack_bolt_engine.py
@@ -969,7 +969,6 @@ class SlackClient:
                     del outstanding[jid]
 
     def run_command_async(self, msg):
-
         """
         :type msg: dict
         :param msg: The message dictionary that contains the command and all information.
@@ -985,6 +984,12 @@ class SlackClient:
         # Check for pillar string representation of dict and convert it to dict
         if "pillar" in kwargs:
             kwargs.update(pillar=ast.literal_eval(kwargs["pillar"]))
+        if "test" in kwargs and cmd.lower() in ["state.apply", "state.highstate"]:
+            if str(kwargs["test"]).lower() in ["true", "false"]:
+                if kwargs["test"].lower() == "true":
+                    kwargs["test"] = True
+                else:
+                    kwargs["test"] = False
 
         # Check for target. Otherwise assume None
         target = msg["target"]["target"]


### PR DESCRIPTION
### What does this PR do?
when calling state.apply or state.highstate commands from slack_bolt_engine the "test" arg should be supplied as a boolean instead of a string

### What issues does this PR fix or reference?
Fixes: #65868 

### Previous Behavior
test arg was passed as a string

### New Behavior
test arg is converted to a boolean

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
