### PR TITLE
[master] Quench unwanted event printouts from master runner

### DIFF
--- a/changelog/58203.fixed.md
+++ b/changelog/58203.fixed.md
@@ -1,0 +1,1 @@
+Fix unwanted YAML event output to stdout when runner functions are executed via the salt master API (peer minion runner path). Pass ``print_event=False`` through ``Runner.run()`` and ``_proc_function`` to suppress event printing in ``RemoteFuncs.minion_runner``.

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -528,6 +528,7 @@ class AsyncClientMixin(ClientStateMixin):
         tag,
         jid,
         daemonize=True,
+        print_event=True,
         full_return=False,
     ):
         """
@@ -553,7 +554,7 @@ class AsyncClientMixin(ClientStateMixin):
         low["__user__"] = user
         low["__tag__"] = tag
 
-        return instance.low(fun, low, full_return=full_return)
+        return instance.low(fun, low, print_event=print_event, full_return=full_return)
 
     def cmd_async(self, low):
         """

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -947,7 +947,7 @@ class RemoteFuncs:
             }
         )
         runner = salt.runner.Runner(opts)
-        return runner.run()
+        return runner.run(print_event=False)
 
     def pub_ret(self, load, skip_verify=False):
         """

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -309,6 +309,7 @@ class Runner(RunnerClient):
                         tag=async_pub["tag"],
                         jid=async_pub["jid"],
                         daemonize=False,
+                        print_event=False,
                         full_return=full_return,
                     )
             except salt.exceptions.SaltException as exc:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -207,7 +207,7 @@ class Runner(RunnerClient):
             print(docs[fun])
 
     # TODO: move to mixin whenever we want a salt-wheel cli
-    def run(self, full_return=False):
+    def run(self, print_event=True, full_return=False):
         """
         Execute the runner sequence
         """
@@ -309,7 +309,7 @@ class Runner(RunnerClient):
                         tag=async_pub["tag"],
                         jid=async_pub["jid"],
                         daemonize=False,
-                        print_event=False,
+                        print_event=print_event,
                         full_return=full_return,
                     )
             except salt.exceptions.SaltException as exc:

--- a/tests/pytests/unit/runners/test_runner_print_event.py
+++ b/tests/pytests/unit/runners/test_runner_print_event.py
@@ -1,0 +1,145 @@
+"""
+Tests that the print_event flag is correctly threaded through the runner call chain.
+Regression tests for issue #58203.
+"""
+
+import salt.client.mixins
+import salt.runner
+from tests.support.mock import MagicMock, patch
+
+
+class TestProcFunctionPrintEvent:
+    """
+    _proc_function must forward print_event to instance.low().
+    """
+
+    def test_proc_function_passes_print_event_false(self):
+        """
+        _proc_function(print_event=False) must call instance.low(..., print_event=False).
+        """
+        mock_instance = MagicMock()
+        mock_instance.low.return_value = "result"
+
+        salt.client.mixins.AsyncClientMixin._proc_function(
+            instance=mock_instance,
+            opts={},
+            fun="test.ping",
+            low={"fun": "test.ping"},
+            user="root",
+            tag="salt/run/1234/ret",
+            jid="1234",
+            daemonize=False,
+            print_event=False,
+        )
+
+        assert mock_instance.low.call_count == 1
+        _, low_kwargs = mock_instance.low.call_args
+        assert (
+            low_kwargs.get("print_event") is False
+        ), "_proc_function must forward print_event=False to instance.low()"
+
+    def test_proc_function_passes_print_event_true_by_default(self):
+        """
+        _proc_function default (no print_event arg) must call instance.low with print_event=True.
+        """
+        mock_instance = MagicMock()
+        mock_instance.low.return_value = "result"
+
+        salt.client.mixins.AsyncClientMixin._proc_function(
+            instance=mock_instance,
+            opts={},
+            fun="test.ping",
+            low={"fun": "test.ping"},
+            user="root",
+            tag="salt/run/1234/ret",
+            jid="1234",
+            daemonize=False,
+        )
+
+        _, low_kwargs = mock_instance.low.call_args
+        assert (
+            low_kwargs.get("print_event", True) is True
+        ), "_proc_function default must keep print_event=True"
+
+
+class TestRunnerRunPrintEvent:
+    """
+    Runner.run() must forward print_event to _proc_function.
+    """
+
+    def test_runner_run_passes_print_event_false(self, master_opts):
+        """
+        Runner.run(print_event=False) must pass print_event=False to _proc_function.
+        """
+        opts = master_opts.copy()
+        opts["fun"] = "test.arg"
+        opts["arg"] = []
+        opts["doc"] = False
+        opts["async"] = False
+        opts["show_jid"] = False
+        opts.pop("eauth", None)
+
+        runner = salt.runner.Runner(opts)
+
+        captured_kwargs = {}
+
+        def fake_proc_function(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {}
+
+        with patch.object(
+            salt.runner.Runner,
+            "_proc_function",
+            staticmethod(fake_proc_function),
+        ), patch.object(
+            runner,
+            "_gen_async_pub",
+            return_value={"jid": "test-jid", "tag": "salt/run/test-jid"},
+        ), patch(
+            "salt.utils.user.get_specific_user", return_value="root"
+        ):
+            runner.run(print_event=False)
+
+        assert (
+            "print_event" in captured_kwargs
+        ), "Runner.run must forward print_event to _proc_function"
+        assert captured_kwargs["print_event"] is False
+
+
+class TestMinionRunnerPrintEvent:
+    """
+    RemoteFuncs.minion_runner must call runner.run(print_event=False).
+    """
+
+    def test_minion_runner_suppresses_print_event(self, master_opts):
+        """
+        minion_runner must call runner.run(print_event=False) to suppress
+        unwanted event output to stdout.
+        """
+        import salt.daemons.masterapi as masterapi
+
+        opts = master_opts.copy()
+        opts["peer_run"] = {"minion-id": ["test.*"]}
+
+        funcs = masterapi.RemoteFuncs(opts)
+        load = {
+            "fun": "test.arg",
+            "arg": [],
+            "id": "minion-id",
+        }
+
+        run_kwargs = {}
+
+        def fake_run(self, **kwargs):
+            run_kwargs.update(kwargs)
+            return {}
+
+        with patch.object(salt.runner.Runner, "run", fake_run):
+            funcs.minion_runner(load)
+
+        assert (
+            "print_event" in run_kwargs
+        ), "minion_runner must pass print_event to runner.run"
+        assert (
+            run_kwargs["print_event"] is False
+        ), "minion_runner must suppress event output: runner.run(print_event=False)"


### PR DESCRIPTION
### What does this PR do?

We've had a problem that our salt master runners are writing enormous amounts of unwanted yaml output in our logs, and this small patch does silence it.  In full disclosure, I do not have a great grasp of the Salt codebase and have not been able to write a meaningful test, so I ask humbly that the experts consider the implications.  In our case the call to Runner.run() comes from RemoteFuncs.minion_runner() in daemons/masterapi.py so it might be possible to parameterize it further up to there if that is more desirable.

### What issues does this PR fix or reference?
Fixes: #58203 maybe

### Previous Behavior
Hundreds of lines of yaml is printed to stdout.

### New Behavior
No yaml is printed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
