### PR TITLE
[3006.x] Add leading slash to salt helper file paths as per dh_links requirement

### DIFF
--- a/changelog/66280.fixed.md
+++ b/changelog/66280.fixed.md
@@ -1,0 +1,1 @@
+Add leading slash to salt helper file paths as per dh_links requirement

--- a/pkg/debian/salt-master.links
+++ b/pkg/debian/salt-master.links
@@ -1,6 +1,6 @@
 opt/saltstack/salt/salt-master /usr/bin/salt-master
-opt/saltstack/salt/salt usr/bin/salt
-opt/saltstack/salt/salt-cp usr/bin/salt-cp
-opt/saltstack/salt/salt-key usr/bin/salt-key
-opt/saltstack/salt/salt-run usr/bin/salt-run
-opt/saltstack/salt/spm usr/bin/spm
+opt/saltstack/salt/salt /usr/bin/salt
+opt/saltstack/salt/salt-cp /usr/bin/salt-cp
+opt/saltstack/salt/salt-key /usr/bin/salt-key
+opt/saltstack/salt/salt-run /usr/bin/salt-run
+opt/saltstack/salt/spm /usr/bin/spm


### PR DESCRIPTION
### What does this PR do?
Add leading slash to salt helper file paths as per dh_links requirement

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66280


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
