### PR TITLE
[3006.x] Fix parallel state execution with Salt-SSH

### DIFF
--- a/changelog/66514.fixed.md
+++ b/changelog/66514.fixed.md
@@ -1,0 +1,1 @@
+Fixed parallel state execution with Salt-SSH

--- a/tests/pytests/integration/ssh/state/test_parallel.py
+++ b/tests/pytests/integration/ssh/state/test_parallel.py
@@ -1,0 +1,61 @@
+"""
+Verify salt-ssh states support ``parallel``.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def state_tree_parallel(base_env_state_tree_root_dir):
+    top_file = """
+    base:
+      'localhost':
+        - parallel
+      '127.0.0.1':
+        - parallel
+    """
+    state_file = """
+    {%- for i in range(5) %}
+    This runs in parallel {{ i }}:
+      cmd.run:
+        - name: sleep 0.{{ i }}
+        - parallel: true
+    {%- endfor %}
+    """
+    top_tempfile = pytest.helpers.temp_file(
+        "top.sls", top_file, base_env_state_tree_root_dir
+    )
+    state_tempfile = pytest.helpers.temp_file(
+        "parallel.sls", state_file, base_env_state_tree_root_dir
+    )
+    with top_tempfile, state_tempfile:
+        yield
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        pytest.param(("state.sls", "parallel"), id="sls"),
+        pytest.param(("state.highstate",), id="highstate"),
+        pytest.param(("state.top", "top.sls"), id="top"),
+    ),
+)
+def test_it(salt_ssh_cli, args):
+    """
+    Ensure states with ``parallel: true`` do not cause a crash.
+    This does not check that they were actually run in parallel
+    since that would result either in a long-running or flaky test.
+    """
+    ret = salt_ssh_cli.run(*args)
+    assert ret.returncode == 0
+    assert isinstance(ret.data, dict)
+    for i in range(5):
+        key = f"cmd_|-This runs in parallel {i}_|-sleep 0.{i}_|-run"
+        assert key in ret.data
+        assert "pid" in ret.data[key]["changes"]
+        assert ret.data[key]["changes"]["retcode"] == 0


### PR DESCRIPTION
### What does this PR do?
Fixes a TypeError that was raised when executing parallel states via Salt-SSH (jid was unset, but the cache dir used for returning the result of a parallel execution depended on it).

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66514
Fixes: https://github.com/saltstack/salt/issues/53538

### Previous Behavior
Exits with retcode=0, shows `sys.doc` of `state.pkg` because of a TypeError (on <3007) / at least errors with retcode=1 and shows the stacktrace (>=3007).

### New Behavior
Executes the states in parallel as requested.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes