### PR TITLE
[master] Don't use Salt's custom YAML loader to load static grains file

### DIFF
--- a/changelog/66445.fixed.md
+++ b/changelog/66445.fixed.md
@@ -1,0 +1,3 @@
+Fixed an issue where conflicting top level keys in the static grains file
+(usually `/etc/salt/grains`) would break all grains states, and prevent static
+grains from being loaded.

--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -2,12 +2,13 @@ import glob
 import logging
 import os
 
+import yaml
+
 import salt.utils
 import salt.utils.data
 import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
-import salt.utils.yaml
 
 __proxyenabled__ = ["*"]
 log = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ def config():
         log.debug("Loading static grains from %s", gfn)
         with salt.utils.files.fopen(gfn, "rb") as fp_:
             try:
-                return salt.utils.data.decode(salt.utils.yaml.safe_load(fp_))
+                return salt.utils.data.decode(yaml.safe_load(fp_))
             except Exception:  # pylint: disable=broad-except
                 log.warning("Bad syntax in grains file! Skipping.")
                 return {}

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -17,6 +17,8 @@ import os
 from collections.abc import Mapping
 from functools import reduce  # pylint: disable=redefined-builtin
 
+import yaml
+
 import salt.utils.compat
 import salt.utils.data
 import salt.utils.files
@@ -262,8 +264,9 @@ def setvals(grains, destructive=False, refresh_pillar=True):
     if os.path.isfile(gfn):
         with salt.utils.files.fopen(gfn, "rb") as fp_:
             try:
-                grains = salt.utils.yaml.safe_load(fp_)
-            except salt.utils.yaml.YAMLError as exc:
+                # DO NOT USE salt.utils.yaml.safe_load HERE
+                grains = yaml.safe_load(fp_)
+            except Exception as exc:  # pylint: disable=broad-except
                 return f"Unable to read existing grains file: {exc}"
         if not isinstance(grains, dict):
             grains = {}

--- a/tests/pytests/unit/grains/test_extra.py
+++ b/tests/pytests/unit/grains/test_extra.py
@@ -1,0 +1,30 @@
+"""
+tests.pytests.unit.grains.test_extra
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import pytest
+
+import salt.grains.extra as extra
+import salt.utils.platform
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {extra: {}}
+
+
+def test_static_grains_file_conflicting_keys(tmp_path):
+    """
+    Test that static grains files with conflicting keys don't result in failure
+    to load all grains from that file.
+    """
+    with (tmp_path / "grains").open("w") as fh:
+        fh.write('foo: bar\nfoo: baz\nno_conflict_here: "yay"\n')
+
+    with patch.object(
+        salt.utils.platform, "is_proxy", MagicMock(return_value=False)
+    ), patch("salt.grains.extra.__opts__", {"conf_file": str(tmp_path / "minion")}):
+        static_grains = extra.config()
+        assert "no_conflict_here" in static_grains


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #66445

### Previous Behavior

Conflicting IDs in /etc/salt/grains would break grains states, and prevent all static grains from being loaded

### New Behavior

These issues are both fixed.

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No