### PR TITLE
[3006.x] fixes #66252 correct use of egrep to parse semanage output

### DIFF
--- a/changelog/66252.fixed.md
+++ b/changelog/66252.fixed.md
@@ -1,0 +1,1 @@
+Applying `selinux.fcontext_policy_present` to a shorter path than an existing entry now works

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -616,7 +616,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | egrep '{filespec}'"
+        cmd = f"semanage fcontext -l | egrep '{filespec} '"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -6,6 +6,8 @@ import salt.modules.selinux as selinux
 from salt.exceptions import SaltInvocationError
 from tests.support.mock import MagicMock, mock_open, patch
 
+pytestmark = [pytest.mark.skip_unless_on_linux]
+
 
 @pytest.fixture
 def configure_loader_modules():

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -410,3 +410,35 @@ def test_selinux_add_policy_regex(name, sel_type):
         mock_cmd_run_all.assert_called_once_with(
             expected_cmd_run_all,
         )
+
+
+@pytest.mark.parametrize(
+    "name,sel_type",
+    (
+        ("/usr/share/munin/plugins/mysql_queries", "services_munin_plugin_exec_t"),
+        ("/usr/share/munin/plugins/mysql_", "unconfined_munin_plugin_exec_t"),
+    ),
+)
+def test_selinux_add_policy_shorter_path(name, sel_type):
+    """
+    Test adding policy with a shorter path than an existing entry
+    """
+    mock_cmd_shell = MagicMock(return_value={"retcode": 0})
+    mock_cmd_run_all = MagicMock(return_value={"retcode": 0})
+
+    with patch.dict(selinux.__salt__, {"cmd.shell": mock_cmd_shell}), patch.dict(
+        selinux.__salt__, {"cmd.run_all": mock_cmd_run_all}
+    ):
+        selinux.fcontext_add_policy(name, sel_type=sel_type)
+        filespec = re.escape(name)
+        expected_cmd_shell = f"semanage fcontext -l | egrep '{filespec}'"
+        mock_cmd_shell.assert_called_once_with(
+            expected_cmd_shell,
+            ignore_retcode=True,
+        )
+        expected_cmd_run_all = (
+            f"semanage fcontext --modify --type {sel_type} {filespec}"
+        )
+        mock_cmd_run_all.assert_called_once_with(
+            expected_cmd_run_all,
+        )


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #66252

### Previous Behavior
Attempting to run `selinux.fcontext_policy_present` with a filecontext which is a shorter version of one which is already defined would fail with

File context for ... is not defined

### New Behavior
The state will now apply correctly

### Merge requirements satisfied?
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
