### PR TITLE
[3006.x] Add the ability to clear the context policy cache

### DIFF
--- a/changelog/62734.fixed.md
+++ b/changelog/62734.fixed.md
@@ -1,0 +1,3 @@
+Fixed an issue with adding new machine policies and applying those same
+policies in the same state by adding a ``refresh_cache`` option to the
+``lgpo.set`` state.

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5314,6 +5314,25 @@ def _get_policy_definitions(path="c:\\Windows\\PolicyDefinitions", language="en-
     return __context__["lgpo.policy_definitions"]
 
 
+def clear_policy_cache():
+    """
+    Clears the policy definitions and resource stored in ``__context__``. They
+    will be rebuilt the next time a policy is applied.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lgpo.clear_policy_cache
+    """
+    if "lgpo.policy_definitions" in __context__:
+        log.debug("LGPO: Removing cached policy definitions")
+        __context__.pop("lgpo.policy_definitions")
+    if "lgpo.policy_resources" in __context__:
+        log.debug("LGPO: Removing cached policy resources")
+        __context__.pop("lgpo.policy_resources")
+
+
 def _get_policy_resources(path="c:\\Windows\\PolicyDefinitions", language="en-US"):
     if "lgpo.policy_resources" not in __context__:
         log.debug("LGPO: Loading policy resources")

--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -285,6 +285,7 @@ def set_(
     user_policy=None,
     cumulative_rights_assignments=True,
     adml_language="en-US",
+    refresh_cache=False,
 ):
     """
     Ensure the specified policy is set.
@@ -323,6 +324,18 @@ def set_(
         adml_language (str):
             The adml language to use for AMDX policy data/display conversions.
             Default is ``en-US``
+
+        refresh_cache (bool):
+            Clear the cached policy definitions before applying the state. This
+            is useful when the underlying policy files (ADMX/ADML) have been
+            added/modified in the same state. This will allow those new policies
+            to be picked up. This adds time to the state run when applied to
+            multiple states within the same run. Therefore, it is best to only
+            apply this to the first policy that is applied. For individual runs
+            this will have no effect. Default is ``False``
+
+            .. versionadded:: 3006.8
+            .. versionadded:: 3007.1
     """
     ret = {"name": name, "result": True, "changes": {}, "comment": ""}
     policy_classes = ["machine", "computer", "user", "both"]
@@ -386,6 +399,10 @@ def set_(
         "user": {"requested_policy": user_policy, "policy_lookup": {}},
         "machine": {"requested_policy": computer_policy, "policy_lookup": {}},
     }
+
+    if refresh_cache:
+        # Remove cached policies so new policies can be picked up
+        __salt__["lgpo.clear_policy_cache"]()
 
     current_policy = {}
     deprecation_comments = []

--- a/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
+++ b/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
@@ -18,6 +18,7 @@ import salt.modules.win_file as win_file
 import salt.modules.win_lgpo as win_lgpo
 import salt.utils.files
 import salt.utils.win_dacl as win_dacl
+from tests.support.mock import patch
 
 log = logging.getLogger(__name__)
 
@@ -106,6 +107,19 @@ def lgpo_bin():
     else:
         log.debug("LGPO.exe already present")
         yield str(sys_dir / "lgpo.exe")
+
+
+def test_clear_policy_cache():
+    context = {
+        "lgpo.policy_definitions": "spongebob",
+        "lgpo.policy_resources": "squarepants",
+    }
+    with patch.dict(win_lgpo.__context__, context):
+        assert "lgpo.policy_definitions" in win_lgpo.__context__
+        assert "lgpo.policy_resources" in win_lgpo.__context__
+        win_lgpo.clear_policy_cache()
+        assert "lgpo.policy_definitions" not in win_lgpo.__context__
+        assert "lgpo.policy_resources" not in win_lgpo.__context__
 
 
 @pytest.mark.destructive_test
@@ -449,6 +463,7 @@ def _test_set_user_policy(lgpo_bin, shell, name, setting, exp_regexes):
         ),
     ],
 )
+@pytest.mark.destructive_test
 def test_set_computer_policy(clean_comp, lgpo_bin, shell, name, setting, exp_regexes):
     _test_set_computer_policy(
         lgpo_bin=lgpo_bin,
@@ -519,6 +534,7 @@ def test_set_computer_policy(clean_comp, lgpo_bin, shell, name, setting, exp_reg
         ),
     ],
 )
+@pytest.mark.destructive_test
 def test_set_user_policy(clean_user, lgpo_bin, shell, name, setting, exp_regexes):
     _test_set_user_policy(
         lgpo_bin=lgpo_bin,
@@ -529,6 +545,7 @@ def test_set_user_policy(clean_user, lgpo_bin, shell, name, setting, exp_regexes
     )
 
 
+@pytest.mark.destructive_test
 def test_set_computer_policy_windows_update(clean_comp, lgpo_bin, shell):
     """
     Test setting/unsetting/changing WindowsUpdate policy
@@ -668,6 +685,7 @@ def test_set_computer_policy_windows_update(clean_comp, lgpo_bin, shell):
     )
 
 
+@pytest.mark.destructive_test
 def test_set_computer_policy_multiple_policies(clean_comp, lgpo_bin, shell):
     """
     Tests setting several ADMX policies in succession and validating the


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where if you add new policy files (ADMX/ADML) to the system and then try to apply those policies in the same state, the new policies weren't getting picked up. This adds a new option (``refresh_cache``) to the ``lgpo.set`` state that allows the system to reload the policies.

### What issues does this PR fix or reference?
Fixes: #62734 

### Previous Behavior
New policies applied to the system weren't getting picked up if the policy was applied in the same state.

### New Behavior
New policies get picked up if the user adds the ``refresh_cache`` to the first ``lgpo.set`` state. This forces the lgpo module to reload the policies.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes