### PR TITLE
[3007.x] Don't unnecessarily download remote sources to cache

### DIFF
--- a/changelog/66342.fixed.md
+++ b/changelog/66342.fixed.md
@@ -1,0 +1,1 @@
+Made `file.managed` skip download of a remote source if the managed file already exists with the correct hash

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2501,8 +2501,12 @@ def managed(
         Set to ``False`` to discard the cached copy of the source file once the
         state completes. This can be useful for larger files to keep them from
         taking up space in minion cache. However, keep in mind that discarding
-        the source file will result in the state needing to re-download the
-        source file if the state is run again.
+        the source file might result in the state needing to re-download the
+        source file if the state is run again. If the source is not a local or
+        ``salt://`` one, the source hash is known, ``skip_verify`` is not true
+        and the managed file exists with the correct hash and is not templated,
+        this is not the case (i.e. remote downloads are avoided if the local hash
+        matches the expected one).
 
         .. versionadded:: 2017.7.3
 
@@ -3219,6 +3223,59 @@ def managed(
         return _error(ret, "Context must be formed as a dict")
     if defaults and not isinstance(defaults, dict):
         return _error(ret, "Defaults must be formed as a dict")
+
+    # If we're pulling from a remote source untemplated and we have a source hash,
+    # check early if the local file exists with the correct hash and skip
+    # managing contents if so. This avoids a lot of overhead.
+    if (
+        contents is None
+        and not template
+        and source
+        and not skip_verify
+        and os.path.exists(name)
+        and replace
+    ):
+        try:
+            # If the source is a list, find the first existing file.
+            # We're doing this after basic checks to not slow down
+            # runs where it does not matter.
+            source, source_hash = __salt__["file.source_list"](
+                source, source_hash, __env__
+            )
+            source_sum = None
+            if (
+                source
+                and source_hash
+                and urllib.parse.urlparse(source).scheme
+                not in (
+                    "salt",
+                    "file",
+                )
+                and not os.path.isabs(source)
+            ):
+                source_sum = __salt__["file.get_source_sum"](
+                    name,
+                    source,
+                    source_hash,
+                    source_hash_name,
+                    __env__,
+                    verify_ssl=verify_ssl,
+                    source_hash_sig=source_hash_sig,
+                    signed_by_any=signed_by_any,
+                    signed_by_all=signed_by_all,
+                    keyring=keyring,
+                    gnupghome=gnupghome,
+                )
+                hsum = __salt__["file.get_hash"](name, source_sum["hash_type"])
+        except (CommandExecutionError, OSError) as err:
+            log.error(
+                "Failed checking existing file's hash against specified source_hash: %s",
+                err,
+                exc_info_on_loglevel=logging.DEBUG,
+            )
+        else:
+            if source_sum and source_sum["hsum"] == hsum:
+                replace = False
 
     if not replace and os.path.exists(name):
         ret_perms = {}

--- a/tests/pytests/functional/states/file/test_managed.py
+++ b/tests/pytests/functional/states/file/test_managed.py
@@ -1042,3 +1042,26 @@ def test_issue_60203(
     assert "Unable to manage file" in ret.comment
     assert "/files/test.tar.gz.sha256" in ret.comment
     assert "dontshowme" not in ret.comment
+
+
+def test_file_managed_remote_source_does_not_refetch_existing_file_with_correct_digest(
+    file, tmp_path, grail_scene33_file, grail_scene33_file_hash
+):
+    """
+    If an existing file is managed from a remote source and its source hash is
+    known beforehand, ensure that `file.managed` checks the local file's digest
+    and if it matches the expected one, does not download the file to the local
+    cache unnecessarily.
+    This is especially important when huge files are managed with `keep_source`
+    set to False.
+    Issue #64373
+    """
+    name = tmp_path / "scene33"
+    name.write_text(grail_scene33_file.read_text())
+    ret = file.managed(
+        str(name),
+        source="http://127.0.0.1:1337/does/not/exist",
+        source_hash=grail_scene33_file_hash,
+    )
+    assert ret.result is True
+    assert not ret.changes

--- a/tests/pytests/functional/states/file/test_managed.py
+++ b/tests/pytests/functional/states/file/test_managed.py
@@ -1057,7 +1057,7 @@ def test_file_managed_remote_source_does_not_refetch_existing_file_with_correct_
     Issue #64373
     """
     name = tmp_path / "scene33"
-    name.write_text(grail_scene33_file.read_text())
+    name.write_bytes(grail_scene33_file.read_bytes())
     ret = file.managed(
         str(name),
         source="http://127.0.0.1:1337/does/not/exist",


### PR DESCRIPTION
### What does this PR do?
Makes `file.managed` check if an existing file's contents match the expected ones early (for remote sources with known source_hash). If they do, forces `replace` to false and thus skips fetching the file to cache.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66342
Ref: https://github.com/saltstack/salt/issues/64373

### Previous Behavior
Essentially manages both intended file and file in cache, wastes resources.

### New Behavior
Only manages intended file.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes