### PR TITLE
[3006.x] Make rpms more universal by replacing systemd_* scriptlets with RHEL7/8 styled forward-compatible definitions

### DIFF
--- a/changelog/65987.fixed.md
+++ b/changelog/65987.fixed.md
@@ -1,0 +1,1 @@
+Fix RPM package systemd scriptlets to make RPM packages more universal

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -436,7 +436,7 @@ find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
 ## - Using hardcoded scriptlet definitions from RHEL 7/8 that are forward-compatible
 %preun master
 # RHEL 9 is giving warning msg if syndic is not installed, supress it
-# %systemd_preun salt-syndic.service > /dev/null 2>&1
+# %%systemd_preun salt-syndic.service > /dev/null 2>&1
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
   systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
@@ -444,7 +444,7 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %preun minion
-# %systemd_preun salt-minion.service
+# %%systemd_preun salt-minion.service
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
   systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
@@ -453,7 +453,7 @@ fi
 
 
 %preun api
-# %systemd_preun salt-api.service
+# %%systemd_preun salt-api.service
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
   systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
@@ -472,8 +472,11 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 
 
 %post master
-# %systemd_post salt-master.service
-if [ $1 -eq 1 ] ; then
+# %%systemd_post salt-master.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  systemctl retry-restart salt-master.service >/dev/null 2>&1 || :
+else
   # Initial installation
   systemctl preset salt-master.service >/dev/null 2>&1 || :
 fi
@@ -497,16 +500,22 @@ if [ $1 -lt 2 ]; then
 fi
 
 %post syndic
-# %systemd_post salt-syndic.service
-if [ $1 -eq 1 ] ; then
+# %%systemd_post salt-syndic.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  systemctl retry-restart salt-syndic.service >/dev/null 2>&1 || :
+else
   # Initial installation
   systemctl preset salt-syndic.service >/dev/null 2>&1 || :
 fi
 ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 
 %post minion
-# %systemd_post salt-minion.service
-if [ $1 -eq 1 ] ; then
+# %%systemd_post salt-minion.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  systemctl retry-restart salt-minion.service >/dev/null 2>&1 || :
+else
   # Initial installation
   systemctl preset salt-minion.service >/dev/null 2>&1 || :
 fi
@@ -531,8 +540,11 @@ fi
 ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 
 %post api
-# %systemd_post salt-api.service
-if [ $1 -eq 1 ] ; then
+# %%systemd_post salt-api.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  systemctl retry-restart salt-api.service >/dev/null 2>&1 || :
+else
   # Initial installation
   systemctl preset salt-api.service >/dev/null 2>&1 || :
 fi
@@ -576,7 +588,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun master
-# %systemd_postun_with_restart salt-master.service
+# %%systemd_postun_with_restart salt-master.service
 systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
@@ -597,7 +609,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun syndic
-# %systemd_postun_with_restart salt-syndic.service
+# %%systemd_postun_with_restart salt-syndic.service
 systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
@@ -605,7 +617,7 @@ if [ $1 -ge 1 ] ; then
 fi
 
 %postun minion
-# %systemd_postun_with_restart salt-minion.service
+# %%systemd_postun_with_restart salt-minion.service
 systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
@@ -626,7 +638,7 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun api
-# %systemd_postun_with_restart salt-api.service
+# %%systemd_postun_with_restart salt-api.service
 systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -432,17 +432,25 @@ find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
 
 
 # assumes systemd for RHEL 7 & 8 & 9
+# foregoing %systemd_* scriptlets due to RHEL 7/8 vs. RHEL 9 incompatibilities
+## - Using hardcoded scriptlet definitions from RHEL 7/8 that are forward-compatible
 %preun master
 # RHEL 9 is giving warning msg if syndic is not installed, supress it
-%systemd_preun salt-syndic.service > /dev/null 2>&1
+# %systemd_preun salt-syndic.service > /dev/null 2>&1
+systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
+systemctl stop salt-syndic.service > /dev/null 2>&1 || :
 
 
 %preun minion
-%systemd_preun salt-minion.service
+# %systemd_preun salt-minion.service
+systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
+systemctl stop salt-minion.service > /dev/null 2>&1 || :
 
 
 %preun api
-%systemd_preun salt-api.service
+# %systemd_preun salt-api.service
+systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
+systemctl stop salt-api.service > /dev/null 2>&1 || :
 
 
 %post
@@ -456,7 +464,8 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 
 
 %post master
-%systemd_post salt-master.service
+# %systemd_post salt-master.service
+systemctl preset salt-master.service >/dev/null 2>&1 || :
 ln -s -f /opt/saltstack/salt/salt %{_bindir}/salt
 ln -s -f /opt/saltstack/salt/salt-cp %{_bindir}/salt-cp
 ln -s -f /opt/saltstack/salt/salt-key %{_bindir}/salt-key
@@ -477,11 +486,13 @@ if [ $1 -lt 2 ]; then
 fi
 
 %post syndic
-%systemd_post salt-syndic.service
+# %systemd_post salt-syndic.service
+systemctl preset salt-syndic.service >/dev/null 2>&1 || :
 ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 
 %post minion
-%systemd_post salt-minion.service
+# %systemd_post salt-minion.service
+systemctl preset salt-minion.service >/dev/null 2>&1 || :
 ln -s -f /opt/saltstack/salt/salt-minion %{_bindir}/salt-minion
 ln -s -f /opt/saltstack/salt/salt-call %{_bindir}/salt-call
 ln -s -f /opt/saltstack/salt/salt-proxy %{_bindir}/salt-proxy
@@ -503,7 +514,8 @@ fi
 ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 
 %post api
-%systemd_post salt-api.service
+# %systemd_post salt-api.service
+systemctl preset salt-api.service >/dev/null 2>&1 || :
 ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 
 
@@ -544,7 +556,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun master
-%systemd_postun_with_restart salt-master.service
+# %systemd_postun_with_restart salt-master.service
+systemctl daemon-reload >/dev/null 2>&1 || :
+systemctl try-restart salt-master.service >/dev/null 2>&1 || :
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
     if [ -z "$(rpm -qi salt-minion | grep Name | grep salt-minion)" ]; then
@@ -560,10 +574,14 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun syndic
-%systemd_postun_with_restart salt-syndic.service
+# %systemd_postun_with_restart salt-syndic.service
+systemctl daemon-reload >/dev/null 2>&1 || :
+systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
 
 %postun minion
-%systemd_postun_with_restart salt-minion.service
+# %systemd_postun_with_restart salt-minion.service
+systemctl daemon-reload >/dev/null 2>&1 || :
+systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
     if [ -z "$(rpm -qi salt-master | grep Name | grep salt-master)" ]; then
@@ -579,8 +597,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %postun api
-%systemd_postun_with_restart salt-api.service
-
+# %systemd_postun_with_restart salt-api.service
+systemctl daemon-reload >/dev/null 2>&1 || :
+systemctl try-restart salt-api.service >/dev/null 2>&1 || :
 
 %changelog
 * Fri Jan 26 2024 Salt Project Packaging <saltproject-packaging@vmware.com> - 3006.6

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -437,20 +437,28 @@ find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
 %preun master
 # RHEL 9 is giving warning msg if syndic is not installed, supress it
 # %systemd_preun salt-syndic.service > /dev/null 2>&1
-systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
-systemctl stop salt-syndic.service > /dev/null 2>&1 || :
-
+if [ $1 -eq 0 ] ; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
+  systemctl stop salt-syndic.service > /dev/null 2>&1 || :
+fi
 
 %preun minion
 # %systemd_preun salt-minion.service
-systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
-systemctl stop salt-minion.service > /dev/null 2>&1 || :
+if [ $1 -eq 0 ] ; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
+  systemctl stop salt-minion.service > /dev/null 2>&1 || :
+fi
 
 
 %preun api
 # %systemd_preun salt-api.service
-systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
-systemctl stop salt-api.service > /dev/null 2>&1 || :
+if [ $1 -eq 0 ] ; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
+  systemctl stop salt-api.service > /dev/null 2>&1 || :
+fi
 
 
 %post
@@ -465,7 +473,10 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 
 %post master
 # %systemd_post salt-master.service
-systemctl preset salt-master.service >/dev/null 2>&1 || :
+if [ $1 -eq 1 ] ; then
+  # Initial installation
+  systemctl preset salt-master.service >/dev/null 2>&1 || :
+fi
 ln -s -f /opt/saltstack/salt/salt %{_bindir}/salt
 ln -s -f /opt/saltstack/salt/salt-cp %{_bindir}/salt-cp
 ln -s -f /opt/saltstack/salt/salt-key %{_bindir}/salt-key
@@ -487,12 +498,18 @@ fi
 
 %post syndic
 # %systemd_post salt-syndic.service
-systemctl preset salt-syndic.service >/dev/null 2>&1 || :
+if [ $1 -eq 1 ] ; then
+  # Initial installation
+  systemctl preset salt-syndic.service >/dev/null 2>&1 || :
+fi
 ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 
 %post minion
 # %systemd_post salt-minion.service
-systemctl preset salt-minion.service >/dev/null 2>&1 || :
+if [ $1 -eq 1 ] ; then
+  # Initial installation
+  systemctl preset salt-minion.service >/dev/null 2>&1 || :
+fi
 ln -s -f /opt/saltstack/salt/salt-minion %{_bindir}/salt-minion
 ln -s -f /opt/saltstack/salt/salt-call %{_bindir}/salt-call
 ln -s -f /opt/saltstack/salt/salt-proxy %{_bindir}/salt-proxy
@@ -515,7 +532,10 @@ ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 
 %post api
 # %systemd_post salt-api.service
-systemctl preset salt-api.service >/dev/null 2>&1 || :
+if [ $1 -eq 1 ] ; then
+  # Initial installation
+  systemctl preset salt-api.service >/dev/null 2>&1 || :
+fi
 ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 
 
@@ -558,7 +578,10 @@ fi
 %postun master
 # %systemd_postun_with_restart salt-master.service
 systemctl daemon-reload >/dev/null 2>&1 || :
-systemctl try-restart salt-master.service >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+  # Package upgrade, not uninstall
+  systemctl try-restart salt-master.service >/dev/null 2>&1 || :
+fi
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
     if [ -z "$(rpm -qi salt-minion | grep Name | grep salt-minion)" ]; then
@@ -576,12 +599,18 @@ fi
 %postun syndic
 # %systemd_postun_with_restart salt-syndic.service
 systemctl daemon-reload >/dev/null 2>&1 || :
-systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+  # Package upgrade, not uninstall
+  systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
+fi
 
 %postun minion
 # %systemd_postun_with_restart salt-minion.service
 systemctl daemon-reload >/dev/null 2>&1 || :
-systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+  # Package upgrade, not uninstall
+  systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
+fi
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
     if [ -z "$(rpm -qi salt-master | grep Name | grep salt-master)" ]; then
@@ -599,7 +628,10 @@ fi
 %postun api
 # %systemd_postun_with_restart salt-api.service
 systemctl daemon-reload >/dev/null 2>&1 || :
-systemctl try-restart salt-api.service >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+  # Package upgrade, not uninstall
+  systemctl try-restart salt-api.service >/dev/null 2>&1 || :
+fi
 
 %changelog
 * Fri Jan 26 2024 Salt Project Packaging <saltproject-packaging@vmware.com> - 3006.6

--- a/tests/pytests/pkg/integration/test_enabled_disabled.py
+++ b/tests/pytests/pkg/integration/test_enabled_disabled.py
@@ -7,15 +7,14 @@ def test_services(install_salt, salt_cli, salt_minion):
     """
     Check if Services are enabled/disabled
     """
+    services_disabled = []
+    services_enabled = []
     if install_salt.distro_id in ("ubuntu", "debian"):
         services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
-        services_disabled = []
     elif install_salt.distro_id in ("centos", "redhat", "amzn", "fedora"):
-        services_enabled = []
         services_disabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
     elif install_salt.distro_id == "photon":
         if float(install_salt.distro_version) < 5:
-            services_enabled = []
             services_disabled = [
                 "salt-master",
                 "salt-minion",
@@ -24,7 +23,6 @@ def test_services(install_salt, salt_cli, salt_minion):
             ]
         else:
             services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
-            services_disabled = []
     elif platform.is_darwin():
         services_enabled = ["salt-minion"]
         services_disabled = []

--- a/tests/pytests/pkg/integration/test_enabled_disabled.py
+++ b/tests/pytests/pkg/integration/test_enabled_disabled.py
@@ -14,15 +14,7 @@ def test_services(install_salt, salt_cli, salt_minion):
     elif install_salt.distro_id in ("centos", "redhat", "amzn", "fedora"):
         services_disabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
     elif install_salt.distro_id == "photon":
-        if float(install_salt.distro_version) < 5:
-            services_disabled = [
-                "salt-master",
-                "salt-minion",
-                "salt-syndic",
-                "salt-api",
-            ]
-        else:
-            services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
+        services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
     elif platform.is_darwin():
         services_enabled = ["salt-minion"]
         services_disabled = []


### PR DESCRIPTION
### What does this PR do?

Uses systemd_* scriptlet definitions from RHEL 7/8 that are forward-compatible with RHEL 9, allowing for the RPMs to be built on newer systems while the built artifacts are still compatible with RHEL 7/8/9.

### What issues does this PR fix or reference?
Fixes: #65987

### Previous Behavior

`systemd_*` scriptlet definitions were not compatible with RHEL 7/8 systems (including Photon OS 3, Photon OS 4, AlmaLinux 8, etc.).

### New Behavior

`systemd_*` scriptlet definitions were used from RHEL 7/8 build macros, allowing for more universal compatibility on RHEL 7/8/9 systems, regardless of OS that package is built on. Definitions have been tested on RHEL 9 systemd and work as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
