### PR TITLE
[master] Port #50460 to master

### DIFF
--- a/changelog/66251.added.md
+++ b/changelog/66251.added.md
@@ -1,0 +1,1 @@
+Added port, tls, username and password to the `smtp` configuration of the highstate returner.

--- a/tests/pytests/unit/returners/test_highstate_return.py
+++ b/tests/pytests/unit/returners/test_highstate_return.py
@@ -9,6 +9,7 @@ import pytest
 
 import salt.returners.highstate_return as highstate
 import salt.utils.files
+from tests.support.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -30,24 +31,9 @@ def configure_loader_modules(output_file):
     }
 
 
-def test_generate_table_should_correctly_escape_html_characters_when_data_contains_both_list_and_dict():
-    unescaped_fnord = "&fnord&"
-    unescaped_dronf = "<dronf>"
-    expected_escaped_fnord = "&amp;fnord&amp;"
-    expected_escaped_dronf = "&lt;dronf&gt;"
-    data = [["something", "or", "another", unescaped_fnord, {"cool": unescaped_dronf}]]
-
-    out = io.StringIO()
-    highstate._generate_html_table(data=data, out=out)
-    out.seek(0)
-    actual_table = out.read()
-
-    assert expected_escaped_fnord in actual_table
-    assert expected_escaped_dronf in actual_table
-
-
-def test_pipe_in_name(output_file):
-    ret = {
+@pytest.fixture
+def ret():
+    return {
         "fun_args": ["test"],
         "jid": "20180308201402941603",
         "return": {
@@ -74,6 +60,25 @@ def test_pipe_in_name(output_file):
         "id": "salt",
         "out": "highstate",
     }
+
+
+def test_generate_table_should_correctly_escape_html_characters_when_data_contains_both_list_and_dict():
+    unescaped_fnord = "&fnord&"
+    unescaped_dronf = "<dronf>"
+    expected_escaped_fnord = "&amp;fnord&amp;"
+    expected_escaped_dronf = "&lt;dronf&gt;"
+    data = [["something", "or", "another", unescaped_fnord, {"cool": unescaped_dronf}]]
+
+    out = io.StringIO()
+    highstate._generate_html_table(data=data, out=out)
+    out.seek(0)
+    actual_table = out.read()
+
+    assert expected_escaped_fnord in actual_table
+    assert expected_escaped_dronf in actual_table
+
+
+def test_pipe_in_name(output_file, ret):
     expected = [
         {
             "stats": [
@@ -120,3 +125,35 @@ def test_pipe_in_name(output_file):
     highstate.returner(ret)
     with salt.utils.files.fopen(str(output_file)) as fh_:
         assert json.load(fh_) == expected
+
+
+def test_smtp_options(ret):
+    """
+    Test to see if the highstate returner uses smtp options
+    """
+    smtp_username = "alice"
+    smtp_password = "p4ssw0rd"
+    smtp_server = "salt.stack.test"
+    smtp_port = 587
+    smtp_tls = True
+
+    options = {
+        "smtp_username": smtp_username,
+        "smtp_password": smtp_password,
+        "smtp_server": smtp_server,
+        "smtp_port": smtp_port,
+        "smtp_tls": smtp_tls,
+        "smtp_recipients": "bob.salt.test",
+        "smtp_sender": "alice.salt.test",
+        "report_delivery": "smtp",
+    }
+
+    with patch(
+        "salt.returners.highstate_return._get_options", MagicMock(return_value=options)
+    ), patch("salt.returners.smtp_return.smtplib.SMTP") as mocked_smtplib:
+        highstate.returner(ret)
+        mocked_smtplib.assert_called_with(host=smtp_server, port=smtp_port)
+        mocked_smtplib.return_value.login.assert_called_with(
+            smtp_username, smtp_password
+        )
+        assert mocked_smtplib.return_value.starttls.called is smtp_tls


### PR DESCRIPTION
### What does this PR do?

Ports saltstack/salt#50460 to the `master` branch. (Previous attempt saltstack/salt#57079)

Adds support for providing smtp port, username, password and enabling tls.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

**Yes**

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
