### PR TITLE
[3006.x] Add xmltodict to Windows requirements

### DIFF
--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -132,6 +132,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.12.0

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -132,6 +132,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.12.0

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -132,6 +132,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.12.0

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -137,6 +137,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.5.0

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -133,6 +133,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.5.0

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -133,6 +133,8 @@ wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt
+xmltodict==0.13.0
+    # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
 zipp==3.5.0

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -29,5 +29,6 @@ urllib3>=1.26.5
 #
 # watchdog>=2.1.3
 wheel>=0.38.1
+xmltodict>=0.13.0
 
 importlib-metadata>=3.3.0

--- a/tests/pytests/pkg/integration/test_check_imports.py
+++ b/tests/pytests/pkg/integration/test_check_imports.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 CHECK_IMPORTS_SLS_CONTENTS = """
 #!py
 import importlib
+import sys
 
 def run():
     config = {}
@@ -81,7 +82,12 @@ def run():
                 ]
             }
 
-    for import_name in ["telnetlib"]:
+    # Import required for all OS'es
+    for import_name in [
+        "jinja2",
+        "telnetlib",
+        "yaml",
+    ]:
         try:
             importlib.import_module(import_name)
             config[import_name] = {
@@ -101,6 +107,40 @@ def run():
                     }
                 ]
             }
+
+    # Windows specific requirements (I think, there may be some for other OSes in here)
+    if sys.platform == "win32":
+        for import_name in [
+            "cffi",
+            "clr_loader",
+            "lxml",
+            "pythonnet",
+            "pytz",
+            "pywintypes",
+            "timelib",
+            "win32",
+            "wmi",
+            "xmltodict",
+        ]:
+            try:
+                importlib.import_module(import_name)
+                config[import_name] = {
+                    'test.succeed_without_changes': [
+                        {
+                            "name": import_name,
+                            'comment': "The '{}' import succeeded.".format(import_name)
+                        }
+                    ]
+                }
+            except ModuleNotFoundError as err:
+                config[import_name] = {
+                    'test.fail_without_changes': [
+                        {
+                            "name": import_name,
+                            'comment': "The '{}' import failed. The error was: {}".format(import_name, err)
+                        }
+                    ]
+                }
     return config
 """
 


### PR DESCRIPTION
### What does this PR do?
Add xmltodict to the Windows requirements. This is a requirement for the `win_event` module. It's a part of CI through pywinrm but is missing from PKG.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65923

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No