### PR TITLE
[3006.x] Fix issue with refresh_db on Windows

### DIFF
--- a/changelog/63848.fixed.md
+++ b/changelog/63848.fixed.md
@@ -1,0 +1,2 @@
+Fixes an issue in pkg.refresh_db on Windows where new package definition
+files were not being picked up on the first run

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -17,6 +17,7 @@ salt/_logging/(impl|handlers).py:
 salt/modules/(apkpkg|aptpkg|ebuildpkg|dpkg_lowpkg|freebsdpkg|mac_brew_pkg|mac_ports_pkg|openbsdpkg|opkg|pacmanpkg|pkgin|pkgng|pkg_resource|rpm_lowpkg|solarisipspkg|solarispkg|win_pkg|xbpspkg|yumpkg|zypperpkg)\.py:
   - pytests.unit.states.test_pkg
   - pytests.functional.modules.test_pkg
+  - pytests.functional.modules.test_win_pkg
   - pytests.functional.states.test_pkg
   - pytests.functional.states.pkgrepo.test_centos
   - pytests.functional.states.pkgrepo.test_debian

--- a/tests/pytests/functional/modules/test_win_pkg.py
+++ b/tests/pytests/functional/modules/test_win_pkg.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module")
+def pkg_def_contents(state_tree):
+    return r"""
+    my-software:
+      '1.0.1':
+        full_name: 'My Software'
+        installer: 'C:\files\mysoftware.msi'
+        install_flags: '/qn /norestart'
+        uninstaller: 'C:\files\mysoftware.msi'
+        uninstall_flags: '/qn /norestart'
+        msiexec: True
+        reboot: False
+    """
+
+
+@pytest.fixture(scope="module")
+def pkg(modules):
+    yield modules.pkg
+
+
+def test_refresh_db(pkg, pkg_def_contents, state_tree, minion_opts):
+    assert len(pkg.get_package_info("my-software")) == 0
+    repo_dir = state_tree / "win" / "repo-ng"
+    with pytest.helpers.temp_file("my-software.sls", pkg_def_contents, repo_dir):
+        pkg.refresh_db()
+    assert len(pkg.get_package_info("my-software")) == 1

--- a/tools/precommit/docstrings.py
+++ b/tools/precommit/docstrings.py
@@ -751,7 +751,6 @@ MISSING_EXAMPLES = {
         "delete_advanced_configs",
         "get_vm",
     ],
-    "salt/modules/win_pkg.py": ["get_package_info"],
     "salt/modules/win_timezone.py": ["zone_compare"],
     "salt/modules/zk_concurrency.py": [
         "lock",


### PR DESCRIPTION
### What does this PR do?
When a new package definition file was added to the repo you had to run refresh_db twice to get it to show up in the package database. This clears the cache before refreshing the database to force changes.

### What issues does this PR fix or reference?
Fixes: #63848 

### New Behavior
`pkg.refresh_db` picks up new package definition files on the first run

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes