### PR TITLE
[3007.x] Update to VC Redist 2022

### DIFF
--- a/pkg/windows/msi/Product.wxs
+++ b/pkg/windows/msi/Product.wxs
@@ -250,11 +250,9 @@ IMCAC - Immediate Custom Action - It's immediate
     <DirectoryRef Id="TARGETDIR">
     <!-- Visual C++ runtimes depend on the target platform -->
     <?if $(var.WIN64)=yes ?>
-      <Merge Id="MSM_VC120_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC120_CRT_x64.msm" DiskId="1" Language="0" />
-      <Merge Id="MSM_VC140_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC140_CRT_x64.msm" DiskId="1" Language="0" />
+      <Merge Id="MSM_VC143_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC143_CRT_x64.msm" DiskId="1" Language="0" />
     <?else ?>
-      <Merge Id="MSM_VC120_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC120_CRT_x86.msm" DiskId="1" Language="0" />
-      <Merge Id="MSM_VC140_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC140_CRT_x86.msm" DiskId="1" Language="0" />
+      <Merge Id="MSM_VC143_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC143_CRT_x86.msm" DiskId="1" Language="0" />
     <?endif ?>
     </DirectoryRef>
     <!-- Add INSTALLDIR to the system Path -->
@@ -269,8 +267,7 @@ IMCAC - Immediate Custom Action - It's immediate
     <!-- Leaving registry keys would mean the product is still installed -->
     <Feature Id="ProductFeature" Title="Minion" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
-      <Feature Id="VC120" Title="VC++ 2013" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC120_CRT" /></Feature>
-      <Feature Id="VC140" Title="VC++ 2015" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC140_CRT" /></Feature>
+      <Feature Id="VC143" Title="VC++ 2022" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC143_CRT" /></Feature>
     </Feature>
 
     <!-- Get the config file template from the msi store only if no config is present -->

--- a/pkg/windows/msi/README-how-to-build.md
+++ b/pkg/windows/msi/README-how-to-build.md
@@ -10,10 +10,8 @@ You need
 - .Net 3.5 SDK (for WiX)<sup>*</sup>
 - [Wix 3](http://wixtoolset.org/releases/)<sup>**</sup>
 - [Build tools 2015](https://www.microsoft.com/en-US/download/confirmation.aspx?id=48159)<sup>**</sup>
-- Microsoft_VC140_CRT_x64.msm from Visual Studio 2015<sup>**</sup>
-- Microsoft_VC140_CRT_x86.msm from Visual Studio 2015<sup>**</sup>
-- Microsoft_VC120_CRT_x64.msm from Visual Studio 2013<sup>**</sup>
-- Microsoft_VC120_CRT_x86.msm from Visual Studio 2013<sup>**</sup>
+- Microsoft_VC143_CRT_x64.msm from Visual Studio 2015<sup>**</sup>
+- Microsoft_VC143_CRT_x86.msm from Visual Studio 2015<sup>**</sup>
 
 Notes:
 - <sup>*</sup> `build.cmd` will open `optionalfeatures` if necessary.

--- a/pkg/windows/msi/build_pkg.ps1
+++ b/pkg/windows/msi/build_pkg.ps1
@@ -51,11 +51,14 @@ function VerifyOrDownload ($local_file, $URL, $SHA256) {
     $filename = Split-Path $local_file -leaf
     if ( Test-Path -Path $local_file ) {
         Write-Host "Verifying hash for $filename`: " -NoNewline
-        if ( (Get-FileHash $local_file).Hash -eq $SHA256 ) {
+        $hash = (Get-FileHash $local_file).Hash
+        if ( $hash -eq $SHA256 ) {
             Write-Result "Verified" -ForegroundColor Green
             return
         } else {
             Write-Result "Failed Hash" -ForegroundColor Red
+            Write-Host "Found Hash: $hash"
+            Write-Host "Expected Hash: $SHA256"
             Remove-Item -Path $local_file -Force
         }
     }
@@ -161,10 +164,8 @@ if ( ! "$env:WIX" ) {
 #-------------------------------------------------------------------------------
 
 $RUNTIMES = @(
-    ("Microsoft_VC120_CRT_x64.msm", "64", "15FD10A495287505184B8913DF8D6A9CA461F44F78BC74115A0C14A5EDD1C9A7"),
-    ("Microsoft_VC120_CRT_x86.msm", "32", "26340B393F52888B908AC3E67B935A80D390E1728A31FF38EBCEC01117EB2579"),
-    ("Microsoft_VC140_CRT_x64.msm", "64", "E1344D5943FB2BBB7A56470ED0B7E2B9B212CD9210D3CC6FA82BC3DA8F11EDA8"),
-    ("Microsoft_VC140_CRT_x86.msm", "32", "0D36CFE6E9ABD7F530DBAA4A83841CDBEF9B2ADCB625614AF18208FDCD6B92A4")
+    ("Microsoft_VC143_CRT_x64.msm", "64", "F209B8906063A79B0DFFBB55D3C20AC0A676252DD4F5377CFCD148C409C859EC"),
+    ("Microsoft_VC143_CRT_x86.msm", "32", "B187BD73C7DC0BA353C5D3A6D9D4E63EF72435F8E68273466F30E5496C1A86F7")
 )
 $RUNTIMES | ForEach-Object {
     $name, $arch, $hash = $_

--- a/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
@@ -602,9 +602,9 @@ Section -install_ucrt
 SectionEnd
 
 
-# Check and install Visual C++ redist 2013 packages
+# Check and install Visual C++ redist 2022 packages
 # Hidden section (-) to install VCRedist
-Section -install_vcredist_2013
+Section -install_vcredist_2022
 
     Var /GLOBAL VcRedistName
     Var /GLOBAL VcRedistReg
@@ -613,11 +613,11 @@ Section -install_vcredist_2013
     # Use RunningX64 here to get the Architecture for the system running the
     # installer.
     ${If} ${RunningX64}
-        StrCpy $VcRedistName "vcredist_x64_2013"
-        StrCpy $VcRedistReg "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
+        StrCpy $VcRedistName "vcredist_x64_2022"
+        StrCpy $VcRedistReg "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
     ${Else}
-        StrCpy $VcRedistName "vcredist_x86_2013"
-        StrCpy $VcRedistReg "SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x86"
+        StrCpy $VcRedistName "vcredist_x86_2022"
+        StrCpy $VcRedistReg "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86"
     ${EndIf}
 
     # Detecting VCRedist Installation

--- a/pkg/windows/nsis/tests/setup.ps1
+++ b/pkg/windows/nsis/tests/setup.ps1
@@ -70,10 +70,8 @@ $directories | ForEach-Object {
 # Create binaries
 #-------------------------------------------------------------------------------
 
-$prereq_files = "vcredist_x86_2013.exe",
-                "vcredist_x64_2013.exe",
-                "ucrt_x86.zip",
-                "ucrt_x64.zip"
+$prereq_files = "vcredist_x86_2022.exe",
+                "vcredist_x64_2022.exe",
 $prereq_files | ForEach-Object {
     Write-Host "Creating $_`: " -NoNewline
     Set-Content -Path "$PREREQS_DIR\$_" -Value "binary"

--- a/pkg/windows/prep_salt.ps1
+++ b/pkg/windows/prep_salt.ps1
@@ -183,21 +183,10 @@ $scripts | ForEach-Object {
     }
 }
 
-# Copy VCRedist 2013 to the prereqs directory
+# Copy VCRedist 2022 to the prereqs directory
 New-Item -Path $PREREQ_DIR -ItemType Directory | Out-Null
-Write-Host "Copying VCRedist 2013 $ARCH_X to prereqs: " -NoNewline
-$file = "vcredist_$ARCH_X`_2013.exe"
-Invoke-WebRequest -Uri "$SALT_DEP_URL/$file" -OutFile "$PREREQ_DIR\$file"
-if ( Test-Path -Path "$PREREQ_DIR\$file" ) {
-    Write-Result "Success" -ForegroundColor Green
-} else {
-    Write-Result "Failed" -ForegroundColor Red
-    exit 1
-}
-
-# Copy Universal C Runtimes to the prereqs directory
-Write-Host "Copying Universal C Runtimes $ARCH_X to prereqs: " -NoNewline
-$file = "ucrt_$ARCH_X.zip"
+Write-Host "Copying VCRedist 2022 $ARCH_X to prereqs: " -NoNewline
+$file = "vcredist_$ARCH_X`_2022.exe"
 Invoke-WebRequest -Uri "$SALT_DEP_URL/$file" -OutFile "$PREREQ_DIR\$file"
 if ( Test-Path -Path "$PREREQ_DIR\$file" ) {
     Write-Result "Success" -ForegroundColor Green


### PR DESCRIPTION
### What does this PR do?
Updates the bundled VC Redist to 2022. Removes Universal C Runtimes as they are now included on supported versions of Windows.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66225

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes