### PR TITLE
[master] Remove extra logic missed in `68131ce`

### DIFF
--- a/.github/workflows/test-action-macos.yml
+++ b/.github/workflows/test-action-macos.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Run Changed Tests
         id: run-fast-changed-tests
-        if: ${{ fromJSON(inputs.testrun)['type'] != 'full' && fromJSON(inputs.testrun)['selected_tests']['fast'] == false }}
+        if: ${{ fromJSON(inputs.testrun)['type'] != 'full' }}
         env:
           SKIP_REQUIREMENTS_INSTALL: "1"
           PRINT_TEST_SELECTION: "0"

--- a/.github/workflows/test-action-windows.yml
+++ b/.github/workflows/test-action-windows.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Run Changed Tests
         id: run-fast-changed-tests
-        if: ${{ fromJSON(inputs.testrun)['type'] != 'full' && fromJSON(inputs.testrun)['selected_tests']['fast'] == false }}
+        if: ${{ fromJSON(inputs.testrun)['type'] != 'full' }}
         run: |
           tools --timestamps --no-output-timeout-secs=1800 --timeout-secs=14400 vm test --skip-requirements-install \
             --nox-session=${{ inputs.nox-session }} --rerun-failures -E SALT_TRANSPORT ${{ matrix.fips && '--fips ' || '' }}${{ inputs.distro-slug }} \


### PR DESCRIPTION
### What does this PR do?
Remove extra logic missed in 68131ce7ab248255feb50436a8b1c6c44813c762
This allowed the tests in https://github.com/saltstack/salt/pull/66169 to pass when they shouldn't