### PR TITLE
[3007.x] Upgrade WIX to 3.14

### DIFF
--- a/pkg/windows/install_wix.ps1
+++ b/pkg/windows/install_wix.ps1
@@ -74,17 +74,15 @@ if ( (Get-WindowsOptionalFeature -Online -FeatureName "NetFx3").State -eq "Enabl
 #-------------------------------------------------------------------------------
 
 Write-Host "Looking for Wix Toolset: " -NoNewline
-# 64bit: {03368010-193D-4AE2-B275-DD2EB32CD427}
-# 32bit: {07188017-A460-4C0D-A386-6B3CEB8E20CD}
-if ((ProductcodeExists "{03368010-193D-4AE2-B275-DD2EB32CD427}") `
-    -or `
-    (ProductcodeExists "{07188017-A460-4C0D-A386-6B3CEB8E20CD}")) {
+$guid_64 = "{A2D09E18-32F8-4E34-946A-33AC8C8303E9}"
+$guid_32 = "{00A0C4F8-9F6C-40FB-A02D-3EAE1D7FD352}"
+if ( (ProductcodeExists $guid_64) -or (ProductcodeExists $guid_32) ) {
     Write-Result "Success" -ForegroundColor Green
 } else {
     Write-Result "Missing" -ForegroundColor Yellow
 
     Write-Host "Downloading Wix Toolset: " -NoNewline
-    $url = "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311.exe"
+    $url = "https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314.exe"
     $file = "$env:TEMP\wix_installer.exe"
     Invoke-WebRequest -Uri $url -OutFile "$file"
     if ( Test-Path -Path "$file" ) {
@@ -95,10 +93,17 @@ if ((ProductcodeExists "{03368010-193D-4AE2-B275-DD2EB32CD427}") `
     }
 
     Write-Host "Installing Wix Toolset: " -NoNewline
-    Start-Process $file -ArgumentList "/install","/quiet","/norestart" -Wait -NoNewWindow
-    if ((ProductcodeExists "{03368010-193D-4AE2-B275-DD2EB32CD427}") `
-    -or `
-    (ProductcodeExists "{07188017-A460-4C0D-A386-6B3CEB8E20CD}")) {
+    $process = Start-Process $file -ArgumentList "/install","/quiet","/norestart" -PassThru -Wait -NoNewWindow
+
+    if ( $process.ExitCode -eq 0 ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Verifying Wix Toolset Installation: " -NoNewline
+    if ( (ProductcodeExists $guid_64) -or (ProductcodeExists $guid_32) ) {
         Write-Result "Success" -ForegroundColor Green
     } else {
         Write-Result "Failed" -ForegroundColor Red


### PR DESCRIPTION
### What does this PR do?

Fixes the wix failures in the pipeline

Wix recently released 3.14, which is a security release, so it makes sense that the runners would update that. Our script was specifically checking for version 3.11. The installer completed successfully but didn't install anything because the newer version was already installed. Then it would check the GUID to verify installation using the GUID for the old installation.

Since 3.14 is a security release, I updated our script to also use WIX 3.14. This should fix the conflict.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes