### PR TITLE
[master] Migrate the digicert runner from `M2Crypto` to `PyCA/cryptography`

### DIFF
--- a/salt/runners/digicertapi.py
+++ b/salt/runners/digicertapi.py
@@ -112,7 +112,7 @@ def _paginate(url, topkey, *args, **kwargs):
     aggregate_ret = ret["dict"][topkey]
     url = args[0]
     for p in range(2, numpages):
-        param_url = url + "?offset={}".format(lim * (p - 1))
+        param_url = url + f"?offset={lim * (p - 1)}"
         next_ret = salt.utils.http.query(param_url, kwargs)
         aggregate_ret[topkey].extend(next_ret["dict"][topkey])
 
@@ -131,9 +131,9 @@ def list_domains(container_id=None):
         salt-run digicert.list_domains
     """
     if container_id:
-        url = "{}/domain?{}".format(_base_url(), container_id)
+        url = f"{_base_url()}/domain?{container_id}"
     else:
-        url = "{}/domain".format(_base_url())
+        url = f"{_base_url()}/domain"
 
     orgs = _paginate(
         url,
@@ -160,9 +160,9 @@ def list_requests(status=None):
         salt-run digicert.list_requests pending
     """
     if status:
-        url = "{}/request?status={}".format(_base_url(), status)
+        url = f"{_base_url()}/request?status={status}"
     else:
-        url = "{}/request".format(_base_url())
+        url = f"{_base_url()}/request"
 
     reqs = _paginate(
         url,
@@ -188,7 +188,7 @@ def list_orders(status=None):
 
         salt-run digicert.list_orders
     """
-    url = "{}/order/certificate".format(_base_url())
+    url = f"{_base_url()}/order/certificate"
 
     reqs = _paginate(
         url,
@@ -238,7 +238,7 @@ def get_certificate(
 
     if order_id:
         order_cert = salt.utils.http.query(
-            "{}/order/certificate/{}".format(_base_url(), order_id),
+            f"{_base_url()}/order/certificate/{order_id}",
             method="GET",
             raise_error=False,
             decode=True,
@@ -372,7 +372,7 @@ def list_organizations(container_id=None, include_validation=True):
     """
 
     orgs = _paginate(
-        "{}/organization".format(_base_url()),
+        f"{_base_url()}/organization",
         "organizations",
         method="GET",
         decode=True,
@@ -495,7 +495,7 @@ def order_certificate(
     encoded_body = salt.utils.json.dumps(body)
 
     qdata = salt.utils.http.query(
-        "{}/order/certificate/ssl".format(_base_url()),
+        f"{_base_url()}/order/certificate/ssl",
         method="POST",
         data=encoded_body,
         decode=True,
@@ -571,7 +571,7 @@ def get_org_details(organization_id):
     """
 
     qdata = salt.utils.http.query(
-        "{}/organization/{}".format(_base_url(), organization_id),
+        f"{_base_url()}/organization/{organization_id}",
         method="GET",
         decode=True,
         decode_type="json",
@@ -623,8 +623,8 @@ def gen_csr(
     if "private_key" not in data:
         data["private_key"] = gen_key(minion_id, dns_name, password, key_len=key_len)
 
-    tmppriv = "{}/priv".format(tmpdir)
-    tmpcsr = "{}/csr".format(tmpdir)
+    tmppriv = f"{tmpdir}/priv"
+    tmpcsr = f"{tmpdir}/csr"
     with salt.utils.files.fopen(tmppriv, "w") as if_:
         if_.write(salt.utils.stringutils.to_str(data["private_key"]))
 
@@ -636,9 +636,9 @@ def gen_csr(
     )
 
     if ou_name:
-        subject = subject + "/OU={}".format(ou_name)
+        subject = subject + f"/OU={ou_name}"
 
-    subject = subject + "/CN={}".format(dns_name)
+    subject = subject + f"/CN={dns_name}"
 
     cmd = "openssl req -new -{} -key {} -out {} -subj '{}'".format(
         shatype, tmppriv, tmpcsr, subject
@@ -689,7 +689,7 @@ def show_organization(domain):
         salt-run digicert.show_company example.com
     """
     data = salt.utils.http.query(
-        "{}/companies/domain/{}".format(_base_url(), domain),
+        f"{_base_url()}/companies/domain/{domain}",
         status=True,
         decode=True,
         decode_type="json",
@@ -712,7 +712,7 @@ def show_csrs():
         salt-run digicert.show_csrs
     """
     data = salt.utils.http.query(
-        "{}/certificaterequests".format(_base_url()),
+        f"{_base_url()}/certificaterequests",
         status=True,
         decode=True,
         decode_type="json",


### PR DESCRIPTION
### What does this PR do?
This PR migrates the `digicert` runner to use the cryptographic library [`PyCA/cryptography`](https://cryptography.io/en/latest/), instead of the older libraries `M2Crypto`, `PyCryptodome` and `PyCrypto`. In particular, it migrates the generation of RSA keys used to create Certificate Signing Requests.

### What issues does this PR fix or reference?
Part of https://github.com/saltstack/salt/issues/66149, which tracks the migration from `M2Crypto` to newer cryptographic libraries.

### Previous Behavior
The RSA key used to sign CSRs (Certificate Signing Request) in the `digicert` runner was generated using `M2Crypto`, or alternatively `PyCryptodome` or `PyCrypto` if the former was not installed.

The generated key was saved in the cache in `PKCS#1` format and encrypted with `DES-EDE3-CBC`.

The generated key was used by the command `openssl req -new` to sign a new CSR.

### New Behavior
The RSA key is generated using `PyCA/cryptography`, a library that is already a Salt dependency and is newer and better maintained compared to the ones used before.

The generated key is saved in the cache in `PKCS#8` format and encrypted with the [best available algorithm](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.BestAvailableEncryption), as decided by the library.

The generated key is used by the command `openssl req -new` to sign a new CSR.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
