### PR TITLE
[3007.x] fix sync_renderers failure when the custom renderer is specified via config

### DIFF
--- a/changelog/66453.fixed.md
+++ b/changelog/66453.fixed.md
@@ -1,0 +1,1 @@
+Fix sync_renderers failure when the custom renderer is specified via config

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -979,7 +979,20 @@ def render(
             "the needed software is unavailable".format(opts["renderer"])
         )
         log.critical(err)
-        raise LoaderError(err)
+        if opts.get("__role") == "minion":
+            default_renderer_config = salt.config.DEFAULT_MINION_OPTS["renderer"]
+        else:
+            default_renderer_config = salt.config.DEFAULT_MASTER_OPTS["renderer"]
+        log.warning(
+            "Attempting fallback to default render pipe: %s", default_renderer_config
+        )
+        if not check_render_pipe_str(
+            default_renderer_config,
+            rend,
+            opts["renderer_blacklist"],
+            opts["renderer_whitelist"],
+        ):
+            raise LoaderError(err)
     return rend
 
 

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -113,16 +113,3 @@ def test_render():
         "salt.loader.check_render_pipe_str", MagicMock(side_effect=[False, False])
     ):
         salt.loader.render(opts, minion_mods)
-
-
-def test_return_named_context_from_loaded_func(tmp_path):
-    opts = {
-        "optimization_order": [0],
-    }
-    contents = """
-    def foobar():
-        return __test__
-    """
-    with pytest.helpers.temp_file("mymod.py", contents, directory=tmp_path):
-        loader = salt.loader.LazyLoader([tmp_path], opts, pack={"__test__": "meh"})
-        assert loader["mymod.foobar"]() == "meh"

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -113,3 +113,16 @@ def test_render():
         "salt.loader.check_render_pipe_str", MagicMock(side_effect=[False, False])
     ):
         salt.loader.render(opts, minion_mods)
+
+
+def test_return_named_context_from_loaded_func(tmp_path):
+    opts = {
+        "optimization_order": [0],
+    }
+    contents = """
+    def foobar():
+        return __test__
+    """
+    with pytest.helpers.temp_file("mymod.py", contents, directory=tmp_path):
+        loader = salt.loader.LazyLoader([tmp_path], opts, pack={"__test__": "meh"})
+        assert loader["mymod.foobar"]() == "meh"


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes #66453 

### Previous Behavior
exception is raised when renderer in pipe fails to be found

### New Behavior
renderer falls back to default if any renderer in pipe fails to be found

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
