### PR TITLE
[master] Fix shell.KEY_VALID_RE to match host authenticity message. Fixes #62782

### DIFF
--- a/changelog/62782.fixed.md
+++ b/changelog/62782.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue with salt-ssh hanging due to non-exposed host key acceptance prompt

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -19,7 +19,7 @@ import salt.utils.vt
 log = logging.getLogger(__name__)
 
 SSH_PASSWORD_PROMPT_RE = re.compile(r"(?:.*)[Pp]assword(?: for .*)?:\s*$", re.M)
-KEY_VALID_RE = re.compile(r".*\(yes\/no\).*")
+KEY_VALID_RE = re.compile(r".*\(yes\/no(/\[fingerprint\])?\).*")
 SSH_PRIVATE_KEY_PASSWORD_PROMPT_RE = re.compile(r"Enter passphrase for key", re.M)
 
 # sudo prompt is used to recognize sudo prompting for a password and should


### PR DESCRIPTION
The shell.KEY_VALID_RE regex only matches messages containing '(yes/no)', and not messages containing '(yes/no/[fingerprint])' This leads to the salt-ssh command hanging, (Shell._run_cmd waits for data on stdout) while the ssh command is waiting on input.

Fix by updating the KEY_VALID_RE regex to match both prompts

### What does this PR do?
Fixes a bug where salt-ssh hangs (waiting for more output), while ssh is waiting on input from user.

### What issues does this PR fix or reference?
Fixes #62782

### Previous Behavior
When output containing `(yes/no)` is found, salt-ssh exits and prints the output from ssh about host authenticity

### New Behavior
When output containing `(yes/no)` or `(yes/no/[fingerprint])` is found, salt-ssh exits and prints the output from ssh about host authenticity

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
