### PR TITLE
[3007.x] Change log level of successful master cluster key exchange from error to info

### DIFF
--- a/changelog/66266.fixed.md
+++ b/changelog/66266.fixed.md
@@ -1,1 +1,1 @@
-Change log level of successful master cluster key exchange from error to debug.
+Change log level of successful master cluster key exchange from error to info.

--- a/changelog/66266.fixed.md
+++ b/changelog/66266.fixed.md
@@ -1,0 +1,1 @@
+Change log level of successful master cluster key exchange from error to debug.

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1074,7 +1074,7 @@ class MasterPubServerChannel:
                 if m_digest != digest:
                     log.error("Invalid aes signature from peer: %s", peer)
                     return
-                log.debug("Received new key from peer %s", peer)
+                log.info("Received new key from peer %s", peer)
                 if peer in self.peer_keys:
                     if self.peer_keys[peer] != key_str:
                         self.peer_keys[peer] = key_str

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1074,7 +1074,7 @@ class MasterPubServerChannel:
                 if m_digest != digest:
                     log.error("Invalid aes signature from peer: %s", peer)
                     return
-                log.error("Received new key from peer %s", peer)
+                log.debug("Received new key from peer %s", peer)
                 if peer in self.peer_keys:
                     if self.peer_keys[peer] != key_str:
                         self.peer_keys[peer] = key_str


### PR DESCRIPTION
### What does this PR do?

Sets the log level of successful master key exchange from error to info.

### What issues does this PR fix or reference?
Fixes: #66266 

### Previous Behavior
Logs indicating successful master key exchange would be logged as errors

### New Behavior
These logs will not be seen unless the master is running with a `log_level` of `info`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
