### PR TITLE
[master] Remove firing useless event and not related comment

### DIFF
--- a/changelog/66279.fixed.md
+++ b/changelog/66279.fixed.md
@@ -1,0 +1,1 @@
+Remove firing useless events with JID as a tag

--- a/salt/master.py
+++ b/salt/master.py
@@ -2580,8 +2580,6 @@ class ClearFuncs(TransportMethods):
         clear_load["jid"] = jid
         delimiter = clear_load.get("kwargs", {}).get("delimiter", DEFAULT_TARGET_DELIM)
 
-        # TODO Error reporting over the master event bus
-        self.event.fire_event({"minions": minions}, clear_load["jid"])
         new_job_load = {
             "jid": clear_load["jid"],
             "tgt_type": clear_load["tgt_type"],


### PR DESCRIPTION
### What does this PR do?

There is a useless event fired and the comment which doesn't seem really related to this operation.
It was introduced long time ago with https://github.com/saltstack/salt/commit/c131c09649a07be2a75d7152c6a91d104542a677
and just issuing the following:
```
20240327120237373936	{"minions": ["evil-004991.demo.org", "evil-004992.demo.org", "evil-004993.demo.org", "evil-004994.demo.org"], "_stamp": "2024-03-27T12:02:37.375454"}
```
in combination with meaningful:
```
salt/job/20240327120237373936/new	{"jid": "20240327120237373936", "tgt_type": "list", "tgt": ["evil-004991.demo.org", "evil-004992.demo.org", "evil-004993.demo.org", "evil-004994.demo.org"], "user": "admin", "fun": "test.arg", "arg": [], "minions": [""evil-004991.demo.org", "evil-004992.demo.org", "evil-004993.demo.org", "evil-004994.demo.org"], "missing": [], "_stamp": "2024-03-27T12:02:37.375807"}
```

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
