### PR TITLE
[master] Allow ssh pre connection hook

### DIFF
--- a/changelog/66210.added.md
+++ b/changelog/66210.added.md
@@ -1,0 +1,1 @@
+Allow pre-connection scripts to be run on host before any ssh commands

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -61,6 +61,9 @@ The information which can be stored in a roster ``target`` is the following:
                      # components. Defaults to /tmp/salt-<hash>.
         cmd_umask:   # umask to enforce for the salt-call command. Should be in
                      # octal (so for 0o077 in YAML you would do 0077, or 63)
+        ssh_pre_hook:   # Path to a script that will run on the host before all other
+                        # salt-ssh commands. Runs every time salt-ssh is run.
+                        # Added in 3008 Release
         ssh_pre_flight: # Path to a script that will run before all other salt-ssh
                         # commands. Will only run the first time when the thin dir
                         # does not exist, unless --pre-flight is passed to salt-ssh
@@ -74,6 +77,25 @@ The information which can be stored in a roster ``target`` is the following:
                      # Example: '$PATH:/usr/local/bin/'. Added in 3001 Release.
         ssh_options: # List of options (as 'option=argument') to pass to ssh.
 
+.. _ssh_pre_hook:
+
+ssh_pre_hook
+------------
+
+Introduced in the 3008 release, the `ssh_pre_hook` is an option in the Salt-SSH roster that allows the execution of a script on the origin server before any SSH connection attempts are made.
+This is particularly useful in environments where dynamic setup is required, such as signing SSH keys or configuring environment variables.
+
+The `ssh_pre_hook` script is specified in the roster file for each target or globally using `roster_defaults`. It runs every time `salt-ssh` is invoked, ensuring that all prerequisites are met before making an SSH connection.
+
+.. code-block:: yaml
+
+    test:
+        host: 257.25.17.66
+        ssh_pre_hook: /path/to/script param1 param2
+
+If the script specified in `ssh_pre_hook` fails (returns a non-zero exit code), `salt-ssh` will halt further execution, preventing connection attempts to the target server.
+
+Usage of `ssh_pre_hook` provides a flexible mechanism to perform necessary preparations and checks, ensuring that the environment conforms to required conditions before proceeding with SSH operations.
 
 .. _ssh_pre_flight:
 

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -65,6 +65,7 @@ class SSHClient:
             ("ssh_scan_timeout", int),
             ("ssh_timeout", int),
             ("ssh_log_file", str),
+            ("ssh_pre_hook", str),
             ("raw_shell", bool),
             ("refresh_cache", bool),
             ("roster", str),


### PR DESCRIPTION
### What does this PR do?
Implements the feature requested in GitHub issue: [FEATURE REQUEST] allow pre-connection scripts to be run on salt-ssh

### What issues does this PR fix or reference?
Closes #66210 

### Previous Behavior
Previously, salt-ssh did not support executing scripts on the origin server before establishing an SSH connection. Users had to manually ensure that their environment was correctly set up prior to running salt-ssh.

### New Behavior
With this PR, users can configure a script to run immediately before salt-ssh attempts to connect to the target server. This script can perform tasks such as refreshing SSH key signatures, setting environment variables, or any other necessary setup steps. This functionality is controlled by the ssh_pre_hook option in the roster, which defaults to None. When set, the specified script will be executed as part of the connection process.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes