### PR TITLE
[master] Using python 3.x syntax for print in example

### DIFF
--- a/doc/topics/tutorials/modules.rst
+++ b/doc/topics/tutorials/modules.rst
@@ -91,7 +91,7 @@ Space-delimited arguments to the function:
 
 .. code-block:: bash
 
-    salt '*' cmd.exec_code python 'import sys; print sys.version'
+    salt '*' cmd.exec_code python 'import sys; print(sys.version)'
 
 Optional, keyword arguments are also supported:
 


### PR DESCRIPTION
### What does this PR do?
Minor syntax update for python in documentation example, changing python 2 print style to python 3 print style, with parens.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`salt '*' cmd.exec_code python 'import sys; print sys.version'`

### New Behavior
`salt '*' cmd.exec_code python 'import sys; print(sys.version)'`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
