### PR TITLE
[3006.x] Make logging calls lighter

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -413,6 +413,7 @@ def set_logging_options_dict(opts):
     except AttributeError:
         pass
     set_logging_options_dict.__options_dict__ = opts
+    set_lowest_log_level_by_opts(opts)
 
 
 def freeze_logging_options_dict():

--- a/tests/pytests/integration/_logging/test_logging.py
+++ b/tests/pytests/integration/_logging/test_logging.py
@@ -48,7 +48,7 @@ def log_nameToLevel(name):
 
 def test_lowest_log_level():
     ret = log_impl.get_lowest_log_level()
-    assert ret is None
+    assert ret is not None
 
     log_impl.set_lowest_log_level(log_nameToLevel("DEBUG"))
     ret = log_impl.get_lowest_log_level()

--- a/tests/pytests/unit/_logging/handlers/test_deferred_stream_handler.py
+++ b/tests/pytests/unit/_logging/handlers/test_deferred_stream_handler.py
@@ -9,6 +9,7 @@ import pytest
 from pytestshellutils.utils.processes import terminate_process
 
 from salt._logging.handlers import DeferredStreamHandler
+from salt._logging.impl import set_lowest_log_level
 from salt.utils.nb_popen import NonBlockingPopen
 from tests.support.helpers import CaptureOutput, dedent
 from tests.support.runtests import RUNTIME_VARS
@@ -20,7 +21,7 @@ def _sync_with_handlers_proc_target():
 
     with CaptureOutput() as stds:
         handler = DeferredStreamHandler(sys.stderr)
-        handler.setLevel(logging.DEBUG)
+        set_lowest_log_level(logging.DEBUG)
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)
         logging.root.addHandler(handler)
@@ -45,7 +46,7 @@ def _deferred_write_on_flush_proc_target():
 
     with CaptureOutput() as stds:
         handler = DeferredStreamHandler(sys.stderr)
-        handler.setLevel(logging.DEBUG)
+        set_lowest_log_level(logging.DEBUG)
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)
         logging.root.addHandler(handler)
@@ -126,7 +127,7 @@ def test_deferred_write_on_atexit(tmp_path):
         # Just loop consuming output
         while True:
             if time.time() > max_time:
-                pytest.fail("Script didn't exit after {} second".format(execution_time))
+                pytest.fail(f"Script didn't exit after {execution_time} second")
 
             time.sleep(0.125)
             _out = proc.recv()
@@ -146,7 +147,7 @@ def test_deferred_write_on_atexit(tmp_path):
     finally:
         terminate_process(proc.pid, kill_children=True)
     if b"Foo" not in err:
-        pytest.fail("'Foo' should be in stderr and it's not: {}".format(err))
+        pytest.fail(f"'Foo' should be in stderr and it's not: {err}")
 
 
 @pytest.mark.skip_on_windows(reason="Windows does not support SIGINT")

--- a/tests/pytests/unit/modules/win_lgpo/test_adv_audit.py
+++ b/tests/pytests/unit/modules/win_lgpo/test_adv_audit.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import salt.modules.win_file as win_file
@@ -158,11 +160,14 @@ def test_set_value_log_messages(caplog):
     mock_set_file_data = MagicMock(return_value=True)
     mock_set_pol_data = MagicMock(return_value=False)
     mock_context = {"lgpo.adv_audit_data": {"test_option": "test_value"}}
-    with patch.object(
-        win_lgpo, "_set_advaudit_file_data", mock_set_file_data
-    ), patch.object(win_lgpo, "_set_advaudit_pol_data", mock_set_pol_data), patch.dict(
-        win_lgpo.__context__, mock_context
-    ):
-        win_lgpo._set_advaudit_value("test_option", None)
-        assert "Failed to apply audit setting:" in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(
+            win_lgpo, "_set_advaudit_file_data", mock_set_file_data
+        ), patch.object(
+            win_lgpo, "_set_advaudit_pol_data", mock_set_pol_data
+        ), patch.dict(
+            win_lgpo.__context__, mock_context
+        ):
+            win_lgpo._set_advaudit_value("test_option", None)
+            assert "Failed to apply audit setting:" in caplog.text
         assert "LGPO: Removing Advanced Audit data:" in caplog.text

--- a/tests/pytests/unit/modules/win_lgpo/test_secedit.py
+++ b/tests/pytests/unit/modules/win_lgpo/test_secedit.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import salt.modules.cmdmod as cmd
@@ -69,15 +71,17 @@ def test_write_secedit_data_import_fail(caplog):
     patch_cmd_retcode = patch.dict(
         win_lgpo.__salt__, {"cmd.retcode": MagicMock(return_value=1)}
     )
-    with patch_cmd_retcode:
-        assert win_lgpo._write_secedit_data("spongebob") is False
-        assert "Secedit failed to import template data" in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        with patch_cmd_retcode:
+            assert win_lgpo._write_secedit_data("spongebob") is False
+            assert "Secedit failed to import template data" in caplog.text
 
 
 def test_write_secedit_data_configure_fail(caplog):
     patch_cmd_retcode = patch.dict(
         win_lgpo.__salt__, {"cmd.retcode": MagicMock(side_effect=[0, 1])}
     )
-    with patch_cmd_retcode:
-        assert win_lgpo._write_secedit_data("spongebob") is False
-        assert "Secedit failed to apply security database" in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        with patch_cmd_retcode:
+            assert win_lgpo._write_secedit_data("spongebob") is False
+            assert "Secedit failed to apply security database" in caplog.text

--- a/tests/pytests/unit/state/test_state_compiler.py
+++ b/tests/pytests/unit/state/test_state_compiler.py
@@ -42,10 +42,11 @@ def test_format_log_list(caplog):
     """
     Test running format_log when ret is not a dictionary
     """
-    ret = ["test1", "test2"]
-    salt.state.format_log(ret)
-    assert "INFO" in caplog.text
-    assert f"{ret}" in caplog.text
+    with caplog.at_level(logging.INFO):
+        ret = ["test1", "test2"]
+        salt.state.format_log(ret)
+        assert "INFO" in caplog.text
+        assert f"{ret}" in caplog.text
 
 
 def test_render_error_on_invalid_requisite(minion_opts):


### PR DESCRIPTION
### What does this PR do?

For some reason the lowest logging level is not set while setting the logging opts from the config with dict. And on each single call like `log.trace`, `log.debug` etc. a lot of calls performed internally anyway even if the current logging level for logfile and console is not supposed to write messages with such logging level. With this change each single call to write logging message in case if the message shouldn't be show become way more lighter.

### Previous Behavior
Some delays on intensive output like `salt-run state.event` with huge amount of messages in the event bus due to the checks on calling `log.trace` and some possible delays in other parts. The case with `salt-run state.event` could cause the growth of the amount of messages to be sent to the `subscriber` inside `EventPublisher`.

### New Behavior
Way less chances to cause delays on potential intensive logging.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
