### PR TITLE
[master] Remove the __orchestration__ key from salt.runner and salt.wheel

### DIFF
--- a/changelog/66151.removed.md
+++ b/changelog/66151.removed.md
@@ -1,0 +1,1 @@
+Remove the __orchestration__ key from salt.runner and salt.wheel return data.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -32,7 +32,6 @@ import salt.output
 import salt.syspaths
 import salt.utils.data
 import salt.utils.event
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -815,14 +814,6 @@ def runner(name, **kwargs):
         "executed" if success else "failed",
     )
 
-    if __opts__["features"].get("enable_deprecated_orchestration_flag", False):
-        ret["__orchestration__"] = True
-        salt.utils.versions.warn_until(
-            3008,
-            "The __orchestration__ return flag will be removed in {version}. "
-            "For more information see https://github.com/saltstack/salt/pull/59917.",
-        )
-
     if "jid" in out:
         ret["__jid__"] = out["jid"]
 
@@ -1063,14 +1054,6 @@ def wheel(name, **kwargs):
         name,
         "executed" if success else "failed",
     )
-
-    if __opts__["features"].get("enable_deprecated_orchestration_flag", False):
-        ret["__orchestration__"] = True
-        salt.utils.versions.warn_until(
-            3008,
-            "The __orchestration__ return flag will be removed in Salt Argon. "
-            "For more information see https://github.com/saltstack/salt/pull/59917.",
-        )
 
     if "jid" in out:
         ret["__jid__"] = out["jid"]


### PR DESCRIPTION
### What does this PR do?

Drops the code that was deprecated in 3006.

### What issues does this PR fix or reference?
References: #59917

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No