### PR TITLE
[3007.x] Fix issue with the salt command on Windows

### DIFF
--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -32,6 +32,8 @@ except ImportError:
     HAS_GRP = False
 
 try:
+    import ctypes.wintypes
+
     import salt.utils.win_functions
 
     HAS_WIN_FUNCTIONS = True

--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -32,13 +32,15 @@ except ImportError:
     HAS_GRP = False
 
 try:
-    import ctypes.wintypes
-
     import salt.utils.win_functions
 
     HAS_WIN_FUNCTIONS = True
 except ImportError:
     HAS_WIN_FUNCTIONS = False
+
+if sys.platform == "win32":
+    import ctypes.wintypes
+
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the salt command on Windows where it checks to see if the user is running as administrator. The salt command wouldn't even start because `wintypes` could not be found. Looks like this broke when pywin32 was updated to 306, though and can't find docs stating a new way to do this. But, apparently, `ctypes.wintypes` needs to be imported in addition to just `ctypes`.

### What issues does this PR fix or reference?
Fixes: #66027 

### Previous Behavior
Couldn't run the salt command

### New Behavior
Now you can run the salt command on Windows

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes