### PR TITLE
[3006.x] Fix #66133: roots fileserver path verification for symlinks

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -101,7 +101,9 @@ def find_file(path, saltenv="base", **kwargs):
         full = os.path.join(root, path)
 
         # Refuse to serve file that is not under the root.
-        if not salt.utils.verify.clean_path(root, full, subdir=True):
+        if not salt.utils.verify.clean_path(
+            root, full, subdir=True, realpath=not __opts__["fileserver_followsymlinks"]
+        ):
             continue
 
         if os.path.isfile(full) and not salt.fileserver.is_file_ignored(__opts__, full):
@@ -149,7 +151,9 @@ def serve_file(load, fnd):
         if saltenv == "__env__":
             root = root.replace("__env__", actual_saltenv)
         # Refuse to serve file that is not under the root.
-        if salt.utils.verify.clean_path(root, fpath, subdir=True):
+        if salt.utils.verify.clean_path(
+            root, fpath, subdir=True, realpath=not __opts__["fileserver_followsymlinks"]
+        ):
             file_in_root = True
     if not file_in_root:
         return ret

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -513,25 +513,28 @@ def _realpath(path):
     return os.path.realpath(path)
 
 
-def clean_path(root, path, subdir=False):
+def clean_path(root, path, subdir=False, realpath=True):
     """
     Accepts the root the path needs to be under and verifies that the path is
     under said root. Pass in subdir=True if the path can result in a
-    subdirectory of the root instead of having to reside directly in the root
+    subdirectory of the root instead of having to reside directly in the root.
+    Pass realpath=False if filesystem links should not be resolved.
     """
-    real_root = _realpath(root)
-    if not os.path.isabs(real_root):
+    if not os.path.isabs(root):
         return ""
+    root = os.path.normpath(root)
     if not os.path.isabs(path):
         path = os.path.join(root, path)
     path = os.path.normpath(path)
-    real_path = _realpath(path)
+    if realpath:
+        root = _realpath(root)
+        path = _realpath(path)
     if subdir:
-        if real_path.startswith(real_root):
-            return real_path
+        if os.path.commonpath([path, root]) == root:
+            return path
     else:
-        if os.path.dirname(real_path) == os.path.normpath(real_root):
-            return real_path
+        if os.path.dirname(path) == root:
+            return path
     return ""
 
 

--- a/tests/pytests/unit/fileserver/test_roots.py
+++ b/tests/pytests/unit/fileserver/test_roots.py
@@ -315,3 +315,28 @@ def test_serve_file_not_in_root(tmp_state_tree):
         assert ret == {"data": "", "dest": "..\\bar"}
     else:
         assert ret == {"data": "", "dest": "../bar"}
+
+
+def test_find_file_symlink_destination_not_in_root(tmp_state_tree):
+    dirname = pathlib.Path(tmp_state_tree).parent / "foo"
+    dirname.mkdir(parents=True, exist_ok=True)
+    testfile = dirname / "testfile"
+    testfile.write_text("testfile")
+    symlink = tmp_state_tree / "bar"
+    symlink.symlink_to(str(dirname))
+    ret = roots.find_file("bar/testfile")
+    assert ret["path"] == str(symlink / "testfile")
+    assert ret["rel"] == "bar/testfile"
+
+
+def test_serve_file_symlink_destination_not_in_root(tmp_state_tree):
+    dirname = pathlib.Path(tmp_state_tree).parent / "foo"
+    dirname.mkdir(parents=True, exist_ok=True)
+    testfile = dirname / "testfile"
+    testfile.write_text("testfile")
+    symlink = tmp_state_tree / "bar"
+    symlink.symlink_to(str(dirname))
+    load = {"path": "bar/testfile", "saltenv": "base", "loc": 0}
+    fnd = {"path": str(symlink / "testfile"), "rel": "bar/testfile"}
+    ret = roots.serve_file(load, fnd)
+    assert ret == {"data": b"testfile", "dest": "bar/testfile"}

--- a/tests/pytests/unit/utils/verify/test_clean_path_link.py
+++ b/tests/pytests/unit/utils/verify/test_clean_path_link.py
@@ -65,3 +65,11 @@ def test_clean_path_symlinked_tgt(setup_links):
     expect_path = str(to_path / "test")
     ret = salt.utils.verify.clean_path(str(from_path), str(test_path))
     assert ret == expect_path, f"{ret} is not {expect_path}"
+
+
+def test_clean_path_symlinked_src_unresolved(setup_links):
+    to_path, from_path = setup_links
+    test_path = from_path / "test"
+    expect_path = str(from_path / "test")
+    ret = salt.utils.verify.clean_path(str(from_path), str(test_path), realpath=False)
+    assert ret == expect_path, f"{ret} is not {expect_path}"


### PR DESCRIPTION
### What does this PR do?
Changes of the path verification so that symlinks to destinations outside of the roots directory work again.
This is broken since the CVE fix commit e0cdb80b55123f4a024759ffcf2b3f0e0788e7ab.

### What issues does this PR fix or reference?
Fixes #66133, #66052, #65977
