### PR TITLE
[3007.x] Change log level of publisher binding from error to debug

### DIFF
--- a/changelog/66179.fixed.md
+++ b/changelog/66179.fixed.md
@@ -1,0 +1,1 @@
+Change log level of publisher binding from error to debug.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1403,12 +1403,12 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             ssl=ctx,
         )
         if self.pub_path:
-            log.error(
+            log.debug(
                 "Publish server binding pub to %s ssl=%r", self.pub_path, self.ssl
             )
             sock = tornado.netutil.bind_unix_socket(self.pub_path)
         else:
-            log.error(
+            log.debug(
                 "Publish server binding pub to %s:%s ssl=%r",
                 self.pub_host,
                 self.pub_port,


### PR DESCRIPTION
### What does this PR do?

Sets the log level of publisher binding from error to debug.

### What issues does this PR fix or reference?
Fixes: #66179

### Previous Behavior
Logs indicating publisher binding were being logged as errors

### New Behavior
These logs will not be seen unless the master is running with a `log_level` of `debug`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
