### PR TITLE
[master] Fix install on latest darwin. immutables 0.15 upgraded to 0.20

### DIFF
--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -162,7 +162,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   contextvars

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -161,7 +161,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   contextvars

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -185,7 +185,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -159,7 +159,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   contextvars

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -155,7 +155,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   contextvars

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -154,7 +154,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   contextvars

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -176,7 +176,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -152,7 +152,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   contextvars

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -214,7 +214,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -155,7 +155,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   contextvars

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -81,7 +81,7 @@ idna==3.7
     #   yarl
 imagesize==1.4.1
     # via sphinx
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -154,7 +154,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   contextvars

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -243,7 +243,7 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -176,7 +176,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -152,7 +152,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   contextvars

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -161,7 +161,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   contextvars

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -180,7 +180,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -159,7 +159,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   contextvars

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -162,7 +162,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   contextvars

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -161,7 +161,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   contextvars

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -180,7 +180,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   contextvars

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -159,7 +159,7 @@ idna==3.7
     #   requests
     #   trustme
     #   yarl
-immutables==0.15
+immutables==0.20
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   contextvars

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -52,7 +52,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -50,7 +50,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -44,7 +44,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -50,7 +50,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -52,7 +52,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -46,7 +46,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -52,7 +52,7 @@ idna==3.7
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.20
     # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/base.txt


### PR DESCRIPTION
### What does this PR do?

This allows proper and working install of salt-ssh on Darwin 14

### What issues does this PR fix or reference?

Fixes: before, salt-ssh wasn't being installable on OSX.

Please note that because of ticket 66203 people have probably bein unable to seamlessly install salt-ssh on osx for several months, so this didn't emerge earlier.

### Previous Behavior

salt-ssh was trying to install immutables 0.15 that was having hard times to be installed on pyython 3.10/3.12

### New Behavior

pip install immutables==0.20 or just installing salt-ssh works properly

### Merge requirements satisfied?

probably not

### Commits signed with GPG?
No

