### PR TITLE
[3006.x] Fix mac_shadow module

### DIFF
--- a/changelog/34658.fixed.md
+++ b/changelog/34658.fixed.md
@@ -1,0 +1,3 @@
+Fix an issue with mac_shadow that was causing a command execution error when
+retrieving values that were not yet set. For example, retrieving last login
+before the user had logged in.

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -202,11 +202,12 @@ def get_account_created(name):
 
         salt '*' shadow.get_account_created admin
     """
-    ret = _get_account_policy_data_value(name, "creationTime")
-
-    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-
-    date_text = _convert_to_datetime(unix_timestamp)
+    try:
+        ret = _get_account_policy_data_value(name, "creationTime")
+        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+        date_text = _convert_to_datetime(unix_timestamp)
+    except CommandExecutionError:
+        date_text = "0"
 
     return date_text
 
@@ -228,11 +229,12 @@ def get_last_change(name):
 
         salt '*' shadow.get_last_change admin
     """
-    ret = _get_account_policy_data_value(name, "passwordLastSetTime")
-
-    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-
-    date_text = _convert_to_datetime(unix_timestamp)
+    try:
+        ret = _get_account_policy_data_value(name, "passwordLastSetTime")
+        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+        date_text = _convert_to_datetime(unix_timestamp)
+    except CommandExecutionError:
+        date_text = "0"
 
     return date_text
 
@@ -254,9 +256,11 @@ def get_login_failed_count(name):
 
         salt '*' shadow.get_login_failed_count admin
     """
-    ret = _get_account_policy_data_value(name, "failedLoginCount")
-
-    return salt.utils.mac_utils.parse_return(ret)
+    try:
+        ret = _get_account_policy_data_value(name, "failedLoginCount")
+        return salt.utils.mac_utils.parse_return(ret)
+    except CommandExecutionError:
+        return "0"
 
 
 def get_login_failed_last(name):
@@ -277,11 +281,12 @@ def get_login_failed_last(name):
 
         salt '*' shadow.get_login_failed_last admin
     """
-    ret = _get_account_policy_data_value(name, "failedLoginTimestamp")
-
-    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-
-    date_text = _convert_to_datetime(unix_timestamp)
+    try:
+        ret = _get_account_policy_data_value(name, "failedLoginTimestamp")
+        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+        date_text = _convert_to_datetime(unix_timestamp)
+    except CommandExecutionError:
+        date_text = "0"
 
     return date_text
 

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -193,7 +193,8 @@ def get_account_created(name):
 
     :param str name: The username of the account
 
-    :return: The date/time the account was created (yyyy-mm-dd hh:mm:ss)
+    :return: The date/time the account was created (yyyy-mm-dd hh:mm:ss) or 0 if
+        the value is not defined
     :rtype: str
 
     :raises: CommandExecutionError on user not found or any other unknown error
@@ -208,7 +209,7 @@ def get_account_created(name):
         ret = _get_account_policy_data_value(name, "creationTime")
     except CommandExecutionError as exc:
         if "Value not found" in exc.message:
-            return 0
+            return "0"
         else:
             raise
 
@@ -222,7 +223,8 @@ def get_last_change(name):
 
     :param str name: The username of the account
 
-    :return: The date/time the account was modified (yyyy-mm-dd hh:mm:ss)
+    :return: The date/time the account was modified (yyyy-mm-dd hh:mm:ss) or 0
+        if the value is not defined
     :rtype: str
 
     :raises: CommandExecutionError on user not found or any other unknown error
@@ -237,7 +239,7 @@ def get_last_change(name):
         ret = _get_account_policy_data_value(name, "passwordLastSetTime")
     except CommandExecutionError as exc:
         if "Value not found" in exc.message:
-            return 0
+            return "0"
         else:
             raise
 
@@ -251,8 +253,9 @@ def get_login_failed_count(name):
 
     :param str name: The username of the account
 
-    :return: The number of failed login attempts
-    :rtype: int
+    :return: The number of failed login attempts. 0 may mean there are no failed
+        login attempts or the value is not defined
+    :rtype: str
 
     :raises: CommandExecutionError on user not found or any other unknown error
 
@@ -266,7 +269,7 @@ def get_login_failed_count(name):
         ret = _get_account_policy_data_value(name, "failedLoginCount")
     except CommandExecutionError as exc:
         if "Value not found" in exc.message:
-            return 0
+            return "0"
         else:
             raise
     return salt.utils.mac_utils.parse_return(ret)
@@ -279,7 +282,7 @@ def get_login_failed_last(name):
     :param str name: The username of the account
 
     :return: The date/time of the last failed login attempt on this account
-        (yyyy-mm-dd hh:mm:ss)
+        (yyyy-mm-dd hh:mm:ss) or 0 if the value is not defined
     :rtype: str
 
     :raises: CommandExecutionError on user not found or any other unknown error
@@ -294,7 +297,7 @@ def get_login_failed_last(name):
         ret = _get_account_policy_data_value(name, "failedLoginTimestamp")
     except CommandExecutionError as exc:
         if "Value not found" in exc.message:
-            return 0
+            return "0"
         else:
             raise
 

--- a/salt/modules/mac_shadow.py
+++ b/salt/modules/mac_shadow.py
@@ -113,7 +113,9 @@ def _get_account_policy_data_value(name, key):
         ret = salt.utils.mac_utils.execute_return_result(cmd)
     except CommandExecutionError as exc:
         if "eDSUnknownNodeName" in exc.strerror:
-            raise CommandExecutionError("User not found: {}".format(name))
+            raise CommandExecutionError(f"User not found: {name}")
+        if "eDSUnknownMatchType" in exc.strerror:
+            raise CommandExecutionError(f"Value not found: {key}")
         raise CommandExecutionError("Unknown error: {}".format(exc.strerror))
 
     return ret
@@ -204,12 +206,14 @@ def get_account_created(name):
     """
     try:
         ret = _get_account_policy_data_value(name, "creationTime")
-        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-        date_text = _convert_to_datetime(unix_timestamp)
-    except CommandExecutionError:
-        date_text = "0"
+    except CommandExecutionError as exc:
+        if "Value not found" in exc.message:
+            return 0
+        else:
+            raise
 
-    return date_text
+    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+    return _convert_to_datetime(unix_timestamp)
 
 
 def get_last_change(name):
@@ -231,12 +235,14 @@ def get_last_change(name):
     """
     try:
         ret = _get_account_policy_data_value(name, "passwordLastSetTime")
-        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-        date_text = _convert_to_datetime(unix_timestamp)
-    except CommandExecutionError:
-        date_text = "0"
+    except CommandExecutionError as exc:
+        if "Value not found" in exc.message:
+            return 0
+        else:
+            raise
 
-    return date_text
+    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+    return _convert_to_datetime(unix_timestamp)
 
 
 def get_login_failed_count(name):
@@ -258,9 +264,12 @@ def get_login_failed_count(name):
     """
     try:
         ret = _get_account_policy_data_value(name, "failedLoginCount")
-        return salt.utils.mac_utils.parse_return(ret)
-    except CommandExecutionError:
-        return "0"
+    except CommandExecutionError as exc:
+        if "Value not found" in exc.message:
+            return 0
+        else:
+            raise
+    return salt.utils.mac_utils.parse_return(ret)
 
 
 def get_login_failed_last(name):
@@ -283,12 +292,14 @@ def get_login_failed_last(name):
     """
     try:
         ret = _get_account_policy_data_value(name, "failedLoginTimestamp")
-        unix_timestamp = salt.utils.mac_utils.parse_return(ret)
-        date_text = _convert_to_datetime(unix_timestamp)
-    except CommandExecutionError:
-        date_text = "0"
+    except CommandExecutionError as exc:
+        if "Value not found" in exc.message:
+            return 0
+        else:
+            raise
 
-    return date_text
+    unix_timestamp = salt.utils.mac_utils.parse_return(ret)
+    return _convert_to_datetime(unix_timestamp)
 
 
 def set_maxdays(name, days):

--- a/tests/pytests/unit/modules/test_mac_shadow.py
+++ b/tests/pytests/unit/modules/test_mac_shadow.py
@@ -20,13 +20,24 @@ def test_get_account_created():
         assert result == expected
 
 
-def test_get_account_created_error():
+def test_get_account_created_no_value():
     with patch.object(
-        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_account_created("junk")
-        expected = "0"
+        expected = 0
         assert result == expected
+
+
+def test_get_account_created_error():
+    with patch.object(
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Unknown error: something happened"),
+    ), pytest.raises(CommandExecutionError):
+        mac_shadow.get_account_created("junk")
 
 
 def test_get_last_change():
@@ -36,13 +47,24 @@ def test_get_last_change():
         assert result == expected
 
 
-def test_get_last_change_error():
+def test_get_last_change_no_value():
     with patch.object(
-        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_last_change("junk")
-        expected = "0"
+        expected = 0
         assert result == expected
+
+
+def test_get_last_change_error():
+    with patch.object(
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Unknown error: something happened"),
+    ), pytest.raises(CommandExecutionError):
+        mac_shadow.get_last_change("junk")
 
 
 def test_login_failed_count():
@@ -52,13 +74,24 @@ def test_login_failed_count():
         assert result == expected
 
 
-def test_get_login_failed_count_error():
+def test_get_login_failed_count_no_value():
     with patch.object(
-        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_login_failed_count("junk")
-        expected = "0"
+        expected = 0
         assert result == expected
+
+
+def test_get_login_failed_count_error():
+    with patch.object(
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Unknown error: something happened"),
+    ), pytest.raises(CommandExecutionError):
+        mac_shadow.get_login_failed_count("junk")
 
 
 def test_login_failed_last():
@@ -68,10 +101,21 @@ def test_login_failed_last():
         assert result == expected
 
 
-def test_get_login_failed_last_error():
+def test_get_login_failed_last_no_value():
     with patch.object(
-        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_login_failed_last("junk")
-        expected = "0"
+        expected = 0
         assert result == expected
+
+
+def test_get_login_failed_last_error():
+    with patch.object(
+        mac_shadow,
+        "_get_account_policy_data_value",
+        side_effect=CommandExecutionError("Unknown error: something happened"),
+    ), pytest.raises(CommandExecutionError):
+        mac_shadow.get_login_failed_last("junk")

--- a/tests/pytests/unit/modules/test_mac_shadow.py
+++ b/tests/pytests/unit/modules/test_mac_shadow.py
@@ -1,0 +1,77 @@
+"""
+Unit Tests for the mac_desktop execution module.
+"""
+
+import pytest
+
+import salt.modules.mac_shadow as mac_shadow
+from salt.exceptions import CommandExecutionError
+from tests.support.mock import patch
+
+pytestmark = [
+    pytest.mark.skip_unless_on_darwin,
+]
+
+
+def test_get_account_created():
+    with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
+        result = mac_shadow.get_account_created("junk")
+        expected = "1969-12-31 17:00:00"
+        assert result == expected
+
+
+def test_get_account_created_error():
+    with patch.object(
+        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+    ):
+        result = mac_shadow.get_account_created("junk")
+        expected = "0"
+        assert result == expected
+
+
+def test_get_last_change():
+    with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
+        result = mac_shadow.get_last_change("junk")
+        expected = "1969-12-31 17:00:00"
+        assert result == expected
+
+
+def test_get_last_change_error():
+    with patch.object(
+        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+    ):
+        result = mac_shadow.get_last_change("junk")
+        expected = "0"
+        assert result == expected
+
+
+def test_login_failed_count():
+    with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
+        result = mac_shadow.get_login_failed_count("junk")
+        expected = "0"
+        assert result == expected
+
+
+def test_get_login_failed_count_error():
+    with patch.object(
+        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+    ):
+        result = mac_shadow.get_login_failed_count("junk")
+        expected = "0"
+        assert result == expected
+
+
+def test_login_failed_last():
+    with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
+        result = mac_shadow.get_login_failed_last("junk")
+        expected = "1969-12-31 17:00:00"
+        assert result == expected
+
+
+def test_get_login_failed_last_error():
+    with patch.object(
+        mac_shadow, "_get_account_policy_data_value", side_effect=CommandExecutionError
+    ):
+        result = mac_shadow.get_login_failed_last("junk")
+        expected = "0"
+        assert result == expected

--- a/tests/pytests/unit/modules/test_mac_shadow.py
+++ b/tests/pytests/unit/modules/test_mac_shadow.py
@@ -1,6 +1,7 @@
 """
 Unit Tests for the mac_desktop execution module.
 """
+from datetime import datetime
 
 import pytest
 
@@ -13,11 +14,15 @@ pytestmark = [
 ]
 
 
-def test_get_account_created():
+@pytest.fixture
+def zero_date():
+    return datetime.fromtimestamp(0).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def test_get_account_created(zero_date):
     with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
         result = mac_shadow.get_account_created("junk")
-        expected = "1969-12-31 17:00:00"
-        assert result == expected
+        assert result == zero_date
 
 
 def test_get_account_created_no_value():
@@ -27,7 +32,7 @@ def test_get_account_created_no_value():
         side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_account_created("junk")
-        expected = 0
+        expected = "0"
         assert result == expected
 
 
@@ -40,11 +45,10 @@ def test_get_account_created_error():
         mac_shadow.get_account_created("junk")
 
 
-def test_get_last_change():
+def test_get_last_change(zero_date):
     with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
         result = mac_shadow.get_last_change("junk")
-        expected = "1969-12-31 17:00:00"
-        assert result == expected
+        assert result == zero_date
 
 
 def test_get_last_change_no_value():
@@ -54,7 +58,7 @@ def test_get_last_change_no_value():
         side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_last_change("junk")
-        expected = 0
+        expected = "0"
         assert result == expected
 
 
@@ -81,7 +85,7 @@ def test_get_login_failed_count_no_value():
         side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_login_failed_count("junk")
-        expected = 0
+        expected = "0"
         assert result == expected
 
 
@@ -94,11 +98,10 @@ def test_get_login_failed_count_error():
         mac_shadow.get_login_failed_count("junk")
 
 
-def test_login_failed_last():
+def test_login_failed_last(zero_date):
     with patch.object(mac_shadow, "_get_account_policy_data_value", return_value="0"):
         result = mac_shadow.get_login_failed_last("junk")
-        expected = "1969-12-31 17:00:00"
-        assert result == expected
+        assert result == zero_date
 
 
 def test_get_login_failed_last_no_value():
@@ -108,7 +111,7 @@ def test_get_login_failed_last_no_value():
         side_effect=CommandExecutionError("Value not found: creationTime"),
     ):
         result = mac_shadow.get_login_failed_last("junk")
-        expected = 0
+        expected = "0"
         assert result == expected
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the mac_shadow module where it would fail to retrieve values that weren't set yet... For example, retrieving the date of the last login before the user has logged in. This was causing the `user.present` state to fail.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/34658

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes