### PR TITLE
[3007.x] Fix `osarch` value in comparisson

### DIFF
--- a/tests/pytests/scenarios/swarm/conftest.py
+++ b/tests/pytests/scenarios/swarm/conftest.py
@@ -46,7 +46,7 @@ def _minion_count(grains):
         return int(env_count)
     # Default to 15 swarm minions
     count = 15
-    if grains["osarch"] != "osarch":
+    if grains["osarch"] != "aarch64":
         return count
     if grains["os"] != "Amazon":
         return count


### PR DESCRIPTION
### What does this PR do?
See title