### PR TITLE
[3006.x] Fix file.directory clobbering paths in test mode when backupname=True

### DIFF
--- a/changelog/66049.fixed.md
+++ b/changelog/66049.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue with file.directory state where paths would be modified in test
+mode if backupname is used.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3897,13 +3897,25 @@ def directory(
                 if not force:
                     return _error(
                         ret,
-                        "File exists where the backup target {} should go".format(
-                            backupname
-                        ),
+                        f"File exists where the backup target {backupname} should go",
                     )
+                if __opts__["test"]:
+                    ret["changes"][
+                        "forced"
+                    ] = f"Existing file at backup path {backupname} would be removed"
                 else:
                     __salt__["file.remove"](backupname)
-            os.rename(name, backupname)
+
+            if __opts__["test"]:
+                ret["changes"]["backup"] = f"{name} would be renamed to {backupname}"
+                ret["changes"][name] = {"directory": "new"}
+                ret[
+                    "comment"
+                ] = f"{name} would be backed up and replaced with a new directory"
+                ret["result"] = None
+                return ret
+            else:
+                os.rename(name, backupname)
         elif force:
             # Remove whatever is in the way
             if os.path.isfile(name):

--- a/tests/pytests/functional/states/file/test_directory.py
+++ b/tests/pytests/functional/states/file/test_directory.py
@@ -436,3 +436,55 @@ def test_issue_12209_follow_symlinks(
         assert one_group_check == state_file_account.group.name
         two_group_check = modules.file.get_group(str(twodir), follow_symlinks=False)
         assert two_group_check == state_file_account.group.name
+
+
+@pytest.mark.parametrize("backupname_isfile", [False, True])
+def test_directory_backupname_force_test_mode_noclobber(
+    file, tmp_path, backupname_isfile
+):
+    """
+    Ensure that file.directory does not make changes when backupname is used
+    alongside force=True and test=True.
+
+    See https://github.com/saltstack/salt/issues/66049
+    """
+    source_dir = tmp_path / "source_directory"
+    dest_dir = tmp_path / "dest_directory"
+    backupname = tmp_path / "backup_dir"
+    source_dir.mkdir()
+    dest_dir.symlink_to(source_dir.resolve())
+
+    if backupname_isfile:
+        backupname.touch()
+        assert backupname.is_file()
+
+    ret = file.directory(
+        name=str(dest_dir),
+        allow_symlink=False,
+        force=True,
+        backupname=str(backupname),
+        test=True,
+    )
+
+    # Confirm None result
+    assert ret.result is None
+    try:
+        # Confirm dest_dir not modified
+        assert dest_dir.readlink() == source_dir
+    except OSError:
+        pytest.fail(f"{dest_dir} was modified")
+
+    # Confirm that comment and changes match what we expect
+    assert (
+        ret.comment
+        == f"{dest_dir} would be backed up and replaced with a new directory"
+    )
+    assert ret.changes[str(dest_dir)] == {"directory": "new"}
+    assert ret.changes["backup"] == f"{dest_dir} would be renamed to {backupname}"
+
+    if backupname_isfile:
+        assert ret.changes["forced"] == (
+            f"Existing file at backup path {backupname} would be removed"
+        )
+    else:
+        assert "forced" not in ret.changes


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with the `file.directory` state where paths would be modified in test mode if `backupname` is used.

### What issues does this PR fix or reference?
Fixes: #66049

### Previous Behavior

Even with `test=True`, backup path would be forcibly removed if present, and destination path renamed to that backup path. However, a directory would not be created at the specified path. So, instead of doing nothing, the state makes partial changes.

### New Behavior

No changes are made in test mode when `backupname` is used.

### Merge requirements satisfied?
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No