### PR TITLE
[master] Add new options to salt cloud for Windows installer

### DIFF
--- a/changelog/61318.added.md
+++ b/changelog/61318.added.md
@@ -1,0 +1,2 @@
+Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+the Windows installer in salt-cloud

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -31,7 +31,6 @@ which Salt Cloud is running. See
 and using the Salt Minion Windows installer.
 
 
-
 .. _new-pywinrm:
 
 Self Signed Certificates with WinRM
@@ -39,18 +38,18 @@ Self Signed Certificates with WinRM
 
 Salt-Cloud can use versions of ``pywinrm<=0.1.1`` or ``pywinrm>=0.2.1``.
 
-For versions greater than `0.2.1`, ``winrm_verify_ssl`` needs to be set to
-`False` if the certificate is self signed and not verifiable.
+For versions greater than ``0.2.1``, ``winrm_verify_ssl`` needs to be set to
+``False`` if the certificate is self signed and not verifiable.
 
 Firewall Settings
 =================
-Because Salt Cloud makes use of `smbclient` and `winexe`, port 445 must be open
-on the target image. This port is not generally open by default on a standard
-Windows distribution, and care must be taken to use an image in which this port
-is open, or the Windows firewall is disabled.
+Because Salt Cloud makes use of ``smbclient`` and ``winexe``, port 445 must be
+open on the target image. This port is not generally open by default on a
+standard Windows distribution, and care must be taken to use an image in which
+this port is open, or the Windows firewall is disabled.
 
 If supported by the cloud provider, a PowerShell script may be used to open up
-this port automatically, using the cloud provider's `userdata`. The following
+this port automatically, using the cloud provider's ``userdata``. The following
 script would open up port 445, and apply the changes:
 
 .. code-block:: text
@@ -62,7 +61,7 @@ script would open up port 445, and apply the changes:
     </powershell>
 
 For EC2, this script may be saved as a file, and specified in the provider or
-profile configuration as `userdata_file`. For instance:
+profile configuration as ``userdata_file``. For instance:
 
 .. code-block:: yaml
 
@@ -142,9 +141,9 @@ the following userdata example:
     Restart-Service winrm
     </powershell>
 
-No certificate store is available by default on EC2 images and creating
-one does not seem possible without an MMC (cannot be automated). To use the
-default EC2 Windows images the above copies the RDP store.
+No certificate store is available by default on EC2 images and creating one does
+not seem possible without an MMC (cannot be automated). To use the default EC2
+Windows images the above copies the RDP store.
 
 Configuration
 =============
@@ -168,23 +167,42 @@ Setting the installer in ``/etc/salt/cloud.providers``:
       win_password: letmein
       smb_port: 445
 
-The default Windows user is `Administrator`, and the default Windows password
+The default Windows user is ``Administrator``, and the default Windows password
 is blank.
 
-If WinRM is to be used ``use_winrm`` needs to be set to `True`. ``winrm_port``
+If WinRM is to be used ``use_winrm`` needs to be set to ``True``. ``winrm_port``
 can be used to specify a custom port (must be HTTPS listener).  And
-``winrm_verify_ssl`` can be set to `False` to use a self signed certificate.
+``winrm_verify_ssl`` can be set to ``False`` to use a self signed certificate.
 
+Two new options have been added to allow you to set some additional parameters
+to pass to the installer. ``win_delay_start`` will set the minion service to
+start delayed. ``win_install_dir`` will allow you to specify the Salt install
+location.
+
+.. code-block:: yaml
+
+    my-softlayer:
+      driver: softlayer
+      user: MYUSER1138
+      apikey: 'e3b68aa711e6deadc62d5b76355674beef7cc3116062ddbacafe5f7e465bfdc9'
+      minion:
+        master: saltmaster.example.com
+      win_installer: /root/Salt-Minion-2014.7.0-AMD64-Setup.exe
+      win_delay_start: True
+      win_install_dir: D:\Program Files\Salt Project\Salt
+      win_username: Administrator
+      win_password: letmein
+      smb_port: 445
 
 Auto-Generated Passwords on EC2
 ===============================
-On EC2, when the `win_password` is set to `auto`, Salt Cloud will query EC2 for
-an auto-generated password. This password is expected to take at least 4 minutes
-to generate, adding additional time to the deploy process.
+On EC2, when the ``win_password`` is set to ``auto``, Salt Cloud will query EC2
+for an auto-generated password. This password is expected to take at least 4
+minutes to generate, adding additional time to the deploy process.
 
 When the EC2 API is queried for the auto-generated password, it will be returned
-in a message encrypted with the specified `keyname`. This requires that the
-appropriate `private_key` file is also specified. Such a profile configuration
+in a message encrypted with the specified ``keyname``. This requires that the
+appropriate ``private_key`` file is also specified. Such a profile configuration
 might look like:
 
 .. code-block:: yaml

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -450,6 +450,78 @@ def test_deploy_windows_programdata_minion_conf():
 
 
 @pytest.mark.skip_unless_on_windows(reason="Only applicable for Windows.")
+def test_deploy_windows_install_delay_start():
+    mock_true = MagicMock(return_value=True)
+    mock_tuple = MagicMock(return_value=(0, 0, 0))
+    mock_conn = MagicMock()
+
+    with patch("salt.utils.smb", MagicMock()) as mock_smb:
+        mock_smb.get_conn.return_value = mock_conn
+        mock_smb.mkdirs.return_value = None
+        mock_smb.put_file.return_value = None
+        mock_smb.put_str.return_value = None
+        mock_smb.delete_file.return_value = None
+        mock_smb.delete_directory.return_value = None
+        with patch("time.sleep", MagicMock()), patch.object(
+            cloud, "wait_for_port", mock_true
+        ), patch.object(cloud, "fire_event", MagicMock()), patch.object(
+            cloud, "wait_for_psexecsvc", mock_true
+        ), patch.object(
+            cloud, "run_psexec_command", mock_tuple
+        ) as mock_psexec:
+            minion_conf = {"master": "test-master"}
+            cloud.deploy_windows(
+                host="test",
+                minion_conf=minion_conf,
+                win_installer="install.exe",
+                win_delay_start=True,
+            )
+            mock_psexec.assert_any_call(
+                "c:\\salttemp\\install.exe",
+                "/S /master=None /minion-name=None /start-minion-delayed",
+                "test",
+                "Administrator",
+                None,
+            )
+
+
+@pytest.mark.skip_unless_on_windows(reason="Only applicable for Windows.")
+def test_deploy_windows_install_install_dir():
+    mock_true = MagicMock(return_value=True)
+    mock_tuple = MagicMock(return_value=(0, 0, 0))
+    mock_conn = MagicMock()
+
+    with patch("salt.utils.smb", MagicMock()) as mock_smb:
+        mock_smb.get_conn.return_value = mock_conn
+        mock_smb.mkdirs.return_value = None
+        mock_smb.put_file.return_value = None
+        mock_smb.put_str.return_value = None
+        mock_smb.delete_file.return_value = None
+        mock_smb.delete_directory.return_value = None
+        with patch("time.sleep", MagicMock()), patch.object(
+            cloud, "wait_for_port", mock_true
+        ), patch.object(cloud, "fire_event", MagicMock()), patch.object(
+            cloud, "wait_for_psexecsvc", mock_true
+        ), patch.object(
+            cloud, "run_psexec_command", mock_tuple
+        ) as mock_psexec:
+            minion_conf = {"master": "test-master"}
+            cloud.deploy_windows(
+                host="test",
+                minion_conf=minion_conf,
+                win_installer="install.exe",
+                win_install_dir="C:\\salt",
+            )
+            mock_psexec.assert_any_call(
+                "c:\\salttemp\\install.exe",
+                '/S /master=None /minion-name=None /install-dir="C:\\salt"',
+                "test",
+                "Administrator",
+                None,
+            )
+
+
+@pytest.mark.skip_unless_on_windows(reason="Only applicable for Windows.")
 def test_winrm_pinnned_version():
     """
     Test that winrm is pinned to a version 0.3.0 or higher.


### PR DESCRIPTION
### What does this PR do?
Adds two new options to pass to the Windows installer in Salt cloud.

``win_delay_start: True`` will pass ``/start-minion-delayed`` to the installer

``win_install_dir: C:\software\Salt`` will pass ``/install-dir="C:\software\Salt"`` to the installer

### What issues does this PR fix or reference?
Fixes: #61318

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes