### PR TITLE
[master] Drop useless double calls for utils LazyLoader with salt.loader.grain_funcs

### DIFF
--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1003,7 +1003,6 @@ def grain_funcs(opts, proxy=None, context=None, loaded_base_name=None):
           grainfuncs = salt.loader.grain_funcs(__opts__)
     """
     _utils = utils(opts, proxy=proxy)
-    pack = {"__utils__": utils(opts, proxy=proxy), "__context__": context}
     ret = LazyLoader(
         _module_dirs(
             opts,
@@ -1014,10 +1013,9 @@ def grain_funcs(opts, proxy=None, context=None, loaded_base_name=None):
         opts,
         tag="grains",
         extra_module_dirs=_utils.module_dirs,
-        pack=pack,
+        pack={"__utils__": _utils, "__context__": context},
         loaded_base_name=loaded_base_name,
     )
-    ret.pack["__utils__"] = _utils
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

There are 2 calls for `utils` in `salt.loader.grain_funcs` instead of just one with no any reason for it.
It's causing two attempts to load utils with LazyLoader when the second call seems useless.

Seems like it was caused by a collision with the following two commits:
https://github.com/saltstack/salt/commit/e5b3e87e55dc512705ff6155b4086add742454f5
https://github.com/saltstack/salt/commit/78725f4cc93134af43c54e6c1d8cc6e97b6cb511

### Previous Behavior
Double `utils` calls in `salt.loader.grain_funcs`.

### New Behavior
Single `utils` call.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
