### PR TITLE
[3006.x] file.managed correctly handles file path with '#'

### DIFF
--- a/changelog/63060.fixed.md
+++ b/changelog/63060.fixed.md
@@ -1,0 +1,1 @@
+file.managed correctly handles file path with '#'

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -481,9 +481,11 @@ class Client:
         """
         Get a single file from a URL.
         """
+        url = urllib.parse.quote(url, safe=":/")
         url_data = urllib.parse.urlparse(url)
         url_scheme = url_data.scheme
         url_path = os.path.join(url_data.netloc, url_data.path).rstrip(os.sep)
+        url_path = urllib.parse.unquote(url_path)
 
         # If dest is a directory, rewrite dest with filename
         if dest is not None and (os.path.isdir(dest) or dest.endswith(("/", "\\"))):

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -481,11 +481,9 @@ class Client:
         """
         Get a single file from a URL.
         """
-        url = urllib.parse.quote(url, safe=":/")
-        url_data = urllib.parse.urlparse(url)
+        url_data = urllib.parse.urlparse(url, allow_fragments=False)
         url_scheme = url_data.scheme
         url_path = os.path.join(url_data.netloc, url_data.path).rstrip(os.sep)
-        url_path = urllib.parse.unquote(url_path)
 
         # If dest is a directory, rewrite dest with filename
         if dest is not None and (os.path.isdir(dest) or dest.endswith(("/", "\\"))):

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -8,12 +8,9 @@ import os
 
 import pytest
 
-try:
-    import salt.utils.files
-    from salt import fileclient
-    from tests.support.mock import AsyncMock, MagicMock, Mock, patch
-except ImportError:
-    ...
+import salt.utils.files
+from salt import fileclient
+from tests.support.mock import AsyncMock, MagicMock, Mock, patch
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -8,9 +8,12 @@ import os
 
 import pytest
 
-import salt.utils.files
-from salt import fileclient
-from tests.support.mock import AsyncMock, MagicMock, Mock, patch
+try:
+    import salt.utils.files
+    from salt import fileclient
+    from tests.support.mock import AsyncMock, MagicMock, Mock, patch
+except ImportError:
+    ...
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -223,6 +223,8 @@ def test_get_file_client(file_client):
     with patch("salt.fileclient.RemoteClient", MagicMock(return_value="remote_client")):
         ret = fileclient.get_file_client(minion_opts)
         assert "remote_client" == ret
+
+
 def test_get_url_with_hash(client_opts):
     """
     Test get_url function with a URL containing a hash character.

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -223,3 +223,17 @@ def test_get_file_client(file_client):
     with patch("salt.fileclient.RemoteClient", MagicMock(return_value="remote_client")):
         ret = fileclient.get_file_client(minion_opts)
         assert "remote_client" == ret
+def test_get_url_with_hash(client_opts):
+    """
+    Test get_url function with a URL containing a hash character.
+    """
+    with patch("os.path.isfile", return_value=True):
+        with patch("os.makedirs", return_value=None):
+            with patch("urllib.request.urlretrieve", return_value=None):
+                client = fileclient.Client(client_opts)
+                url = "file:///path/to/file#with#hash"
+                dest = "/mocked/destination"
+
+                result = client.get_url(url, dest)
+
+                assert result == "/path/to/file#with#hash"


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in the file.managed state where file paths containing a "#" character are not handled correctly.

### What issues does this PR fix or reference?
Fixes: 63060

### Previous Behavior
The file.managed state fails to manage files correctly on subsequent runs if the file path contains a "#" character. The file is created correctly on the first run, but any subsequent run fails to manage the file. Salt attempts to diff on the incorrect file path, truncating the path at the "#" character.

### New Behavior
The file.managed state now correctly handles file paths containing a "#" character. Files are managed correctly on all runs, and the correct file path is used for diffing.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes