### PR TITLE
[3006.x] Fix content-type backwards compatability

### DIFF
--- a/changelog/66127.fixed.md
+++ b/changelog/66127.fixed.md
@@ -1,0 +1,1 @@
+Fix content type backwards compatablity with http proxy post requests in the http utils module.

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -247,6 +247,17 @@ def query(
         else:
             http_proxy_url = f"http://{proxy_host}:{proxy_port}"
 
+        if header_dict is None:
+            header_dict = {}
+
+        if method == "POST" and "Content-Type" not in header_dict:
+            log.debug(
+                "Content-Type not provided for POST request, assuming application/x-www-form-urlencoded"
+            )
+            header_dict["Content-Type"] = "application/x-www-form-urlencoded"
+            if "Content-Length" not in header_dict:
+                header_dict["Content-Length"] = f"{len(data)}"
+
     match = re.match(
         r"https?://((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)($|/)",
         url,

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -247,17 +247,6 @@ def query(
         else:
             http_proxy_url = f"http://{proxy_host}:{proxy_port}"
 
-        if header_dict is None:
-            header_dict = {}
-
-        if method == "POST" and "Content-Type" not in header_dict:
-            log.debug(
-                "Content-Type not provided for POST request, assuming application/x-www-form-urlencoded"
-            )
-            header_dict["Content-Type"] = "application/x-www-form-urlencoded"
-            if "Content-Length" not in header_dict:
-                header_dict["Content-Length"] = f"{len(data)}"
-
     match = re.match(
         r"https?://((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)($|/)",
         url,
@@ -363,6 +352,19 @@ def query(
     if agent == USERAGENT:
         agent = f"{agent} http.query()"
     header_dict["User-agent"] = agent
+
+    if (
+        proxy_host
+        and proxy_port
+        and method == "POST"
+        and "Content-Type" not in header_dict
+    ):
+        log.debug(
+            "Content-Type not provided for POST request, assuming application/x-www-form-urlencoded"
+        )
+        header_dict["Content-Type"] = "application/x-www-form-urlencoded"
+        if "Content-Length" not in header_dict:
+            header_dict["Content-Length"] = f"{len(data)}"
 
     if backend == "requests":
         sess = requests.Session()

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -1,3 +1,5 @@
+import urllib
+
 import pytest
 import requests
 from pytestshellutils.utils import ports
@@ -309,3 +311,27 @@ def test_backends_decode_body_true(httpserver, backend):
     )
     body = ret.get("body", "")
     assert isinstance(body, str)
+
+
+def test_requests_post_content_type(httpserver):
+    url = httpserver.url_for("/post-content-type")
+    data = urllib.parse.urlencode({"payload": "test"})
+    opts = {
+        "proxy_host": "127.0.0.1",
+        "proxy_port": 88,
+    }
+    with patch("requests.Session") as mock_session:
+        sess = MagicMock()
+        sess.headers = {}
+        mock_session.return_value = sess
+        ret = http.query(
+            url,
+            method="POST",
+            data=data,
+            backend="tornado",
+            opts=opts,
+        )
+        assert "Content-Type" in sess.headers
+        assert sess.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert "Content-Length" in sess.headers
+        assert sess.headers["Content-Length"] == "12"


### PR DESCRIPTION
### What does this PR do?

Set content type on proxy requests that do not provide a content type header. This fixes backwards compatibility with old curl client.

### What issues does this PR fix or reference?
Fixes: #66127



### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
