### PR TITLE
[3006.x] move fix from #66164 for #65703

### DIFF
--- a/changelog/66705.fixed.md
+++ b/changelog/66705.fixed.md
@@ -1,0 +1,1 @@
+backport the fix from #66164 to fix #65703. use OrderedDict to fix bad indexing.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import tempfile
 import time
+from collections import OrderedDict
 from urllib.error import HTTPError
 from urllib.request import Request as _Request
 from urllib.request import urlopen as _urlopen
@@ -204,24 +205,26 @@ if not HAS_APT:
             repo_line.append(self.type)
             opts = _get_opts(self.line)
             if self.architectures:
-                archs = ",".join(self.architectures)
-                opts["arch"]["full"] = f"arch={archs}"
+                if "arch" not in opts:
+                    opts["arch"] = {}
+                opts["arch"]["full"] = f"arch={','.join(self.architectures)}"
                 opts["arch"]["value"] = self.architectures
             if self.signedby:
+                if "signedby" not in opts:
+                    opts["signedby"] = {}
                 opts["signedby"]["full"] = f"signed-by={self.signedby}"
                 opts["signedby"]["value"] = self.signedby
 
-            ordered_opts = [
-                opt_type for opt_type, opt in opts.items() if opt["full"] != ""
-            ]
+            ordered_opts = []
 
             for opt in opts.values():
                 if opt["full"] != "":
-                    ordered_opts[opt["index"]] = opt["full"]
+                    ordered_opts.append(opt["full"])
 
             if ordered_opts:
-                repo_line.append("[{}]".format(" ".join(ordered_opts)))
+                repo_line.append(f"[{' '.join(ordered_opts)}]")
 
+            print("repo_line")
             repo_line += [self.uri, self.dist, " ".join(self.comps)]
             if self.comment:
                 repo_line.append(f"#{self.comment}")
@@ -237,10 +240,12 @@ if not HAS_APT:
             if repo_line[1].startswith("["):
                 repo_line = [x for x in (line.strip("[]") for line in repo_line) if x]
                 opts = _get_opts(self.line)
-                self.architectures.extend(opts["arch"]["value"])
-                self.signedby = opts["signedby"]["value"]
-                for opt in opts:
-                    opt = opts[opt]["full"]
+                if "arch" in opts:
+                    self.architectures.extend(opts["arch"]["value"])
+                if "signedby" in opts:
+                    self.signedby = opts["signedby"]["value"]
+                for opt in opts.values():
+                    opt = opt["full"]
                     if opt:
                         try:
                             repo_line.pop(repo_line.index(opt))
@@ -1732,31 +1737,27 @@ def _get_opts(line):
     Return all opts in [] for a repo line
     """
     get_opts = re.search(r"\[(.*=.*)\]", line)
-    ret = {
-        "arch": {"full": "", "value": "", "index": 0},
-        "signedby": {"full": "", "value": "", "index": 0},
-    }
 
+    ret = OrderedDict()
     if not get_opts:
         return ret
     opts = get_opts.group(0).strip("[]")
     architectures = []
-    for idx, opt in enumerate(opts.split()):
+    for opt in opts.split():
         if opt.startswith("arch"):
             architectures.extend(opt.split("=", 1)[1].split(","))
+            ret["arch"] = {}
             ret["arch"]["full"] = opt
             ret["arch"]["value"] = architectures
-            ret["arch"]["index"] = idx
         elif opt.startswith("signed-by"):
+            ret["signedby"] = {}
             ret["signedby"]["full"] = opt
             ret["signedby"]["value"] = opt.split("=", 1)[1]
-            ret["signedby"]["index"] = idx
         else:
             other_opt = opt.split("=", 1)[0]
             ret[other_opt] = {}
             ret[other_opt]["full"] = opt
             ret[other_opt]["value"] = opt.split("=", 1)[1]
-            ret[other_opt]["index"] = idx
     return ret
 
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1770,7 +1770,11 @@ def _split_repo_str(repo):
     if not HAS_APT:
         signedby = entry.signedby
     else:
-        signedby = _get_opts(line=repo)["signedby"].get("value", "")
+        opts = _get_opts(line=repo)
+        if "signedby" in opts:
+            signedby = opts["signedby"].get("value", "")
+        else:
+            signedby = ""
         if signedby:
             # python3-apt does not support signedby. So if signedby
             # is in the repo we have to check our code to see if the
@@ -1938,7 +1942,12 @@ def list_repos(**kwargs):
         if not HAS_APT:
             signedby = source.signedby
         else:
-            signedby = _get_opts(line=source.line)["signedby"].get("value", "")
+            opts = _get_opts(line=source.line)
+            if "signedby" in opts:
+                signedby = opts["signedby"].get("value", "")
+            else:
+                signedby = ""
+
         repo = {}
         repo["file"] = source.file
         repo["comps"] = getattr(source, "comps", [])
@@ -2958,7 +2967,11 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
     if not HAS_APT:
         signedby = mod_source.signedby
     else:
-        signedby = _get_opts(repo)["signedby"].get("value", "")
+        opts = _get_opts(repo)
+        if "signedby" in opts:
+            signedby = opts["signedby"].get("value", "")
+        else:
+            signedby = ""
 
     return {
         repo: {
@@ -3059,7 +3072,11 @@ def _expand_repo_def(os_name, os_codename=None, **kwargs):
         signedby = source_entry.signedby
         kwargs["signedby"] = signedby
     else:
-        signedby = _get_opts(repo)["signedby"].get("value", "")
+        opts = _get_opts(repo)
+        if "signedby" in opts:
+            signedby = opts["signedby"].get("value", "")
+        else:
+            signedby = ""
 
     _source_entry = source_list.add(
         type=source_entry.type,

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -2303,3 +2303,38 @@ def test_set_selections_test():
     with patch_get_sel, patch_call_apt, patch_opts:
         ret = aptpkg.set_selections(selection=f'{{"hold": [{pkg}]}}')
     assert ret == {}
+
+
+def test__get_opts():
+    tests = [
+        {
+            "oneline": "deb [signed-by=/etc/apt/keyrings/example.key arch=amd64] https://example.com/pub/repos/apt xenial main",
+            "result": {
+                "signedby": {
+                    "full": "signed-by=/etc/apt/keyrings/example.key",
+                    "value": "/etc/apt/keyrings/example.key",
+                },
+                "arch": {"full": "arch=amd64", "value": ["amd64"]},
+            },
+        },
+        {
+            "oneline": "deb [arch=amd64 signed-by=/etc/apt/keyrings/example.key]  https://example.com/pub/repos/apt xenial main",
+            "result": {
+                "arch": {"full": "arch=amd64", "value": ["amd64"]},
+                "signedby": {
+                    "full": "signed-by=/etc/apt/keyrings/example.key",
+                    "value": "/etc/apt/keyrings/example.key",
+                },
+            },
+        },
+        {
+            "oneline": "deb [arch=amd64]  https://example.com/pub/repos/apt xenial main",
+            "result": {
+                "arch": {"full": "arch=amd64", "value": ["amd64"]},
+            },
+        },
+    ]
+
+    for test in tests:
+        ret = aptpkg._get_opts(test["oneline"])
+        assert ret == test["result"]


### PR DESCRIPTION
### What does this PR do?

switches from a broken index in a dict to an OrderedDict to keep thins like #65703 from happening

### What issues does this PR fix or reference?
Fixes: #65703 

### Previous Behavior
_get_opts returned a dict with an index that was really fragile. 

### New Behavior
_get_opts now returns a OrderedDict with built in order. allowing for keeping the proper order of items without having to result to a fragile index that was not always respected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated
