### PR TITLE
[3006.x] Upgrade to `cryptography==42.0.5` due to a few security issues

### DIFF
--- a/changelog/66141.security.md
+++ b/changelog/66141.security.md
@@ -1,0 +1,5 @@
+Upgrade to `cryptography==42.0.5` due to a few security issues:
+
+* https://github.com/advisories/GHSA-9v9h-cgj8-h64p
+* https://github.com/advisories/GHSA-3ww4-gg4f-jr7f
+* https://github.com/advisories/GHSA-6vqw-3v5j-54x4

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -122,7 +122,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -88,7 +88,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -85,7 +85,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -134,7 +134,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -94,7 +94,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -80,7 +80,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -118,7 +118,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -84,7 +84,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -83,7 +83,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -130,7 +130,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -92,7 +92,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -78,7 +78,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -118,7 +118,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -84,7 +84,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -83,7 +83,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -130,7 +130,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -92,7 +92,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -78,7 +78,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -136,7 +136,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -95,7 +95,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -102,7 +102,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -87,7 +87,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -131,7 +131,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -90,7 +90,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -139,7 +139,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -97,7 +97,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -82,7 +82,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -131,7 +131,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -93,7 +93,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -90,7 +90,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -135,7 +135,7 @@ croniter==0.3.29 ; sys_platform != "win32"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -95,7 +95,7 @@ contextvars==2.4
     #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -82,7 +82,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.6
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==42.0.3
+cryptography==42.0.5
     # via
     #   -r requirements/windows.txt
     #   pyopenssl


### PR DESCRIPTION
### What does this PR do?
Upgrade to `cryptography==42.0.5` due to a few security issues

* https://github.com/advisories/GHSA-9v9h-cgj8-h64p
* https://github.com/advisories/GHSA-3ww4-gg4f-jr7f
* https://github.com/advisories/GHSA-6vqw-3v5j-54x4