### PR TITLE
[master] Introduce a new grain for storing 'cpe'

### DIFF
--- a/changelog/65905.added.md
+++ b/changelog/65905.added.md
@@ -1,0 +1,5 @@
+Added a ``cpe`` grain that exposes the operating system's CPE (Common Platform
+Enumeration) identifier. The value is taken directly from the ``CPE_NAME``
+field in ``/etc/os-release`` when present; for Debian and Ubuntu systems
+that omit ``CPE_NAME`` the grain is derived from the ``os`` and ``osrelease``
+grains.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2238,8 +2238,33 @@ def _os_release_to_grains(os_release):
         or _os_release_quirks_for_osrelease(os_release),
     }
 
+    cpe = os_release.get("CPE_NAME") or _derive_cpe_grain(
+        grains.get("os"), grains.get("osrelease")
+    )
+    if cpe:
+        grains["cpe"] = cpe
+
     # oscodename and osrelease could be empty or None. Remove those.
     return {key: value for key, value in grains.items() if key}
+
+
+def _derive_cpe_grain(os, osrelease):
+    """
+    Derive the 'cpe' grain from the 'os' and 'osrelease' grains.
+
+    Normally, the 'cpe' grain can be extracted from the os_release file, but not all
+    distributions include it. In that case, we attempt to derive the CPE based on other
+    grains. Returns ``None`` if a CPE cannot be derived.
+
+    .. versionadded:: 3009.0
+    """
+    if not osrelease:
+        return None
+    if os == "Debian":
+        return "cpe:/o:debian:debian_linux:" + osrelease
+    elif os == "Ubuntu":
+        return "cpe:/o:canonical:ubuntu_linux:" + osrelease
+    return None
 
 
 def _linux_distribution_data():

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -5640,3 +5640,107 @@ def test_fibre_channel_host(status):
         grains = core.fibre_channel_host()
         assert "fibre_channel_host" in grains
         assert grains["fibre_channel_host"] is status
+
+
+# ---------------------------------------------------------------------------
+# Tests for the 'cpe' grain introduced in PR #65905
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "os_name,osrelease,expected",
+    [
+        ("Debian", "12", "cpe:/o:debian:debian_linux:12"),
+        ("Debian", "11", "cpe:/o:debian:debian_linux:11"),
+        ("Ubuntu", "22.04", "cpe:/o:canonical:ubuntu_linux:22.04"),
+        ("Ubuntu", "20.04", "cpe:/o:canonical:ubuntu_linux:20.04"),
+        # Unknown OS → no CPE derivable
+        ("CentOS", "8", None),
+        ("Arch", "rolling", None),
+        # Missing version → no CPE derivable
+        ("Debian", None, None),
+        ("Debian", "", None),
+        ("Ubuntu", None, None),
+    ],
+)
+def test_derive_cpe_grain(os_name, osrelease, expected):
+    """
+    _derive_cpe_grain returns a CPE string for Debian/Ubuntu and None otherwise.
+    It also returns None when osrelease is falsy (None or empty string).
+    """
+    result = core._derive_cpe_grain(os_name, osrelease)
+    assert result == expected
+
+
+def test_os_release_to_grains_cpe_from_os_release():
+    """
+    When CPE_NAME is present in os-release, the 'cpe' grain is taken directly.
+    """
+    os_release = {
+        "ID": "centos",
+        "NAME": "CentOS Linux",
+        "PRETTY_NAME": "CentOS Linux 8 (Core)",
+        "VERSION_ID": "8",
+        "CPE_NAME": "cpe:/o:centos:centos:8",
+    }
+    grains = core._os_release_to_grains(os_release)
+    assert grains["cpe"] == "cpe:/o:centos:centos:8"
+
+
+def test_os_release_to_grains_cpe_derived_debian():
+    """
+    When CPE_NAME is absent but OS is Debian, 'cpe' is derived from osrelease.
+    """
+    os_release = {
+        "ID": "debian",
+        "NAME": "Debian GNU/Linux",
+        "PRETTY_NAME": "Debian GNU/Linux 12 (bookworm)",
+        "VERSION_ID": "12",
+        "VERSION_CODENAME": "bookworm",
+    }
+    grains = core._os_release_to_grains(os_release)
+    assert grains["cpe"] == "cpe:/o:debian:debian_linux:12"
+
+
+def test_os_release_to_grains_cpe_derived_ubuntu():
+    """
+    When CPE_NAME is absent but OS is Ubuntu, 'cpe' is derived from osrelease.
+    """
+    os_release = {
+        "ID": "ubuntu",
+        "NAME": "Ubuntu",
+        "PRETTY_NAME": "Ubuntu 22.04.3 LTS",
+        "VERSION_ID": "22.04",
+        "VERSION_CODENAME": "jammy",
+    }
+    grains = core._os_release_to_grains(os_release)
+    assert grains["cpe"] == "cpe:/o:canonical:ubuntu_linux:22.04"
+
+
+def test_os_release_to_grains_no_cpe_for_unknown_os():
+    """
+    When CPE_NAME is absent and OS is not in the derivation map, 'cpe' is not set.
+    """
+    os_release = {
+        "ID": "arch",
+        "NAME": "Arch Linux",
+        "PRETTY_NAME": "Arch Linux",
+        "VERSION_ID": "rolling",
+    }
+    grains = core._os_release_to_grains(os_release)
+    assert "cpe" not in grains
+
+
+def test_os_release_to_grains_no_cpe_when_version_missing():
+    """
+    When CPE_NAME is absent and VERSION_ID is missing, 'cpe' is not set even
+    for Debian — avoids a TypeError from concatenating None.
+    """
+    os_release = {
+        "ID": "debian",
+        "NAME": "Debian GNU/Linux",
+        "PRETTY_NAME": "Debian GNU/Linux (unknown version)",
+        # No VERSION_ID intentionally — osrelease will be None/empty
+    }
+    grains = core._os_release_to_grains(os_release)
+    assert "cpe" not in grains


### PR DESCRIPTION
### What does this PR do?

Introduce a new grain for storing the operating system's cpe.

The implementation works by looking up the CPE_NAME property in the os_release file and using that if available. If not, it attempts to derive the CPE based on entries from the NVD database. For example, this is a  [cpe for Debian](https://nvd.nist.gov/products/cpe/detail/B394E34F-9572-4857-A7E4-C5E73F40FEF7?namingFormat=2.3&orderBy=CPEURI&status=FINAL); we only need to change the version part.

I haven't created any tests or documentation yet as I want to confirm that this proposed change aligns with the project goals before moving forward.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
