### PR TITLE
[master] This addresses the discovery of libcrypto on the latest OSX 

### DIFF
--- a/changelog/66206.fixed.md
+++ b/changelog/66206.fixed.md
@@ -1,0 +1,1 @@
+Fix libcrypto discovery on macOS when libcrypto is installed directly under the Homebrew prefix lib directory.

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -68,6 +68,7 @@ def _find_libcrypto():
             lib = lib or glob.glob(
                 os.path.join(brew_prefix, "opt/openssl@*/lib/libcrypto.dylib")
             )
+            lib = lib or glob.glob(os.path.join(brew_prefix, "lib/libcrypto.dylib"))
 
         # look in macports.
         lib = lib or glob.glob("/opt/local/lib/libcrypto.dylib")

--- a/tests/pytests/unit/utils/test_rsax931.py
+++ b/tests/pytests/unit/utils/test_rsax931.py
@@ -305,6 +305,31 @@ def test_find_libcrypto_darwin_bigsur_packaged():
                 lib_path = _find_libcrypto()
 
 
+def test_find_libcrypto_darwin_brew_lib():
+    """
+    Test _find_libcrypto on a macOS host where libcrypto lives directly
+    under the Homebrew prefix lib directory (e.g. after 'brew install openssl'
+    without the versioned opt symlink).
+    """
+    expected = "/test/homebrew/prefix/lib/libcrypto.dylib"
+    mock_env = {"HOMEBREW_PREFIX": "/test/homebrew/prefix"}
+
+    def test_glob(pattern):
+        if fnmatch.fnmatch(expected, pattern):
+            return [expected]
+        return []
+
+    with patch.object(salt.utils.platform, "is_darwin", lambda: True), patch.object(
+        platform, "mac_ver", lambda: ("14.0.0", (), "")
+    ), patch.object(sys, "platform", "macosx"), patch.dict(
+        os.environ, mock_env
+    ), patch.object(
+        glob, "glob", test_glob
+    ):
+        lib_path = _find_libcrypto()
+    assert lib_path == expected
+
+
 def test_find_libcrypto_unsupported():
     """
     Ensure that _find_libcrypto works correctly on an unsupported host OS.


### PR DESCRIPTION
…atest brew.

### What does this PR do?

On the latest darwin with homebrew salt-ssh doesn't work because (among all the issues) it doesn't find libcrypto.

### What issues does this PR fix or reference?

Fixes: this allows proper discovery of libcrypto

### Merge requirements satisfied?

Probably not.

### Commits signed with GPG?
No

