### PR TITLE
[3006.x] Preserve target permissions when setting link ownership

### DIFF
--- a/changelog/66400.fixed.md
+++ b/changelog/66400.fixed.md
@@ -1,0 +1,1 @@
+The file module correctly perserves file permissions on link target.

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5147,7 +5147,7 @@ def check_perms(
                 if err:
                     ret["result"] = False
                     ret["comment"].append(err)
-                else:
+                elif not is_link:
                     # Python os.chown() resets the suid and sgid, hence we
                     # setting the previous mode again. Pending mode changes
                     # will be applied later.
@@ -5198,7 +5198,6 @@ def check_perms(
                 ret["comment"].append(f"Failed to change group to {group}")
         elif "cgroup" in perms:
             ret["changes"]["group"] = group
-
     if mode is not None:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -1210,6 +1210,7 @@ def test_contents_file(salt_master, salt_call_cli, tmp_path):
             assert target_path.is_file()
 
 
+@pytest.mark.skip_on_windows
 def test_directory_recurse(salt_master, salt_call_cli, tmp_path):
     """
     Test modifying ownership of symlink without affecting the link target's


### PR DESCRIPTION
Set ownerhip on symlinks without running chown. Running chown on a link will set the permissions on a target because link perms are meaningless.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes #66400


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

