### PR TITLE
[3006.x] Clarify that state.apply with no arguments runs a highstate

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -637,7 +637,8 @@ def apply_(mods=None, **kwargs):
 
     .. rubric:: APPLYING ALL STATES CONFIGURED IN TOP.SLS (A.K.A. :ref:`HIGHSTATE <running-highstate>`)
 
-    To apply all configured states, simply run ``state.apply``:
+    To apply all configured states, simply run ``state.apply`` with no SLS
+    targets, like so:
 
     .. code-block:: bash
 


### PR DESCRIPTION
NOTE: This was supposed to be a simple docs change but precommit pulled in additional changes.