### PR TITLE
[master] Fix file.managed and file.serialize default tmp_dir to relative path

### DIFF
--- a/changelog/66098.fixed.md
+++ b/changelog/66098.fixed.md
@@ -1,0 +1,1 @@
+Fix file.managed and file.serialize default tmp_dir to relative path

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2295,7 +2295,7 @@ def managed(
     show_changes=True,
     create=True,
     contents=None,
-    tmp_dir="",
+    tmp_dir=None,
     tmp_ext="",
     contents_pillar=None,
     contents_grains=None,
@@ -8029,7 +8029,7 @@ def serialize(
     serializer_opts=None,
     deserializer_opts=None,
     check_cmd=None,
-    tmp_dir="",
+    tmp_dir=None,
     tmp_ext="",
     **kwargs,
 ):

--- a/tests/pytests/unit/states/file/test_serialize.py
+++ b/tests/pytests/unit/states/file/test_serialize.py
@@ -1,0 +1,46 @@
+import pytest
+
+import salt.serializers.json as jsonserializer
+import salt.serializers.msgpack as msgpackserializer
+import salt.serializers.plist as plistserializer
+import salt.serializers.python as pythonserializer
+import salt.serializers.yaml as yamlserializer
+import salt.states.file as filestate
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        filestate: {
+            "__env__": "base",
+            "__salt__": {"file.manage_file": False},
+            "__serializers__": {
+                "yaml.serialize": yamlserializer.serialize,
+                "yaml.seserialize": yamlserializer.serialize,
+                "python.serialize": pythonserializer.serialize,
+                "json.serialize": jsonserializer.serialize,
+                "plist.serialize": plistserializer.serialize,
+                "msgpack.serialize": msgpackserializer.serialize,
+            },
+            "__opts__": {"test": False, "cachedir": ""},
+            "__instance_id__": "",
+            "__low__": {},
+            "__utils__": {},
+        }
+    }
+
+
+def test_file_managed_tmp_dir_system_temp(tmp_path):
+    tmp_file = tmp_path / "tmp.txt"
+    mock_mkstemp = MagicMock()
+    with patch("salt.utils.files.mkstemp", mock_mkstemp), patch.dict(
+        filestate.__salt__,
+        {
+            "cmd.run_all": MagicMock(return_value={"retcode": 0}),
+            "file.file_exists": MagicMock(return_value=False),
+            "file.manage_file": MagicMock(),
+        },
+    ):
+        filestate.serialize(str(tmp_file), dataset={"wollo": "herld"}, check_cmd="true")
+        mock_mkstemp.assert_called_with(suffix="", dir=None)

--- a/tests/pytests/unit/states/file/test_serialize.py
+++ b/tests/pytests/unit/states/file/test_serialize.py
@@ -31,7 +31,7 @@ def configure_loader_modules():
     }
 
 
-def test_file_managed_tmp_dir_system_temp(tmp_path):
+def test_file_serialize_tmp_dir_system_temp(tmp_path):
     tmp_file = tmp_path / "tmp.txt"
     mock_mkstemp = MagicMock()
     with patch("salt.utils.files.mkstemp", mock_mkstemp), patch.dict(


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #66098

### Previous Behavior
`tmp_dir` for `check_cmd` was relative by default.

### New Behavior
`tmp_dir` for `check_cmd` uses system temp by default.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
