### PR TITLE
[3007.x] Fixing vault client unwrap function to respect server.verify option.

### DIFF
--- a/changelog/66213.fixed.md
+++ b/changelog/66213.fixed.md
@@ -1,0 +1,1 @@
+Fix vault module doesn't respect `server.verify` option during unwrap if verify is set to `False` or CA file on the disk

--- a/salt/utils/vault/client.py
+++ b/salt/utils/vault/client.py
@@ -240,17 +240,14 @@ class VaultClient:
                     namespace=self.namespace,
                     verify=self.verify,
                 )
-        url = self._get_url("sys/wrapping/unwrap")
+        endpoint = "sys/wrapping/unwrap"
         headers = self._get_headers()
         payload = {}
         if "X-Vault-Token" not in headers:
             headers["X-Vault-Token"] = str(wrapped)
         else:
             payload["token"] = str(wrapped)
-        res = self.session.request("POST", url, headers=headers, json=payload)
-        if not res.ok:
-            self._raise_status(res)
-        return res.json()
+        return self.post(endpoint=endpoint, add_headers=headers, payload=payload)
 
     def wrap_info(self, wrapped):
         """

--- a/tests/pytests/unit/utils/vault/test_client.py
+++ b/tests/pytests/unit/utils/vault/test_client.py
@@ -280,6 +280,24 @@ def test_vault_client_unwrap_should_default_to_token_header_before_payload(
         assert headers.get("X-Vault-Token") == token
 
 
+@pytest.mark.usefixtures("server_config")
+@pytest.mark.parametrize(
+    "server_config",
+    ({"verify": "/usr/local/share/ca-certificates/my-ca.crt"},),
+    indirect=True,
+)
+def test_vault_client_unwrap_respects_verify_option(role_id_response, client, req):
+    """
+    As unwrap is special call which can be done both authenticated and unauthenticated
+    we need to ensure that in both cases it respects verify option.
+    """
+    token = "test-wrapping-token"
+    req.return_value = _mock_json_response(role_id_response)
+    client.unwrap(token)
+    verify = req.call_args.kwargs.get("verify", None)
+    assert verify == client.get_config()["verify"]
+
+
 @pytest.mark.parametrize("func", ["unwrap", "token_lookup"])
 @pytest.mark.parametrize(
     "req_failed,expected",


### PR DESCRIPTION


### What does this PR do?
Currently `VaultClient.unwrap` is doing own request call without respecting verify option. Any other function is reusing self.request or self.raw_request function which are respecting correctly verify opt. This will change unwrap function to also utilize self.post() which is reusing self.request.
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66213

### Previous Behavior
Vault module not working with self-signed certificate on disk or `verify: False`

### New Behavior
Vault modules works as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

