### PR TITLE
[master] Decode oscap byte stream to string

### DIFF
--- a/changelog/66234.fixed.md
+++ b/changelog/66234.fixed.md
@@ -1,0 +1,1 @@
+Decode OpenSCAP byte stream to string

--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -155,10 +155,11 @@ def xccdf_eval(
         proc = subprocess.Popen(
             cmd_opts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=tempdir
         )
-        (stdoutdata, error) = proc.communicate()
+        (_, error) = proc.communicate()
+        error = error.decode("ascii", errors="ignore")
         success = _OSCAP_EXIT_CODES_MAP.get(proc.returncode, False)
         if proc.returncode < 0:
-            error += f"\nKilled by signal {proc.returncode}\n".encode("ascii")
+            error += f"\nKilled by signal {proc.returncode}\n"
         returncode = proc.returncode
         if success:
             if not __salt__["cp.push_dir"](tempdir):

--- a/tests/pytests/unit/modules/test_openscap.py
+++ b/tests/pytests/unit/modules/test_openscap.py
@@ -210,7 +210,9 @@ def test_new_openscap_xccdf_eval_success(policy_file):
     with patch(
         "salt.modules.openscap.subprocess.Popen",
         MagicMock(
-            return_value=Mock(**{"returncode": 0, "communicate.return_value": ("", "")})
+            return_value=Mock(
+                **{"returncode": 0, "communicate.return_value": (bytes(0), bytes(0))}
+            )
         ),
     ):
         response = openscap.xccdf_eval(
@@ -257,7 +259,9 @@ def test_new_openscap_xccdf_eval_success_with_extra_ovalfiles(policy_file):
     with patch(
         "salt.modules.openscap.subprocess.Popen",
         MagicMock(
-            return_value=Mock(**{"returncode": 0, "communicate.return_value": ("", "")})
+            return_value=Mock(
+                **{"returncode": 0, "communicate.return_value": (bytes(0), bytes(0))}
+            )
         ),
     ):
         response = openscap.xccdf_eval(
@@ -307,7 +311,13 @@ def test_new_openscap_xccdf_eval_success_with_failing_rules(policy_file):
         "salt.modules.openscap.subprocess.Popen",
         MagicMock(
             return_value=Mock(
-                **{"returncode": 2, "communicate.return_value": ("", "some error")}
+                **{
+                    "returncode": 2,
+                    "communicate.return_value": (
+                        bytes(0),
+                        bytes("some error", "UTF-8"),
+                    ),
+                }
             )
         ),
     ):
@@ -358,7 +368,10 @@ def test_new_openscap_xccdf_eval_evaluation_error(policy_file):
             return_value=Mock(
                 **{
                     "returncode": 1,
-                    "communicate.return_value": ("", "evaluation error"),
+                    "communicate.return_value": (
+                        bytes(0),
+                        bytes("evaluation error", "UTF-8"),
+                    ),
                 }
             )
         ),


### PR DESCRIPTION
### What does this PR do?

In the openscap module, we send non-escaped byte error stream from the oscap output to salt-master. However, the error stream may contain non-ascii characters, which Uyuni cannot process further. This means that user doesn't see any errors in the UI, just decoding exceptions in the logs.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
