### PR TITLE
[master] Fixing ssh auth options

### DIFF
--- a/changelog/60769.fixed.md
+++ b/changelog/60769.fixed.md
@@ -1,0 +1,1 @@
+Add logic for options handling when using source with ssh_auth


### PR DESCRIPTION
### What does this PR do?

This PR is an up-to-date version of #60770 which was closed for inactivity:
This should fix the behavior of ssh_auth when dealing with authorized_keys provided by files (source) and using the 'options' inside functions like 'ssh_auth.present'.

### What issues does this PR fix or reference?

This fixes issue #60769 

### Previous Behavior

Inside test functions, using options inside a SLS was not taken into account (ie. tests results always says that the key has to be changed).
Secondly, the filehasoptions variable was misleading: regular expression that is used is explicitly matching keys that has NO options.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [X] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No
