### PR TITLE
[3006.x] Make directory structure the same on WinRepo

### DIFF
--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -174,7 +174,7 @@ def update_git_repos(opts=None, clean=False, masterless=False):
                     rev, remote_url = remote_info.strip().split()
                 except ValueError:
                     remote_url = remote_info
-                gittarget = os.path.join(base_dir, targetname).replace(".", "_")
+                gittarget = os.path.join(base_dir, targetname).replace(".git", "")
                 if masterless:
                     result = __salt__["state.single"](
                         "git.latest",

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -472,7 +472,7 @@ class GitProvider:
                 "/", "_"
             )  # replace "/" with "_" to not cause trouble with file system
         self._cache_hash = salt.utils.path.join(cache_root, self._cache_basehash)
-        self._cache_basename = "_"
+        self._cache_basename = ""
         if self.id.startswith("__env__"):
             try:
                 self._cache_basename = self.get_checkout_target()

--- a/tests/pytests/functional/runners/test_winrepo.py
+++ b/tests/pytests/functional/runners/test_winrepo.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from salt.runners import winrepo
@@ -10,27 +12,21 @@ pytestmark = [
 
 @pytest.fixture
 def configure_loader_modules(minion_opts, tmp_path):
-    opts = minion_opts.copy()
     winrepo_dir = tmp_path / "winrepo"
     winrepo_dir.mkdir()
     winrepo_dir_ng = tmp_path / "winrepo_ng"
     winrepo_dir_ng.mkdir()
-    opts["winrepo_dir"] = str(winrepo_dir)
-    opts["winrepo_dir_ng"] = str(winrepo_dir_ng)
-
-    return {
-        winrepo: {
-            "__opts__": opts,
-        }
-    }
+    minion_opts["winrepo_dir"] = str(winrepo_dir)
+    minion_opts["winrepo_dir_ng"] = str(winrepo_dir_ng)
+    return {winrepo: {"__opts__": minion_opts}}
 
 
 @pytest.fixture
 def winrepo_remotes(minion_opts):
-    winrepo_remotes = minion_opts.get("winrepo_remotes", [])
-    winrepo_remotes_ng = minion_opts.get("winrepo_remotes_ng", [])
-    winrepo_remotes.extend(winrepo_remotes_ng)
-    return winrepo_remotes
+    remotes = set()
+    remotes.update(minion_opts.get("winrepo_remotes", []))
+    remotes.update(minion_opts.get("winrepo_remotes_ng", []))
+    return remotes
 
 
 def test_update_git_repos(winrepo_remotes):
@@ -38,15 +34,18 @@ def test_update_git_repos(winrepo_remotes):
     Ensure update git repos works as intended.
     """
     res = winrepo.update_git_repos()
-
     assert res
 
     for remote in winrepo_remotes:
         assert remote in res
         assert res[remote]
 
+        # Make sure there are package definitions in the root
+        pkg_def = os.path.join(res[remote], "7zip.sls")
+        assert os.path.exists(pkg_def)
 
-def test_legacy_update_git_repos(winrepo_remotes):
+
+def test_legacy_update_git_repos(winrepo_remotes, minion_opts):
     """
     Ensure update git repos works as intended with legacy (non-gitfs) code.
     """
@@ -58,3 +57,15 @@ def test_legacy_update_git_repos(winrepo_remotes):
         for remote in winrepo_remotes:
             assert remote in res
             assert res[remote]
+
+            # Make sure there are package definitions in the root
+            # We have to look up the actual repo dir here because the legacy
+            # update only returns True or False, not a path
+            if "-ng" in remote:
+                path = minion_opts["winrepo_dir_ng"]
+                pkg_def = os.path.join(path, "salt-winrepo-ng", "7zip.sls")
+            else:
+                path = minion_opts["winrepo_dir"]
+                pkg_def = os.path.join(path, "salt-winrepo", "7zip.sls")
+
+            assert os.path.exists(pkg_def)

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -248,4 +248,4 @@ def test_checkout_pygit2(_prepare_provider):
     reason="Skip Pygit2 on windows, due to pygit2 access error on windows"
 )
 def test_get_cachedir_basename_pygit2(_prepare_provider):
-    assert "_" == _prepare_provider.get_cache_basename()
+    assert "" == _prepare_provider.get_cache_basename()

--- a/tests/unit/utils/test_gitfs.py
+++ b/tests/unit/utils/test_gitfs.py
@@ -117,11 +117,11 @@ class TestGitBase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_get_cachedir_basename(self):
         self.assertEqual(
             self.main_class.remotes[0].get_cache_basename(),
-            "_",
+            "",
         )
         self.assertEqual(
             self.main_class.remotes[1].get_cache_basename(),
-            "_",
+            "",
         )
 
     def test_git_provider_mp_lock(self):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `winrepo.update_git_repos` runner where the directory structure differs when run on a master using gitfs or run on a minion using gitpython.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
When run using gitfs the file path was (`salt-run winrepo.update_git_repos` on Linux):
`/srv/salt/win/repo_ng/salt-winrepo-ng/_/*`
When run using GitPython or PyGit2 (`salt-call --local winrepo.update_git_repos` on Windows):
`/srv/salt/win/repo_ng/salt-winrepo-ng_git/*`

### New Behavior
The directory structure is the same regardless of what system is being used:
`/srv/salt/win/repo_ng/salt-winrepo-ng/*`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes