### PR TITLE
[master] Remove deprecated module search path priority

### DIFF
--- a/changelog/66025.removed.md
+++ b/changelog/66025.removed.md
@@ -1,0 +1,1 @@
+Remove deprecated module search path priority (`features.enable_deprecated_module_search_path_priority`)

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -250,17 +250,7 @@ def _module_dirs(
         if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
 
-    if opts.get("features", {}).get(
-        "enable_deprecated_module_search_path_priority", False
-    ):
-        salt.utils.versions.warn_until(
-            3008,
-            "The old module search path priority will be removed in Salt 3008. "
-            "For more information see https://github.com/saltstack/salt/pull/65938.",
-        )
-        return cli_module_dirs + ext_type_types + ext_types + sys_types
-    else:
-        return cli_module_dirs + ext_types + ext_type_types + sys_types
+    return cli_module_dirs + ext_types + ext_type_types + sys_types
 
 
 def minion_mods(

--- a/tests/pytests/functional/loader/test_loader.py
+++ b/tests/pytests/functional/loader/test_loader.py
@@ -79,24 +79,6 @@ def test_module_dirs_priority(venv, salt_extension, minion_opts, module_dirs):
             tail
         ), f"{module_dirs_return[i]} does not end with {tail}"
 
-    # Test the deprecated mode as well
-    minion_opts["features"] = {"enable_deprecated_module_search_path_priority": True}
-    ret = venv.run_code(code, input=json.dumps(minion_opts))
-    module_dirs_return = json.loads(ret.stdout)
-    assert len(module_dirs_return) == 5
-    for i, tail in enumerate(
-        [
-            "/module-dir-base/modules",
-            "/module-dir-base",
-            "/site-packages/salt_ext_loader_test/modules",
-            "/var/cache/salt/minion/extmods/modules",
-            "/site-packages/salt/modules",
-        ]
-    ):
-        assert module_dirs_return[i].endswith(
-            tail
-        ), f"{module_dirs_return[i]} does not end with {tail}"
-
 
 def test_new_entry_points_passing_module(venv, salt_extension, salt_minion_factory):
     # Install our extension into the virtualenv


### PR DESCRIPTION
### What does this PR do?

Remove the `features.enable_deprecated_module_search_path_priority` option in 3008 (introduced in #65938).

### Merge requirements satisfied?

- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
