### PR TITLE
[3006.x] fix inline pillar being saved to pillarcache when it shouldn't be

### DIFF
--- a/changelog/66292.fixed.md
+++ b/changelog/66292.fixed.md
@@ -1,0 +1,1 @@
+fix cacheing inline pillar, by not rendering inline pillar during cache save function.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -460,12 +460,15 @@ class PillarCache:
         """
         return os.path.join(self.opts["cachedir"], "pillar_cache", minion_id)
 
-    def fetch_pillar(self):
+    def fetch_pillar(self, save_override=True):
         """
         In the event of a cache miss, we need to incur the overhead of caching
         a new pillar.
         """
         log.debug("Pillar cache getting external pillar with ext: %s", self.ext)
+        override = None
+        if save_override:
+            override = self.pillar_override
         fresh_pillar = Pillar(
             self.opts,
             self.grains,
@@ -473,7 +476,7 @@ class PillarCache:
             self.saltenv,
             ext=self.ext,
             functions=self.functions,
-            pillar_override=self.pillar_override,
+            pillar_override=override,
             pillarenv=self.pillarenv,
             extra_minion_data=self.extra_minion_data,
         )
@@ -528,7 +531,7 @@ class PillarCache:
                 return fresh_pillar
         else:
             # We haven't seen this minion yet in the cache. Store it.
-            fresh_pillar = self.fetch_pillar()
+            fresh_pillar = self.fetch_pillar(save_override=False)
             self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
             log.debug("Pillar cache miss for minion %s", self.minion_id)
             log.debug("Current pillar cache: %s", cache_dict)  # FIXME hack!

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -460,15 +460,12 @@ class PillarCache:
         """
         return os.path.join(self.opts["cachedir"], "pillar_cache", minion_id)
 
-    def fetch_pillar(self, save_override=True):
+    def fetch_pillar(self):
         """
         In the event of a cache miss, we need to incur the overhead of caching
         a new pillar.
         """
         log.debug("Pillar cache getting external pillar with ext: %s", self.ext)
-        override = None
-        if save_override:
-            override = self.pillar_override
         fresh_pillar = Pillar(
             self.opts,
             self.grains,
@@ -476,7 +473,7 @@ class PillarCache:
             self.saltenv,
             ext=self.ext,
             functions=self.functions,
-            pillar_override=override,
+            pillar_override=None,
             pillarenv=self.pillarenv,
             extra_minion_data=self.extra_minion_data,
         )
@@ -531,7 +528,7 @@ class PillarCache:
                 return fresh_pillar
         else:
             # We haven't seen this minion yet in the cache. Store it.
-            fresh_pillar = self.fetch_pillar(save_override=False)
+            fresh_pillar = self.fetch_pillar()
             self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
             log.debug("Pillar cache miss for minion %s", self.minion_id)
             log.debug("Current pillar cache: %s", cache_dict)  # FIXME hack!

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -164,7 +164,7 @@ def test_pillar_get_cache_disk(temp_salt_minion, caplog):
         assert fresh_pillar == {}
 
 
-def test_pillar_save_cache(temp_salt_minion, caplog):
+def test_pillar_fetch_pillar_override_skipped(temp_salt_minion, caplog):
     with pytest.helpers.temp_directory() as temp_path:
         tmp_cachedir = Path(str(temp_path) + "/pillar_cache/")
         tmp_cachedir.mkdir(parents=True)
@@ -188,10 +188,8 @@ def test_pillar_save_cache(temp_salt_minion, caplog):
             pillar_override=pillar_override,
         )
 
-        fresh_pillar = pillar.fetch_pillar(save_override=False)
+        fresh_pillar = pillar.fetch_pillar()
         assert fresh_pillar == {}
-        fresh_pillar2 = pillar.fetch_pillar()
-        assert fresh_pillar2 == pillar_override
 
 
 def test_remote_pillar_timeout(temp_salt_minion, tmp_path):

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -164,6 +164,36 @@ def test_pillar_get_cache_disk(temp_salt_minion, caplog):
         assert fresh_pillar == {}
 
 
+def test_pillar_save_cache(temp_salt_minion, caplog):
+    with pytest.helpers.temp_directory() as temp_path:
+        tmp_cachedir = Path(str(temp_path) + "/pillar_cache/")
+        tmp_cachedir.mkdir(parents=True)
+        assert tmp_cachedir.exists()
+        tmp_cachefile = Path(str(temp_path) + "/pillar_cache/" + temp_salt_minion.id)
+        assert tmp_cachefile.exists() is False
+
+        opts = temp_salt_minion.config.copy()
+        opts["pillarenv"] = None
+        opts["pillar_cache"] = True
+        opts["cachedir"] = str(temp_path)
+
+        pillar_override = {"inline_pillar": True}
+
+        caplog.at_level(logging.DEBUG)
+        pillar = salt.pillar.PillarCache(
+            opts=opts,
+            grains=salt.loader.grains(opts),
+            minion_id=temp_salt_minion.id,
+            saltenv="base",
+            pillar_override=pillar_override,
+        )
+
+        fresh_pillar = pillar.fetch_pillar(save_override=False)
+        assert fresh_pillar == {}
+        fresh_pillar2 = pillar.fetch_pillar()
+        assert fresh_pillar2 == pillar_override
+
+
 def test_remote_pillar_timeout(temp_salt_minion, tmp_path):
     opts = temp_salt_minion.config.copy()
     opts["master_uri"] = "tcp://127.0.0.1:12323"


### PR DESCRIPTION
### What does this PR do?

stops the pillar_override from being saved when saving the cache file. but other wise is included in pillar rendering.

### What issues does this PR fix or reference?
Fixes #66292 

### Previous Behavior
inline_pillar being saved in cache

### New Behavior
inline_pillar not saved in cachet

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
