### PR TITLE
[master] pillar.netbox: do not fail if site is undefined

### DIFF
--- a/changelog/66325.fixed.md
+++ b/changelog/66325.fixed.md
@@ -1,0 +1,1 @@
+update netbox pillar to not crash if site for vm/device is undefined

--- a/salt/pillar/netbox.py
+++ b/salt/pillar/netbox.py
@@ -1142,16 +1142,17 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
             ret["netbox"]["interfaces"] = _associate_ips_to_interfaces(
                 interfaces_list, interface_ips_list
             )
-    site_id = ret["netbox"]["site"]["id"]
-    site_name = ret["netbox"]["site"]["name"]
-    if site_details:
-        ret["netbox"]["site"] = _get_site_details(
-            api_url, minion_id, site_name, site_id, headers
-        )
-    if site_prefixes:
-        ret["netbox"]["site"]["prefixes"] = _get_site_prefixes(
-            api_url, minion_id, site_name, site_id, headers, api_query_result_limit
-        )
+    if ret["netbox"].get("site"):
+        site_id = ret["netbox"]["site"]["id"]
+        site_name = ret["netbox"]["site"]["name"]
+        if site_details:
+            ret["netbox"]["site"] = _get_site_details(
+                api_url, minion_id, site_name, site_id, headers
+            )
+        if site_prefixes:
+            ret["netbox"]["site"]["prefixes"] = _get_site_prefixes(
+                api_url, minion_id, site_name, site_id, headers, api_query_result_limit
+            )
     if connected_devices:
         ret["netbox"]["connected_devices"] = _get_connected_devices(
             api_url, minion_id, ret["netbox"]["interfaces"], headers

--- a/tests/pytests/unit/pillar/test_netbox.py
+++ b/tests/pytests/unit/pillar/test_netbox.py
@@ -108,6 +108,13 @@ def device_results():
 
 
 @pytest.fixture
+def device_without_site_results(device_results):
+    result = device_results
+    result["dict"]["results"][0]["site"] = None
+    return result
+
+
+@pytest.fixture
 def multiple_device_results():
     return {
         "dict": {
@@ -1587,6 +1594,13 @@ def pillar_results():
 
 
 @pytest.fixture
+def pillar_without_site_results(pillar_results):
+    result = pillar_results
+    result["netbox"]["site"] = None
+    return result
+
+
+@pytest.fixture
 def connected_devices_results():
     return {
         512: {
@@ -2310,6 +2324,49 @@ def test_when_we_retrieve_everything_successfully_then_return_dict(
         get_interface_ips.return_value = device_ip_results["dict"]["results"]
         get_site_details.return_value = site_results["dict"]
         get_site_prefixes.return_value = site_prefixes
+        get_proxy_details.return_value = proxy_details
+        get_connected_decvices.return_value = connected_devices_results
+
+        actual_result = netbox.ext_pillar(**default_kwargs)
+
+        assert actual_result == expected_result
+
+
+def test_when_we_retrieve_everything_successfully_without_site_then_return_dict(
+    default_kwargs,
+    device_without_site_results,
+    no_results,
+    device_interfaces_list,
+    device_ip_results,
+    proxy_details,
+    pillar_without_site_results,
+    connected_devices_results,
+):
+
+    expected_result = pillar_without_site_results
+
+    default_kwargs["virtual_machines"] = False
+    default_kwargs["interfaces"] = True
+    default_kwargs["interface_ips"] = True
+    default_kwargs["proxy_return"] = True
+    default_kwargs["connected_devices"] = True
+
+    with patch("salt.pillar.netbox._get_devices", autospec=True) as get_devices, patch(
+        "salt.pillar.netbox._get_virtual_machines", autospec=True
+    ) as get_virtual_machines, patch(
+        "salt.pillar.netbox._get_interfaces", autospec=True
+    ) as get_interfaces, patch(
+        "salt.pillar.netbox._get_interface_ips", autospec=True
+    ) as get_interface_ips, patch(
+        "salt.pillar.netbox._get_proxy_details", autospec=True
+    ) as get_proxy_details, patch(
+        "salt.pillar.netbox._get_connected_devices", autospec=True
+    ) as get_connected_decvices:
+
+        get_devices.return_value = device_without_site_results["dict"]["results"]
+        get_virtual_machines.return_value = no_results["dict"]["results"]
+        get_interfaces.return_value = device_interfaces_list
+        get_interface_ips.return_value = device_ip_results["dict"]["results"]
         get_proxy_details.return_value = proxy_details
         get_connected_decvices.return_value = connected_devices_results
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes netbox pillar in case site is not set for a given vm/device

### Previous Behavior
pillar_refresh fails with the following error in salt-master logs:
```
[ERROR   ] Exception caught loading ext_pillar 'netbox':
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/__init__.py", line 1219, in ext_pillar
    ext = self._external_pillar_data(pillar, val, key)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/__init__.py", line 1139, in _external_pillar_data
    ext = self.ext_pillars[key](self.minion_id, pillar, **val)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 160, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1233, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1248, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/netbox.py", line 1145, in ext_pillar
    site_id = ret["netbox"]["site"]["id"]
[CRITICAL] Pillar render error: Failed to load ext_pillar netbox: 'NoneType' object is not subscriptable
```

### New Behavior
There is no such error. Instead all data except site related data are filled in the pillar

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
