### PR TITLE
[3006.x] Fix #66382 (nftables): Produce correct ip family for rules with saddr or daddr

### DIFF
--- a/changelog/66382.fixed.md
+++ b/changelog/66382.fixed.md
@@ -1,0 +1,1 @@
+Fixed nftables.build_rule breaks ipv6 rules by using the wrong syntax for source and destination addresses

--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -165,14 +165,18 @@ def build_rule(
         del kwargs["counter"]
 
     if "saddr" in kwargs or "source" in kwargs:
-        rule += "ip saddr {} ".format(kwargs.get("saddr") or kwargs.get("source"))
+        rule += "{} saddr {} ".format(
+            nft_family, kwargs.get("saddr") or kwargs.get("source")
+        )
         if "saddr" in kwargs:
             del kwargs["saddr"]
         if "source" in kwargs:
             del kwargs["source"]
 
     if "daddr" in kwargs or "destination" in kwargs:
-        rule += "ip daddr {} ".format(kwargs.get("daddr") or kwargs.get("destination"))
+        rule += "{} daddr {} ".format(
+            nft_family, kwargs.get("daddr") or kwargs.get("destination")
+        )
         if "daddr" in kwargs:
             del kwargs["daddr"]
         if "destination" in kwargs:

--- a/tests/pytests/unit/modules/test_nftables.py
+++ b/tests/pytests/unit/modules/test_nftables.py
@@ -103,6 +103,26 @@ def test_build_rule():
         "comment": "Successfully built rule",
     }
 
+    assert nftables.build_rule(
+        table="filter",
+        chain="input",
+        family="ip6",
+        command="insert",
+        position="3",
+        full="True",
+        connstate="related,established",
+        saddr="::/0",
+        daddr="fe80:cafe::1",
+        jump="accept",
+    ) == {
+        "result": True,
+        "rule": (
+            "nft insert rule ip6 filter input position 3 ct state {"
+            " related,established } ip6 saddr ::/0 ip6 daddr fe80:cafe::1 accept"
+        ),
+        "comment": "Successfully built rule",
+    }
+
     assert nftables.build_rule() == {"result": True, "rule": "", "comment": ""}
 
 


### PR DESCRIPTION
### What does this PR do?
Changes nftables.build_rule so that it adds the correct family identifier to rules containing `saddr` or `daddr` parts.

### What issues does this PR fix or reference?
Fixes saltstack/salt#66382

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
