### PR TITLE
[master] Fix config.items return value

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -561,4 +561,4 @@ def items():
 
         salt '*' config.items
     """
-    return __opts__
+    return __opts__.value()


### PR DESCRIPTION
### What does this PR do?

Fix return value of `config.items` to prevent not expected return values.

### Previous Behavior
Could return the following instead of the proper `dict`:
```
demo.example.org:
    <salt.loader.context.NamedLoaderContext object at 0x7f31461b80a0>
```

### New Behavior
Return the expected `dict` output

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
