### PR TITLE
[master] Two tweaks for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,7 @@ Pipfile.lock
 #   top of salt such as
 # - /some/path$ git clone https://github.com/thatch45/salt.git
 # - /some/path$ virtualenv --python=/usr/bin/python2.6 salt
-/env/
-/.env/
+/.?env/
 /bin/
 /etc/
 /include/
@@ -37,7 +36,7 @@ Pipfile.lock
 /tests/cachedir/
 /tests/unit/templates/roots/
 /var/
-/venv/
+/.?venv/
 
 # setuptools stuff
 *.egg-info


### PR DESCRIPTION
1. `/env/` and `/.env` can be represented in a single entry using `/.?env/`
2. Update `/venv/` entry to also ignore `/.venv/`. Some tools (for example [poetry](https://python-poetry.org/)) will look for and use virtualenvs in the root of a project if they are named `.venv`. While Salt doesn't have poetry configurations in its pyproject.toml, nor a poetry.lock, the use of virtualenvs named `.venv` as opposed to `venv` are likely to be in many developers' workflows, and this naming convention should be supported.