### PR TITLE
[3006.x] Make sure the root minion process handles SIGUSR1

### DIFF
--- a/changelog/66095.fixed.md
+++ b/changelog/66095.fixed.md
@@ -1,0 +1,1 @@
+Make sure the root minion process handles SIGUSR1 and emits a traceback like the child minion processes

--- a/changelog/66095.fixed.md
+++ b/changelog/66095.fixed.md
@@ -1,1 +1,1 @@
-Make sure the root minion process handles SIGUSR1 and emits a traceback like the child minion processes
+Make sure the root minion process handles SIGUSR1 and emits a traceback like it's child processes

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -162,8 +162,11 @@ def salt_minion():
     """
     import signal
 
+    import salt.utils.debug
     import salt.utils.platform
     import salt.utils.process
+
+    salt.utils.debug.enable_sigusr1_handler()
 
     salt.utils.process.notify_systemd()
 


### PR DESCRIPTION
### What does this PR do?

Makes the root minion process handle SIGUSR1 as described here https://docs.saltproject.io/en/latest/topics/troubleshooting/minion.html#live-python-debug-output

### What issues does this PR fix or reference?
References: https://github.com/saltstack/salt/pull/1241
 
### Previous Behavior

Minion dies:

```
kill -USR1 $(pgrep -fw salt-minion | head -1)

salt-minion
zsh: user-defined signal 1  salt-minion
[ERROR   ] Minion process encountered exception: [Errno 3] No such process
```

### New Behavior

Sending SIGUSR1 prints a traceback

### Merge requirements satisfied?

- [ ] Docs - covered by existing ones
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests - not sure how to write one. Any hints?
 
### Commits signed with GPG?
No
