### PR TITLE
[3006.x] Try disconnecting while we wait

### DIFF
--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -72,12 +72,12 @@ def install(app_id, enable=True, tries=3, wait=10):
                         "Error installing app({}): {}".format(app_id, exc)
                     )
                 elif num_tries < tries:
-                    time.sleep(wait)
                     num_tries += 1
                 else:
                     raise CommandExecutionError(
                         "Error installing app({}): {}".format(app_id, exc)
                     )
+        time.sleep(wait)
 
 
 def installed(app_id):


### PR DESCRIPTION
Another round of trying to fix the `attempt to write a readonly database` flaky mac os tests. If this doesn't resolve those flaky tests we should mark them as XFAIL since the only report we have acknowledges the issue and has no resolution to date: #37356