### PR TITLE
[master] Fix datetime.datetime.utcnow() deprecated in Python 3.12

### DIFF
--- a/.github/workflows/scripts/label-and-assign.py
+++ b/.github/workflows/scripts/label-and-assign.py
@@ -72,7 +72,7 @@ def label_and_assign_issue(options):
         json.dumps(
             {
                 "username": next_triage_account.login,
-                "when": str(datetime.datetime.utcnow()),
+                "when": str(datetime.datetime.now(tz=datetime.timezone.utc)),
             }
         )
     )

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -408,7 +408,7 @@ class SSH(MultiprocessingStateMixin):
                         '# Automatically added by "{s_user}" at {s_time}\n{hostname}:\n'
                         "    host: {hostname}\n    user: {user}\n    passwd: {passwd}\n".format(
                             s_user=getpass.getuser(),
-                            s_time=datetime.datetime.utcnow().isoformat(),
+                            s_time=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
                             hostname=self.opts.get("tgt", ""),
                             user=self.opts.get("ssh_user", ""),
                             passwd=self.opts.get("ssh_passwd", ""),

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -290,7 +290,7 @@ def query(
     attempts = 0
     while attempts < aws.AWS_MAX_RETRIES:
         params_with_headers = params.copy()
-        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         if not location:
             location = get_location()
@@ -327,7 +327,7 @@ def query(
         host = endpoint.strip()
 
         # Create a date for headers and the credential string
-        t = datetime.datetime.utcnow()
+        t = datetime.datetime.now(tz=datetime.timezone.utc)
         amz_date = t.strftime("%Y%m%dT%H%M%SZ")  # Format date as YYYYMMDD'T'HHMMSS'Z'
         datestamp = t.strftime("%Y%m%d")  # Date w/o time, used in credential scope
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -1159,7 +1159,7 @@ def query(action=None, command=None, args=None, method="GET", location=None, dat
     if (not user) or (not ssh_keyfile) or (not ssh_keyname) or (not location):
         return None
 
-    timenow = datetime.datetime.utcnow()
+    timenow = datetime.datetime.now(tz=datetime.timezone.utc)
     timestamp = timenow.strftime("%a, %d %b %Y %H:%M:%S %Z").strip()
     rsa_key = salt.crypt.get_rsa_key(ssh_keyfile, None)
     if HAS_M2:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2833,11 +2833,11 @@ def ip_fqdn():
             ret[key] = []
         else:
             try:
-                start_time = datetime.datetime.utcnow()
+                start_time = datetime.datetime.now(tz=datetime.timezone.utc)
                 info = socket.getaddrinfo(_fqdn, None, socket_type)
                 ret[key] = list({item[4][0] for item in info})
             except (OSError, UnicodeError):
-                timediff = datetime.datetime.utcnow() - start_time
+                timediff = datetime.datetime.now(tz=datetime.timezone.utc) - start_time
                 if timediff.seconds > 5 and __opts__["__role"] == "master":
                     log.warning(
                         'Unable to find IPv%s record for "%s" causing a %s '

--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -72,7 +72,7 @@ class CsvDB:
 
         :return:
         """
-        return datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        return datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
 
     def new(self):
         """

--- a/salt/modules/purefa.py
+++ b/salt/modules/purefa.py
@@ -52,7 +52,7 @@ Installation Prerequisites
 
 import os
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 
 from salt.exceptions import CommandExecutionError
 
@@ -235,7 +235,7 @@ def snap_create(name, suffix=None):
     array = _get_system()
     if suffix is None:
         suffix = "snap-" + str(
-            (datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
+            (datetime.now(tz=timezone.utc) - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
         )
         suffix = suffix.replace(".", "")
     if _get_volume(name, array) is not None:

--- a/salt/modules/purefb.py
+++ b/salt/modules/purefb.py
@@ -51,7 +51,7 @@ Installation Prerequisites
 
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from salt.exceptions import CommandExecutionError
 
@@ -195,7 +195,7 @@ def snap_create(name, suffix=None):
     blade = _get_blade()
     if suffix is None:
         suffix = "snap-" + str(
-            (datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
+            (datetime.now(tz=timezone.utc) - datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
         )
         suffix = suffix.replace(".", "")
     if _get_fs(name, blade) is not None:

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -14,7 +14,7 @@ Support for reboot, shutdown, etc on POSIX-like systems.
 
 import os.path
 import re
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, tzinfo, timezone
 
 import salt.utils.files
 import salt.utils.path
@@ -255,7 +255,7 @@ def _get_offset_time(utc_offset):
     if utc_offset is not None:
         minutes = _offset_to_min(utc_offset)
         offset = timedelta(minutes=minutes)
-        offset_time = datetime.utcnow() + offset
+        offset_time = datetime.now(tz=timezone.utc) + offset
         offset_time = offset_time.replace(tzinfo=_FixedOffset(minutes))
     else:
         offset_time = datetime.now()

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -105,7 +105,7 @@ import math
 import os
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import salt.utils.data
 import salt.utils.files
@@ -357,7 +357,7 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
                 try:
                     days = (
                         datetime.strptime(cert.get_notAfter(), "%Y%m%d%H%M%SZ")
-                        - datetime.utcnow()
+                        - datetime.now(tz=timezone.utc)
                     ).days
                 except (ValueError, TypeError):
                     days = 365
@@ -763,7 +763,7 @@ def create_ca(
                     err,
                 )
                 bck = "{}.unloadable.{}".format(
-                    ca_keyp, datetime.utcnow().strftime("%Y%m%d%H%M%S")
+                    ca_keyp, datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
                 )
                 log.info("Saving unloadable CA ssl key in %s", bck)
                 os.rename(ca_keyp, bck)
@@ -821,7 +821,7 @@ def create_ca(
     keycontent = OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
     write_key = True
     if os.path.exists(ca_keyp):
-        bck = "{}.{}".format(ca_keyp, datetime.utcnow().strftime("%Y%m%d%H%M%S"))
+        bck = "{}.{}".format(ca_keyp, datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S"))
         with salt.utils.files.fopen(ca_keyp) as fic:
             old_key = salt.utils.stringutils.to_unicode(fic.read()).strip()
             if old_key.strip() == keycontent.strip():
@@ -1912,7 +1912,7 @@ def revoke_cert(
     )
     index_r_data = "R\t{}\t{}\t{}".format(
         expire_date,
-        _four_digit_year_to_two_digit(datetime.utcnow()),
+        _four_digit_year_to_two_digit(datetime.now(tz=timezone.utc)),
         index_serial_subject,
     )
 

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -2,7 +2,7 @@
 Module for managing timezone on Windows systems.
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from salt.exceptions import CommandExecutionError
 
@@ -240,7 +240,7 @@ def get_offset():
     """
     # http://craigglennie.com/programming/python/2013/07/21/working-with-timezones-using-Python-and-pytz-localize-vs-normalize/
     tz_object = pytz.timezone(get_zone())
-    utc_time = pytz.utc.localize(datetime.utcnow())
+    utc_time = pytz.utc.localize(datetime.now(tz=timezone.utc))
     loc_time = utc_time.astimezone(tz_object)
     norm_time = tz_object.normalize(loc_time)
     return norm_time.strftime("%z")
@@ -260,7 +260,7 @@ def get_zonecode():
         salt '*' timezone.get_zonecode
     """
     tz_object = pytz.timezone(get_zone())
-    loc_time = tz_object.localize(datetime.utcnow())
+    loc_time = tz_object.localize(datetime.now(tz=timezone.utc))
     return loc_time.tzname()
 
 

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1959,7 +1959,7 @@ def expired(certificate):
             ret["path"] = certificate
             cert = _get_certificate_obj(certificate)
 
-            _now = datetime.datetime.utcnow()
+            _now = datetime.datetime.now(tz=datetime.timezone.utc)
             _expiration_date = cert.get_not_after().get_datetime()
 
             ret["cn"] = _parse_subject(cert.get_subject())["CN"]
@@ -2003,7 +2003,7 @@ def will_expire(certificate, days):
 
             cert = _get_certificate_obj(certificate)
 
-            _check_time = datetime.datetime.utcnow() + datetime.timedelta(days=days)
+            _check_time = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=days)
             _expiration_date = cert.get_not_after().get_datetime()
 
             ret["cn"] = _parse_subject(cert.get_subject())["CN"]

--- a/salt/modules/x509_v2.py
+++ b/salt/modules/x509_v2.py
@@ -1407,7 +1407,7 @@ def expires(certificate, days=0):
     """
     cert = x509util.load_cert(certificate)
     # dates are encoded in UTC/GMT, they are returned as a naive datetime object
-    return cert.not_valid_after <= datetime.datetime.utcnow() + datetime.timedelta(
+    return cert.not_valid_after <= datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
         days=days
     )
 

--- a/salt/spm/pkgdb/sqlite3.py
+++ b/salt/spm/pkgdb/sqlite3.py
@@ -167,7 +167,7 @@ def register_pkg(name, formula_def, conn=None):
             name,
             formula_def["version"],
             formula_def["release"],
-            datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT"),
+            datetime.datetime.now(tz=datetime.timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT"),
             formula_def.get("os", None),
             formula_def.get("os_family", None),
             formula_def.get("dependencies", None),

--- a/salt/state.py
+++ b/salt/state.py
@@ -173,11 +173,11 @@ def _calculate_fake_duration():
     Generate a NULL duration for when states do not run
     but we want the results to be consistent.
     """
-    utc_start_time = datetime.datetime.utcnow()
+    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
     local_start_time = utc_start_time - (
-        datetime.datetime.utcnow() - datetime.datetime.now()
+        datetime.datetime.now(tz=datetime.timezone.utc) - datetime.datetime.now()
     )
-    utc_finish_time = datetime.datetime.utcnow()
+    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
     start_time = local_start_time.time().isoformat()
     delta = utc_finish_time - utc_start_time
     # duration in milliseconds.microseconds
@@ -2153,7 +2153,7 @@ class State:
             instance = cls(**init_kwargs)
         # we need to re-record start/end duration here because it is impossible to
         # correctly calculate further down the chain
-        utc_start_time = datetime.datetime.utcnow()
+        utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
         instance.format_slots(cdata)
         tag = _gen_tag(low)
@@ -2173,8 +2173,8 @@ class State:
                 "comment": f"An exception occurred in this state: {trb}",
             }
 
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        timezone_delta = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.datetime.now()
         local_finish_time = utc_finish_time - timezone_delta
         local_start_time = utc_start_time - timezone_delta
         ret["start_time"] = local_start_time.time().isoformat()
@@ -2206,8 +2206,8 @@ class State:
                         *cdata["args"], **cdata["kwargs"]
                     )
 
-                    utc_start_time = datetime.datetime.utcnow()
-                    utc_finish_time = datetime.datetime.utcnow()
+                    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+                    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
                     delta = utc_finish_time - utc_start_time
                     duration = (delta.seconds * 1000000 + delta.microseconds) / 1000.0
                     retry_ret["duration"] = duration
@@ -2294,9 +2294,9 @@ class State:
         Call a state directly with the low data structure, verify data
         before processing.
         """
-        utc_start_time = datetime.datetime.utcnow()
+        utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
         local_start_time = utc_start_time - (
-            datetime.datetime.utcnow() - datetime.datetime.now()
+            datetime.datetime.now(tz=datetime.timezone.utc) - datetime.datetime.now()
         )
         log.info(
             "Running state [%s] at time %s",
@@ -2486,8 +2486,8 @@ class State:
         self.__run_num += 1
         format_log(ret)
         self.check_refresh(low, ret)
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        timezone_delta = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.datetime.now()
         local_finish_time = utc_finish_time - timezone_delta
         local_start_time = utc_start_time - timezone_delta
         ret["start_time"] = local_start_time.time().isoformat()

--- a/salt/states/boto_dynamodb.py
+++ b/salt/states/boto_dynamodb.py
@@ -833,7 +833,7 @@ def _next_datetime_with_utc_hour(table_name, utc_hour):
         second=_get_deterministic_value_for_table_name(table_name, 60),
     )
 
-    if start_date_time < datetime.datetime.utcnow():
+    if start_date_time < datetime.datetime.now(tz=datetime.timezone.utc):
         one_day = datetime.timedelta(days=1)
         start_date_time += one_day
 

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -294,7 +294,7 @@ def thing_type_absent(
                 _deprecation_date_str, "%Y-%m-%d %H:%M:%S.%f"
             )
 
-            _elapsed_time_delta = datetime.datetime.utcnow() - _deprecation_date
+            _elapsed_time_delta = datetime.datetime.now(tz=datetime.timezone.utc) - _deprecation_date
             if _elapsed_time_delta.seconds >= 300:
                 _delete_wait_timer = 0
             else:

--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -335,7 +335,7 @@ def team_present(
 
     manage_members = members is not None
 
-    mfa_deadline = datetime.datetime.utcnow() - datetime.timedelta(
+    mfa_deadline = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
         seconds=no_mfa_grace_seconds
     )
     members_no_mfa = __salt__["github.list_members_without_mfa"](profile=profile)

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -489,7 +489,7 @@ def certificate_managed(
 
                 if (
                     current.not_valid_after
-                    < datetime.datetime.utcnow()
+                    < datetime.datetime.now(tz=datetime.timezone.utc)
                     + datetime.timedelta(days=days_remaining)
                 ):
                     changes["expiration"] = True
@@ -897,7 +897,7 @@ def crl_managed(
                     changes["encoding"] = encoding
                 if days_remaining and (
                     current.next_update
-                    < datetime.datetime.utcnow()
+                    < datetime.datetime.now(tz=datetime.timezone.utc)
                     + datetime.timedelta(days=days_remaining)
                 ):
                     changes["expiration"] = True

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -17,7 +17,7 @@ import re
 import time
 import urllib.parse
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -120,7 +120,7 @@ def creds(provider):
     ## if needed
     if provider["id"] == IROLE_CODE or provider["key"] == IROLE_CODE:
         # Check to see if we have cache credentials that are still good
-        if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime(
+        if not __Expiration__ or __Expiration__ < datetime.now(tz=timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         ):
             # We don't have any cached credentials, or they are expired, get them
@@ -163,7 +163,7 @@ def sig2(method, endpoint, params, provider, aws_api_version):
 
     http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
     """
-    timenow = datetime.utcnow()
+    timenow = datetime.now(tz=timezone.utc)
     timestamp = timenow.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Retrieve access credentials from meta-data, or use provided
@@ -200,7 +200,7 @@ def assumed_creds(prov_dict, role_arn, location=None):
     valid_session_name_re = re.compile("[^a-z0-9A-Z+=,.@-]")
 
     # current time in epoch seconds
-    now = time.mktime(datetime.utcnow().timetuple())
+    now = time.mktime(datetime.now(tz=timezone.utc).timetuple())
 
     for key, creds in copy.deepcopy(__AssumeCache__).items():
         if (creds["Expiration"] - now) <= 120:
@@ -273,7 +273,7 @@ def sig4(
     http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
     http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     """
-    timenow = datetime.utcnow()
+    timenow = datetime.now(tz=timezone.utc)
 
     # Retrieve access credentials from meta-data, or use provided
     if role_arn is None:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -730,7 +730,7 @@ class SaltEvent:
             if not self.connect_pull(timeout=timeout_s):
                 return False
 
-        data["_stamp"] = datetime.datetime.utcnow().isoformat()
+        data["_stamp"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
         self.pusher.publish(msg)
@@ -765,7 +765,7 @@ class SaltEvent:
             if not self.connect_pull(timeout=timeout_s):
                 return False
 
-        data["_stamp"] = datetime.datetime.utcnow().isoformat()
+        data["_stamp"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
         if self._run_io_loop_sync:

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import os
 from calendar import month_abbr as months
+from datetime import datetime, timezone
 
 import salt.utils.stringutils
 
@@ -16,7 +17,7 @@ def _utc_now():
     """
     Helper method so tests do not have to patch the built-in method.
     """
-    return datetime.datetime.utcnow()
+    return datetime.now(tz=timezone.utc)
 
 
 def gen_jid(opts):

--- a/salt/utils/timeutil.py
+++ b/salt/utils/timeutil.py
@@ -6,6 +6,7 @@ Functions various time manipulations.
 import logging
 import time
 from datetime import datetime, timedelta
+from datetime import datetime, timezone
 
 # Import Salt modules
 
@@ -33,7 +34,7 @@ def get_timestamp_at(time_in=None, time_at=None):
                 minutes = 0
             hours, minutes = int(hours), int(minutes)
         dt = timedelta(hours=hours, minutes=minutes)
-        time_now = datetime.utcnow()
+        time_now = datetime.now(tz=timezone.utc)
         time_at = time_now + dt
         return time.mktime(time_at.timetuple())
     elif time_at:

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -242,7 +242,7 @@ def warn_until_date(
         # Attribute the warning to the calling function, not to warn_until_date()
         stacklevel = 2
 
-    today = _current_date or datetime.datetime.utcnow().date()
+    today = _current_date or datetime.datetime.now(tz=datetime.timezone.utc).date()
     if today >= date:
         caller = inspect.getframeinfo(sys._getframe(stacklevel - 1))
         deprecated_message = (

--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -315,12 +315,12 @@ def build_crt(
     not_before = (
         datetime.datetime.strptime(not_before, TIME_FMT)
         if not_before
-        else datetime.datetime.utcnow()
+        else datetime.datetime.now(tz=datetime.timezone.utc)
     )
     not_after = (
         datetime.datetime.strptime(not_after, TIME_FMT)
         if not_after
-        else datetime.datetime.utcnow() + datetime.timedelta(days=days_valid)
+        else datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=days_valid)
     )
     builder = builder.not_valid_before(not_before).not_valid_after(not_after)
 
@@ -440,14 +440,14 @@ def build_crl(
             raise SaltInvocationError("Need serial_number or certificate")
         serial_number = _get_serial_number(serial_number)
         if not_after and not include_expired:
-            if datetime.datetime.utcnow() > not_after:
+            if datetime.datetime.now(tz=datetime.timezone.utc) > not_after:
                 continue
         if "revocation_date" in rev:
             revocation_date = datetime.datetime.strptime(
                 rev["revocation_date"], TIME_FMT
             )
         else:
-            revocation_date = datetime.datetime.utcnow()
+            revocation_date = datetime.datetime.now(tz=datetime.timezone.utc)
 
         revoked_cert = cx509.RevokedCertificateBuilder(
             serial_number=serial_number, revocation_date=revocation_date

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 
 # pylint: disable=no-name-in-module
 from distutils import log
@@ -54,7 +54,7 @@ except ImportError:
 try:
     DATE = datetime.utcfromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
 except (KeyError, ValueError):
-    DATE = datetime.utcnow()
+    DATE = datetime.now(tz=timezone.utc)
 
 # Change to salt source's directory prior to running any command
 try:

--- a/tests/pytests/functional/modules/test_system.py
+++ b/tests/pytests/functional/modules/test_system.py
@@ -49,7 +49,7 @@ def fmt_str():
 
 @pytest.fixture(scope="function")
 def setup_teardown_vars(file, service, system):
-    _orig_time = datetime.datetime.utcnow()
+    _orig_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
     if os.path.isfile("/etc/machine-info"):
         with salt.utils.files.fopen("/etc/machine-info", "r") as mach_info:
@@ -186,7 +186,7 @@ def test_get_system_date_time_utc(setup_teardown_vars, system, fmt_str):
     """
     Test we are able to get the correct time with utc
     """
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.datetime.now(tz=datetime.timezone.utc)
     res = system.get_system_date_time("+0000")
     t2 = datetime.datetime.strptime(res, fmt_str)
     msg = "Difference in times is too large. Now: {} Fake: {}".format(t1, t2)
@@ -222,10 +222,10 @@ def test_set_system_date_time_utc(setup_teardown_vars, system, hwclock_has_compa
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7)
     result = _set_time(system, cmp_time, offset="+0000")
 
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time
@@ -245,11 +245,11 @@ def test_set_system_date_time_utcoffset_east(
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7)
     # 25200 seconds = 7 hours
     time_to_set = cmp_time - datetime.timedelta(seconds=25200)
     result = _set_time(system, time_to_set, offset="-0700")
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time
@@ -269,11 +269,11 @@ def test_set_system_date_time_utcoffset_west(
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7)
     # 7200 seconds = 2 hours
     time_to_set = cmp_time + datetime.timedelta(seconds=7200)
     result = _set_time(system, time_to_set, offset="+0200")
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time

--- a/tests/pytests/unit/test_fileserver.py
+++ b/tests/pytests/unit/test_fileserver.py
@@ -52,7 +52,7 @@ def test_future_file_list_cache_file_ignored(tmp_path):
                 _f.write(b"\x80")
 
     # Set modification time to file list cache file to 1 year in the future
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     future = now + datetime.timedelta(days=365)
     mod_time = time.mktime(future.timetuple())
     os.utime(os.path.join(back_cachedir, "base.p"), (mod_time, mod_time))

--- a/tests/pytests/unit/utils/test_aws.py
+++ b/tests/pytests/unit/utils/test_aws.py
@@ -7,7 +7,7 @@
 import io
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import requests
@@ -78,11 +78,11 @@ def test_get_metadata_imdsv2():
 def test_assumed_creds_not_updating_dictionary_while_iterating():
     mock_cache = {
         "expired": {
-            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+            "Expiration": time.mktime(datetime.now(tz=timezone.utc).timetuple()),
         },
         "not_expired_1": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(days=1)).timetuple()
+                (datetime.now(tz=timezone.utc) + timedelta(days=1)).timetuple()
             ),
             "AccessKeyId": "mock_AccessKeyId",
             "SecretAccessKey": "mock_SecretAccessKey",
@@ -90,7 +90,7 @@ def test_assumed_creds_not_updating_dictionary_while_iterating():
         },
         "not_expired_2": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+                (datetime.now(tz=timezone.utc) + timedelta(seconds=300)).timetuple()
             ),
         },
     }
@@ -103,11 +103,11 @@ def test_assumed_creds_not_updating_dictionary_while_iterating():
 def test_assumed_creds_deletes_expired_key():
     mock_cache = {
         "expired": {
-            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+            "Expiration": time.mktime(datetime.now(tz=timezone.utc).timetuple()),
         },
         "not_expired_1": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(days=1)).timetuple()
+                (datetime.now(tz=timezone.utc) + timedelta(days=1)).timetuple()
             ),
             "AccessKeyId": "mock_AccessKeyId",
             "SecretAccessKey": "mock_SecretAccessKey",
@@ -115,7 +115,7 @@ def test_assumed_creds_deletes_expired_key():
         },
         "not_expired_2": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+                (datetime.now(tz=timezone.utc) + timedelta(seconds=300)).timetuple()
             ),
         },
     }
@@ -152,7 +152,7 @@ def test_creds_with_role_arn_should_always_call_assumed_creds():
     access_key_id = "mock_AccessKeyId"
     secret_access_key = "mock_SecretAccessKey"
     token = "mock_Token"
-    expiration = (datetime.utcnow() + timedelta(seconds=900)).strftime(
+    expiration = (datetime.now(tz=timezone.utc) + timedelta(seconds=900)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
 

--- a/tests/unit/modules/test_x509.py
+++ b/tests/unit/modules/test_x509.py
@@ -185,7 +185,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
 
         fmt = "%Y-%m-%d %H:%M:%S"
         # We also gonna use the current date in UTC format for verification
-        not_after = datetime.datetime.utcnow()
+        not_after = datetime.datetime.now(tz=datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_after = not_after.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_after_str = datetime.datetime.strftime(not_after, fmt)
@@ -226,7 +226,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
 
         fmt = "%Y-%m-%d %H:%M:%S"
         # We also gonna use the current date in UTC format for verification
-        not_before = datetime.datetime.utcnow()
+        not_before = datetime.datetime.now(tz=datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_before = not_before.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_before_str = datetime.datetime.strftime(not_before, fmt)
@@ -319,7 +319,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
         fmt = "%Y-%m-%d %H:%M:%S"
         # Here we gonna use the current date as the not_before date
         # First we again take the UTC for verification
-        not_before = datetime.datetime.utcnow()
+        not_before = datetime.datetime.now(tz=datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_before = not_before.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_before_str = datetime.datetime.strftime(not_before, fmt)

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -104,7 +104,7 @@ def update_rpm(ctx: Context, salt_version: Version, draft: bool = False):
         capture=True,
         check=True,
     ).stdout.decode()
-    dt = datetime.datetime.utcnow()
+    dt = datetime.datetime.now(tz=datetime.timezone.utc)
     date = dt.strftime("%a %b %d %Y")
     header = f"* {date} Salt Project Packaging <saltproject-packaging@vmware.com> - {str_salt_version}\n"
     parts = orig.split("%changelog")
@@ -147,7 +147,7 @@ def update_deb(ctx: Context, salt_version: Version, draft: bool = False):
         salt_version = _get_salt_version(ctx)
     changes = _get_pkg_changelog_contents(ctx, salt_version)
     formated = "\n".join([f"  {_.replace('-', '*', 1)}" for _ in changes.split("\n")])
-    dt = datetime.datetime.utcnow()
+    dt = datetime.datetime.now(tz=datetime.timezone.utc)
     date = dt.strftime("%a, %d %b %Y %H:%M:%S +0000")
     tmpchanges = "pkg/rpm/salt.spec.1"
     debian_changelog_path = "pkg/debian/changelog"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -11,7 +11,7 @@ import os
 import pathlib
 import shutil
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import boto3
@@ -485,7 +485,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime('%Y-%m-%d')}/"
+            base_url = f"salt-dev/{nightly_build_from}/{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}/"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"

--- a/tools/utils/repo.py
+++ b/tools/utils/repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ptscripts import Context
@@ -87,7 +87,7 @@ def create_top_level_repo_path(
             create_repo_path
             / "salt-dev"
             / nightly_build_from
-            / datetime.utcnow().strftime("%Y-%m-%d")
+            / datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
         )
         create_repo_path.mkdir(exist_ok=True, parents=True)
         with ctx.chdir(create_repo_path.parent):

--- a/tools/vm.py
+++ b/tools/vm.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import textwrap
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from typing import TYPE_CHECKING, cast
 
@@ -1103,7 +1103,7 @@ class VM:
                     }
                 )
         else:
-            name = f"{self.name} started on {datetime.utcnow()}"
+            name = f"{self.name} started on {datetime.now(tz=timezone.utc)}"
         tags.append(
             {
                 "Key": "Name",


### PR DESCRIPTION
### What does this PR do?
This changes all instances of datetime.utcnow() to datetime.now(tz=timezone.utc).
### What issues does this PR fix or reference?
Fixes: #65604

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
