### PR TITLE
[master] Enable executor properties in salt-ssh

### DIFF
--- a/changelog/66340.added.md
+++ b/changelog/66340.added.md
@@ -1,0 +1,3 @@
+Added ``--module-executors`` and ``--executor-opts`` CLI options to ``salt-ssh``
+so that executor properties can be passed on the command line, matching the
+behaviour of the regular ``salt`` CLI.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1238,6 +1238,10 @@ class Single:
         self.minion_opts.update(opts.get("ssh_minion_opts", {}))
         if minion_opts is not None:
             self.minion_opts.update(minion_opts)
+        if opts.get("module_executors") is not None:
+            self.minion_opts.update({"module_executors": opts.get("module_executors")})
+        if opts.get("executor_opts") is not None:
+            self.minion_opts.update({"executor_opts": opts.get("executor_opts")})
         # Post apply system needed defaults
         self.minion_opts.update(
             {

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3148,6 +3148,7 @@ class SaltRunOptionParser(
 
 class SaltSSHOptionParser(
     OptionParser,
+    ExecutorsMixIn,
     ConfigDirMixIn,
     MergeConfigMixIn,
     LogLevelMixIn,

--- a/tests/pytests/unit/cli/test_ssh.py
+++ b/tests/pytests/unit/cli/test_ssh.py
@@ -1,5 +1,22 @@
+import salt.utils.parsers
 from salt.cli.ssh import SaltSSH
 from tests.support.mock import MagicMock, call, patch
+
+
+def test_salt_ssh_parser_accepts_executor_options():
+    """
+    Verify that SaltSSHOptionParser includes ExecutorsMixIn so that
+    --module-executors and --executor-opts are valid CLI options.
+    """
+    assert issubclass(
+        salt.utils.parsers.SaltSSHOptionParser,
+        salt.utils.parsers.ExecutorsMixIn,
+    )
+    # Verify that the option is registered without invoking parse_args
+    # (which has filesystem side-effects requiring root or existing /var/log/salt).
+    parser = salt.utils.parsers.SaltSSHOptionParser()
+    assert parser.has_option("--module-executors")
+    assert parser.has_option("--executor-opts")
 
 
 def test_fsclient_destroy_called(minion_opts):

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -980,3 +980,50 @@ def test_check_thin_dir_with_backslash_user(opts):
     )
     assert single.thin_dir == single.opts["thin_dir"]
     assert ".exampledomain_user_" in single.thin_dir
+
+
+def test_executor_opts_propagate_to_minion_opts(opts, target):
+    """
+    Verify that module_executors and executor_opts from the master opts
+    are forwarded into the Single's minion_opts so that salt-ssh executors
+    work the same way as the regular salt CLI.
+    """
+    opts["module_executors"] = ["direct_call"]
+    opts["executor_opts"] = {"direct_call": {"timeout": 5}}
+
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "localhost",
+        mods={},
+        fsclient=None,
+        mine=False,
+        **target,
+    )
+
+    assert single.minion_opts.get("module_executors") == ["direct_call"]
+    assert single.minion_opts.get("executor_opts") == {"direct_call": {"timeout": 5}}
+
+
+def test_executor_opts_absent_when_not_set(opts, target):
+    """
+    Verify that module_executors and executor_opts are NOT injected into
+    minion_opts when not present in master opts (i.e. they remain None /
+    absent rather than overwriting roster/ssh_minion_opts values).
+    """
+    opts.pop("module_executors", None)
+    opts.pop("executor_opts", None)
+
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "localhost",
+        mods={},
+        fsclient=None,
+        mine=False,
+        **target,
+    )
+
+    # Keys must not be injected when the option was not supplied
+    assert "module_executors" not in single.minion_opts
+    assert "executor_opts" not in single.minion_opts


### PR DESCRIPTION
### What does this PR do?

The `salt-ssh` binary does not accept the `module_executors` and `executor_opts` properties, yet the `salt` binary does. This PR unifies the differences so that we can use the executors property for `salt-ssh` as well.

### Previous Behavior
`salt-ssh` could only read the `module_executors` property from the roster file (`minion_opts`) or from the `ssh_minion_opts` config.

### New Behavior
`salt-ssh` can read the `module_executors` property from the command-line arguments as well.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
