### PR TITLE
[3006.x] Honor saltenv in refresh_db on Windows

### DIFF
--- a/changelog/61807.fixed.md
+++ b/changelog/61807.fixed.md
@@ -1,0 +1,1 @@
+pkg.refresh_db on Windows now honors saltenv

--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -301,15 +301,15 @@ winrepo_source_dir
 
 :conf_minion:`winrepo_source_dir` (str)
 
-The location of the .sls files on the Salt file server. This allows for using
-different environments. Default is ``salt://win/repo-ng/``.
+The location of the .sls files on the Salt file server. Default is
+``salt://win/repo-ng/``.
 
 .. warning::
-    If the default for ``winrepo_dir_ng`` is changed, this setting may need to
-    changed on each minion. The default setting for ``winrepo_dir_ng`` is
-    ``/srv/salt/win/repo-ng``. If that were changed to ``/srv/salt/new/repo-ng``
-    then the ``winrepo_source_dir`` would need to be changed to
-    ``salt://new/repo-ng``
+    If the default for ``winrepo_dir_ng`` is changed, then this setting will
+    also need to be changed on each minion. The default setting for
+    ``winrepo_dir_ng`` is ``/srv/salt/win/repo-ng``. If that were changed to
+    ``/srv/salt/new/repo-ng`` then the ``winrepo_source_dir`` would need to be
+    changed to ``salt://new/repo-ng``
 
 Masterless Minion Configuration
 ===============================
@@ -332,7 +332,7 @@ winrepo_dir
 
 This setting is maintained for backwards compatibility with legacy minions. It
 points to the location in the ``file_roots`` where the winrepo files are kept.
-The default is: ``C:\salt\srv\salt\win\repo``
+The default is: ``C:\ProgramData\Salt Project\Salt\srv\salt\win\repo``
 
 winrepo_dir_ng
 --------------
@@ -340,7 +340,7 @@ winrepo_dir_ng
 :conf_minion:`winrepo_dir_ng` (str)
 
 The location in the ``file_roots where the winrepo files are kept. The default
-is ``C:\salt\srv\salt\win\repo-ng``.
+is ``C:\ProgramData\Salt Project\Salt\srv\salt\win\repo-ng``.
 
 .. warning::
     You can change the location of the winrepo directory. However, it must
@@ -465,6 +465,137 @@ that succeeded or failed to compile:
 .. note::
     Use ``pkg.refresh_db`` when developing new Windows package definitions to
     check for errors in the definitions against one or more Windows minions.
+
+
+Sample Configurations
+*********************
+
+Masterless
+==========
+
+The configs in this section are for working with winrepo on a Windows minion
+using ``salt-call --local``.
+
+Default Configuration
+---------------------
+
+This is the default configuration if nothing is configured in the minion config.
+The config is shown here for clarity. These are the defaults:
+
+.. code-block:: yaml
+
+    file_roots:
+      base:
+        - C:\ProgramData\Salt Project\Salt\srv\salt
+    winrepo_source_dir: 'salt://win/repo-ng'
+    winrepo_dir_ng: C:\ProgramData\Salt Project\Salt\srv\salt\win\repo-ng
+
+The :mod:`winrepo.update_git_repos <salt.modules.winrepo.update_git_repos>`
+command will clone the repository to ``win\repo-ng`` on the file_roots.
+
+Multiple Salt Environments
+--------------------------
+
+This starts to get a little tricky. The winrepo repository doesn't
+get cloned to each environment when you run
+:mod:`winrepo.update_git_repos <salt.runners.winrepo.update_git_repos>`, so to
+make this work, all environments share the same winrepo. Applying states using
+the ``saltenv`` option will find the state files in the appropriate environment,
+but the package definition files will always be pulled from the same location.
+Therefore, you have to put the same winrepo location in each saltenv. Here's how
+this would look:
+
+.. code-block:: yaml
+
+    file_roots:
+      base:
+        - C:\ProgramData\Salt Project\Salt\srv\salt\base
+        - C:\ProgramData\Salt Project\Salt\srv\salt\winrepo
+      test:
+        - C:\ProgramData\Salt Project\Salt\srv\salt\test
+        - C:\ProgramData\Salt Project\Salt\srv\salt\winrepo
+    winrepo_source_dir: 'salt://salt-winrepo-ng'
+    winrepo_dir_ng: C:\ProgramData\Salt Project\Salt\srv\salt\winrepo
+    winrepo_dir: C:\ProgramData\Salt Project\Salt\srv\salt\winrepo
+
+When you run
+:mod:`winrepo.update_git_repos <salt.runners.winrepo.update_git_repos>` the
+Git repository will be cloned to the location specified in the
+``winrepo_dir_ng`` setting. I specified the ``winrepo_dir`` setting just so
+everything gets cloned to the same place. The directory that gets cloned is
+named ``salt-winrepo-ng`` so you specify that in the ``winrepo_source_dir``
+setting.
+
+The ``winrepo`` directory should only contain the package definition files. You
+wouldn't want to place any states in the ``winrepo`` directory as they will be
+available to both environments.
+
+Master
+======
+
+When working in a Master/Minion environment you have to split up some of the
+config settings between the master and the minion. Here are some sample configs
+for winrepo in a Master/Minion environment.
+
+Default Configuration
+---------------------
+
+This is the default configuration if nothing is configured. The config is shown
+here for clarity. These are the defaults on the master:
+
+.. code-block:: yaml
+
+    file_roots:
+      base:
+        - /srv/salt
+    winrepo_dir_ng: /srv/salt/win/repo-ng
+
+This is the default in the minion config:
+
+.. code-block:: yaml
+
+    winrepo_source_dir: 'salt://win/repo-ng'
+
+The :mod:`winrepo.update_git_repos <salt.runners.winrepo.update_git_repos>`
+command will clone the repository to ``win\repo-ng`` on the file_roots.
+
+Multiple Salt Environments
+--------------------------
+
+To set up multiple saltenvs using a Master/Minion configuration set the
+following in the master config:
+
+.. code-block:: yaml
+
+    file_roots:
+      base:
+        - /srv/salt/base
+        - /srv/salt/winrepo
+      test:
+        - /srv/salt/test
+        - /srv/salt/winrepo
+    winrepo_dir_ng: /srv/salt/winrepo
+    winrepo_dir: /srv/salt/winrepo
+
+Use the winrepo runner to set up the winrepo repository on the master.
+
+.. code-block:: bash
+
+    salt-run winrepo.update_git_repos
+
+The winrepo will be cloned to ``/srv/salt/winrepo`` under a directory named
+``salt-winrepo-ng``.
+
+Set the following on the minion config so the minion knows where to find the
+package definition files in the file_roots:
+
+.. code-block:: yaml
+
+    winrepo_source_dir: 'salt://salt-winrepo-ng'
+
+The same stipulations apply in a Master/Minion configuration as they do in a
+Masterless configuration
+
 
 Usage
 *****

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -907,7 +907,7 @@ def refresh_db(**kwargs):
     The database is stored in a serialized format located by default at the
     following location:
 
-    ``C:\salt\var\cache\salt\minion\files\base\win\repo-ng\winrepo.p``
+    ``C:\ProgramData\Salt Project\Salt\var\cache\salt\minion\files\base\win\repo-ng\winrepo.p``
 
     This module performs the following steps to generate the software metadata
     database:
@@ -976,7 +976,7 @@ def refresh_db(**kwargs):
 
     .. warning::
         When calling this command from a state using `module.run` be sure to
-        pass `failhard: False`. Otherwise the state will report failure if it
+        pass `failhard: False`. Otherwise, the state will report failure if it
         encounters a bad software definition file.
 
     CLI Example:
@@ -1170,10 +1170,11 @@ def genrepo(**kwargs):
             if name.endswith(".sls"):
                 total_files_processed += 1
                 _repo_process_pkg_sls(
-                    os.path.join(root, name),
-                    os.path.join(short_path, name),
-                    ret,
-                    successful_verbose,
+                    filename=os.path.join(root, name),
+                    short_path_name=os.path.join(short_path, name),
+                    ret=ret,
+                    successful_verbose=successful_verbose,
+                    saltenv=saltenv,
                 )
 
     with salt.utils.files.fopen(repo_details.winrepo_file, "wb") as repo_cache:
@@ -1212,7 +1213,9 @@ def genrepo(**kwargs):
         return results
 
 
-def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
+def _repo_process_pkg_sls(
+    filename, short_path_name, ret, successful_verbose, saltenv="base"
+):
     renderers = salt.loader.render(__opts__, __salt__)
 
     def _failed_compile(prefix_msg, error_msg):
@@ -1227,6 +1230,7 @@ def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
             __opts__["renderer"],
             __opts__.get("renderer_blacklist", ""),
             __opts__.get("renderer_whitelist", ""),
+            saltenv=saltenv,
         )
     except SaltRenderError as exc:
         return _failed_compile("Failed to compile", exc)

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -755,3 +755,21 @@ def test__reverse_cmp_pkg_versions(v1, v2, expected):
     assert result == expected, "cmp({}, {}) should be {}, got {}".format(
         v1, v2, expected, result
     )
+
+
+def test__repo_process_pkg_sls():
+    patch_render = patch("salt.loader.render")
+    patch_opts = patch.dict(win_pkg.__opts__, {"renderer": None})
+    patch_compile = patch("salt.template.compile_template", return_value="junk")
+    with patch_opts, patch_render as render, patch_compile as test:
+        ret = win_pkg._repo_process_pkg_sls(
+            filename="junk",
+            short_path_name="junk",
+            ret={},
+            successful_verbose=False,
+            saltenv="spongebob",
+        )
+        assert ret is False
+        test.assert_called_once_with(
+            "junk", render(), None, "", "", saltenv="spongebob"
+        )


### PR DESCRIPTION
### What does this PR do?
Fixes the pkg.refresh_db function in ``win_pkg.py`` so that it will pass the saltenv environment when rendering the package definitions
Adds some config examples for working with winrepo in multiple environments

### What issues does this PR fix or reference?
Fixes: #61807

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes