### PR TITLE
[3006.x] Windows needs more complex passwords. Use the auto generated one.

### DIFF
--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -54,7 +54,7 @@ def salt_eauth_account_factory():
 
 @pytest.fixture(scope="session")
 def salt_auto_account_factory():
-    return TestAccount(username="saltdev_auto", password="saltdev")
+    return TestAccount(username="saltdev-auto")
 
 
 @pytest.fixture(scope="session")

--- a/tests/pytests/integration/client/conftest.py
+++ b/tests/pytests/integration/client/conftest.py
@@ -13,12 +13,6 @@ def client_config(salt_master):
     return config
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 @pytest.fixture
 def auth_creds(salt_auto_account):
     return {

--- a/tests/pytests/integration/conftest.py
+++ b/tests/pytests/integration/conftest.py
@@ -107,3 +107,9 @@ def salt_ssh_cli(salt_master, salt_ssh_roster_file, sshd_config_dir):
         client_key=str(sshd_config_dir / "client_key"),
         base_script_args=["--ignore-host-keys"],
     )
+
+
+@pytest.fixture(scope="module")
+def salt_auto_account(salt_auto_account_factory):
+    with salt_auto_account_factory as account:
+        yield account

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -62,12 +62,6 @@ def salt_auth_account_1(salt_auth_account_1_factory):
         yield account
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 def test_ssh(client, auth_creds, salt_ssh_roster_file, rosters_dir, ssh_priv_key):
     low = {
         "client": "ssh",

--- a/tests/pytests/integration/wheel/conftest.py
+++ b/tests/pytests/integration/wheel/conftest.py
@@ -18,12 +18,6 @@ def client(client_config):
     return salt.wheel.Wheel(client_config)
 
 
-@pytest.fixture(scope="module")
-def salt_auto_account(salt_auto_account_factory):
-    with salt_auto_account_factory as account:
-        yield account
-
-
 @pytest.fixture
 def auth_creds(salt_auto_account):
     return {


### PR DESCRIPTION
### What does this PR do?
Windows needs more complex passwords. Use the auto generated one.
Reduce fixture duplication.