### PR TITLE
[master] Distribute saltexts in salt-ssh thin package

### DIFF
--- a/changelog/66559.changed.md
+++ b/changelog/66559.changed.md
@@ -1,0 +1,1 @@
+Included Salt extensions in Salt-SSH thin archive

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1667,6 +1667,8 @@ Pass a list of importable Python modules that are typically located in
 the `site-packages` Python directory so they will be also always included
 into the Salt Thin, once generated.
 
+.. conf_master:: min_extra_mods
+
 ``min_extra_mods``
 ------------------
 
@@ -1674,6 +1676,47 @@ Default: None
 
 Identical as `thin_extra_mods`, only applied to the Salt Minimal.
 
+.. conf_master:: thin_exclude_saltexts
+
+``thin_exclude_saltexts``
+-------------------------
+
+Default: False
+
+By default, Salt-SSH autodiscovers Salt extensions in the current Python environment
+and adds them to the Salt Thin. This disables that behavior.
+
+.. note::
+
+    When the list of modules/extensions to include in the Salt Thin changes
+    for any reason (e.g. Saltext was added/removed, :conf_master:`thin_exclude_saltexts`,
+    :conf_master:`thin_saltext_allowlist` or :conf_master:`thin_saltext_blocklist`
+    was changed), you typically need to regenerate the Salt Thin by passing
+    ``--regen-thin`` to the next Salt-SSH invocation.
+
+.. conf_master:: thin_saltext_allowlist
+
+``thin_saltext_allowlist``
+--------------------------
+
+Default: None
+
+A list of Salt extension **distribution** names which are allowed to be
+included in the Salt Thin (when :conf_master:`thin_exclude_saltexts`
+is inactive) and they are discovered. Any extension not in this list
+will be excluded. If unset, all discovered extensions are added,
+unless present in :conf_master:`thin_saltext_blocklist`.
+
+.. conf_master:: thin_saltext_blocklist
+
+``thin_saltext_blocklist``
+--------------------------
+
+Default: None
+
+A list of Salt extension **distribution** names which should never be
+included in the Salt Thin (when :conf_master:`thin_exclude_saltexts`
+is inactive).
 
 .. _master-security-settings:
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -315,7 +315,9 @@ class SSH(MultiprocessingStateMixin):
             extra_mods=self.opts.get("thin_extra_mods"),
             overwrite=self.opts["regen_thin"],
             extended_cfg=self.opts.get("ssh_ext_alternatives"),
-            include_saltexts=self.opts.get("thin_include_saltexts", False),
+            exclude_saltexts=self.opts.get("thin_exclude_saltexts", False),
+            saltext_allowlist=self.opts.get("thin_saltext_allowlist"),
+            saltext_blocklist=self.opts.get("thin_saltext_blocklist"),
         )
         self.mods = mod_data(self.fsclient)
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -315,6 +315,7 @@ class SSH(MultiprocessingStateMixin):
             extra_mods=self.opts.get("thin_extra_mods"),
             overwrite=self.opts["regen_thin"],
             extended_cfg=self.opts.get("ssh_ext_alternatives"),
+            include_saltexts=self.opts.get("thin_include_saltexts", False),
         )
         self.mods = mod_data(self.fsclient)
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -907,6 +907,9 @@ VALID_OPTS = immutabletypes.freeze(
         # Thin and minimal Salt extra modules
         "thin_extra_mods": str,
         "min_extra_mods": str,
+        "thin_exclude_saltexts": bool,
+        "thin_saltext_allowlist": (type(None), list),
+        "thin_saltext_blocklist": list,
         # Default returners minion should use. List or comma-delimited string
         "return": (str, list),
         # TLS/SSL connection options. This could be set to a dictionary containing arguments
@@ -1630,6 +1633,9 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "memcache_debug": False,
         "thin_extra_mods": "",
         "min_extra_mods": "",
+        "thin_exclude_saltexts": False,
+        "thin_saltext_allowlist": None,
+        "thin_saltext_blocklist": [],
         "ssl": None,
         "extmod_whitelist": {},
         "extmod_blacklist": {},

--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -196,6 +196,19 @@ class DigestCollector:
             for chunk in iter(lambda: ifile.read(self.__buff), b""):
                 self.__digest.update(chunk)
 
+    def add_data(self, data):
+        """
+        Update digest with the file content directly.
+
+        :param data:
+        :return:
+        """
+        try:
+            data = data.encode("utf8")
+        except AttributeError:
+            pass
+        self.__digest.update(data)
+
     def digest(self):
         """
         Get digest.

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3177,11 +3177,11 @@ class SaltSSHOptionParser(
             ),
         )
         self.add_option(
-            "--thin-include-saltexts",
+            "--thin-exclude-saltexts",
             default=False,
             action="store_true",
-            dest="thin_include_saltexts",
-            help=("Include Salt extension modules in generated Thin Salt."),
+            dest="thin_exclude_saltexts",
+            help="Exclude Salt extension modules from generated Thin Salt.",
         )
         self.add_option(
             "-v",

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3177,6 +3177,13 @@ class SaltSSHOptionParser(
             ),
         )
         self.add_option(
+            "--thin-include-saltexts",
+            default=False,
+            action="store_true",
+            dest="thin_include_saltexts",
+            help=("Include Salt extension modules in generated Thin Salt."),
+        )
+        self.add_option(
             "-v",
             "--verbose",
             default=False,

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -667,7 +667,7 @@ def _discover_saltexts(allowlist=None, blocklist=None):
                     iter(
                         file.parent.name
                         for file in entry_point.dist.files
-                        if "dist-info" in file.parent.name
+                        if file.parent.suffix == ".dist-info"
                     )
                 )
             except StopIteration:

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -99,6 +99,12 @@ discovery: false
 #enable_ssh_minions: True
 #ignore_host_keys: True
 
+# Ensure pytest-salt-factories is not included
+# in the thin tar during integration tests
+# (it defines a saltext, which are autodiscovered by default)
+thin_saltext_blocklist:
+  - pytest-salt-factories
+
 sdbetcd:
   driver: etcd
   etcd.host: 127.0.0.1

--- a/tests/pytests/integration/ssh/test_saltext.py
+++ b/tests/pytests/integration/ssh/test_saltext.py
@@ -17,25 +17,41 @@ def salt_extension(tmp_path_factory):
 
 
 @pytest.fixture(scope="module")
-def other_salt_extension(tmp_path_factory):
+def namespaced_salt_extension(tmp_path_factory):
     with FakeSaltExtension(
         tmp_path_factory=tmp_path_factory,
-        name="salt-ext2-ssh-test",
+        name="saltext.ssh-test2",
         virtualname="barbaz",
     ) as extension:
         yield extension
 
 
 @pytest.fixture(scope="module")
-def venv(tmp_path_factory, salt_extension, other_salt_extension):
+def namespaced_salt_extension_2(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory,
+        name="saltext.ssh-test3",
+        virtualname="wut",
+    ) as extension:
+        yield extension
+
+
+@pytest.fixture(scope="module")
+def venv(
+    tmp_path_factory,
+    salt_extension,
+    namespaced_salt_extension,
+    namespaced_salt_extension_2,
+):
     venv_dir = tmp_path_factory.mktemp("saltext-ssh-test-venv")
+    saltexts = (salt_extension, namespaced_salt_extension, namespaced_salt_extension_2)
     try:
         with SaltVirtualEnv(venv_dir=venv_dir) as _venv:
-            _venv.install(str(salt_extension.srcdir))
-            _venv.install(str(other_salt_extension.srcdir))
+            for saltext in saltexts:
+                _venv.install(str(saltext.srcdir))
             installed_packages = _venv.get_installed_packages()
-            assert salt_extension.name in installed_packages
-            assert other_salt_extension.name in installed_packages
+            for saltext in saltexts:
+                assert saltext.name in installed_packages
             yield _venv
     finally:
         shutil.rmtree(venv_dir, ignore_errors=True)
@@ -67,8 +83,8 @@ def args(venv, salt_master, salt_ssh_roster_file, sshd_config_dir):
     "saltext_conf",
     (
         {},
-        {"thin_saltext_allowlist": ["salt-ext-ssh-test"]},
-        {"thin_saltext_blocklist": ["salt-ext2-ssh-test"]},
+        {"thin_saltext_allowlist": ["salt-ext-ssh-test", "saltext.ssh-test3"]},
+        {"thin_saltext_blocklist": ["saltext.ssh-test2"]},
     ),
     indirect=True,
 )
@@ -87,6 +103,9 @@ def test_saltexts_are_available_on_target(venv, args, saltext_conf):
     else:
         assert res.returncode > 0
         assert "'barbaz.echo1' is not available" in res.stdout
+    ext3_args = args + ["wut.echo1", "wat"]
+    res = venv.run(*ext3_args, check=True)
+    assert res.stdout == "localhost:\n    wat\n"
 
 
 @pytest.mark.usefixtures("saltext_conf")
@@ -94,7 +113,7 @@ def test_saltexts_are_available_on_target(venv, args, saltext_conf):
     "saltext_conf", ({"thin_exclude_saltexts": True},), indirect=True
 )
 def test_saltexts_can_be_excluded(venv, args):
-    for ext in ("foobar", "barbaz"):
+    for ext in ("foobar", "barbaz", "wut"):
         ext_args = args + [f"{ext}.echo1", "foo"]
         res = venv.run(*ext_args, check=False)
         assert res.returncode > 0

--- a/tests/pytests/integration/ssh/test_saltext.py
+++ b/tests/pytests/integration/ssh/test_saltext.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tests.support.helpers import SaltVirtualEnv
+from tests.support.pytest.helpers import FakeSaltExtension
+
+
+@pytest.fixture(scope="module")
+def salt_extension(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory, name="salt-ext-ssh-test"
+    ) as extension:
+        yield extension
+
+
+@pytest.fixture
+def venv(tmp_path):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as _venv:
+        yield _venv
+
+
+def test_saltext_is_available_on_target(
+    venv, salt_extension, salt_ssh_roster_file, sshd_config_dir, salt_master
+):
+    venv.install(str(salt_extension.srcdir))
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+    args = [
+        venv.venv_bin_dir / "salt-ssh",
+        "--thin-include-saltexts",
+        f"--config-dir={salt_master.config_dir}",
+        f"--roster-file={salt_ssh_roster_file}",
+        f"--priv={sshd_config_dir / 'client_key'}",
+        "localhost",
+        "foobar.echo1",
+        "foo",
+    ]
+    res = venv.run(*args, check=True)
+    assert res.stdout == "localhost:\n    foo\n"

--- a/tests/pytests/integration/ssh/test_saltext.py
+++ b/tests/pytests/integration/ssh/test_saltext.py
@@ -1,3 +1,7 @@
+import json
+import shutil
+from pathlib import Path
+
 import pytest
 
 from tests.support.helpers import SaltVirtualEnv
@@ -12,27 +16,86 @@ def salt_extension(tmp_path_factory):
         yield extension
 
 
+@pytest.fixture(scope="module")
+def other_salt_extension(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory,
+        name="salt-ext2-ssh-test",
+        virtualname="barbaz",
+    ) as extension:
+        yield extension
+
+
+@pytest.fixture(scope="module")
+def venv(tmp_path_factory, salt_extension, other_salt_extension):
+    venv_dir = tmp_path_factory.mktemp("saltext-ssh-test-venv")
+    try:
+        with SaltVirtualEnv(venv_dir=venv_dir) as _venv:
+            _venv.install(str(salt_extension.srcdir))
+            _venv.install(str(other_salt_extension.srcdir))
+            installed_packages = _venv.get_installed_packages()
+            assert salt_extension.name in installed_packages
+            assert other_salt_extension.name in installed_packages
+            yield _venv
+    finally:
+        shutil.rmtree(venv_dir, ignore_errors=True)
+
+
+@pytest.fixture(params=({},))
+def saltext_conf(request, salt_master):
+    with pytest.helpers.temp_file(
+        "saltext_ssh.conf",
+        json.dumps(request.param),
+        Path(salt_master.config_dir) / "master.d",
+    ):
+        yield request.param
+
+
 @pytest.fixture
-def venv(tmp_path):
-    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as _venv:
-        yield _venv
-
-
-def test_saltext_is_available_on_target(
-    venv, salt_extension, salt_ssh_roster_file, sshd_config_dir, salt_master
-):
-    venv.install(str(salt_extension.srcdir))
-    installed_packages = venv.get_installed_packages()
-    assert salt_extension.name in installed_packages
-    args = [
+def args(venv, salt_master, salt_ssh_roster_file, sshd_config_dir):
+    return [
         venv.venv_bin_dir / "salt-ssh",
-        "--thin-include-saltexts",
         f"--config-dir={salt_master.config_dir}",
         f"--roster-file={salt_ssh_roster_file}",
         f"--priv={sshd_config_dir / 'client_key'}",
+        "--regen-thin",
         "localhost",
-        "foobar.echo1",
-        "foo",
     ]
-    res = venv.run(*args, check=True)
+
+
+@pytest.mark.parametrize(
+    "saltext_conf",
+    (
+        {},
+        {"thin_saltext_allowlist": ["salt-ext-ssh-test"]},
+        {"thin_saltext_blocklist": ["salt-ext2-ssh-test"]},
+    ),
+    indirect=True,
+)
+def test_saltexts_are_available_on_target(venv, args, saltext_conf):
+    ext1_args = args + ["foobar.echo1", "foo"]
+    res = venv.run(*ext1_args, check=True)
     assert res.stdout == "localhost:\n    foo\n"
+    ext2_args = args + ["barbaz.echo1", "bar"]
+    res = venv.run(*ext2_args, check=False)
+    if (
+        "thin_saltext_allowlist" not in saltext_conf
+        and "thin_saltext_blocklist" not in saltext_conf
+    ):
+        assert res.returncode == 0
+        assert res.stdout == "localhost:\n    bar\n"
+    else:
+        assert res.returncode > 0
+        assert "'barbaz.echo1' is not available" in res.stdout
+
+
+@pytest.mark.usefixtures("saltext_conf")
+@pytest.mark.parametrize(
+    "saltext_conf", ({"thin_exclude_saltexts": True},), indirect=True
+)
+def test_saltexts_can_be_excluded(venv, args):
+    for ext in ("foobar", "barbaz"):
+        ext_args = args + [f"{ext}.echo1", "foo"]
+        res = venv.run(*ext_args, check=False)
+        assert res.returncode > 0
+        assert f"'{ext}.echo1' is not available" in res.stdout

--- a/tests/pytests/unit/utils/test_thin.py
+++ b/tests/pytests/unit/utils/test_thin.py
@@ -1,9 +1,15 @@
+import importlib
+import os
+import sys
+
 import pytest
+import saltfactories.utils.saltext
 
 import salt.exceptions
 import salt.utils.stringutils
 import salt.utils.thin
 from tests.support.mock import MagicMock, patch
+from tests.support.pytest.helpers import FakeSaltExtension
 
 
 def _mock_popen(return_value=None, side_effect=None, returncode=0):
@@ -77,3 +83,45 @@ def test_get_ext_tops(version):
     else:
         assert not [x for x in ret["namespace"]["dependencies"] if "distro" in x]
         assert [x for x in ret["namespace"]["dependencies"] if "msgpack" in x]
+
+
+def test_get_package_root_mod():
+    res = salt.utils.thin._get_package_root_mod(saltfactories.utils.saltext)
+    assert res[0] is saltfactories
+    assert res[1] == ()
+
+
+@pytest.fixture
+def namespaced_saltext(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory,
+        name="saltext.wut",
+    ) as extension:
+        try:
+            sys.path.insert(0, str(extension.srcdir / "src"))
+            yield extension
+        finally:
+            sys.path.pop(0)
+
+
+def test_get_namespaced_package_root_mod(namespaced_saltext):
+    saltext = importlib.import_module(namespaced_saltext.name)
+    res = salt.utils.thin._get_package_root_mod(saltext)
+    assert res[0].__name__ == namespaced_saltext.name
+    assert res[1] == ("saltext",)
+
+
+def test_discover_saltexts():
+    """
+    pytest-salt-factories provides a saltext, which can be discovered here.
+    """
+    mods, dists = salt.utils.thin._discover_saltexts()
+    assert mods
+    assert any(mod.endswith(f"{os.sep}saltfactories") and not ns for mod, ns in mods)
+    assert dists
+    dist = "pytest-salt-factories"
+    assert dist in dists
+    assert "entrypoints" in dists[dist]
+    assert "name" in dists[dist]
+    assert dists[dist]["name"].startswith("pytest_salt_factories")
+    assert dists[dist]["name"].endswith(".dist-info")

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -445,6 +445,7 @@ class FakeSaltExtension:
     name = attr.ib()
     pkgname = attr.ib(init=False)
     srcdir = attr.ib(init=False)
+    virtualname = attr.ib(default="foobar")
 
     @srcdir.default
     def _srcdir(self):
@@ -550,10 +551,10 @@ class FakeSaltExtension:
             runners1_dir = extension_package_dir / "runners1"
             runners1_dir.mkdir()
             runners1_dir.joinpath("__init__.py").write_text("")
-            runners1_dir.joinpath("foobar1.py").write_text(
+            runners1_dir.joinpath(f"{self.virtualname}1.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -567,10 +568,10 @@ class FakeSaltExtension:
             runners2_dir = extension_package_dir / "runners2"
             runners2_dir.mkdir()
             runners2_dir.joinpath("__init__.py").write_text("")
-            runners2_dir.joinpath("foobar2.py").write_text(
+            runners2_dir.joinpath(f"{self.virtualname}2.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -584,10 +585,10 @@ class FakeSaltExtension:
             modules_dir = extension_package_dir / "modules"
             modules_dir.mkdir()
             modules_dir.joinpath("__init__.py").write_text("")
-            modules_dir.joinpath("foobar1.py").write_text(
+            modules_dir.joinpath(f"{self.virtualname}1.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -597,10 +598,10 @@ class FakeSaltExtension:
             """
                 )
             )
-            modules_dir.joinpath("foobar2.py").write_text(
+            modules_dir.joinpath(f"{self.virtualname}2.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -614,10 +615,10 @@ class FakeSaltExtension:
             wheel_dir = extension_package_dir / "the_wheel_modules"
             wheel_dir.mkdir()
             wheel_dir.joinpath("__init__.py").write_text("")
-            wheel_dir.joinpath("foobar1.py").write_text(
+            wheel_dir.joinpath(f"{self.virtualname}1.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -627,10 +628,10 @@ class FakeSaltExtension:
             """
                 )
             )
-            wheel_dir.joinpath("foobar2.py").write_text(
+            wheel_dir.joinpath(f"{self.virtualname}2.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
@@ -644,16 +645,16 @@ class FakeSaltExtension:
             states_dir = extension_package_dir / "states1"
             states_dir.mkdir()
             states_dir.joinpath("__init__.py").write_text("")
-            states_dir.joinpath("foobar1.py").write_text(
+            states_dir.joinpath(f"{self.virtualname}1.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True
 
             def echoed(string):
-                ret = {"name": name, "changes": {}, "result": True, "comment": string}
+                ret = {{"name": name, "changes": {{}}, "result": True, "comment": string}}
                 return ret
             """
                 )
@@ -662,10 +663,10 @@ class FakeSaltExtension:
             utils_dir = extension_package_dir / "utils"
             utils_dir.mkdir()
             utils_dir.joinpath("__init__.py").write_text("")
-            utils_dir.joinpath("foobar1.py").write_text(
+            utils_dir.joinpath(f"{self.virtualname}1.py").write_text(
                 textwrap.dedent(
-                    """\
-            __virtualname__ = "foobar"
+                    f"""\
+            __virtualname__ = "{self.virtualname}"
 
             def __virtual__():
                 return True

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -481,9 +481,9 @@ class FakeSaltExtension:
         if not setup_cfg.exists():
             setup_cfg.write_text(
                 textwrap.dedent(
-                    """\
+                    f"""\
             [metadata]
-            name = {0}
+            name = {self.name}
             version = 1.0
             description = Salt Extension Test
             author = Pedro
@@ -504,27 +504,30 @@ class FakeSaltExtension:
             [options]
             zip_safe = False
             include_package_data = True
-            packages = find:
+            package_dir =
+                =src
+            packages = find{'_namespace' if '.' in self.pkgname else ''}:
             python_requires = >= 3.5
             setup_requires =
               wheel
               setuptools>=50.3.2
 
+            [options.packages.find]
+            where = src
+
             [options.entry_points]
             salt.loader=
-              module_dirs = {1}
-              runner_dirs = {1}.loader:get_runner_dirs
-              states_dirs = {1}.loader:get_state_dirs
-              wheel_dirs = {1}.loader:get_new_style_entry_points
-            """.format(
-                        self.name, self.pkgname
-                    )
+              module_dirs = {self.pkgname}
+              runner_dirs = {self.pkgname}.loader:get_runner_dirs
+              states_dirs = {self.pkgname}.loader:get_state_dirs
+              wheel_dirs = {self.pkgname}.loader:get_new_style_entry_points
+            """
                 )
             )
 
-        extension_package_dir = self.srcdir / self.pkgname
+        extension_package_dir = self.srcdir.joinpath("src", *self.pkgname.split("."))
         if not extension_package_dir.exists():
-            extension_package_dir.mkdir()
+            extension_package_dir.mkdir(parents=True)
             extension_package_dir.joinpath("__init__.py").write_text("")
             extension_package_dir.joinpath("loader.py").write_text(
                 textwrap.dedent(


### PR DESCRIPTION
### What does this PR do?
Adds packages that provide a `salt.loader` entrypoint to the Salt-SSH thin archive.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66559

(marginally related: https://github.com/saltstack/salt-bootstrap/issues/1975 https://gitlab.com/saltstack/pop/heist-salt/-/issues/9 https://gitlab.com/saltstack/pop/heist-salt/-/issues/73)

### Previous Behavior
No way of using Salt extensions via Salt-SSH

### New Behavior
Salt extensions can work via Salt-SSH

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

### Additional context
Definite issues:
* Extension requirements are not included (same as for custom extmods - but in many cases they could be, I suspect, at least explicitly - defined by the extension.)

Possible issues:
* Not sure if I'm missing something obvious, this is very far out of my comfort zone
* The `entry_points.txt` file stats are not set at all (we could just include the file itself if the filtering is unnecessary, but I'm not exactly sure how to get the absolute path to it without accessing an internal attribute)
* No support for the alternatives system in the current form

I don't think this has any security implications since the modules are loaded on the master anyways.