### PR TITLE
[3006.x] Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ### What does this PR do?
 
 ### What issues does this PR fix or reference?
-Fixes:
+Fixes
 
 ### Previous Behavior
 Remove this section if not relevant


### PR DESCRIPTION
### What does this PR do?
Removes the colon after the word `Fixes`. I think this interferes with GitHub's ability to auto-close the issue when the PR is closed.

https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue