### PR TITLE
[3006.x] Bump to `pygments==2.17.2` due to https://github.com/advisories/GHSA-mrwq-x4v8-fh7p

### DIFF
--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.14.0
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.10/tools.txt
+++ b/requirements/static/ci/py3.10/tools.txt
@@ -40,7 +40,7 @@ pydantic-core==2.16.2
     # via pydantic
 pydantic==2.6.1
     # via python-tools-scripts
-pygments==2.13.0
+pygments==2.17.2
     # via rich
 python-dateutil==2.8.1
     # via botocore

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.14.0
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.11/tools.txt
+++ b/requirements/static/ci/py3.11/tools.txt
@@ -38,7 +38,7 @@ pydantic-core==2.16.2
     # via pydantic
 pydantic==2.6.1
     # via python-tools-scripts
-pygments==2.13.0
+pygments==2.17.2
     # via rich
 python-dateutil==2.8.1
     # via botocore

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.14.0
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.12/tools.txt
+++ b/requirements/static/ci/py3.12/tools.txt
@@ -38,7 +38,7 @@ pydantic-core==2.16.2
     # via pydantic
 pydantic==2.6.1
     # via python-tools-scripts
-pygments==2.13.0
+pygments==2.17.2
     # via rich
 python-dateutil==2.8.1
     # via botocore

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -127,7 +127,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.8.1
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.8.1
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -127,7 +127,7 @@ pycryptodomex==3.19.1
     #   -r requirements/crypto.txt
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.14.0
+pygments==2.17.2
     # via sphinx
 pytz==2022.1
     # via

--- a/requirements/static/ci/py3.9/tools.txt
+++ b/requirements/static/ci/py3.9/tools.txt
@@ -40,7 +40,7 @@ pydantic-core==2.16.2
     # via pydantic
 pydantic==2.6.1
     # via python-tools-scripts
-pygments==2.13.0
+pygments==2.17.2
     # via rich
 python-dateutil==2.8.1
     # via botocore


### PR DESCRIPTION
### What does this PR do?
Bump to `pygments==2.17.2` due to https://github.com/advisories/GHSA-mrwq-x4v8-fh7p
