### PR TITLE
[3007.x] Fix aptpkg.remove "Unable to locate package" for non-existent package

### DIFF
--- a/changelog/66260.fixed.md
+++ b/changelog/66260.fixed.md
@@ -1,0 +1,1 @@
+Fixed `aptpkg.remove` "unable to locate package" error for non-existent package

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1067,9 +1067,17 @@ def _uninstall(action="remove", name=None, pkgs=None, **kwargs):
 
     old = list_pkgs()
     old_removed = list_pkgs(removed=True)
-    targets = salt.utils.pkg.match_wildcard(old, pkg_params)
+    targets = [
+        _pkg for _pkg in salt.utils.pkg.match_wildcard(old, pkg_params) if _pkg in old
+    ]
     if action == "purge":
-        targets.update(salt.utils.pkg.match_wildcard(old_removed, pkg_params))
+        targets.extend(
+            [
+                _pkg
+                for _pkg in salt.utils.pkg.match_wildcard(old_removed, pkg_params)
+                if _pkg in old_removed
+            ]
+        )
     if not targets:
         return {}
     cmd = ["apt-get", "-q", "-y", action]

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -398,3 +398,9 @@ def test_aptpkg_remove_wildcard():
     assert ret["nginx-light"]["old"]
     assert not ret["nginx-doc"]["new"]
     assert ret["nginx-doc"]["old"]
+
+
+@pytest.mark.skip_if_not_root
+def test_aptpkg_remove_unknown_package():
+    ret = aptpkg.remove(name="thispackageistotallynotthere")
+    assert not ret


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #66260 

### Previous Behavior
"Unable to locate package" error when attempting to remove a non-existent package.

### New Behavior
Reverting to previous behavior of ignoring the non-existent package since it's technically already removed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
