### PR TITLE
[3006.x] Replace AlmaLinux 8 and 9 with Rocky Linux 8 and 9 (ultimately replacing CentOS Stream)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,16 +477,16 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
-  almalinux-8-pkg-tests:
-    name: Alma Linux 8 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-8') }}
+  rockylinux-8-pkg-tests:
+    name: Rocky Linux 8 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-8') }}
     needs:
       - prepare-workflow
       - build-pkgs-onedir
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -498,16 +498,16 @@ jobs:
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-8-arm64-pkg-tests:
-    name: Alma Linux 8 Arm64 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-8-arm64') }}
+  rockylinux-8-arm64-pkg-tests:
+    name: Rocky Linux 8 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-8-arm64') }}
     needs:
       - prepare-workflow
       - build-pkgs-onedir
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -519,8 +519,8 @@ jobs:
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-pkg-tests:
-    name: Alma Linux 9 Package Test
+  rockylinux-9-pkg-tests:
+    name: Rocky Linux 9 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -528,7 +528,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -540,16 +540,16 @@ jobs:
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-arm64-pkg-tests:
-    name: Alma Linux 9 Arm64 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-9-arm64') }}
+  rockylinux-9-arm64-pkg-tests:
+    name: Rocky Linux 9 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-9-arm64') }}
     needs:
       - prepare-workflow
       - build-pkgs-onedir
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1264,15 +1264,15 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
-  almalinux-8:
-    name: Alma Linux 8 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-8') }}
+  rockylinux-8:
+    name: Rocky Linux 8 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-8') }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1285,15 +1285,15 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
-  almalinux-8-arm64:
-    name: Alma Linux 8 Arm64 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-8-arm64') }}
+  rockylinux-8-arm64:
+    name: Rocky Linux 8 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-8-arm64') }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1306,15 +1306,15 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
-  almalinux-9:
-    name: Alma Linux 9 Test
+  rockylinux-9:
+    name: Rocky Linux 9 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1327,15 +1327,15 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
-  almalinux-9-arm64:
-    name: Alma Linux 9 Arm64 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'almalinux-9-arm64') }}
+  rockylinux-9-arm64:
+    name: Rocky Linux 9 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'rockylinux-9-arm64') }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1806,10 +1806,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -1960,10 +1960,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -1985,10 +1985,10 @@ jobs:
       - ubuntu-2004-arm64
       - ubuntu-2204
       - ubuntu-2204-arm64
-      - almalinux-8-pkg-tests
-      - almalinux-8-arm64-pkg-tests
-      - almalinux-9-pkg-tests
-      - almalinux-9-arm64-pkg-tests
+      - rockylinux-8-pkg-tests
+      - rockylinux-8-arm64-pkg-tests
+      - rockylinux-9-pkg-tests
+      - rockylinux-9-arm64-pkg-tests
       - amazonlinux-2-pkg-tests
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -534,8 +534,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
-  almalinux-8-pkg-tests:
-    name: Alma Linux 8 Package Test
+  rockylinux-8-pkg-tests:
+    name: Rocky Linux 8 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -543,7 +543,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -555,8 +555,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-8-arm64-pkg-tests:
-    name: Alma Linux 8 Arm64 Package Test
+  rockylinux-8-arm64-pkg-tests:
+    name: Rocky Linux 8 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -564,7 +564,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -576,8 +576,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-pkg-tests:
-    name: Alma Linux 9 Package Test
+  rockylinux-9-pkg-tests:
+    name: Rocky Linux 9 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -585,7 +585,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -597,8 +597,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-arm64-pkg-tests:
-    name: Alma Linux 9 Arm64 Package Test
+  rockylinux-9-arm64-pkg-tests:
+    name: Rocky Linux 9 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -606,7 +606,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1321,15 +1321,15 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
-  almalinux-8:
-    name: Alma Linux 8 Test
+  rockylinux-8:
+    name: Rocky Linux 8 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1342,15 +1342,15 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
-  almalinux-8-arm64:
-    name: Alma Linux 8 Arm64 Test
+  rockylinux-8-arm64:
+    name: Rocky Linux 8 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1363,15 +1363,15 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
-  almalinux-9:
-    name: Alma Linux 9 Test
+  rockylinux-9:
+    name: Rocky Linux 9 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1384,15 +1384,15 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
-  almalinux-9-arm64:
-    name: Alma Linux 9 Arm64 Test
+  rockylinux-9-arm64:
+    name: Rocky Linux 9 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1863,10 +1863,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -2773,10 +2773,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -2856,10 +2856,10 @@ jobs:
       - build-pkgs-src
       - combine-all-code-coverage
       - publish-repositories
-      - almalinux-8-pkg-tests
-      - almalinux-8-arm64-pkg-tests
-      - almalinux-9-pkg-tests
-      - almalinux-9-arm64-pkg-tests
+      - rockylinux-8-pkg-tests
+      - rockylinux-8-arm64-pkg-tests
+      - rockylinux-9-pkg-tests
+      - rockylinux-9-arm64-pkg-tests
       - amazonlinux-2-pkg-tests
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -511,8 +511,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
-  almalinux-8-pkg-tests:
-    name: Alma Linux 8 Package Test
+  rockylinux-8-pkg-tests:
+    name: Rocky Linux 8 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -520,7 +520,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -532,8 +532,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-8-arm64-pkg-tests:
-    name: Alma Linux 8 Arm64 Package Test
+  rockylinux-8-arm64-pkg-tests:
+    name: Rocky Linux 8 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -541,7 +541,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -553,8 +553,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-pkg-tests:
-    name: Alma Linux 9 Package Test
+  rockylinux-9-pkg-tests:
+    name: Rocky Linux 9 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -562,7 +562,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -574,8 +574,8 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-arm64-pkg-tests:
-    name: Alma Linux 9 Arm64 Package Test
+  rockylinux-9-arm64-pkg-tests:
+    name: Rocky Linux 9 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -583,7 +583,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1298,15 +1298,15 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
-  almalinux-8:
-    name: Alma Linux 8 Test
+  rockylinux-8:
+    name: Rocky Linux 8 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1319,15 +1319,15 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
-  almalinux-8-arm64:
-    name: Alma Linux 8 Arm64 Test
+  rockylinux-8-arm64:
+    name: Rocky Linux 8 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1340,15 +1340,15 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
-  almalinux-9:
-    name: Alma Linux 9 Test
+  rockylinux-9:
+    name: Rocky Linux 9 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1361,15 +1361,15 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
-  almalinux-9-arm64:
-    name: Alma Linux 9 Arm64 Test
+  rockylinux-9-arm64:
+    name: Rocky Linux 9 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1840,10 +1840,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -1996,10 +1996,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -2021,10 +2021,10 @@ jobs:
       - ubuntu-2004-arm64
       - ubuntu-2204
       - ubuntu-2204-arm64
-      - almalinux-8-pkg-tests
-      - almalinux-8-arm64-pkg-tests
-      - almalinux-9-pkg-tests
-      - almalinux-9-arm64-pkg-tests
+      - rockylinux-8-pkg-tests
+      - rockylinux-8-arm64-pkg-tests
+      - rockylinux-9-pkg-tests
+      - rockylinux-9-arm64-pkg-tests
       - amazonlinux-2-pkg-tests
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -524,8 +524,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
 
-  almalinux-8-pkg-tests:
-    name: Alma Linux 8 Package Test
+  rockylinux-8-pkg-tests:
+    name: Rocky Linux 8 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -533,7 +533,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -545,8 +545,8 @@ jobs:
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-8-arm64-pkg-tests:
-    name: Alma Linux 8 Arm64 Package Test
+  rockylinux-8-arm64-pkg-tests:
+    name: Rocky Linux 8 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -554,7 +554,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -566,8 +566,8 @@ jobs:
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-pkg-tests:
-    name: Alma Linux 9 Package Test
+  rockylinux-9-pkg-tests:
+    name: Rocky Linux 9 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -575,7 +575,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -587,8 +587,8 @@ jobs:
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  almalinux-9-arm64-pkg-tests:
-    name: Alma Linux 9 Arm64 Package Test
+  rockylinux-9-arm64-pkg-tests:
+    name: Rocky Linux 9 Arm64 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
@@ -596,7 +596,7 @@ jobs:
       - build-ci-deps
     uses: ./.github/workflows/test-packages-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1311,15 +1311,15 @@ jobs:
       workflow-slug: staging
       default-timeout: 180
 
-  almalinux-8:
-    name: Alma Linux 8 Test
+  rockylinux-8:
+    name: Rocky Linux 8 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8
+      distro-slug: rockylinux-8
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1332,15 +1332,15 @@ jobs:
       workflow-slug: staging
       default-timeout: 180
 
-  almalinux-8-arm64:
-    name: Alma Linux 8 Arm64 Test
+  rockylinux-8-arm64:
+    name: Rocky Linux 8 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-8-arm64
+      distro-slug: rockylinux-8-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -1353,15 +1353,15 @@ jobs:
       workflow-slug: staging
       default-timeout: 180
 
-  almalinux-9:
-    name: Alma Linux 9 Test
+  rockylinux-9:
+    name: Rocky Linux 9 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9
+      distro-slug: rockylinux-9
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
@@ -1374,15 +1374,15 @@ jobs:
       workflow-slug: staging
       default-timeout: 180
 
-  almalinux-9-arm64:
-    name: Alma Linux 9 Arm64 Test
+  rockylinux-9-arm64:
+    name: Rocky Linux 9 Arm64 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
     needs:
       - prepare-workflow
       - build-ci-deps
     uses: ./.github/workflows/test-action-linux.yml
     with:
-      distro-slug: almalinux-9-arm64
+      distro-slug: rockylinux-9-arm64
       nox-session: ci-test-onedir
       platform: linux
       arch: arm64
@@ -2752,10 +2752,10 @@ jobs:
       - macos-12
       - macos-13
       - macos-13-arm64
-      - almalinux-8
-      - almalinux-8-arm64
-      - almalinux-9
-      - almalinux-9-arm64
+      - rockylinux-8
+      - rockylinux-8-arm64
+      - rockylinux-9
+      - rockylinux-9-arm64
       - amazonlinux-2
       - amazonlinux-2-arm64
       - amazonlinux-2023
@@ -2777,10 +2777,10 @@ jobs:
       - ubuntu-2004-arm64
       - ubuntu-2204
       - ubuntu-2204-arm64
-      - almalinux-8-pkg-tests
-      - almalinux-8-arm64-pkg-tests
-      - almalinux-9-pkg-tests
-      - almalinux-9-arm64-pkg-tests
+      - rockylinux-8-pkg-tests
+      - rockylinux-8-arm64-pkg-tests
+      - rockylinux-9-pkg-tests
+      - rockylinux-9-arm64-pkg-tests
       - amazonlinux-2-pkg-tests
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests

--- a/.github/workflows/test-package-downloads-action.yml
+++ b/.github/workflows/test-package-downloads-action.yml
@@ -69,24 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro-slug: almalinux-8
-            arch: x86_64
-            pkg-type: package
-          - distro-slug: almalinux-8-arm64
-            arch: aarch64
-            pkg-type: package
-          - distro-slug: almalinux-8-arm64
-            arch: arm64
-            pkg-type: package
-          - distro-slug: almalinux-9
-            arch: x86_64
-            pkg-type: package
-          - distro-slug: almalinux-9-arm64
-            arch: aarch64
-            pkg-type: package
-          - distro-slug: almalinux-9-arm64
-            arch: arm64
-            pkg-type: package
           - distro-slug: amazonlinux-2
             arch: x86_64
             pkg-type: package
@@ -157,6 +139,24 @@ jobs:
             arch: aarch64
             pkg-type: package
           - distro-slug: photonos-5-arm64
+            arch: arm64
+            pkg-type: package
+          - distro-slug: rockylinux-8
+            arch: x86_64
+            pkg-type: package
+          - distro-slug: rockylinux-8-arm64
+            arch: aarch64
+            pkg-type: package
+          - distro-slug: rockylinux-8-arm64
+            arch: arm64
+            pkg-type: package
+          - distro-slug: rockylinux-9
+            arch: x86_64
+            pkg-type: package
+          - distro-slug: rockylinux-9-arm64
+            arch: aarch64
+            pkg-type: package
+          - distro-slug: rockylinux-9-arm64
             arch: arm64
             pkg-type: package
           - distro-slug: ubuntu-20.04

--- a/cicd/golden-images.json
+++ b/cicd/golden-images.json
@@ -1,48 +1,8 @@
 {
-  "almalinux-8-arm64": {
-    "ami": "ami-045a65c1d4ceb04a5",
-    "ami_description": "CI Image of AlmaLinux 8 arm64",
-    "ami_name": "salt-project/ci/almalinux/8/arm64/20240209.1843",
-    "arch": "arm64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "m6g.large",
-    "is_windows": "false",
-    "ssh_username": "ec2-user"
-  },
-  "almalinux-8": {
-    "ami": "ami-0b9c2b7ba679e691d",
-    "ami_description": "CI Image of AlmaLinux 8 x86_64",
-    "ami_name": "salt-project/ci/almalinux/8/x86_64/20240209.1843",
-    "arch": "x86_64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "t3a.large",
-    "is_windows": "false",
-    "ssh_username": "ec2-user"
-  },
-  "almalinux-9-arm64": {
-    "ami": "ami-0cbdf762adc955d47",
-    "ami_description": "CI Image of AlmaLinux 9 arm64",
-    "ami_name": "salt-project/ci/almalinux/9/arm64/20240209.1844",
-    "arch": "arm64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "m6g.large",
-    "is_windows": "false",
-    "ssh_username": "ec2-user"
-  },
-  "almalinux-9": {
-    "ami": "ami-086c8ef0ef6951a8f",
-    "ami_description": "CI Image of AlmaLinux 9 x86_64",
-    "ami_name": "salt-project/ci/almalinux/9/x86_64/20240209.1843",
-    "arch": "x86_64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "t3a.large",
-    "is_windows": "false",
-    "ssh_username": "ec2-user"
-  },
   "amazonlinux-2-arm64": {
-    "ami": "ami-07bc422e281c67f10",
+    "ami": "ami-0fa1d515b17aa5832",
     "ami_description": "CI Image of AmazonLinux 2 arm64",
-    "ami_name": "salt-project/ci/amazonlinux/2/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/amazonlinux/2/arm64/20240325.2133",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -50,9 +10,9 @@
     "ssh_username": "ec2-user"
   },
   "amazonlinux-2": {
-    "ami": "ami-01ecdeb9a8251824e",
+    "ami": "ami-0c9a41917d788911e",
     "ami_description": "CI Image of AmazonLinux 2 x86_64",
-    "ami_name": "salt-project/ci/amazonlinux/2/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/amazonlinux/2/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -60,9 +20,9 @@
     "ssh_username": "ec2-user"
   },
   "amazonlinux-2023-arm64": {
-    "ami": "ami-0b8a0efa9ea7ebfa4",
+    "ami": "ami-00644e6cc81cb8fc0",
     "ami_description": "CI Image of AmazonLinux 2023 arm64",
-    "ami_name": "salt-project/ci/amazonlinux/2023/arm64/20240209.1844",
+    "ami_name": "salt-project/ci/amazonlinux/2023/arm64/20240325.2133",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -70,9 +30,9 @@
     "ssh_username": "ec2-user"
   },
   "amazonlinux-2023": {
-    "ami": "ami-0f013d0d9dbaf3b06",
+    "ami": "ami-01ba1cac2a9ba4845",
     "ami_description": "CI Image of AmazonLinux 2023 x86_64",
-    "ami_name": "salt-project/ci/amazonlinux/2023/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/amazonlinux/2023/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -90,9 +50,9 @@
     "ssh_username": "arch"
   },
   "centos-7-arm64": {
-    "ami": "ami-09c1e87fa7a2be337",
+    "ami": "ami-0a0c4ce5d61416643",
     "ami_description": "CI Image of CentOS 7 arm64",
-    "ami_name": "salt-project/ci/centos/7/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/centos/7/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -100,9 +60,9 @@
     "ssh_username": "centos"
   },
   "centos-7": {
-    "ami": "ami-010faf67fdabfbcdf",
+    "ami": "ami-06fec7a8fe157fe7d",
     "ami_description": "CI Image of CentOS 7 x86_64",
-    "ami_name": "salt-project/ci/centos/7/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/centos/7/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -110,9 +70,9 @@
     "ssh_username": "centos"
   },
   "debian-10-arm64": {
-    "ami": "ami-018ff5d81815e307f",
+    "ami": "ami-0a4d0583945dba7a7",
     "ami_description": "CI Image of Debian 10 arm64",
-    "ami_name": "salt-project/ci/debian/10/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/10/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "false",
     "instance_type": "m6g.large",
@@ -120,9 +80,9 @@
     "ssh_username": "admin"
   },
   "debian-10": {
-    "ami": "ami-033f768666c97d386",
+    "ami": "ami-0f474f6f3b4f1a981",
     "ami_description": "CI Image of Debian 10 x86_64",
-    "ami_name": "salt-project/ci/debian/10/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/10/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -130,9 +90,9 @@
     "ssh_username": "admin"
   },
   "debian-11-arm64": {
-    "ami": "ami-02dfec8b374ad8fc8",
+    "ami": "ami-0e1d6f34aaeba1e58",
     "ami_description": "CI Image of Debian 11 arm64",
-    "ami_name": "salt-project/ci/debian/11/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/11/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "false",
     "instance_type": "m6g.large",
@@ -140,9 +100,9 @@
     "ssh_username": "admin"
   },
   "debian-11": {
-    "ami": "ami-06e4f77ed230e2def",
+    "ami": "ami-012327dae48ce80ac",
     "ami_description": "CI Image of Debian 11 x86_64",
-    "ami_name": "salt-project/ci/debian/11/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/11/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -150,9 +110,9 @@
     "ssh_username": "admin"
   },
   "debian-12-arm64": {
-    "ami": "ami-05c7771a9ec62dfb2",
+    "ami": "ami-0527ef47cece68f54",
     "ami_description": "CI Image of Debian 12 arm64",
-    "ami_name": "salt-project/ci/debian/12/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/12/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "false",
     "instance_type": "m6g.large",
@@ -160,9 +120,9 @@
     "ssh_username": "admin"
   },
   "debian-12": {
-    "ami": "ami-0ac4b96d4ae5faa23",
+    "ami": "ami-0d9d685ae10656958",
     "ami_description": "CI Image of Debian 12 x86_64",
-    "ami_name": "salt-project/ci/debian/12/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/debian/12/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -170,9 +130,9 @@
     "ssh_username": "admin"
   },
   "fedora-39-arm64": {
-    "ami": "ami-04f69299edce3ff91",
+    "ami": "ami-00d2f2e1fccac457d",
     "ami_description": "CI Image of Fedora 39 arm64",
-    "ami_name": "salt-project/ci/fedora/39/arm64/20240209.1844",
+    "ami_name": "salt-project/ci/fedora/39/arm64/20240325.2133",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -180,9 +140,9 @@
     "ssh_username": "fedora"
   },
   "fedora-39": {
-    "ami": "ami-033bf14cad5d795a2",
+    "ami": "ami-072c01a40a6519153",
     "ami_description": "CI Image of Fedora 39 x86_64",
-    "ami_name": "salt-project/ci/fedora/39/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/fedora/39/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -190,9 +150,9 @@
     "ssh_username": "fedora"
   },
   "opensuse-15": {
-    "ami": "ami-023efb1898809e8fe",
+    "ami": "ami-04cfbfd3c214348bc",
     "ami_description": "CI Image of Opensuse 15 x86_64",
-    "ami_name": "salt-project/ci/opensuse/15/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/opensuse/15/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -200,9 +160,9 @@
     "ssh_username": "ec2-user"
   },
   "photonos-4-arm64": {
-    "ami": "ami-0d164263b5095dc45",
+    "ami": "ami-0bd76e6234ee685a7",
     "ami_description": "CI Image of PhotonOS 4 arm64",
-    "ami_name": "salt-project/ci/photonos/4/arm64/20240209.1844",
+    "ami_name": "salt-project/ci/photonos/4/arm64/20240325.2133",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -210,9 +170,9 @@
     "ssh_username": "root"
   },
   "photonos-4": {
-    "ami": "ami-0454d6f4e80b94412",
+    "ami": "ami-0b1947785de4b2a6e",
     "ami_description": "CI Image of PhotonOS 4 x86_64",
-    "ami_name": "salt-project/ci/photonos/4/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/photonos/4/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -220,9 +180,9 @@
     "ssh_username": "root"
   },
   "photonos-5-arm64": {
-    "ami": "ami-094f4c1e098fc2192",
+    "ami": "ami-0d02f34b9820752e4",
     "ami_description": "CI Image of PhotonOS 5 arm64",
-    "ami_name": "salt-project/ci/photonos/5/arm64/20240209.1844",
+    "ami_name": "salt-project/ci/photonos/5/arm64/20240325.2133",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -230,19 +190,59 @@
     "ssh_username": "root"
   },
   "photonos-5": {
-    "ami": "ami-037344b8f3d9e2650",
+    "ami": "ami-0fd58f07139e9622e",
     "ami_description": "CI Image of PhotonOS 5 x86_64",
-    "ami_name": "salt-project/ci/photonos/5/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/photonos/5/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
     "is_windows": "false",
     "ssh_username": "root"
   },
+  "rockylinux-8-arm64": {
+    "ami": "ami-0e5d23f57141e5ac4",
+    "ami_description": "CI Image of RockyLinux 8 arm64",
+    "ami_name": "salt-project/ci/rockylinux/8/arm64/20240325.2134",
+    "arch": "arm64",
+    "cloudwatch-agent-available": "true",
+    "instance_type": "m6g.large",
+    "is_windows": "false",
+    "ssh_username": "rocky"
+  },
+  "rockylinux-8": {
+    "ami": "ami-0e2cac6a847d700aa",
+    "ami_description": "CI Image of RockyLinux 8 x86_64",
+    "ami_name": "salt-project/ci/rockylinux/8/x86_64/20240325.2134",
+    "arch": "x86_64",
+    "cloudwatch-agent-available": "true",
+    "instance_type": "t3a.large",
+    "is_windows": "false",
+    "ssh_username": "rocky"
+  },
+  "rockylinux-9-arm64": {
+    "ami": "ami-0054d3b25a08d2b41",
+    "ami_description": "CI Image of RockyLinux 9 arm64",
+    "ami_name": "salt-project/ci/rockylinux/9/arm64/20240325.2134",
+    "arch": "arm64",
+    "cloudwatch-agent-available": "true",
+    "instance_type": "m6g.large",
+    "is_windows": "false",
+    "ssh_username": "rocky"
+  },
+  "rockylinux-9": {
+    "ami": "ami-042d3b81138968bdb",
+    "ami_description": "CI Image of RockyLinux 9 x86_64",
+    "ami_name": "salt-project/ci/rockylinux/9/x86_64/20240325.2134",
+    "arch": "x86_64",
+    "cloudwatch-agent-available": "true",
+    "instance_type": "t3a.large",
+    "is_windows": "false",
+    "ssh_username": "rocky"
+  },
   "ubuntu-20.04-arm64": {
-    "ami": "ami-0eb0f403664076b82",
+    "ami": "ami-0bd2e3ee99c5a2f52",
     "ami_description": "CI Image of Ubuntu 20.04 arm64",
-    "ami_name": "salt-project/ci/ubuntu/20.04/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/20.04/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -250,9 +250,9 @@
     "ssh_username": "ubuntu"
   },
   "ubuntu-20.04": {
-    "ami": "ami-07ad57960d22a8b65",
+    "ami": "ami-0fdc19cb94bc96db3",
     "ami_description": "CI Image of Ubuntu 20.04 x86_64",
-    "ami_name": "salt-project/ci/ubuntu/20.04/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/20.04/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -260,9 +260,9 @@
     "ssh_username": "ubuntu"
   },
   "ubuntu-22.04-arm64": {
-    "ami": "ami-05197331792cbc895",
+    "ami": "ami-0690e86bc116a6245",
     "ami_description": "CI Image of Ubuntu 22.04 arm64",
-    "ami_name": "salt-project/ci/ubuntu/22.04/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/22.04/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -270,9 +270,9 @@
     "ssh_username": "ubuntu"
   },
   "ubuntu-22.04": {
-    "ami": "ami-01d9f296a69eaec3c",
+    "ami": "ami-0285c21e3abc8b2b2",
     "ami_description": "CI Image of Ubuntu 22.04 x86_64",
-    "ami_name": "salt-project/ci/ubuntu/22.04/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/22.04/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -280,9 +280,9 @@
     "ssh_username": "ubuntu"
   },
   "ubuntu-23.04-arm64": {
-    "ami": "ami-0511f6146f198b645",
+    "ami": "ami-09e0eb04bbf2a2f35",
     "ami_description": "CI Image of Ubuntu 23.04 arm64",
-    "ami_name": "salt-project/ci/ubuntu/23.04/arm64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/23.04/arm64/20240325.2134",
     "arch": "arm64",
     "cloudwatch-agent-available": "true",
     "instance_type": "m6g.large",
@@ -290,9 +290,9 @@
     "ssh_username": "ubuntu"
   },
   "ubuntu-23.04": {
-    "ami": "ami-0f09467d281f1a312",
+    "ami": "ami-029edca569b26d625",
     "ami_description": "CI Image of Ubuntu 23.04 x86_64",
-    "ami_name": "salt-project/ci/ubuntu/23.04/x86_64/20240209.1843",
+    "ami_name": "salt-project/ci/ubuntu/23.04/x86_64/20240325.2134",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.large",
@@ -300,9 +300,9 @@
     "ssh_username": "ubuntu"
   },
   "windows-2016": {
-    "ami": "ami-015acc248b175fb3c",
+    "ami": "ami-0474d8e7e13c81883",
     "ami_description": "CI Image of Windows 2016 x86_64",
-    "ami_name": "salt-project/ci/windows/2016/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/windows/2016/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.xlarge",
@@ -310,9 +310,9 @@
     "ssh_username": "Administrator"
   },
   "windows-2019": {
-    "ami": "ami-0318f14f8690bf17f",
+    "ami": "ami-07afee87d071123bf",
     "ami_description": "CI Image of Windows 2019 x86_64",
-    "ami_name": "salt-project/ci/windows/2019/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/windows/2019/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.xlarge",
@@ -320,9 +320,9 @@
     "ssh_username": "Administrator"
   },
   "windows-2022": {
-    "ami": "ami-0a78a28f614a662ad",
+    "ami": "ami-08f69046343f92cc4",
     "ami_description": "CI Image of Windows 2022 x86_64",
-    "ami_name": "salt-project/ci/windows/2022/x86_64/20240209.1844",
+    "ami_name": "salt-project/ci/windows/2022/x86_64/20240325.2133",
     "arch": "x86_64",
     "cloudwatch-agent-available": "true",
     "instance_type": "t3a.xlarge",

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -2,7 +2,7 @@ nox_version: "2022.8.7"
 python_version: "3.10.13"
 relenv_version: "0.15.1"
 mandatory_os_slugs:
-  - almalinux-9
+  - rockylinux-9
   - amazonlinux-2023-arm64
   - archlinux-lts
   - macos-13-arm64

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -113,9 +113,9 @@ def _rand_key_name(length):
 
 
 def _check_skip(grains):
-    if grains["os"] == "CentOS Stream" and grains["osmajorrelease"] == 9:
-        return True
-    if grains["os"] == "AlmaLinux" and grains["osmajorrelease"] == 9:
+    if (grains["os"] in ("CentOS Stream", "AlmaLinux", "Rocky")) and grains[
+        "osmajorrelease"
+    ] == 9:
         return True
     return False
 

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -54,7 +54,7 @@ def salt_eauth_account_factory():
 
 @pytest.fixture(scope="session")
 def salt_auto_account_factory():
-    return TestAccount(username="saltdev_auto", password="saltdev")
+    return TestAccount(username="saltdev-auto")
 
 
 @pytest.fixture(scope="session")

--- a/tests/pytests/functional/states/pkgrepo/test_centos.py
+++ b/tests/pytests/functional/states/pkgrepo/test_centos.py
@@ -243,7 +243,7 @@ def copr_pkgrepo_with_comments_name(pkgrepo, grains):
     ):
         pytest.skip("copr plugin not installed on {} CI".format(grains["osfinger"]))
     if (
-        grains["os"] in ("CentOS Stream", "AlmaLinux")
+        grains["os"] in ("CentOS Stream", "AlmaLinux", "Rocky")
         and grains["osmajorrelease"] == 9
         or grains["osfinger"] == "Amazon Linux-2023"
     ):

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -55,7 +55,7 @@ def PKG_TARGETS(grains):
             else:
                 _PKG_TARGETS = ["wget", "zsh-html"]
         elif (
-            grains["os"] in ("CentOS Stream", "AlmaLinux")
+            grains["os"] in ("CentOS Stream", "Rocky", "AlmaLinux")
             and grains["osmajorrelease"] == 9
         ):
             _PKG_TARGETS = ["units", "zsh"]

--- a/tests/pytests/integration/client/conftest.py
+++ b/tests/pytests/integration/client/conftest.py
@@ -13,12 +13,6 @@ def client_config(salt_master):
     return config
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 @pytest.fixture
 def auth_creds(salt_auto_account):
     return {

--- a/tests/pytests/integration/conftest.py
+++ b/tests/pytests/integration/conftest.py
@@ -107,3 +107,9 @@ def salt_ssh_cli(salt_master, salt_ssh_roster_file, sshd_config_dir):
         client_key=str(sshd_config_dir / "client_key"),
         base_script_args=["--ignore-host-keys"],
     )
+
+
+@pytest.fixture(scope="module")
+def salt_auto_account(salt_auto_account_factory):
+    with salt_auto_account_factory as account:
+        yield account

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -62,12 +62,6 @@ def salt_auth_account_1(salt_auth_account_1_factory):
         yield account
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 def test_ssh(client, auth_creds, salt_ssh_roster_file, rosters_dir, ssh_priv_key):
     low = {
         "client": "ssh",

--- a/tests/pytests/integration/wheel/conftest.py
+++ b/tests/pytests/integration/wheel/conftest.py
@@ -18,12 +18,6 @@ def client(client_config):
     return salt.wheel.Wheel(client_config)
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 @pytest.fixture
 def auth_creds(salt_auto_account):
     return {

--- a/tests/pytests/pkg/integration/test_enabled_disabled.py
+++ b/tests/pytests/pkg/integration/test_enabled_disabled.py
@@ -11,7 +11,14 @@ def test_services(install_salt, salt_cli, salt_minion):
     services_enabled = []
     if install_salt.distro_id in ("ubuntu", "debian"):
         services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
-    elif install_salt.distro_id in ("almalinux", "centos", "redhat", "amzn", "fedora"):
+    elif install_salt.distro_id in (
+        "almalinux",
+        "rocky",
+        "centos",
+        "redhat",
+        "amzn",
+        "fedora",
+    ):
         services_disabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]
     elif install_salt.distro_id == "photon":
         services_enabled = ["salt-master", "salt-minion", "salt-syndic", "salt-api"]

--- a/tests/pytests/pkg/integration/test_salt_user.py
+++ b/tests/pytests/pkg/integration/test_salt_user.py
@@ -190,6 +190,7 @@ def test_paths_log_rotation(
 
     if install_salt.distro_id not in (
         "almalinux",
+        "rocky",
         "centos",
         "redhat",
         "amzn",

--- a/tests/pytests/pkg/integration/test_systemd_config.py
+++ b/tests/pytests/pkg/integration/test_systemd_config.py
@@ -16,6 +16,8 @@ def test_system_config(grains):
         if grains["osfinger"] in (
             "AlmaLinux-8",
             "AlmaLinux-9",
+            "Rocky Linux-8",
+            "Rocky Linux-9",
             "CentOS Stream-8",
             "CentOS Linux-8",
             "CentOS Stream-9",

--- a/tests/pytests/pkg/integration/test_version.py
+++ b/tests/pytests/pkg/integration/test_version.py
@@ -127,6 +127,7 @@ def test_compare_pkg_versions_redhat_rc(version, install_salt):
     """
     if install_salt.distro_id not in (
         "almalinux",
+        "rocky",
         "centos",
         "redhat",
         "amzn",

--- a/tests/support/pkg.py
+++ b/tests/support/pkg.py
@@ -113,6 +113,7 @@ class SaltPkgInstall:
     def _default_pkg_mngr(self):
         if self.distro_id in (
             "almalinux",
+            "rocky",
             "centos",
             "redhat",
             "amzn",
@@ -129,6 +130,7 @@ class SaltPkgInstall:
     def _default_rm_pkg(self):
         if self.distro_id in (
             "almalinux",
+            "rocky",
             "centos",
             "redhat",
             "amzn",
@@ -144,6 +146,7 @@ class SaltPkgInstall:
         dbg_pkg = None
         if self.distro_id in (
             "almalinux",
+            "rocky",
             "centos",
             "redhat",
             "amzn",
@@ -167,6 +170,7 @@ class SaltPkgInstall:
         ]
         if self.distro_id in (
             "almalinux",
+            "rocky",
             "centos",
             "redhat",
             "amzn",
@@ -607,7 +611,7 @@ class SaltPkgInstall:
             "3006.0"
         )
         distro_name = self.distro_name
-        if distro_name in ("almalinux", "centos", "fedora"):
+        if distro_name in ("almalinux", "rocky", "centos", "fedora"):
             distro_name = "redhat"
         root_url = "salt/py3/"
         if self.classic:
@@ -615,6 +619,7 @@ class SaltPkgInstall:
 
         if self.distro_name in [
             "almalinux",
+            "rocky",
             "redhat",
             "centos",
             "amazon",

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -807,7 +807,7 @@ def pkg_matrix(
 
         if name == "amazonlinux":
             name = "amazon"
-        elif "centos" in name or name == "almalinux":
+        elif "centos" in name or name == "rockylinux":
             name = "redhat"
         elif "photon" in name:
             name = "photon"

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -107,16 +107,16 @@ def generate_workflows(ctx: Context):
     test_salt_listing = PlatformDefinitions(
         {
             "linux": [
-                Linux(slug="almalinux-8", display_name="Alma Linux 8", arch="x86_64"),
+                Linux(slug="rockylinux-8", display_name="Rocky Linux 8", arch="x86_64"),
                 Linux(
-                    slug="almalinux-8-arm64",
-                    display_name="Alma Linux 8 Arm64",
+                    slug="rockylinux-8-arm64",
+                    display_name="Rocky Linux 8 Arm64",
                     arch="arm64",
                 ),
-                Linux(slug="almalinux-9", display_name="Alma Linux 9", arch="x86_64"),
+                Linux(slug="rockylinux-9", display_name="Rocky Linux 9", arch="x86_64"),
                 Linux(
-                    slug="almalinux-9-arm64",
-                    display_name="Alma Linux 9 Arm64",
+                    slug="rockylinux-9-arm64",
+                    display_name="Rocky Linux 9 Arm64",
                     arch="arm64",
                 ),
                 Linux(
@@ -211,26 +211,26 @@ def generate_workflows(ctx: Context):
         {
             "linux": [
                 Linux(
-                    slug="almalinux-8",
-                    display_name="Alma Linux 8",
+                    slug="rockylinux-8",
+                    display_name="Rocky Linux 8",
                     arch="x86_64",
                     pkg_type="rpm",
                 ),
                 Linux(
-                    slug="almalinux-8-arm64",
-                    display_name="Alma Linux 8 Arm64",
+                    slug="rockylinux-8-arm64",
+                    display_name="Rocky Linux 8 Arm64",
                     arch="arm64",
                     pkg_type="rpm",
                 ),
                 Linux(
-                    slug="almalinux-9",
-                    display_name="Alma Linux 9",
+                    slug="rockylinux-9",
+                    display_name="Rocky Linux 9",
                     arch="x86_64",
                     pkg_type="rpm",
                 ),
                 Linux(
-                    slug="almalinux-9-arm64",
-                    display_name="Alma Linux 9 Arm64",
+                    slug="rockylinux-9-arm64",
+                    display_name="Rocky Linux 9 Arm64",
                     arch="arm64",
                     pkg_type="rpm",
                 ),
@@ -419,7 +419,7 @@ def generate_workflows(ctx: Context):
         }
     )
     rpm_slugs = (
-        "almalinux",
+        "rockylinux",
         "amazonlinux",
         "centos",
         "fedora",
@@ -508,7 +508,7 @@ def generate_workflows(ctx: Context):
         if slug.endswith("-arm64"):
             continue
         if not slug.startswith(
-            ("amazonlinux", "almalinux", "centos", "fedora", "photonos")
+            ("amazonlinux", "rockylinux", "centos", "fedora", "photonos")
         ):
             continue
         os_name, os_version = slug.split("-")

--- a/tools/utils/gh.py
+++ b/tools/utils/gh.py
@@ -219,7 +219,7 @@ def download_pkgs_artifact(
         if slug.startswith(("debian", "ubuntu")):
             artifact_name += f"{arch}-deb"
         elif slug.startswith(
-            ("almalinux", "amazonlinux", "centos", "fedora", "opensuse", "photonos")
+            ("rockylinux", "amazonlinux", "centos", "fedora", "opensuse", "photonos")
         ):
             artifact_name += f"{arch}-rpm"
         else:


### PR DESCRIPTION
### What does this PR do?

Replace AlmaLinux with Rocky Linux, as Salt Project is planning to use Rocky Linux as the ultimate replacement of CentOS and CentOS Stream operating systems (instead of AlmaLinux).

### Previous Behavior

AlmaLinux 8 and AlmaLinux 9 were being used as replacements of CentOS Stream.

### New Behavior

Rocky Linux 8 and Rocky Linux 9 will replace usage of CentOS Stream and Alma Linux within CI/CD pipelines.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
