### PR TITLE
[master] Remove redundant `_file_find` call to the master

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1180,10 +1180,7 @@ class RemoteClient(Client):
         if senv:
             saltenv = senv
 
-        if not salt.utils.platform.is_windows():
-            hash_server, stat_server = self.hash_and_stat_file(path, saltenv)
-        else:
-            hash_server = self.hash_file(path, saltenv)
+        hash_server = self.hash_file(path, saltenv)
 
         # Check if file exists on server, before creating files and
         # directories
@@ -1224,10 +1221,7 @@ class RemoteClient(Client):
         )
 
         if dest2check and os.path.isfile(dest2check):
-            if not salt.utils.platform.is_windows():
-                hash_local, stat_local = self.hash_and_stat_file(dest2check, saltenv)
-            else:
-                hash_local = self.hash_file(dest2check, saltenv)
+            hash_local = self.hash_file(dest2check, saltenv)
 
             if hash_local == hash_server:
                 return dest2check


### PR DESCRIPTION
### What does this PR do?

This PR is intended to improve the performance in the large scale deployments as there is a useless call to get stats of the syncronized files which is not used.
Seem it's a leftover of removing the code with https://github.com/saltstack/salt/pull/40609 due to https://github.com/advisories/GHSA-xcx4-5wq7-g5g7 introduced with https://github.com/saltstack/salt/commit/73a156d28cafd45dcc6c2aac9f1ac3ad905695e3 (https://github.com/saltstack/salt/pull/34807 ???)

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Redundant `_file_find` calls in combination with `_file_hash`.

### New Behavior
No redundant `_file_find` calls on files syncronization.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
