### PR TITLE
[master] MongoDB returner reuse database connections

### DIFF
--- a/changelog/55999.changed.md
+++ b/changelog/55999.changed.md
@@ -1,0 +1,1 @@
+Improve MongoDB returner performance by reusing database connections


### PR DESCRIPTION
### What does this PR do?

Improves `mongo_future_return` performance when used as master job cache by reusing database connections.

Probably no difference for `mongo_return`, but updated anyway for consistency.

### What issues does this PR fix or reference?
Fixes: #55999 

### Previous Behavior
A new database connection established every time a returner function is called.

### New Behavior
A database connection is reused when multiple functions are called in a single run.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
