### PR TITLE
[master] Make reactor engine less blocking the EventPublisher

### DIFF
--- a/changelog/66158.changed.md
+++ b/changelog/66158.changed.md
@@ -1,0 +1,1 @@
+Make reactor engine less blocking the EventPublisher

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -6,6 +6,7 @@ import fnmatch
 import glob
 import logging
 import os
+from threading import Lock
 
 import salt.client
 import salt.defaults.exitcodes
@@ -195,13 +196,6 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
         self.resolve_aliases(chunks)
         return chunks
 
-    def call_reactions(self, chunks):
-        """
-        Execute the reaction state
-        """
-        for chunk in chunks:
-            self.wrap.run(chunk)
-
     def run(self):
         """
         Enter into the server loop
@@ -219,7 +213,7 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
         ) as event:
             self.wrap = ReactWrap(self.opts)
 
-            for data in event.iter_events(full=True):
+            for data in event.iter_events(full=True, auto_reconnect=True):
                 # skip all events fired by ourselves
                 if data["data"].get("user") == self.wrap.event_user:
                     continue
@@ -269,15 +263,9 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
                     if not self.is_leader:
                         continue
                     else:
-                        reactors = self.list_reactors(data["tag"])
-                        if not reactors:
-                            continue
-                        chunks = self.reactions(data["tag"], data["data"], reactors)
-                        if chunks:
-                            try:
-                                self.call_reactions(chunks)
-                            except SystemExit:
-                                log.warning("Exit ignored by reactor")
+                        self.wrap.call_reactions(
+                            data, self.list_reactors, self.reactions
+                        )
 
 
 class ReactWrap:
@@ -298,6 +286,7 @@ class ReactWrap:
 
     def __init__(self, opts):
         self.opts = opts
+        self._run_lock = Lock()
         if ReactWrap.client_cache is None:
             ReactWrap.client_cache = salt.utils.cache.CacheDict(
                 opts["reactor_refresh_interval"]
@@ -483,3 +472,24 @@ class ReactWrap:
         Wrap LocalCaller to execute remote exec functions locally on the Minion
         """
         self.client_cache["caller"].cmd(fun, *kwargs["arg"], **kwargs["kwarg"])
+
+    def _call_reactions(self, data, list_reactors, get_reactions):
+        reactors = list_reactors(data["tag"])
+        if not reactors:
+            return
+        chunks = get_reactions(data["tag"], data["data"], reactors)
+        if not chunks:
+            return
+        with self._run_lock:
+            try:
+                for chunk in chunks:
+                    self.run(chunk)
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error(
+                    "Exception while calling the reactions: %s", exc, exc_info=True
+                )
+
+    def call_reactions(self, data, list_reactors, get_reactions):
+        return self.pool.fire_async(
+            self._call_reactions, args=(data, list_reactors, get_reactions)
+        )

--- a/tests/pytests/unit/utils/test_reactor.py
+++ b/tests/pytests/unit/utils/test_reactor.py
@@ -1,6 +1,9 @@
+import threading
+
 import pytest
 
 import salt.utils.data
+import salt.utils.event
 import salt.utils.reactor as reactor
 from tests.support.mock import MagicMock, call, patch
 
@@ -55,3 +58,37 @@ def test_run_master_reactor(master_opts, master_reactor):
                 master_reactor.run()
                 calls = [call(9)]
                 os_nice_mock.assert_has_calls(calls)
+
+
+@pytest.mark.skip_on_windows(reason="Reactors unavailable on Windows")
+def test_reactors_list_in_separate_thread(master_opts, master_reactor):
+    """
+    Test that some of the tasks for reactors are performed in the separate thread
+    """
+
+    list_reactors_thread_id = None
+    get_reactions_thread_id = None
+
+    def list_reactors(*args, **kwargs):
+        nonlocal list_reactors_thread_id
+        list_reactors_thread_id = threading.get_ident()
+        return ["test_reactor"]
+
+    def get_reactions(*args, **kwargs):
+        nonlocal get_reactions_thread_id
+        get_reactions_thread_id = threading.get_ident()
+        return []
+
+    with patch.object(
+        salt.utils.event.SaltEvent,
+        "iter_events",
+        return_value=iter([{"tag": "test", "data": {}}]),
+    ), patch.object(master_reactor, "list_reactors", list_reactors), patch.object(
+        master_reactor, "reactions", get_reactions
+    ):
+        main_thread_id = threading.get_ident()
+        master_reactor.run()
+        assert main_thread_id != list_reactors_thread_id
+        assert main_thread_id != get_reactions_thread_id
+        assert list_reactors_thread_id == get_reactions_thread_id
+        assert None not in (list_reactors_thread_id, get_reactions_thread_id)


### PR DESCRIPTION
### What does this PR do?

The `reactor` engine in some cases could cause blocking on reading the events from EventPublisher so it has to hold the events until they will be retrived by the engine.

This change improves the way of handling the events by the `reactor` engine by pushing more work to the thread pool which is already available inside the engine, in this case more work is handled with the distinct thread instead of performing this work with the main thread of the `reactor` engine.

### Previous Behavior
In some cases could cause some growth of the memory consumption with `EventPublisher` as it has to hold the events to be consumed by the stream from `reactor` engine.

### New Behavior
The events from the stream from `EventPublisher` are handled faster.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
