### PR TITLE
[master] salt-ssh - This implements the ssh_pre_hook setting in the roster, 

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -965,6 +965,7 @@ class Single:
         thin=None,
         mine=False,
         minion_opts=None,
+        pre_ssh_hook=None,
         identities_only=False,
         sudo_user=None,
         remote_port_forwards=None,
@@ -1004,6 +1005,8 @@ class Single:
         self.opts["thin_dir"] = self.thin_dir
         self.fsclient = fsclient
         self.context = {"master_opts": self.opts, "fileclient": self.fsclient}
+
+        self.ssh_pre_hook = kwargs.get("ssh_pre_hook", None)
 
         self.ssh_pre_flight = kwargs.get("ssh_pre_flight", None)
         self.ssh_pre_flight_args = kwargs.get("ssh_pre_flight_args", None)
@@ -1164,6 +1167,15 @@ class Single:
         """
         stdout = stderr = ""
         retcode = salt.defaults.exitcodes.EX_OK
+
+        if self.ssh_pre_hook:
+            parts = self.ssh_pre_hook.split()
+            if not os.path.exists(parts[0]):
+                log.error(
+                    "The ssh_pre_hook script %s does not exist", parts[0]
+                )
+            else:
+                subprocess.call(['sh'] + parts)
 
         if self.ssh_pre_flight:
             if not self.opts.get("ssh_run_pre_flight", False) and self.check_thin_dir():


### PR DESCRIPTION
### What does this PR do?

This creates a new option in the roster, called `ssh_pre_hook`, that runs a script before any ssh/scp connection is made

### What issues does this PR fix or reference?
Fixes: ticket #66210 contains the feature request. This is an attempt to fullfil it.

### Merge requirements satisfied?

Probably not.

### Commits signed with GPG?
No
