### PR TITLE
[3006.x] We no longer use `aarch64` on artifact filenames

### DIFF
--- a/tools/testsuite/__init__.py
+++ b/tools/testsuite/__init__.py
@@ -46,7 +46,7 @@ ts = command_group(name="ts", help="Test Suite Related Commands", description=__
         },
         "arch": {
             "help": "The onedir artifact architecture",
-            "choices": ("x86_64", "aarch64", "amd64", "x86"),
+            "choices": ("x86_64", "arm64", "amd64", "x86"),
         },
         "slug": {
             "help": "The OS slug",
@@ -106,7 +106,7 @@ def setup_testsuite(
         ctx.exit(1)
 
     if "arm64" in slug:
-        arch = "aarch64"
+        arch = "arm64"
 
     ctx.warn(
         "Consider this in preliminary support. There are most likely things to iron out still."

--- a/tools/utils/gh.py
+++ b/tools/utils/gh.py
@@ -40,15 +40,15 @@ def download_onedir_artifact(
             )
             return ExitCode.FAIL
     else:
-        if arch == "arm64":
-            ctx.info(f"Turning passed arch {arch!r} into 'aarch64'")
-            arch = "aarch64"
+        if arch == "aarch64":
+            ctx.info(f"Turning passed arch {arch!r} into 'arm64'")
+            arch = "arm64"
         elif arch == "x64":
             ctx.info(f"Turning passed arch {arch!r} into 'x86_64'")
             arch = "x86_64"
-        if arch not in ("x86_64", "aarch64"):
+        if arch not in ("x86_64", "arm64"):
             ctx.error(
-                f"The allowed values for '--arch' on {platform.title()} are 'x86_64', 'aarch64' or 'arm64'"
+                f"The allowed values for '--arch' on {platform.title()} are 'x86_64' or 'arm64'"
             )
             return ExitCode.FAIL
     artifacts_path = tools.utils.REPO_ROOT / "artifacts"
@@ -129,15 +129,15 @@ def download_nox_artifact(
             )
             return ExitCode.FAIL
     else:
-        if arch == "arm64":
-            ctx.info(f"Turning passed arch {arch!r} into 'aarch64'")
-            arch = "aarch64"
+        if arch == "aarch64":
+            ctx.info(f"Turning passed arch {arch!r} into 'arm64'")
+            arch = "arm64"
         elif arch == "x64":
             ctx.info(f"Turning passed arch {arch!r} into 'x86_64'")
             arch = "x86_64"
-        if arch not in ("x86_64", "aarch64"):
+        if arch not in ("x86_64", "arm64"):
             ctx.error(
-                f"The allowed values for '--arch' on {platform.title()} are 'x86_64', 'aarch64' or 'arm64'"
+                f"The allowed values for '--arch' on {platform.title()} are 'x86_64' or 'arm64'"
             )
             return ExitCode.FAIL
 
@@ -204,15 +204,15 @@ def download_pkgs_artifact(
             return ExitCode.FAIL
         artifact_name += f"{arch}-MSI"
     else:
-        if arch == "arm64":
-            ctx.info(f"Turning passed arch {arch!r} into 'aarch64'")
-            arch = "aarch64"
+        if arch == "aarch64":
+            ctx.info(f"Turning passed arch {arch!r} into 'arm64'")
+            arch = "arm64"
         elif arch == "x64":
             ctx.info(f"Turning passed arch {arch!r} into 'x86_64'")
             arch = "x86_64"
-        if arch not in ("x86_64", "aarch64"):
+        if arch not in ("x86_64", "arm64"):
             ctx.error(
-                f"The allowed values for '--arch' for {slug} are 'x86_64', 'aarch64' or 'arm64'"
+                f"The allowed values for '--arch' for {slug} are 'x86_64' or 'arm64'"
             )
             return ExitCode.FAIL
 


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes #66502