### PR TITLE
[3006.x] Allow synced modules to override salt extensions

### DIFF
--- a/changelog/65938.changed.md
+++ b/changelog/65938.changed.md
@@ -1,0 +1,1 @@
+Change module search path priority, so Salt extensions can be overridden by syncable modules and module_dirs. You can switch back to the old logic by setting features.enable_deprecated_module_search_path_priority to true, but it will be removed in Salt 3008.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -28,6 +28,7 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import LoaderError
+from salt.features import features
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -251,7 +252,15 @@ def _module_dirs(
         if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
 
-    return cli_module_dirs + ext_types + ext_type_types + sys_types
+    if features.get("enable_deprecated_module_search_path_priority", False):
+        salt.utils.versions.warn_until(
+            3008,
+            "The old module search path priority will be removed in Salt Argon. "
+            "For more information see https://github.com/saltstack/salt/pull/65938.",
+        )
+        return cli_module_dirs + ext_type_types + ext_types + sys_types
+    else:
+        return cli_module_dirs + ext_types + ext_type_types + sys_types
 
 
 def minion_mods(

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -28,7 +28,6 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import LoaderError
-from salt.features import features
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -252,10 +251,12 @@ def _module_dirs(
         if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
 
-    if features.get("enable_deprecated_module_search_path_priority", False):
+    if opts.get("features", {}).get(
+        "enable_deprecated_module_search_path_priority", False
+    ):
         salt.utils.versions.warn_until(
             3008,
-            "The old module search path priority will be removed in Salt Argon. "
+            "The old module search path priority will be removed in Salt 3008. "
             "For more information see https://github.com/saltstack/salt/pull/65938.",
         )
         return cli_module_dirs + ext_type_types + ext_types + sys_types

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -130,17 +130,18 @@ def _module_dirs(
 ):
     if tag is None:
         tag = ext_type
-    sys_types = os.path.join(base_path or str(SALT_BASE_PATH), int_type or ext_type)
-    return_types = [sys_types]
-    if opts.get("extension_modules"):
-        ext_types = os.path.join(opts["extension_modules"], ext_type)
-        return_types.insert(0, ext_types)
+    sys_types = [os.path.join(base_path or str(SALT_BASE_PATH), int_type or ext_type)]
 
-    if not sys_types.startswith(SALT_INTERNAL_LOADERS_PATHS):
+    if opts.get("extension_modules"):
+        ext_types = [os.path.join(opts["extension_modules"], ext_type)]
+    else:
+        ext_types = []
+
+    if not sys_types[0].startswith(SALT_INTERNAL_LOADERS_PATHS):
         raise RuntimeError(
             "{!r} is not considered a salt internal loader path. If this "
             "is a new loader being added, please also add it to "
-            "{}.SALT_INTERNAL_LOADERS_PATHS.".format(sys_types, __name__)
+            "{}.SALT_INTERNAL_LOADERS_PATHS.".format(sys_types[0], __name__)
         )
 
     ext_type_types = []
@@ -250,7 +251,7 @@ def _module_dirs(
         if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
 
-    return cli_module_dirs + ext_type_types + return_types
+    return cli_module_dirs + ext_types + ext_type_types + sys_types
 
 
 def minion_mods(

--- a/tests/pytests/functional/loader/test_loader.py
+++ b/tests/pytests/functional/loader/test_loader.py
@@ -67,6 +67,24 @@ def test_module_dirs_priority(venv, salt_extension, minion_opts, module_dirs):
             tail
         ), f"{module_dirs_return[i]} does not end with {tail}"
 
+    # Test the deprecated mode as well
+    minion_opts["features"] = {"enable_deprecated_module_search_path_priority": True}
+    ret = venv.run_code(code, input=json.dumps(minion_opts))
+    module_dirs_return = json.loads(ret.stdout)
+    assert len(module_dirs_return) == 5
+    for i, tail in enumerate(
+        [
+            "/module-dir-base/modules",
+            "/module-dir-base",
+            "/site-packages/salt_ext_loader_test/modules",
+            "/var/cache/salt/minion/extmods/modules",
+            "/site-packages/salt/modules",
+        ]
+    ):
+        assert module_dirs_return[i].endswith(
+            tail
+        ), f"{module_dirs_return[i]} does not end with {tail}"
+
 
 def test_new_entry_points_passing_module(venv, salt_extension, salt_minion_factory):
     # Install our extension into the virtualenv


### PR DESCRIPTION
### What does this PR do?
 
Swap (3) and (4) in the module search path order, see the Previous Behavior below

### Previous Behavior

Current module search path:

1. CLI arg --module-dirs to salt-call
2. Config option TYPE_dirs
3. Setuptools entrypoints
4. Module cache dir (saltutil syncs here)
5. Builtin modules

It doesn't allow a user to override a module that was migrated to extension.

### New Behavior

The new priorities and their use-cases:

1. Cli arg is useful for quick development iterations and one-off commands
2. Config option is the same, but set permanently in the master or minion config. Very useful to keep modules between salt upgrades and cache cleans
3. Cache dir is for syncable modules (easy to keep custom mods in the state tree)
4. Entrypoints are for 3rd party extensions
5. Builtin are for core

This follows a logical progression from a more user-controlled to less user-controlled. And allows user-supplied overrides/extends for each level.

If a user has a custom module in `_modules` that overrides/extends a core module, and the core module was migrated to an extension, the user-supplied override will still work.

### Merge requirements satisfied?


- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
