### PR TITLE
[master] Enhancing the ps beacon.

### DIFF
--- a/changelog/65922.changed.md
+++ b/changelog/65922.changed.md
@@ -1,0 +1,6 @@
+Enhanced the ``ps`` beacon to return the username and create_time of each matched
+process and support filtering by username. The beacon config format has changed
+from a flat ``running``/``stopped`` string value to a dict with a ``status`` key
+and an optional ``username`` key; the new format also wraps ``processes`` entries
+in a list instead of a dict. This is a **breaking change** — existing ps beacon
+configurations must be updated.

--- a/salt/beacons/ps.py
+++ b/salt/beacons/ps.py
@@ -1,10 +1,28 @@
 """
-Send events covering process status
+Send events based on process status.
+
+The config below sets up beacons to check that
+processes are running or stopped. If there are multiple
+instances of a process running, you may specify which
+user's process to watch (good example would be
+IIS App Pools).
+
+.. code-block:: yaml
+
+    beacons:
+      ps:
+        processes:
+          - powershell.exe:
+             status: running
+          - w3svc.exe:
+             status: running
+             username: "DOMAIN\\username1"
+          - mysql:
+             status: stopped
+
 """
 
 import logging
-
-import salt.utils.beacons
 
 try:
     import psutil
@@ -16,14 +34,14 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ps"
+__accepted_statuses__ = ["sleeping", "idle", "running", "stopped"]
 
 
 def __virtual__():
     if not HAS_PSUTIL:
-        return (
-            False,
-            f"Unable to load {__virtualname__} beacon: psutil library not installed",
-        )
+        err_msg = "psutil library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     return __virtualname__
 
 
@@ -31,63 +49,100 @@ def validate(config):
     """
     Validate the beacon configuration
     """
-    # Configuration for ps beacon should be a list of dicts
-    if not isinstance(config, list):
-        return False, "Configuration for ps beacon must be a list."
-    else:
-        config = salt.utils.beacons.list_to_dict(config)
+    # Configuration for ps beacon should be a dictionary with a 'processes' key
+    if not isinstance(config, dict):
+        return (
+            False,
+            "Configuration for ps beacon must be a dictionary with key 'processes' that contains a list.",
+        )
 
-        if "processes" not in config:
-            return False, "Configuration for ps beacon requires processes."
-        else:
-            if not isinstance(config["processes"], dict):
-                return False, "Processes for ps beacon must be a dictionary."
+    if "processes" not in config:
+        return False, "Configuration for ps beacon requires processes."
+
+    if not isinstance(config["processes"], list):
+        return False, "Processes for ps beacon must be a list."
+
+    for entry in config["processes"]:
+        proc_config = next(iter(entry.values()))
+        status = proc_config.get("status", "")
+        if status not in __accepted_statuses__:
+            return (
+                False,
+                f"Status not supported, currently supported are {', '.join(__accepted_statuses__)}.",
+            )
 
     return True, "Valid beacon configuration"
 
 
 def beacon(config):
     """
-    Scan for processes and fire events
-
-    Example Config
-
-    .. code-block:: yaml
-
-        beacons:
-          ps:
-            - processes:
-                salt-master: running
-                mysql: stopped
-
-    The config above sets up beacons to check that
-    processes are running or stopped.
+    Search for given process(es) by name and optionally username.
     """
     ret = []
     procs = []
+
     for proc in psutil.process_iter():
         try:
-            _name = proc.name()
-        except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
-            # The process is now gone or we can't access it
+            procs.append(proc)
+        except psutil.NoSuchProcess:
             continue
-        if _name not in procs:
-            procs.append(_name)
 
-    config = salt.utils.beacons.list_to_dict(config)
+    for process in config.get("processes", []):
+        process_name = next(iter(process.keys()))
+        proc_config = process[process_name]
+        expected_status = proc_config.get("status", "running")
 
-    for process in config.get("processes", {}):
-        ret_dict = {}
-        if config["processes"][process] == "running":
-            if process in procs:
-                ret_dict[process] = "Running"
-                ret.append(ret_dict)
-        elif config["processes"][process] == "stopped":
-            if process not in procs:
-                ret_dict[process] = "Stopped"
-                ret.append(ret_dict)
-        else:
-            if process not in procs:
-                ret_dict[process] = False
-                ret.append(ret_dict)
-    return ret
+        found = [p for p in procs if _safe_name(p) == process_name]
+
+        # Skip if the expected status condition is not met
+        if (found and expected_status == "stopped") or (
+            not found and expected_status == "running"
+        ):
+            continue
+
+        current_result = {process_name: {}}
+        username = proc_config.get("username", "")
+
+        if username:
+            found = [
+                p
+                for p in procs
+                if _safe_name(p) == process_name and _safe_username(p) == username
+            ]
+
+        current_result[process_name]["status"] = "running" if found else "stopped"
+
+        current_result[process_name]["instances"] = (
+            sorted(map(_context_pull_props, found), key=lambda x: x[0]) if found else []
+        )
+
+        ret.append(current_result)
+
+    return sorted(ret, key=lambda x: list(x.keys()))
+
+
+def _safe_name(proc):
+    """Return process name, or empty string if unavailable."""
+    try:
+        return proc.name()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return ""
+
+
+def _safe_username(proc):
+    """Return process username, or empty string if unavailable."""
+    try:
+        return proc.username()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return ""
+
+
+def _context_pull_props(proc):
+    """
+    Retrieve process properties.
+
+    Uses ``oneshot()`` to cache multiple attributes in a single call.
+    See https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot
+    """
+    with proc.oneshot():
+        return (proc.pid, proc.username(), proc.create_time())

--- a/salt/beacons/ps.py
+++ b/salt/beacons/ps.py
@@ -23,6 +23,7 @@ IIS App Pools).
 """
 
 import logging
+from typing import Any
 
 try:
     import psutil
@@ -37,7 +38,7 @@ __virtualname__ = "ps"
 __accepted_statuses__ = ["sleeping", "idle", "running", "stopped"]
 
 
-def __virtual__():
+def __virtual__() -> str | tuple[bool, str]:
     if not HAS_PSUTIL:
         err_msg = "psutil library is missing."
         log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
@@ -45,9 +46,18 @@ def __virtual__():
     return __virtualname__
 
 
-def validate(config):
+def validate(config: dict[str, Any]) -> tuple[bool, str]:
     """
     Validate the beacon configuration
+
+    :param config: Beacon configuration dictionary. Must contain a ``processes``
+        key whose value is a list of single-key dicts. Each entry maps a process
+        name to a dict with a required ``status`` key (one of
+        ``sleeping``, ``idle``, ``running``, ``stopped``) and an optional
+        ``username`` key.
+    :type config: dict
+    :returns: ``(True, "Valid beacon configuration")`` or ``(False, <reason>)``.
+    :rtype: tuple(bool, str)
     """
     # Configuration for ps beacon should be a dictionary with a 'processes' key
     if not isinstance(config, dict):
@@ -74,12 +84,60 @@ def validate(config):
     return True, "Valid beacon configuration"
 
 
-def beacon(config):
+def beacon(config: dict[str, Any]) -> list[dict[str, Any]]:
     """
-    Search for given process(es) by name and optionally username.
+    Search for given process(es) by name and optionally username, and return
+    their status along with per-instance details.
+
+    .. versionchanged:: 3009.0
+        The ``processes`` config key now accepts a list of single-key dicts
+        (each mapping a process name to a sub-dict with ``status`` and an
+        optional ``username``) instead of a flat ``process_name: running``
+        mapping.  Each matched entry in the return value now includes
+        ``username`` and ``create_time`` in the instance tuples.
+
+    :param config: Beacon configuration dictionary. Must contain a
+        ``processes`` key (see :func:`validate` for the expected structure).
+    :type config: dict
+
+    Example Config
+
+    .. code-block:: yaml
+
+        beacons:
+          ps:
+            processes:
+              - powershell.exe:
+                 status: running
+              - w3svc.exe:
+                 status: running
+                 username: "DOMAIN\\username1"
+              - mysql:
+                 status: stopped
+
+    The ``username`` key is optional. When present only instances running
+    under that user are returned; when absent all instances are returned.
+
+    The beacon fires only when the observed state matches the configured
+    ``status``.  For example, a ``status: running`` entry is included in
+    the return value only when at least one matching process is found;
+    a ``status: stopped`` entry is included only when no matching process
+    is found.
+
+    :returns: A sorted list of dicts, one per matched process entry.  Each
+        dict maps the process name to a sub-dict with:
+
+        ``status``
+            ``"running"`` or ``"stopped"``.
+
+        ``instances``
+            A list of ``(pid, username, create_time)`` tuples, sorted by
+            PID.  Empty when ``status`` is ``"stopped"``.
+
+    :rtype: list[dict]
     """
-    ret = []
-    procs = []
+    ret: list[dict[str, Any]] = []
+    procs: list[Any] = []
 
     for proc in psutil.process_iter():
         try:
@@ -100,7 +158,7 @@ def beacon(config):
         ):
             continue
 
-        current_result = {process_name: {}}
+        current_result: dict[str, Any] = {process_name: {}}
         username = proc_config.get("username", "")
 
         if username:
@@ -121,7 +179,7 @@ def beacon(config):
     return sorted(ret, key=lambda x: list(x.keys()))
 
 
-def _safe_name(proc):
+def _safe_name(proc: Any) -> str:
     """Return process name, or empty string if unavailable."""
     try:
         return proc.name()
@@ -129,7 +187,7 @@ def _safe_name(proc):
         return ""
 
 
-def _safe_username(proc):
+def _safe_username(proc: Any) -> str:
     """Return process username, or empty string if unavailable."""
     try:
         return proc.username()
@@ -137,12 +195,16 @@ def _safe_username(proc):
         return ""
 
 
-def _context_pull_props(proc):
+def _context_pull_props(proc: Any) -> tuple[int, str, float]:
     """
     Retrieve process properties.
 
     Uses ``oneshot()`` to cache multiple attributes in a single call.
     See https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot
+
+    :param proc: A :class:`psutil.Process` instance.
+    :returns: A ``(pid, username, create_time)`` tuple.
+    :rtype: tuple(int, str, float)
     """
     with proc.oneshot():
         return (proc.pid, proc.username(), proc.create_time())

--- a/tests/pytests/unit/beacons/test_ps.py
+++ b/tests/pytests/unit/beacons/test_ps.py
@@ -5,6 +5,8 @@
     ps usage beacon test cases
 """
 
+from contextlib import contextmanager
+
 import pytest
 
 import salt.beacons.ps as ps
@@ -12,12 +14,24 @@ from tests.support.mock import patch
 
 
 class FakeProcess:
-    def __init__(self, _name, pid):
+    def __init__(self, _name, _username, _create_time, pid):
         self._name = _name
+        self._username = _username
+        self._create_time = _create_time
         self.pid = pid
 
     def name(self):
         return self._name
+
+    def username(self):
+        return self._username
+
+    def create_time(self):
+        return self._create_time
+
+    @contextmanager
+    def oneshot(self):
+        yield (self.pid, self._username, self._create_time)
 
 
 @pytest.fixture
@@ -25,18 +39,31 @@ def configure_loader_modules():
     return {}
 
 
-def test_non_list_config():
-    config = {}
+def test_non_dict_config():
+    config = []
 
     ret = ps.validate(config)
-    assert ret == (False, "Configuration for ps beacon must be a list.")
+    assert ret == (
+        False,
+        "Configuration for ps beacon must be a dictionary with key 'processes' that contains a list.",
+    )
 
 
 def test_empty_config():
-    config = [{}]
+    config = {}
 
     ret = ps.validate(config)
     assert ret == (False, "Configuration for ps beacon requires processes.")
+
+
+def test_invalid_status_config():
+    config = {"processes": [{"mysql": {"status": "oop"}}]}
+
+    ret = ps.validate(config)
+    assert ret == (
+        False,
+        "Status not supported, currently supported are sleeping, idle, running, stopped.",
+    )
 
 
 def test_ps_running():
@@ -44,16 +71,236 @@ def test_ps_running():
         "psutil.process_iter", autospec=True, spec_set=True
     ) as mock_process_iter:
         mock_process_iter.return_value = [
-            FakeProcess(_name="salt-master", pid=3),
-            FakeProcess(_name="salt-minion", pid=4),
+            FakeProcess(
+                _name="salt-master",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="salt-minion",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
         ]
-        config = [{"processes": {"salt-master": "running"}}]
+        config = {"processes": [{"salt-master": {"status": "running"}}]}
 
         ret = ps.validate(config)
         assert ret == (True, "Valid beacon configuration")
 
         ret = ps.beacon(config)
-        assert ret == [{"salt-master": "Running"}]
+        assert ret == [
+            {
+                "salt-master": {
+                    "status": "running",
+                    "instances": [(3, "DOMAIN\\username1", 1307289803.47)],
+                }
+            }
+        ]
+
+
+def test_ps_running_but_not_found():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="salt-minion",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+        ]
+        config = {"processes": [{"salt-master": {"status": "running"}}]}
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == []
+
+
+def test_multiple_ps_running():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="salt-master",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="salt-minion",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+        ]
+        config = {
+            "processes": [
+                {"salt-master": {"status": "running"}},
+                {"salt-minion": {"status": "running"}},
+            ]
+        }
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == [
+            {
+                "salt-master": {
+                    "status": "running",
+                    "instances": [(3, "DOMAIN\\username1", 1307289803.47)],
+                }
+            },
+            {
+                "salt-minion": {
+                    "status": "running",
+                    "instances": [(4, "DOMAIN\\username2", 1306289803.47)],
+                },
+            },
+        ]
+
+
+def test_multiple_ps_running_but_not_found():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="redis",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="mysql",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+        ]
+        config = {
+            "processes": [
+                {"salt-master": {"status": "running"}},
+                {"salt-minion": {"status": "running"}},
+            ]
+        }
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == []
+
+
+def test_multiple_ps_select_by_username_running():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="w3svc.exe",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="w3svc.exe",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+            FakeProcess(
+                _name="powershell.exe",
+                pid=56,
+                _username="DOMAIN\\username5",
+                _create_time=1306269803.47,
+            ),
+        ]
+        config = {
+            "processes": [
+                {"w3svc.exe": {"status": "running", "username": "DOMAIN\\username2"}},
+                {"powershell.exe": {"status": "running"}},
+            ]
+        }
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == [
+            {
+                "powershell.exe": {
+                    "status": "running",
+                    "instances": [(56, "DOMAIN\\username5", 1306269803.47)],
+                },
+            },
+            {
+                "w3svc.exe": {
+                    "status": "running",
+                    "instances": [(4, "DOMAIN\\username2", 1306289803.47)],
+                }
+            },
+        ]
+
+
+def test_multiple_instances_of_ps_running():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="w3svc.exe",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="w3svc.exe",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+            FakeProcess(
+                _name="powershell.exe",
+                pid=56,
+                _username="DOMAIN\\username5",
+                _create_time=1306269803.47,
+            ),
+        ]
+        config = {
+            "processes": [
+                {"w3svc.exe": {"status": "running"}},
+                {"powershell.exe": {"status": "running"}},
+            ]
+        }
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == [
+            {
+                "powershell.exe": {
+                    "status": "running",
+                    "instances": [(56, "DOMAIN\\username5", 1306269803.47)],
+                },
+            },
+            {
+                "w3svc.exe": {
+                    "status": "running",
+                    "instances": [
+                        (3, "DOMAIN\\username1", 1307289803.47),
+                        (4, "DOMAIN\\username2", 1306289803.47),
+                    ],
+                }
+            },
+        ]
 
 
 def test_ps_not_running():
@@ -61,13 +308,79 @@ def test_ps_not_running():
         "psutil.process_iter", autospec=True, spec_set=True
     ) as mock_process_iter:
         mock_process_iter.return_value = [
-            FakeProcess(_name="salt-master", pid=3),
-            FakeProcess(_name="salt-minion", pid=4),
+            FakeProcess(
+                _name="salt-master",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="salt-minion",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
         ]
-        config = [{"processes": {"mysql": "stopped"}}]
+        config = {"processes": [{"mysql": {"status": "stopped"}}]}
 
         ret = ps.validate(config)
         assert ret == (True, "Valid beacon configuration")
 
         ret = ps.beacon(config)
-        assert ret == [{"mysql": "Stopped"}]
+        assert ret == [{"mysql": {"status": "stopped", "instances": []}}]
+
+
+def test_multiple_ps_not_running():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="salt-master",
+                pid=3,
+                _username="DOMAIN\\username1",
+                _create_time=1307289803.47,
+            ),
+            FakeProcess(
+                _name="salt-minion",
+                pid=4,
+                _username="DOMAIN\\username2",
+                _create_time=1306289803.47,
+            ),
+        ]
+        config = {
+            "processes": [
+                {"mysql": {"status": "stopped"}},
+                {"redis": {"status": "stopped"}},
+            ]
+        }
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == [
+            {"mysql": {"status": "stopped", "instances": []}},
+            {"redis": {"status": "stopped", "instances": []}},
+        ]
+
+
+def test_ps_not_running_but_is_running():
+    with patch(
+        "psutil.process_iter", autospec=True, spec_set=True
+    ) as mock_process_iter:
+        mock_process_iter.return_value = [
+            FakeProcess(
+                _name="redis",
+                pid=45,
+                _username="DOMAIN\\username2",
+                _create_time=1304289803.47,
+            ),
+        ]
+        config = {"processes": [{"redis": {"status": "stopped"}}]}
+
+        ret = ps.validate(config)
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = ps.beacon(config)
+        assert ret == []


### PR DESCRIPTION
Enhancing the ps beacon to return username of the process and the create_time. The ps beacon can also check for processes running under a specific user. Updated doc strings and added more unit tests.

### What does this PR do?
* ps Beacon will now:
  * Return username of the process and the create_time.
  * Returns multiple instances of process to watch if a username is not specified in the config.
  * Have the ability to check for a process running under a specific user.
  * Beacon now returns empty list if expected status of process not found.
  * Restricted to checking for specific process statuses and can be extended later.
* Add unit tests to support new functionality as well as scenarios not previously covered.
* Updated doc strings to reflect new behavior.

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
Beacon would return a list of objects with a key of the process name and the discovered status as a string "Running" or "Stopped". If the process to watch is not found the returned dictionary with the process name as the key and False as the value. Example config and return values:

```
# config:
beacons:
  ps:
    - processes:
       process_name: running
       other_process: stopped
       some_other: oop
[
  {
    "process_name": "Running" <-- Found the process is running, expected state.
  },
  {
    "other_process": "Stopped" <-- Found the process is not running, expected state.
  },
  {
    "some_other": False <-- Process not found and config provided invalid status to check for.
  }
]
```

### New Behavior
* Return object now can return multiple instances of watched process if running under multiple users as well as the create_time and PID. If expected statuses are not found, empty list is returned. Example return values and config:
```
config:

beacons:
  ps:
    processes:
      - process_name:
         status: running
      - other_process:
         status: stopped
      - some_other:
         status: oop <-- Get a config validation error.
[
  {
    "process_name": {
      "status": "running",
      "instances": [
        (24, "kichikawa", 1307289803.47),
        (45, "tuser", 1307289703.47)
      ]
    },
    {
      "other_process": {
        "status": "stopped",
        "instances": []
    }
  }
]
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
