### PR TITLE
[master] Add runner proc files

### DIFF
--- a/changelog/66007.added.md
+++ b/changelog/66007.added.md
@@ -1,0 +1,1 @@
+Make `salt-run jobs.master` return runner jobs that are currently running on a master.

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -378,11 +378,9 @@ class SyncClientMixin(ClientStateMixin):
                 data["fun_args"] = list(args) + ([kwargs] if kwargs else [])
                 func_globals["__jid_event__"].fire_event(data, "new")
 
-                sdata = copy.deepcopy(data)
                 proc_fn = os.path.join(self.opts["cachedir"], "proc", jid)
-                sdata["pid"] = os.getpid()
                 with salt.utils.files.fopen(proc_fn, "w+b") as fp_:
-                    fp_.write(salt.payload.dumps(sdata))
+                    fp_.write(salt.payload.dumps(dict(data, pid=os.getpid())))
 
                 func = self.functions[fun]
                 try:

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -378,6 +378,12 @@ class SyncClientMixin(ClientStateMixin):
                 data["fun_args"] = list(args) + ([kwargs] if kwargs else [])
                 func_globals["__jid_event__"].fire_event(data, "new")
 
+                sdata = copy.deepcopy(data)
+                proc_fn = os.path.join(self.opts["cachedir"], "proc", jid)
+                sdata["pid"] = os.getpid()
+                with salt.utils.files.fopen(proc_fn, "w+b") as fp_:
+                    fp_.write(salt.payload.dumps(sdata))
+
                 func = self.functions[fun]
                 try:
                     data["return"] = func(*args, **kwargs)
@@ -408,6 +414,12 @@ class SyncClientMixin(ClientStateMixin):
                     )
                 data["success"] = False
                 data["retcode"] = 1
+            finally:
+                # Job has finished or issue found, so let's clean up after ourselves
+                try:
+                    os.remove(proc_fn)
+                except OSError as err:
+                    log.debug("Error attempting to remove master job tracker: %s", err)
 
             if self.store_job:
                 try:

--- a/salt/master.py
+++ b/salt/master.py
@@ -305,6 +305,7 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
                 salt.daemons.masterapi.clean_old_jobs(self.opts)
                 salt.daemons.masterapi.clean_expired_tokens(self.opts)
                 salt.daemons.masterapi.clean_pub_auth(self.opts)
+                salt.utils.master.clean_proc_dir(self.opts)
             if not last or (now - last_git_pillar_update) >= git_pillar_update_interval:
                 last_git_pillar_update = now
                 self.handle_git_pillar()

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -64,7 +64,14 @@ def clean_proc_dir(opts):
     proc_dir = os.path.join(opts["cachedir"], "proc")
     for fn_ in os.listdir(proc_dir):
         proc_file = os.path.join(proc_dir, fn_)
-        data = _read_proc_file(proc_file, opts)
+        try:
+            data = _read_proc_file(proc_file, opts)
+        except OSError:
+            # proc files may be removed at any time during this process by
+            # the master process that is executing the JID in question, so
+            # we must ignore ENOENT during this process
+            log.trace("%s removed during processing by master process", proc_file)
+            continue
         if not data:
             try:
                 log.warning(

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -111,7 +111,7 @@ def _read_proc_file(path, opts):
                 log.debug("Unable to remove proc file %s.", path)
             return None
     if not isinstance(data, dict):
-        # Invalid serial object
+        # Invalid payload object
         return None
     if not salt.utils.process.os_is_running(data["pid"]):
         # The process is no longer running, clear out the file and

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 def get_running_jobs(opts):
     """
-    Return the running jobs on this minion
+    Return the running jobs on this master
     """
 
     ret = []
@@ -51,6 +51,40 @@ def get_running_jobs(opts):
             # we must ignore ENOENT during this process
             log.trace("%s removed during processing by master process", path)
     return ret
+
+
+def clean_proc_dir(opts):
+    """
+    Clean out old tracked jobs running on the master
+    Generally, anything tracking a job should remove the job
+    once the job has finished. However, this will remove any
+    jobs that for some reason were not properly removed
+    when finished or errored.
+    """
+    proc_dir = os.path.join(opts["cachedir"], "proc")
+    for fn_ in os.listdir(proc_dir):
+        proc_file = os.path.join(proc_dir, fn_)
+        data = _read_proc_file(proc_file, opts)
+        if not data:
+            try:
+                log.warning(
+                    "Found proc file %s without proper data. Removing from tracked proc files.",
+                    proc_file,
+                )
+                os.remove(proc_file)
+            except OSError as err:
+                log.error("Unable to remove proc file: %s.", err)
+            continue
+        if not _check_cmdline(data):
+            try:
+                log.warning(
+                    "PID %s not owned by salt or no longer running. Removing tracked proc file %s",
+                    data["pid"],
+                    proc_file,
+                )
+                os.remove(proc_file)
+            except OSError as err:
+                log.error("Unable to remove proc file: %s.", err)
 
 
 def _read_proc_file(path, opts):

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -136,7 +136,6 @@ def _check_cmdline(data):
         return False
     try:
         with salt.utils.files.fopen(path, "rb") as fp_:
-            if b"salt" in fp_.read():
-                return True
+            return b"salt" in fp_.read()
     except OSError:
         return False

--- a/tests/pytests/integration/runners/test_jobs.py
+++ b/tests/pytests/integration/runners/test_jobs.py
@@ -1,6 +1,7 @@
 """
 Tests for the salt-run command
 """
+
 import os
 
 import pytest

--- a/tests/pytests/integration/runners/test_jobs.py
+++ b/tests/pytests/integration/runners/test_jobs.py
@@ -1,6 +1,7 @@
 """
 Tests for the salt-run command
 """
+import os
 
 import pytest
 
@@ -10,13 +11,25 @@ pytestmark = [
 ]
 
 
-def test_master(salt_run_cli, salt_minion):
+def test_master(salt_run_cli, salt_master):
     """
     jobs.master
     """
     ret = salt_run_cli.run("jobs.master")
-    assert ret.data == []
-    assert ret.stdout.strip() == "[]"
+    assert os.listdir(os.path.join(salt_master.config["cachedir"], "proc")) == []
+    assert len(ret.data) == 1
+    assert sorted(ret.data[0].keys()) == [
+        "_stamp",
+        "fun",
+        "fun_args",
+        "jid",
+        "pid",
+        "user",
+    ]
+    fun = "runner.jobs.master"
+    assert ret.data[0]["fun"] == fun
+    assert ret.data[0]["fun_args"] == []
+    assert fun in ret.stdout
 
 
 def test_active(salt_run_cli, salt_minion):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -912,6 +912,7 @@ def test_run_func(maintenance):
     mocked_clean_old_jobs = MockTimedFunc()
     mocked_clean_expired_tokens = MockTimedFunc()
     mocked_clean_pub_auth = MockTimedFunc()
+    mocked_clean_proc_dir = MockTimedFunc()
     mocked_handle_git_pillar = MockTimedFunc()
     mocked_handle_schedule = MockTimedFunc()
     mocked_handle_key_cache = MockTimedFunc()
@@ -927,6 +928,8 @@ def test_run_func(maintenance):
         "salt.daemons.masterapi.clean_expired_tokens", mocked_clean_expired_tokens
     ), patch(
         "salt.daemons.masterapi.clean_pub_auth", mocked_clean_pub_auth
+    ), patch(
+        "salt.utils.master.clean_proc_dir", mocked_clean_proc_dir
     ), patch(
         "salt.master.Maintenance.handle_git_pillar", mocked_handle_git_pillar
     ), patch(
@@ -949,6 +952,7 @@ def test_run_func(maintenance):
         assert mocked_clean_old_jobs.call_times == [0, 120, 180]
         assert mocked_clean_expired_tokens.call_times == [0, 120, 180]
         assert mocked_clean_pub_auth.call_times == [0, 120, 180]
+        assert mocked_clean_proc_dir.call_times == [0, 120, 180]
         assert mocked_handle_git_pillar.call_times == [0]
         assert mocked_handle_schedule.call_times == [0, 60, 120, 180]
         assert mocked_handle_key_cache.call_times == [0, 60, 120, 180]

--- a/tests/pytests/unit/utils/test_master.py
+++ b/tests/pytests/unit/utils/test_master.py
@@ -1,0 +1,53 @@
+import pytest
+
+import salt.utils.master
+from tests.support.mock import mock_open, patch
+
+
+@pytest.mark.skip_on_platforms(linux=True)
+def test_check_cmdline_returns_true():
+    assert salt.utils.master._check_cmdline({"pid": 99999999}) is True
+
+
+@pytest.mark.skip_unless_on_linux
+def test_check_cmdline_no_pid():
+    assert salt.utils.master._check_cmdline({}) is False
+
+
+def test_check_cmdline_no_proc_dir():
+    with patch("salt.utils.platform.is_linux", return_value=True), patch(
+        "os.path.isdir", return_value=False
+    ):
+        assert salt.utils.master._check_cmdline({"pid": 99999999}) is True
+
+
+@pytest.mark.skip_unless_on_linux
+def test_check_cmdline_no_proc_file():
+    with patch("os.path.isfile", return_value=True) as mock_isfile:
+        pid = 99999999
+        assert salt.utils.master._check_cmdline({"pid": pid}) is False
+        mock_isfile.assert_called_with(f"/proc/{pid}/cmdline")
+
+
+@pytest.mark.skip_unless_on_linux
+def test_check_cmdline_not_salt_process():
+    with patch("os.path.isfile", return_value=True), patch(
+        "salt.utils.files.fopen", mock_open(read_data=b"blah")
+    ):
+        assert salt.utils.master._check_cmdline({"pid": 99999999}) is False
+
+
+@pytest.mark.skip_unless_on_linux
+def test_check_cmdline_salt_process():
+    with patch("os.path.isfile", return_value=True), patch(
+        "salt.utils.files.fopen", mock_open(read_data=b"salt")
+    ):
+        assert salt.utils.master._check_cmdline({"pid": 99999999}) is True
+
+
+@pytest.mark.skip_unless_on_linux
+def test_check_cmdline_proc_vanishes():
+    with patch("os.path.isfile", return_value=True), patch(
+        "salt.utils.files.fopen", side_effect=OSError
+    ):
+        assert salt.utils.master._check_cmdline({"pid": 99999999}) is False


### PR DESCRIPTION
### What does this PR do?

Make `salt-run jobs.master` return runner jobs currently running on a master.

Fixes https://github.com/saltstack/salt/issues/56254

A note to reviewers: I diverged a bit from the original PR #51629 in order to have `utils.master` functions as similar as possible to `utils.minion`.  It is better to refactor them in sync later (if needed)
 
### Previous Behavior

The following two PRs were submitted against the old `develop` branch (pre-Neon): https://github.com/saltstack/salt/pull/51629 https://github.com/saltstack/salt/pull/52241. The second of those PRs was ported to Neon in https://github.com/saltstack/salt/pull/56440, but the first one was forgotten. Without it, `salt-run jobs.master` usually returns nothing, unless master runs a scheduled job (master proc files for scheduled jobs were added in https://github.com/saltstack/salt/pull/50130)

Other slightly related issues: https://github.com/saltstack/salt/issues/57486 https://github.com/saltstack/salt/issues/65095 https://github.com/saltstack/salt/pull/55653 


### Merge requirements satisfied?

- [ ] Docs (covered by existing ones) 
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
