### PR TITLE
[3006.x] Find libcrypto in pip installed environments

### DIFF
--- a/changelog/65954.fixed.md
+++ b/changelog/65954.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue where Salt can't find libcrypto when pip installed from a cloned repo

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -2,7 +2,6 @@
 Create and verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
 """
 
-
 import ctypes.util
 import glob
 import os

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -44,8 +44,7 @@ def _find_libcrypto():
         lib = glob.glob("/opt/salt/lib/libcrypto.dylib")
 
         # look in location salt is running from
-        # this accounts for running from an unpacked
-        # onedir file
+        # this accounts for running from an unpacked onedir file
         lib = lib or glob.glob("lib/libcrypto.dylib")
 
         # Look in the location relative to the python binary

--- a/tests/pytests/unit/utils/test_rsax931.py
+++ b/tests/pytests/unit/utils/test_rsax931.py
@@ -1,7 +1,6 @@
 """
 Test the RSA ANSI X9.31 signer and verifier
 """
-
 import ctypes
 import ctypes.util
 import fnmatch
@@ -19,7 +18,7 @@ from salt.utils.rsax931 import (
     _find_libcrypto,
     _load_libcrypto,
 )
-from tests.support.mock import patch, MagicMock
+from tests.support.mock import patch
 
 
 @pytest.fixture
@@ -215,6 +214,7 @@ def test_find_libcrypto_darwin_catalina():
     assert "/usr/lib/libcrypto.44.dylib" == lib_path
 
 
+@pytest.mark.skip_unless_on_darwin
 def test_find_libcrypto_darwin_pip_install():
     """
     Test _find_libcrypto on a macOS host where there salt has been installed
@@ -223,15 +223,17 @@ def test_find_libcrypto_darwin_pip_install():
     bin_path = "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10"
     expected = "/Library/Frameworks/Python.framework/Versions/3.10/lib/libcrypto.dylib"
     glob_effect = ([], [], ["yay"], [], [], [], [])
-    with patch("salt.utils.platform.is_darwin", lambda: True),\
-            patch("sys.executable", bin_path),\
-            patch("os.path.islink", return_value=False),\
-            patch.object(glob, "glob", side_effect=glob_effect) as mock_glob:
+    with patch("salt.utils.platform.is_darwin", lambda: True), patch(
+        "sys.executable", bin_path
+    ), patch("os.path.islink", return_value=False), patch.object(
+        glob, "glob", side_effect=glob_effect
+    ) as mock_glob:
         lib_path = _find_libcrypto()
         assert lib_path == "yay"
         mock_glob.assert_any_call(expected)
 
 
+@pytest.mark.skip_unless_on_darwin
 def test_find_libcrypto_darwin_pip_install_venv():
     """
     Test _find_libcrypto on a macOS host where there salt has been installed
@@ -241,11 +243,13 @@ def test_find_libcrypto_darwin_pip_install_venv():
     lnk_path = "/Users/bill/src/salt/venv/bin/python"
     expected = "/Library/Frameworks/Python.framework/Versions/3.10/lib/libcrypto.dylib"
     glob_effect = ([], [], ["yay"], [], [], [], [])
-    with patch("salt.utils.platform.is_darwin", lambda: True), \
-            patch("sys.executable", lnk_path), \
-            patch("os.path.islink", return_value=True), \
-            patch("os.path.realpath", return_value=src_path), \
-            patch.object(glob, "glob", side_effect=glob_effect) as mock_glob:
+    with patch("salt.utils.platform.is_darwin", lambda: True), patch(
+        "sys.executable", lnk_path
+    ), patch("os.path.islink", return_value=True), patch(
+        "os.path.realpath", return_value=src_path
+    ), patch.object(
+        glob, "glob", side_effect=glob_effect
+    ) as mock_glob:
         lib_path = _find_libcrypto()
         assert lib_path == "yay"
         mock_glob.assert_any_call(expected)

--- a/tests/pytests/unit/utils/test_rsax931.py
+++ b/tests/pytests/unit/utils/test_rsax931.py
@@ -19,7 +19,7 @@ from salt.utils.rsax931 import (
     _find_libcrypto,
     _load_libcrypto,
 )
-from tests.support.mock import patch
+from tests.support.mock import patch, MagicMock
 
 
 @pytest.fixture
@@ -213,6 +213,42 @@ def test_find_libcrypto_darwin_catalina():
     ), patch.object(sys, "platform", "macosx"), patch.object(glob, "glob", test_glob):
         lib_path = _find_libcrypto()
     assert "/usr/lib/libcrypto.44.dylib" == lib_path
+
+
+def test_find_libcrypto_darwin_pip_install():
+    """
+    Test _find_libcrypto on a macOS host where there salt has been installed
+    into an existing python or virtual environment.
+    """
+    bin_path = "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10"
+    expected = "/Library/Frameworks/Python.framework/Versions/3.10/lib/libcrypto.dylib"
+    glob_effect = ([], [], ["yay"], [], [], [], [])
+    with patch("salt.utils.platform.is_darwin", lambda: True),\
+            patch("sys.executable", bin_path),\
+            patch("os.path.islink", return_value=False),\
+            patch.object(glob, "glob", side_effect=glob_effect) as mock_glob:
+        lib_path = _find_libcrypto()
+        assert lib_path == "yay"
+        mock_glob.assert_any_call(expected)
+
+
+def test_find_libcrypto_darwin_pip_install_venv():
+    """
+    Test _find_libcrypto on a macOS host where there salt has been installed
+    into an existing python or virtual environment.
+    """
+    src_path = "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10"
+    lnk_path = "/Users/bill/src/salt/venv/bin/python"
+    expected = "/Library/Frameworks/Python.framework/Versions/3.10/lib/libcrypto.dylib"
+    glob_effect = ([], [], ["yay"], [], [], [], [])
+    with patch("salt.utils.platform.is_darwin", lambda: True), \
+            patch("sys.executable", lnk_path), \
+            patch("os.path.islink", return_value=True), \
+            patch("os.path.realpath", return_value=src_path), \
+            patch.object(glob, "glob", side_effect=glob_effect) as mock_glob:
+        lib_path = _find_libcrypto()
+        assert lib_path == "yay"
+        mock_glob.assert_any_call(expected)
 
 
 def test_find_libcrypto_darwin_bigsur_packaged():


### PR DESCRIPTION
### What does this PR do?
Find libcrypto in non-relenv installations where Salt is installed using
pip. For example: `pip install -e .`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65954

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes