### PR TITLE
[master] Fixed incorrect version argument will be ignored warning

### DIFF
--- a/changelog/64563.fixed.md
+++ b/changelog/64563.fixed.md
@@ -1,0 +1,1 @@
+Fixed incorrect version argument will be ignored for multiple package targets warning when using pkgs argument to yumpkg module.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1427,8 +1427,8 @@ def install(
                 'version': '<new-version>',
                 'arch': '<new-arch>'}}}
     """
-    if "version" in kwargs:
-        kwargs["version"] = str(kwargs["version"])
+    if (version := kwargs.get("version")) is not None:
+        kwargs["version"] = str(version)
     options = _get_options(**kwargs)
 
     if salt.utils.data.is_true(refresh):

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -231,7 +231,7 @@ def test_pkg_002_installed_with_version(PKG_TARGETS, states, latest_version):
 
 @pytest.mark.requires_salt_states("pkg.installed", "pkg.removed")
 @pytest.mark.slow_test
-def test_pkg_003_installed_multipkg(PKG_TARGETS, modules, states):
+def test_pkg_003_installed_multipkg(caplog, PKG_TARGETS, modules, states):
     """
     This is a destructive test as it installs and then removes two packages
     """
@@ -247,6 +247,7 @@ def test_pkg_003_installed_multipkg(PKG_TARGETS, modules, states):
     try:
         ret = states.pkg.installed(name=None, pkgs=PKG_TARGETS, refresh=False)
         assert ret.result is True
+        assert "WARNING" not in caplog.text
     finally:
         ret = states.pkg.removed(name=None, pkgs=PKG_TARGETS)
         assert ret.result is True


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #64563

### Previous Behavior
Prints `[WARNING ] 'version' argument will be ignored for multiple package targets` when `pkgs` argument is used to pkg.installed on systems with yum/dnf.

### New Behavior
No longer prints the warning.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
