### PR TITLE
[master] Fix file.is_link hangs on paths that are hung mounts

### DIFF
--- a/changelog/66096.fixed.md
+++ b/changelog/66096.fixed.md
@@ -1,0 +1,1 @@
+Fix file.is_link hangs on paths that are hung mounts

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3815,9 +3815,23 @@ def is_hardlink(path):
     return res and res["st_nlink"] > 1
 
 
-def is_link(path):
+def is_link(path, nostat=False):
     """
     Check if the path is a symbolic link
+
+    Args:
+
+        path (str): The path to check if it is a link.
+
+        nostat (bool):
+            Use information from parent directory to determine if entry
+            is a symbolic link. This avoids the stat operation, which
+            may hang under certain circumstances.
+
+            .. versionadded:: 3008.0
+
+    Returns:
+        bool: ``True`` if a symbolic link, otherwise returns ``False``.
 
     CLI Example:
 
@@ -3829,6 +3843,17 @@ def is_link(path):
     # therefore a custom function will need to be called. This function
     # therefore helps API consistency by providing a single function to call for
     # both operating systems.
+    if nostat:
+        if not os.path.exists(path):
+            return False
+
+        parent_directory = os.path.dirname(path)
+
+        with os.scandir(path=parent_directory) as directory_contents:
+            for item in directory_contents:
+                if item.path == path:
+                    return item.is_symlink()
+        return False
 
     return os.path.islink(os.path.expanduser(path))
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3826,7 +3826,10 @@ def is_link(path, nostat=False):
         nostat (bool):
             Use information from parent directory to determine if entry
             is a symbolic link. This avoids the stat operation, which
-            may hang under certain circumstances.
+            may hang under certain circumstances. For example, NFS mounts
+            which have gone offline or are suffering some network issues.
+            This will make the check quite slower on parent directories
+            with a lot of files, but will reduce the chances of hanging.
 
             .. versionadded:: 3008.0
 
@@ -3844,9 +3847,6 @@ def is_link(path, nostat=False):
     # therefore helps API consistency by providing a single function to call for
     # both operating systems.
     if nostat:
-        if not os.path.exists(path):
-            return False
-
         parent_directory = os.path.dirname(path)
 
         with os.scandir(path=parent_directory) as directory_contents:

--- a/tests/pytests/functional/modules/file/test_is_link.py
+++ b/tests/pytests/functional/modules/file/test_is_link.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def file(modules):
+    return modules.file
+
+
+@pytest.fixture(scope="function")
+def source():
+    with pytest.helpers.temp_file(contents="Source content") as source:
+        yield source
+
+
+def test_is_link_nostat(file, source):
+    target = source.parent / "symlink.lnk"
+    target.symlink_to(source)
+    try:
+        assert file.is_link(str(source), nostat=True) is False
+        assert file.is_link(str(target), nostat=True) is True
+    finally:
+        target.unlink()


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #66096

### Previous Behavior
It was possible for the `file.is_link` function to hang if the target was on a hung mount.

### New Behavior
The `nostat` parameter handles link checking in a way that won't hang in those circumstances.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
