### PR TITLE
[3006.x] Clean newlines from presented minions pubkey. Fixes #66126

### DIFF
--- a/changelog/66126.fixed.md
+++ b/changelog/66126.fixed.md
@@ -1,0 +1,2 @@
+Fixed a issue with server channel where a minion's public key
+would be rejected if it contained a final newline character.

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -371,7 +371,15 @@ class ReqServerChannel:
         elif os.path.isfile(pubfn):
             # The key has been accepted, check it
             with salt.utils.files.fopen(pubfn, "r") as pubfn_handle:
-                if salt.crypt.clean_key(pubfn_handle.read()) != load["pub"]:
+                keyFromDisk = pubfn_handle.read()
+
+                # if the keyFromDisk has a final newline it is a oldstyle key
+                # if we clean it, it will not match. Only clean the key if it
+                # is a new style key.
+                if keyFromDisk[-1:] != "\n":
+                    keyFromDisk = salt.crypt.clean(orgkey)
+
+                if  keyFromDisk != load["pub"]:
                     log.error(
                         "Authentication attempt from %s failed, the public "
                         "keys did not match. This may be an attempt to compromise "

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -371,15 +371,7 @@ class ReqServerChannel:
         elif os.path.isfile(pubfn):
             # The key has been accepted, check it
             with salt.utils.files.fopen(pubfn, "r") as pubfn_handle:
-                keyFromDisk = pubfn_handle.read()
-
-                # if the keyFromDisk has a final newline it is a oldstyle key
-                # if we clean it, it will not match. Only clean the key if it
-                # is a new style key.
-                if keyFromDisk[-1:] != "\n":
-                    keyFromDisk = salt.crypt.clean_key(keyFromDisk)
-
-                if  keyFromDisk != load["pub"]:
+                if salt.crypt.clean_key(pubfn_handle.read()) != salt.crypt.clean_key(load["pub"])
                     log.error(
                         "Authentication attempt from %s failed, the public "
                         "keys did not match. This may be an attempt to compromise "

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -377,7 +377,7 @@ class ReqServerChannel:
                 # if we clean it, it will not match. Only clean the key if it
                 # is a new style key.
                 if keyFromDisk[-1:] != "\n":
-                    keyFromDisk = salt.crypt.clean(orgkey)
+                    keyFromDisk = salt.crypt.clean_key(keyFromDisk)
 
                 if  keyFromDisk != load["pub"]:
                     log.error(


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #66126 

### Previous Behavior
The payload containing the minion's public key was not cleaned by the `salt.crypt.clean_key` function. Which caused pubkeys created by older minions (which contained a newline at the end of the file) to be denied. 

### New Behavior
The pubkey as send by the minion is now being cleaned by the `salt.crypt.clean_key` function. Effectively stripping extra newlines in the received payload.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
