### PR TITLE
[3006.x] Fix systemctl try-restart instead of retry-restart within the RPM spec, properly restarting upgraded services

### DIFF
--- a/changelog/66143.fixed.md
+++ b/changelog/66143.fixed.md
@@ -1,0 +1,1 @@
+Fix systemctl with "try-restart" instead of "retry-restart" within the RPM spec, properly restarting upgraded services

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -176,7 +176,7 @@ cd $RPM_BUILD_DIR
 
   # Fix any hardcoded paths to the relenv python binary on any of the scripts installed in
   # the <onedir>/bin directory
-  find $RPM_BUILD_DIR/build/salt/bin/ -type f -exec sed -i 's:#!/\(.*\)salt/bin/python3:#!/bin/sh -x\n"exec" "$(dirname $(readlink -f $0))/python3" "$0" "$@":g' {} \;
+  find $RPM_BUILD_DIR/build/salt/bin/ -type f -exec sed -i 's:#!/\(.*\)salt/bin/python3:#!/bin/sh\n"exec" "$(dirname $(readlink -f $0))/python3" "$0" "$@":g' {} \;
 
   $RPM_BUILD_DIR/build/venv/bin/tools pkg build salt-onedir . --package-name $RPM_BUILD_DIR/build/salt --platform linux
   $RPM_BUILD_DIR/build/venv/bin/tools pkg pre-archive-cleanup --pkg $RPM_BUILD_DIR/build/salt
@@ -472,14 +472,6 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 
 
 %post master
-# %%systemd_post salt-master.service
-if [ $1 -gt 1 ] ; then
-  # Upgrade
-  /bin/systemctl try-restart salt-master.service >/dev/null 2>&1 || :
-else
-  # Initial installation
-  /bin/systemctl preset salt-master.service >/dev/null 2>&1 || :
-fi
 ln -s -f /opt/saltstack/salt/salt %{_bindir}/salt
 ln -s -f /opt/saltstack/salt/salt-cp %{_bindir}/salt-cp
 ln -s -f /opt/saltstack/salt/salt-key %{_bindir}/salt-key
@@ -498,8 +490,17 @@ if [ $1 -lt 2 ]; then
     fi
   fi
 fi
+# %%systemd_post salt-master.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  /bin/systemctl try-restart salt-master.service >/dev/null 2>&1 || :
+else
+  # Initial installation
+  /bin/systemctl preset salt-master.service >/dev/null 2>&1 || :
+fi
 
 %post syndic
+ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 # %%systemd_post salt-syndic.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
@@ -508,17 +509,8 @@ else
   # Initial installation
   /bin/systemctl preset salt-syndic.service >/dev/null 2>&1 || :
 fi
-ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 
 %post minion
-# %%systemd_post salt-minion.service
-if [ $1 -gt 1 ] ; then
-  # Upgrade
-  /bin/systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
-else
-  # Initial installation
-  /bin/systemctl preset salt-minion.service >/dev/null 2>&1 || :
-fi
 ln -s -f /opt/saltstack/salt/salt-minion %{_bindir}/salt-minion
 ln -s -f /opt/saltstack/salt/salt-call %{_bindir}/salt-call
 ln -s -f /opt/saltstack/salt/salt-proxy %{_bindir}/salt-proxy
@@ -535,11 +527,20 @@ if [ $1 -lt 2 ]; then
     fi
   fi
 fi
+# %%systemd_post salt-minion.service
+if [ $1 -gt 1 ] ; then
+  # Upgrade
+  /bin/systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
+else
+  # Initial installation
+  /bin/systemctl preset salt-minion.service >/dev/null 2>&1 || :
+fi
 
 %post ssh
 ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 
 %post api
+ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 # %%systemd_post salt-api.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
@@ -548,7 +549,6 @@ else
   # Initial installation
   /bin/systemctl preset salt-api.service >/dev/null 2>&1 || :
 fi
-ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 
 
 %posttrans cloud

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -475,7 +475,7 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 # %%systemd_post salt-master.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl retry-restart salt-master.service >/dev/null 2>&1 || :
+  systemctl try-restart salt-master.service >/dev/null 2>&1 || :
 else
   # Initial installation
   systemctl preset salt-master.service >/dev/null 2>&1 || :
@@ -503,7 +503,7 @@ fi
 # %%systemd_post salt-syndic.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl retry-restart salt-syndic.service >/dev/null 2>&1 || :
+  systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
 else
   # Initial installation
   systemctl preset salt-syndic.service >/dev/null 2>&1 || :
@@ -514,7 +514,7 @@ ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 # %%systemd_post salt-minion.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl retry-restart salt-minion.service >/dev/null 2>&1 || :
+  systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
 else
   # Initial installation
   systemctl preset salt-minion.service >/dev/null 2>&1 || :
@@ -543,7 +543,7 @@ ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 # %%systemd_post salt-api.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl retry-restart salt-api.service >/dev/null 2>&1 || :
+  systemctl try-restart salt-api.service >/dev/null 2>&1 || :
 else
   # Initial installation
   systemctl preset salt-api.service >/dev/null 2>&1 || :

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -176,7 +176,7 @@ cd $RPM_BUILD_DIR
 
   # Fix any hardcoded paths to the relenv python binary on any of the scripts installed in
   # the <onedir>/bin directory
-  find $RPM_BUILD_DIR/build/salt/bin/ -type f -exec sed -i 's:#!/\(.*\)salt/bin/python3:#!/bin/sh\n"exec" "$(dirname $(readlink -f $0))/python3" "$0" "$@":g' {} \;
+  find $RPM_BUILD_DIR/build/salt/bin/ -type f -exec sed -i 's:#!/\(.*\)salt/bin/python3:#!/bin/sh -x\n"exec" "$(dirname $(readlink -f $0))/python3" "$0" "$@":g' {} \;
 
   $RPM_BUILD_DIR/build/venv/bin/tools pkg build salt-onedir . --package-name $RPM_BUILD_DIR/build/salt --platform linux
   $RPM_BUILD_DIR/build/venv/bin/tools pkg pre-archive-cleanup --pkg $RPM_BUILD_DIR/build/salt
@@ -439,16 +439,16 @@ find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
 # %%systemd_preun salt-syndic.service > /dev/null 2>&1
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
-  systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
-  systemctl stop salt-syndic.service > /dev/null 2>&1 || :
+  /bin/systemctl --no-reload disable salt-syndic.service > /dev/null 2>&1 || :
+  /bin/systemctl stop salt-syndic.service > /dev/null 2>&1 || :
 fi
 
 %preun minion
 # %%systemd_preun salt-minion.service
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
-  systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
-  systemctl stop salt-minion.service > /dev/null 2>&1 || :
+  /bin/systemctl --no-reload disable salt-minion.service > /dev/null 2>&1 || :
+  /bin/systemctl stop salt-minion.service > /dev/null 2>&1 || :
 fi
 
 
@@ -456,8 +456,8 @@ fi
 # %%systemd_preun salt-api.service
 if [ $1 -eq 0 ] ; then
   # Package removal, not upgrade
-  systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
-  systemctl stop salt-api.service > /dev/null 2>&1 || :
+  /bin/systemctl --no-reload disable salt-api.service > /dev/null 2>&1 || :
+  /bin/systemctl stop salt-api.service > /dev/null 2>&1 || :
 fi
 
 
@@ -475,10 +475,10 @@ ln -s -f /opt/saltstack/salt/salt-cloud %{_bindir}/salt-cloud
 # %%systemd_post salt-master.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl try-restart salt-master.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-master.service >/dev/null 2>&1 || :
 else
   # Initial installation
-  systemctl preset salt-master.service >/dev/null 2>&1 || :
+  /bin/systemctl preset salt-master.service >/dev/null 2>&1 || :
 fi
 ln -s -f /opt/saltstack/salt/salt %{_bindir}/salt
 ln -s -f /opt/saltstack/salt/salt-cp %{_bindir}/salt-cp
@@ -503,10 +503,10 @@ fi
 # %%systemd_post salt-syndic.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
 else
   # Initial installation
-  systemctl preset salt-syndic.service >/dev/null 2>&1 || :
+  /bin/systemctl preset salt-syndic.service >/dev/null 2>&1 || :
 fi
 ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 
@@ -514,10 +514,10 @@ ln -s -f /opt/saltstack/salt/salt-syndic %{_bindir}/salt-syndic
 # %%systemd_post salt-minion.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
 else
   # Initial installation
-  systemctl preset salt-minion.service >/dev/null 2>&1 || :
+  /bin/systemctl preset salt-minion.service >/dev/null 2>&1 || :
 fi
 ln -s -f /opt/saltstack/salt/salt-minion %{_bindir}/salt-minion
 ln -s -f /opt/saltstack/salt/salt-call %{_bindir}/salt-call
@@ -543,10 +543,10 @@ ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 # %%systemd_post salt-api.service
 if [ $1 -gt 1 ] ; then
   # Upgrade
-  systemctl try-restart salt-api.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-api.service >/dev/null 2>&1 || :
 else
   # Initial installation
-  systemctl preset salt-api.service >/dev/null 2>&1 || :
+  /bin/systemctl preset salt-api.service >/dev/null 2>&1 || :
 fi
 ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 
@@ -589,10 +589,10 @@ fi
 
 %postun master
 # %%systemd_postun_with_restart salt-master.service
-systemctl daemon-reload >/dev/null 2>&1 || :
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
-  systemctl try-restart salt-master.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-master.service >/dev/null 2>&1 || :
 fi
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
@@ -610,18 +610,18 @@ fi
 
 %postun syndic
 # %%systemd_postun_with_restart salt-syndic.service
-systemctl daemon-reload >/dev/null 2>&1 || :
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
-  systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-syndic.service >/dev/null 2>&1 || :
 fi
 
 %postun minion
 # %%systemd_postun_with_restart salt-minion.service
-systemctl daemon-reload >/dev/null 2>&1 || :
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
-  systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-minion.service >/dev/null 2>&1 || :
 fi
 if [ $1 -eq 0 ]; then
   if [ $(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2 | sed  's/\"//g' | cut -d '.' -f 1) = "8" ]; then
@@ -639,10 +639,10 @@ fi
 
 %postun api
 # %%systemd_postun_with_restart salt-api.service
-systemctl daemon-reload >/dev/null 2>&1 || :
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 if [ $1 -ge 1 ] ; then
   # Package upgrade, not uninstall
-  systemctl try-restart salt-api.service >/dev/null 2>&1 || :
+  /bin/systemctl try-restart salt-api.service >/dev/null 2>&1 || :
 fi
 
 %changelog

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -32,17 +32,25 @@ def test_salt_upgrade(salt_call_cli, install_salt):
     assert "Authentication information could" in use_lib.stderr
 
     # Verify there is a running minion by getting its PID
+    salt_name = "salt"
     if platform.is_windows():
         process_name = "salt-minion.exe"
     else:
         process_name = "salt-minion"
-    old_pid = None
+
+    old_pid = []
+
+    # psutil process name only returning first part of the command '/opt/saltstack/'
+    # need to check all of command line for salt-minion
+    # ['/opt/saltstack/salt/bin/python3.10 /usr/bin/salt-minion MultiMinionProcessManager MinionProcessManager']
+    # and psutil is only returning the salt-minion once
     for proc in psutil.process_iter():
-        if process_name in proc.name():
-            if psutil.Process(proc.ppid()).name() != process_name:
-                old_pid = proc.pid
-                break
-    assert old_pid is not None
+        if salt_name in proc.name():
+            cmdl_strg = " ".join(str(element) for element in proc.cmdline())
+            if process_name in cmdl_strg:
+                old_pid.append(proc.pid)
+
+    assert old_pid
 
     # Upgrade Salt from previous version and test
     install_salt.install(upgrade=True)
@@ -54,13 +62,14 @@ def test_salt_upgrade(salt_call_cli, install_salt):
 
     # Verify there is a new running minion by getting its PID and comparing it
     # with the PID from before the upgrade
-    new_pid = None
+    new_pid = []
     for proc in psutil.process_iter():
-        if process_name in proc.name():
-            if psutil.Process(proc.ppid()).name() != process_name:
-                new_pid = proc.pid
-                break
-    assert new_pid is not None
+        if salt_name in proc.name():
+            cmdl_strg = " ".join(str(element) for element in proc.cmdline())
+            if process_name in cmdl_strg:
+                new_pid.append(proc.pid)
+
+    assert new_pid
     assert new_pid != old_pid
 
     if install_salt.relenv:


### PR DESCRIPTION
### What does this PR do?
Fix systemctl typo in the RPM spec where systemctl retry-restart was being used, instead of the correct command of systemctl try-restart.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66143

### Previous Behavior
Services weren't being restarted because systemctl retry-restart wasn't valid

### New Behavior
Services are properly restarting because systemctl try-restart is the valid command

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
