### PR TITLE
[master] Fix cmdmod _run log level checking bug

### DIFF
--- a/changelog/65904.fixed.md
+++ b/changelog/65904.fixed.md
@@ -1,0 +1,1 @@
+Fix ``cmdmod._run`` log level check after ``_check_loglevel()`` converts ``"quiet"`` to ``None``, preventing spurious error logs when ``output_loglevel="quiet"`` and output contains non-decodable bytes.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -888,7 +888,7 @@ def _run(
             proc_stdout = proc.stdout
             proc_stderr = proc.stderr
 
-        if output_loglevel != "quiet" and output_encoding is not None:
+        if output_loglevel is not None and output_encoding is not None:
             log.debug(
                 "Decoding output from command %s using %s encoding",
                 cmd,
@@ -906,7 +906,7 @@ def _run(
             out = salt.utils.stringutils.to_unicode(
                 proc_stdout, encoding=output_encoding, errors="replace"
             )
-            if output_loglevel != "quiet":
+            if output_loglevel is not None:
                 log.error(
                     "Failed to decode stdout from command %s, non-decodable "
                     "characters have been replaced",
@@ -924,7 +924,7 @@ def _run(
             err = salt.utils.stringutils.to_unicode(
                 proc_stderr, encoding=output_encoding, errors="replace"
             )
-            if output_loglevel != "quiet":
+            if output_loglevel is not None:
                 log.error(
                     "Failed to decode stderr from command %s, non-decodable "
                     "characters have been replaced",

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -783,6 +783,32 @@ def test_run_all_binary_replace():
     assert ret["stderr"] == stderr_unicode
 
 
+def test_run_all_binary_replace_quiet(caplog):
+    """
+    Test that when output_loglevel="quiet" and stdout/stderr contain
+    non-decodable bytes, no error is logged.  Before the fix, _check_loglevel()
+    converted "quiet" to None but the UnicodeDecodeError handler still
+    compared output_loglevel != "quiet" (always True when None), causing
+    spurious log.error calls.
+    """
+    # bytes that cannot be decoded as utf-8
+    stdout_bytes = b"\xff\xfe non-utf8 bytes"
+    stderr_bytes = b"\xff\xfe non-utf8 stderr"
+
+    proc = MagicMock(
+        return_value=MockTimedProc(stdout=stdout_bytes, stderr=stderr_bytes)
+    )
+    with patch("salt.utils.timed_subprocess.TimedProc", proc):
+        with caplog.at_level(logging.ERROR, logger="salt.modules.cmdmod"):
+            cmdmod.run_all(
+                "some command",
+                output_loglevel="quiet",
+                output_encoding="utf-8",
+            )
+
+    assert "non-decodable" not in caplog.text
+
+
 def test_run_all_none():
     """
     Tests cases when proc.stdout or proc.stderr are None. These should be


### PR DESCRIPTION
Early in the _run() function, on the command execution module, the [_check_loglevel()](https://github.com/saltstack/salt/blob/master/salt/modules/cmdmod.py#L335) function is called, and the value of the output_loglevel variable is rewritten with the output of this function.

The [_check_loglevel()](https://github.com/saltstack/salt/blob/master/salt/modules/cmdmod.py#L190-L191) function seems to sanitise the input variable, but if the requested log level is "quiet", it returns None.

Later on, in the _run() function, there are checks comparing [output_loglevel != "quiet"](https://github.com/saltstack/salt/blob/master/salt/modules/cmdmod.py#L769), which is always true at that point, since the _check_loglevel() function set the output_loglevel to None if the input parameter was "quiet".

This leads to error messages being logged if the output of the executed command contains non-decodable data, using the provided encoding (e.g. https://github.com/saltstack/salt/blob/4b652eb666045ccff231c49065f47f74b91ee4ab/salt/modules/cmdmod.py#L788 ) even though this call requested no logs to be produced.

This commit fixes the erroneous output_loglevel checks, to compare against None rather than "quiet" after the output_loglevel variable has been processed.