### PR TITLE
[3007.x] Address minion log flood from zeromq

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -394,7 +394,9 @@ class PublishClient(salt.transport.base.PublishClient):
                             await callback(msg)
                         except TypeError:
                             if callback is not None:
-                                log.exception("Exception while running callback: %s", callback)
+                                log.exception(
+                                    "Exception while running callback: %s", callback
+                                )
                         except Exception:  # pylint: disable=broad-except
                             log.error("Exception while running callback", exc_info=True)
                     # log.debug("Callback done %r", callback)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -392,6 +392,9 @@ class PublishClient(salt.transport.base.PublishClient):
                     if msg:
                         try:
                             await callback(msg)
+                        except TypeError as exc:  # pylint: disable=broad-except
+                            if callback is not None:
+                                log.error("Exception while running callback %s", exc, exc_info=True)
                         except Exception:  # pylint: disable=broad-except
                             log.error("Exception while running callback", exc_info=True)
                     # log.debug("Callback done %r", callback)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -392,9 +392,9 @@ class PublishClient(salt.transport.base.PublishClient):
                     if msg:
                         try:
                             await callback(msg)
-                        except TypeError as exc:  # pylint: disable=broad-except
+                        except TypeError:
                             if callback is not None:
-                                log.error("Exception while running callback %s", exc, exc_info=True)
+                                log.exception("Exception while running callback: %s", callback)
                         except Exception:  # pylint: disable=broad-except
                             log.error("Exception while running callback", exc_info=True)
                     # log.debug("Callback done %r", callback)


### PR DESCRIPTION
### What does this PR do?
Checks if callback object in zeromq consume method is not None when handling logging as error.

### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/65898
and 
https://github.com/saltstack/salt/issues/66177

### Previous Behavior
Every minion will see many log errors for an:
`TypeError: object NoneType can't be used in 'await' expression`
from zeromq callback exception handling

### New Behavior
The consume method will now only log an error if there is an exception from with callback.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
