### PR TITLE
[develop] Fix: Prevent full system upgrade in pkg.installed for Arch Linux

### DIFF
--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -551,7 +551,7 @@ def install(name=None,
         cmd.append('-S')
         if refresh is True:
             cmd.append('-y')
-        if sysupgrade is True or (sysupgrade is None and refresh is True):
+        if sysupgrade is True:
             cmd.append('-u')
         cmd.extend(['--noprogressbar', '--noconfirm', '--needed'])
         wildcards = []

--- a/tests/unit/modules/test_pacmanpkg.py
+++ b/tests/unit/modules/test_pacmanpkg.py
@@ -131,3 +131,16 @@ class PacmanTestCase(TestCase, LoaderModuleMockMixin):
                 }):
             results = pacman.group_diff('testgroup')
             self.assertEqual(results['default'], {'installed': ['A'], 'not installed': ['C']})
+            
+    def test_pkg_installed_sysupgrade_flag(self):
+        '''
+        Test if the pkg.installed state appends the '-u' flag only when sysupgrade is True
+        '''
+        with patch.dict(pacman.__salt__, {'cmd.run': MagicMock()}):
+            pacman.pkg_installed(name='somepkg', sysupgrade=True)
+            args, kwargs = pacman.__salt__['cmd.run'].call_args
+            self.assertIn('-u', args[0])
+
+            pacman.pkg_installed(name='somepkg', sysupgrade=None, refresh=True)
+            args, kwargs = pacman.__salt__['cmd.run'].call_args
+            self.assertNotIn('-u', args[0])


### PR DESCRIPTION
### What does this PR do?

This change modifies the logic in the pacman module to only append the '-u' flag to the pacman command if sysupgrade is explicitly set to True. This prevents the pkg.installed state from triggering a full system upgrade by default on Arch Linux systems, addressing an issue where unintended system-wide upgrades could occur during package installation.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65200

### Previous Behavior
The pkg.installed state would trigger a full system upgrade on Arch Linux systems by using the -u flag in the pacman command, even when only installing a single package.

### New Behavior
The pkg.installed state only triggers a system upgrade on Arch Linux systems if sysupgrade is explicitly set to True, preventing unintended full system upgrades.

### Commits signed with GPG?
No