### PR TITLE
[master] Add a minimal SSH test.pkg_opts minion cache.

### DIFF
--- a/changelog/66016.added.md
+++ b/changelog/66016.added.md
@@ -1,0 +1,1 @@
+Added a very simple SSH minion cache

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1755,10 +1755,10 @@ the script will only run when the thin dir does not exist on the targeted
 minion. This will force the script to run and not check if the thin dir
 exists first.
 
-.. conf_master:: thin_extra_mods
+.. conf_master:: ssh_minion_opts_cache
 
 ``ssh_minion_opts_cache``
------------------------
+-------------------------
 
 .. versionadded:: 3007.1
 
@@ -1777,6 +1777,8 @@ This value is ignored for standard minions or any other kind of minion not SSH.
 .. code-block:: yaml
 
     ssh_minion_opts_cache: 3600
+
+.. conf_master:: thin_extra_mods
 
 ``thin_extra_mods``
 -------------------

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1757,6 +1757,27 @@ exists first.
 
 .. conf_master:: thin_extra_mods
 
+``ssh_minion_opts_cache``
+-----------------------
+
+.. versionadded:: 3007.1
+
+Default: ``0``
+
+If a positive integer, defines the number of seconds for which the initial options query
+to an SSH minion is cached on disk, run prior to any module execution on an SSH minion.
+This can speed up large runs, and halves the amount of SSH sessions that ``salt-ssh``
+opens to a minion.
+
+The cached data changes infrequently (for instance, when a full version system upgrade
+is performed on a minion) so it is relatively safe to leave this cache at a high value.
+
+This value is ignored for standard minions or any other kind of minion not SSH.
+
+.. code-block:: yaml
+
+    ssh_minion_opts_cache: 3600
+
 ``thin_extra_mods``
 -------------------
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -57,6 +57,13 @@ from salt.utils.process import Process
 from salt.utils.zeromq import zmq
 
 try:
+    import fcntl
+
+    HAS_FCNTL = True
+except ImportError:
+    HAS_FCNTL = False
+
+try:
     import saltwinshell
 
     HAS_WINSHELL = True
@@ -325,6 +332,133 @@ else:
     SSH_PY_SHIM = None
 
 log = logging.getLogger(__name__)
+
+
+def cache_context_manager(cache_path):
+    """Returns a context manager that allows for disk file cache persistence.
+
+    Uses the fcntl module.  If no fcntl module is available, falls back to no cache.
+
+    This is multiprocessing-safe because fcntl works across processes.
+    """
+
+    if HAS_FCNTL:
+
+        class filecache:
+            """fcntl-enabled single-file disk cache."""
+
+            def __init__(self, path):
+                self.path = path
+                self.file = None
+                self.payload = None
+
+            def __enter__(self):
+                """Tries to create and lock the cache file.
+
+                On failure, returns an ineffective but usable self.
+                """
+                cdir = os.path.dirname(self.path)
+                try:
+                    if not os.path.isdir(cdir):
+                        os.makedirs(cdir)
+                    self.file = salt.utils.files.fopen(self.path, "a+b")
+                    fcntl.flock(self.file.fileno(), fcntl.LOCK_EX)
+                except Exception:
+                    log.exception(
+                        "Cache file %s could not be opened or locked; proceeding without cache",
+                        self.path,
+                    )
+                return self
+
+            def __exit__(self, _, __, ___):
+                if self.file:
+                    try:
+                        fcntl.flock(self.file.fileno(), fcntl.LOCK_UN)
+                        self.file.close()
+                    finally:
+                        self.file = None
+
+            def invalidate(self):
+                """Invalidates the cache."""
+                if self.file:
+                    self.file.seek(0)
+                    self.file.truncate()
+
+            def retrieve(self):
+                """Retrieves the cache.  Returns None if no valid cache is found."""
+                if not self.file:
+                    return None
+                try:
+                    log.debug("Loading from %s", self.path)
+                    self.file.seek(0)
+                    payload = self.file.read()
+                    if not payload:
+                        log.debug("No data in cache file")
+                        return None
+                    self.payload = payload
+                    # Do not use payload.load -- closes file.
+                    return salt.payload.loads(payload)
+                except Exception:
+                    log.exception(
+                        "Cached data could not be loaded from file %s; proceeding without cache",
+                        self.path,
+                    )
+                    self.invalidate()
+
+            def persist(self, data):
+                """Persists into cache.  Handles errors best-effort."""
+                if not self.file:
+                    return
+                payload = salt.payload.dumps(data)
+                if self.payload == payload:
+                    log.debug(
+                        "Not saving data to cache file %s -- it has not changed",
+                        self.path,
+                    )
+                    return
+                log.debug("Saving to cache file %s", self.path)
+                try:
+                    self.file.seek(0)
+                    self.file.truncate()
+                    self.file.write(payload)
+                except Exception:
+                    log.exception(
+                        "Data could not be persisted to cache file %s; ignoring and proceeding",
+                        self.path,
+                    )
+                    self.invalidate()
+
+            def older_than(self, timestamp):
+                """Is cache older than the supplied UNIX timestamp?"""
+                if not self.file:
+                    return True
+                return os.stat(self.path).st_mtime < timestamp
+
+    class nocache:
+        """Dummy version of the cache above."""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _, __, ___):
+            pass
+
+        def invalidate(self):
+            pass
+
+        def retrieve(self):
+            return None
+
+        def persist(self, _):
+            pass
+
+        def older_than(self, _):
+            return True
+
+    if HAS_FCNTL and cache_path:
+        return filecache(cache_path)
+
+    return nocache()
 
 
 class SSH(MultiprocessingStateMixin):
@@ -1523,41 +1657,72 @@ class Single:
         """
         # Ensure that opts/grains are up to date
         # Execute routine
-        data_cache = False
-        data = None
-        cdir = os.path.join(self.opts["cachedir"], "minions", self.id)
-        if not os.path.isdir(cdir):
-            os.makedirs(cdir)
-        datap = os.path.join(cdir, "ssh_data.p")
-        refresh = False
-        if not os.path.isfile(datap):
-            refresh = True
-        else:
-            passed_time = (time.time() - os.stat(datap).st_mtime) / 60
-            if passed_time > self.opts.get("cache_life", 60):
-                refresh = True
 
-        if self.opts.get("refresh_cache"):
-            refresh = True
-        conf_grains = {}
-        # Save conf file grains before they get clobbered
-        if "ssh_grains" in self.opts:
-            conf_grains = self.opts["ssh_grains"]
-        if not data_cache:
-            refresh = True
-        if refresh:
-            # Make the datap
-            # TODO: Auto expire the datap
-            pre_wrapper = salt.client.ssh.wrapper.FunctionWrapper(
-                self.opts,
-                self.id,
-                fsclient=self.fsclient,
-                minion_opts=self.minion_opts,
-                **self.target,
+        # Implement a very lightweight cache, whose only purpose is to avoid
+        # contacting the minion twice on every SSH operation.  The computation
+        # that used to be cached by Salt pre-2014 is no longer cached.  Only
+        # the minion test.opts_pkg call result is cached, resulting in a solid
+        # performance improvement, most noticeable in large orchestration runs.
+        #
+        # The code used for the cache is generic and can be used to implement
+        # other types of caches.
+        minion_cache_timeout = self.opts.get("ssh_minion_opts_cache", 0)
+        if not isinstance(minion_cache_timeout, int) or minion_cache_timeout < 0:
+            log.warning("ssh_minion_opts_cache set but not a positive integer")
+            minion_cache_timeout = 0
+
+        if minion_cache_timeout and not HAS_FCNTL:
+            log.warning(
+                "ssh_minion_opts_cache option cannot be enabled on systems without"
+                "the fcntl module; proceeding without minion cache anyway"
             )
+            minion_cache_timeout = 0
 
-            opts_pkg = pre_wrapper["test.opts_pkg"]()  # pylint: disable=E1102
+        cache_path = (
+            os.path.join(
+                os.path.join(self.opts["cachedir"], "minions", self.id),
+                "ssh_test_opts_pkg.p",
+            )
+            if minion_cache_timeout
+            else None
+        )
+        context = cache_context_manager(cache_path)
 
+        with context as cache:
+            opts_pkg = None
+            if self.opts.get("refresh_cache"):
+                cache.invalidate()
+            elif cache.older_than(time.time() - minion_cache_timeout):
+                cache.invalidate()
+            else:
+                opts_pkg = cache.retrieve()
+
+            # Save conf file grains before they get clobbered.
+            # It is currently unclear to me if the call to the
+            # pre_wrapper will clobber these opts, but we need
+            # them below to complete the opts_pkg.  I'm carrying
+            # this precaution from the prior commit anyway.
+            conf_grains = self.opts.get("ssh_grains", {})
+            if opts_pkg is None:
+                pre_wrapper = salt.client.ssh.wrapper.FunctionWrapper(
+                    self.opts,
+                    self.id,
+                    fsclient=self.fsclient,
+                    minion_opts=self.minion_opts,
+                    **self.target,
+                )
+                opts_pkg = pre_wrapper["test.opts_pkg"]()  # pylint: disable=E1102
+
+            if "_error" in opts_pkg:
+                # Refresh failed
+                cache.invalidate()
+                retcode = opts_pkg["retcode"]
+                ret = salt.utils.json.dumps({"local": opts_pkg})
+                return ret, retcode
+            else:
+                cache.persist(opts_pkg)
+
+        if True:  # Left to reduce indentation diff.
             opts_pkg["file_roots"] = self.opts["file_roots"]
             opts_pkg["pillar_roots"] = self.opts["pillar_roots"]
             opts_pkg["ext_pillar"] = self.opts["ext_pillar"]
@@ -1611,21 +1776,13 @@ class Single:
                 opts_pkg.get("saltenv", "base"),
             )
             pillar_data = pillar.compile_pillar()
+            # TODO: cache generated pkg_opts and pillar in a separate cache
+            # context manager instance. Invalidation of this cached data
+            # will be difficult due to the need to determine what inputs
+            # and environment of this function influence these values.
 
-            # TODO: cache minion opts in datap in master.py
-            data = {
-                "opts": opts_pkg,
-                "grains": opts_pkg["grains"],
-                "pillar": pillar_data,
-            }
-            if data_cache:
-                with salt.utils.files.fopen(datap, "w+b") as fp_:
-                    fp_.write(salt.payload.dumps(data))
-        if not data and data_cache:
-            with salt.utils.files.fopen(datap, "rb") as fp_:
-                data = salt.payload.load(fp_)
-        opts = data.get("opts", {})
-        opts["grains"] = data.get("grains")
+        opts = opts_pkg
+        opts["grains"] = opts_pkg["grains"]
 
         # Restore master grains and roster grains
         # Use dict merge instead of nested mutations to avoid OptsDict deepcopy
@@ -1637,12 +1794,10 @@ class Single:
         if grains_updates:
             opts["grains"] = {**opts["grains"], **grains_updates}
 
-        opts["pillar"] = data.get("pillar")
+        opts["pillar"] = pillar_data
 
         # Restore --wipe. Note: Since it is also a CLI option, it should not
-        # be read from cache, hence it is restored here. This is currently only
-        # of semantic distinction since data_cache has been disabled, so refresh
-        # above always evaluates to True. TODO: cleanup?
+        # be read from cache, hence it is restored here.
         opts["ssh_wipe"] = self.opts.get("ssh_wipe", False)
 
         # Propagate relenv settings to nested Single instances (wrapper-initiated calls)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -361,9 +361,13 @@ def cache_context_manager(cache_path):
                 try:
                     if not os.path.isdir(cdir):
                         os.makedirs(cdir)
-                    self.file = salt.utils.files.fopen(self.path, "a+b")
+                    self.file = (
+                        salt.utils.files.fopen(  # pylint: disable=resource-leakage
+                            self.path, "a+b"
+                        )
+                    )
                     fcntl.flock(self.file.fileno(), fcntl.LOCK_EX)
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     log.exception(
                         "Cache file %s could not be opened or locked; proceeding without cache",
                         self.path,
@@ -398,7 +402,7 @@ def cache_context_manager(cache_path):
                     self.payload = payload
                     # Do not use payload.load -- closes file.
                     return salt.payload.loads(payload)
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     log.exception(
                         "Cached data could not be loaded from file %s; proceeding without cache",
                         self.path,
@@ -421,7 +425,7 @@ def cache_context_manager(cache_path):
                     self.file.seek(0)
                     self.file.truncate()
                     self.file.write(payload)
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     log.exception(
                         "Data could not be persisted to cache file %s; ignoring and proceeding",
                         self.path,
@@ -1722,64 +1726,61 @@ class Single:
             else:
                 cache.persist(opts_pkg)
 
-        if True:  # Left to reduce indentation diff.
-            opts_pkg["file_roots"] = self.opts["file_roots"]
-            opts_pkg["pillar_roots"] = self.opts["pillar_roots"]
-            opts_pkg["ext_pillar"] = self.opts["ext_pillar"]
-            # For SSH, don't override extension_modules if it's already set correctly in minion_opts
-            # (pointing to the remote system's cache, not the master's cache)
-            if (
-                "extension_modules" not in opts_pkg
-                or opts_pkg["extension_modules"] == self.opts["extension_modules"]
-            ):
-                # Only override if it's still using the master's path or not set
-                if "extension_modules" in self.minion_opts:
-                    opts_pkg["extension_modules"] = self.minion_opts[
-                        "extension_modules"
-                    ]
-                else:
-                    opts_pkg["extension_modules"] = self.opts["extension_modules"]
-            opts_pkg["module_dirs"] = self.opts["module_dirs"]
-            opts_pkg["_ssh_version"] = self.opts["_ssh_version"]
-            opts_pkg["thin_dir"] = self.opts["thin_dir"]
-            opts_pkg["master_tops"] = self.opts["master_tops"]
-            opts_pkg["extra_filerefs"] = self.opts.get("extra_filerefs", "")
-            opts_pkg["__master_opts__"] = self.context["master_opts"]
-            if "known_hosts_file" in self.opts:
-                opts_pkg["known_hosts_file"] = self.opts["known_hosts_file"]
-            if "_caller_cachedir" in self.opts:
-                opts_pkg["_caller_cachedir"] = self.opts["_caller_cachedir"]
+        opts_pkg["file_roots"] = self.opts["file_roots"]
+        opts_pkg["pillar_roots"] = self.opts["pillar_roots"]
+        opts_pkg["ext_pillar"] = self.opts["ext_pillar"]
+        # For SSH, don't override extension_modules if it's already set correctly in minion_opts
+        # (pointing to the remote system's cache, not the master's cache)
+        if (
+            "extension_modules" not in opts_pkg
+            or opts_pkg["extension_modules"] == self.opts["extension_modules"]
+        ):
+            # Only override if it's still using the master's path or not set
+            if "extension_modules" in self.minion_opts:
+                opts_pkg["extension_modules"] = self.minion_opts["extension_modules"]
             else:
-                opts_pkg["_caller_cachedir"] = self.opts["cachedir"]
-            # Use the ID defined in the roster file
-            opts_pkg["id"] = self.id
+                opts_pkg["extension_modules"] = self.opts["extension_modules"]
+        opts_pkg["module_dirs"] = self.opts["module_dirs"]
+        opts_pkg["_ssh_version"] = self.opts["_ssh_version"]
+        opts_pkg["thin_dir"] = self.opts["thin_dir"]
+        opts_pkg["master_tops"] = self.opts["master_tops"]
+        opts_pkg["extra_filerefs"] = self.opts.get("extra_filerefs", "")
+        opts_pkg["__master_opts__"] = self.context["master_opts"]
+        if "known_hosts_file" in self.opts:
+            opts_pkg["known_hosts_file"] = self.opts["known_hosts_file"]
+        if "_caller_cachedir" in self.opts:
+            opts_pkg["_caller_cachedir"] = self.opts["_caller_cachedir"]
+        else:
+            opts_pkg["_caller_cachedir"] = self.opts["cachedir"]
+        # Use the ID defined in the roster file
+        opts_pkg["id"] = self.id
 
-            retcode = salt.defaults.exitcodes.EX_OK
+        retcode = salt.defaults.exitcodes.EX_OK
 
-            # Restore master grains
-            for grain in conf_grains:
-                opts_pkg["grains"][grain] = conf_grains[grain]
-            # Enable roster grains support
-            if "grains" in self.target:
-                for grain in self.target["grains"]:
-                    opts_pkg["grains"][grain] = self.target["grains"][grain]
+        # Restore master grains
+        for grain in conf_grains:
+            opts_pkg["grains"][grain] = conf_grains[grain]
+        # Enable roster grains support
+        if "grains" in self.target:
+            for grain in self.target["grains"]:
+                opts_pkg["grains"][grain] = self.target["grains"][grain]
 
-            # Pillar compilation needs the master opts primarily,
-            # same as during regular operation.
-            popts = {}
-            popts.update(opts_pkg)
-            popts.update(opts_pkg["__master_opts__"])
-            pillar = salt.pillar.Pillar(
-                popts,
-                opts_pkg["grains"],
-                opts_pkg["id"],
-                opts_pkg.get("saltenv", "base"),
-            )
-            pillar_data = pillar.compile_pillar()
-            # TODO: cache generated pkg_opts and pillar in a separate cache
-            # context manager instance. Invalidation of this cached data
-            # will be difficult due to the need to determine what inputs
-            # and environment of this function influence these values.
+        # Pillar compilation needs the master opts primarily,
+        # same as during regular operation.
+        popts = {}
+        popts.update(opts_pkg)
+        popts.update(opts_pkg["__master_opts__"])
+        pillar = salt.pillar.Pillar(
+            popts,
+            opts_pkg["grains"],
+            opts_pkg["id"],
+            opts_pkg.get("saltenv", "base"),
+        )
+        pillar_data = pillar.compile_pillar()
+        # TODO: cache generated pkg_opts and pillar in a separate cache
+        # context manager instance. Invalidation of this cached data
+        # will be difficult due to the need to determine what inputs
+        # and environment of this function influence these values.
 
         opts = opts_pkg
         opts["grains"] = opts_pkg["grains"]

--- a/tests/pytests/unit/client/ssh/test_ssh_classes.py
+++ b/tests/pytests/unit/client/ssh/test_ssh_classes.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import pytest
 from saltfactories.utils.tempfiles import temp_directory
@@ -126,3 +127,107 @@ def test_single_init_with_minion_opts_no_ext_pillar():
     assert (
         single.minion_opts["ext_pillar"] == []
     ), "ext_pillar should default to [] when absent from minion opts"
+
+
+class TestCacheContextManager:
+    """Tests for cache_context_manager() in salt.client.ssh.__init__."""
+
+    def test_nocache_returned_when_no_path(self):
+        """cache_context_manager(None) must return a nocache, not a filecache."""
+        ctx = dunder_ssh.cache_context_manager(None)
+        with ctx as cache:
+            assert cache.retrieve() is None
+            assert cache.older_than(time.time()) is True
+            # These must not raise.
+            cache.invalidate()
+            cache.persist({"key": "value"})
+
+    def test_nocache_returned_when_no_fcntl(self, tmp_path):
+        """When fcntl is unavailable, cache_context_manager falls back to nocache."""
+        cache_file = str(tmp_path / "test_cache.p")
+        with patch.object(dunder_ssh, "HAS_FCNTL", False):
+            ctx = dunder_ssh.cache_context_manager(cache_file)
+        with ctx as cache:
+            assert cache.retrieve() is None
+            assert cache.older_than(time.time()) is True
+
+    def test_filecache_persist_and_retrieve(self, tmp_path):
+        """filecache must serialise data to disk and deserialise it correctly."""
+        if not dunder_ssh.HAS_FCNTL:
+            pytest.skip("fcntl not available on this platform")
+
+        cache_file = str(tmp_path / "ssh_test_opts.p")
+        data = {"grains": {"os": "Linux"}, "version": 42}
+
+        # Persist data.
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            assert cache.retrieve() is None  # nothing stored yet
+            cache.persist(data)
+
+        # Retrieve data in a new context.
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            retrieved = cache.retrieve()
+        assert retrieved == data
+
+    def test_filecache_invalidate_clears_data(self, tmp_path):
+        """invalidate() must wipe cached content so retrieve() returns None."""
+        if not dunder_ssh.HAS_FCNTL:
+            pytest.skip("fcntl not available on this platform")
+
+        cache_file = str(tmp_path / "ssh_test_opts.p")
+        data = {"key": "value"}
+
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            cache.persist(data)
+
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            cache.invalidate()
+            assert cache.retrieve() is None
+
+    def test_filecache_older_than(self, tmp_path):
+        """older_than() returns False for a fresh file and True for a stale threshold."""
+        if not dunder_ssh.HAS_FCNTL:
+            pytest.skip("fcntl not available on this platform")
+
+        cache_file = str(tmp_path / "ssh_test_opts.p")
+        data = {"key": "value"}
+
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            cache.persist(data)
+            # The file was just written, so it is newer than (now - 1 hour).
+            assert cache.older_than(time.time() - 3600) is False
+            # A threshold in the future means the file is "older than" that time.
+            assert cache.older_than(time.time() + 3600) is True
+
+    def test_filecache_persist_skips_unchanged_data_after_retrieve(self, tmp_path):
+        """persist() must not write to disk when data matches what was retrieved."""
+        if not dunder_ssh.HAS_FCNTL:
+            pytest.skip("fcntl not available on this platform")
+
+        cache_file = str(tmp_path / "ssh_test_opts.p")
+        data = {"key": "value"}
+
+        # Persist data first.
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            cache.persist(data)
+
+        # In a new context: retrieve, then persist the same data — no write expected.
+        with dunder_ssh.cache_context_manager(cache_file) as cache:
+            retrieved = cache.retrieve()
+            assert retrieved == data
+
+            # Wrap write to count calls.
+            original_write = cache.file.write
+            write_call_count = []
+
+            def counting_write(buf):
+                write_call_count.append(len(buf))
+                return original_write(buf)
+
+            cache.file.write = counting_write
+            # Persist the same (unchanged) data — write must NOT be called.
+            cache.persist(data)
+
+        assert (
+            write_call_count == []
+        ), "persist() should not write to disk when data matches the retrieved payload"


### PR DESCRIPTION
This only attempts to accelerate repeated contacts with the SSH minion. The amount of data formerly cached is not contemplated in this patch, due to the complexity of ensuring that all that data is invalidated.

### What does this PR do?

Accelerates repeated contacts with SSH minions by roughly 1 second, or more if latency is high.

Halves the total amount of SSH connections established with SSH minions.

In particular, orchestration runs become faster.

Most of the change is indentation whitespace.

### What issues does this PR fix or reference?

None.

### Previous Behavior

Every SSH minion run was prefaced with a `test.opts_pkg` call, slowing down minion runs.

### New Behavior

SSH minion runs recently contacted  to obtain the `test.opts_pkg`
data are not contacted for that data anymore.  Instead, this data is read from a local minion
cache file, which is properly locked to protect data integrity.

This is by default turned off.

### Merge requirements satisfied?

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] No tests have been updated -- please point me in the right direction.

### Commits signed with GPG?

Yes.