### PR TITLE
[3006.x] Drop CentOS 7 support, and build RPM packages with Rocky Linux 9 container

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -276,7 +276,7 @@ jobs:
           - ${{ inputs.source }}
 
     container:
-      image: ghcr.io/saltstack/salt-ci-containers/packaging:centosstream-9
+      image: ghcr.io/saltstack/salt-ci-containers/packaging:rockylinux-9
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,27 +645,6 @@ jobs:
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  centos-7-pkg-tests:
-    name: CentOS 7 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'centos-7') }}
-    needs:
-      - prepare-workflow
-      - build-pkgs-onedir
-      - build-ci-deps
-    uses: ./.github/workflows/test-packages-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      pkg-type: rpm
-      nox-version: 2022.8.7
-      python-version: "3.10"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
-
   debian-11-pkg-tests:
     name: Debian 11 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'debian-11') }}
@@ -1558,27 +1537,6 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
-  centos-7:
-    name: CentOS 7 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'centos-7') }}
-    needs:
-      - prepare-workflow
-      - build-ci-deps
-    uses: ./.github/workflows/test-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      nox-version: 2022.8.7
-      gh-actions-python-version: "3.10"
-      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
-      workflow-slug: ci
-      default-timeout: 180
-
   debian-11:
     name: Debian 11 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] && contains(fromJSON(needs.prepare-workflow.outputs.os-labels), 'debian-11') }}
@@ -2027,7 +1985,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2195,7 +2152,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2224,7 +2180,6 @@ jobs:
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests
       - amazonlinux-2023-arm64-pkg-tests
-      - centos-7-pkg-tests
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - debian-12-pkg-tests

--- a/.github/workflows/lint-action.yml
+++ b/.github/workflows/lint-action.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ contains(fromJSON('["push", "schedule", "workflow_dispatch"]'), github.event_name) || fromJSON(inputs.changed-files)['salt'] || fromJSON(inputs.changed-files)['lint'] }}
 
     container:
-      image: ghcr.io/saltstack/salt-ci-containers/python:3.9
+      image: ghcr.io/saltstack/salt-ci-containers/python:3.10
 
     steps:
       - name: Install System Deps
@@ -66,7 +66,7 @@ jobs:
     if: ${{ contains(fromJSON('["push", "schedule", "workflow_dispatch"]'), github.event_name) || fromJSON(inputs.changed-files)['tests'] || fromJSON(inputs.changed-files)['lint'] }}
 
     container:
-      image: ghcr.io/saltstack/salt-ci-containers/python:3.8
+      image: ghcr.io/saltstack/salt-ci-containers/python:3.10
 
     steps:
       - name: Install System Deps

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -707,27 +707,6 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  centos-7-pkg-tests:
-    name: CentOS 7 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-pkgs-onedir
-      - build-ci-deps
-    uses: ./.github/workflows/test-packages-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      pkg-type: rpm
-      nox-version: 2022.8.7
-      python-version: "3.10"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: false
-      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
-
   debian-11-pkg-tests:
     name: Debian 11 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1620,27 +1599,6 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
-  centos-7:
-    name: CentOS 7 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-ci-deps
-    uses: ./.github/workflows/test-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      nox-version: 2022.8.7
-      gh-actions-python-version: "3.10"
-      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: false
-      workflow-slug: nightly
-      default-timeout: 360
-
   debian-11:
     name: Debian 11 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2089,7 +2047,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2535,18 +2492,6 @@ jobs:
           - pkg-type: rpm
             distro: photon
             version: "5"
-            arch: aarch64
-          - pkg-type: rpm
-            distro: redhat
-            version: "7"
-            arch: x86_64
-          - pkg-type: rpm
-            distro: redhat
-            version: "7"
-            arch: arm64
-          - pkg-type: rpm
-            distro: redhat
-            version: "7"
             arch: aarch64
           - pkg-type: rpm
             distro: redhat
@@ -3009,7 +2954,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -3096,7 +3040,6 @@ jobs:
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests
       - amazonlinux-2023-arm64-pkg-tests
-      - centos-7-pkg-tests
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - debian-12-pkg-tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -684,27 +684,6 @@ jobs:
       skip-code-coverage: false
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  centos-7-pkg-tests:
-    name: CentOS 7 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-pkgs-onedir
-      - build-ci-deps
-    uses: ./.github/workflows/test-packages-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      pkg-type: rpm
-      nox-version: 2022.8.7
-      python-version: "3.10"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: false
-      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
-
   debian-11-pkg-tests:
     name: Debian 11 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1597,27 +1576,6 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
-  centos-7:
-    name: CentOS 7 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-ci-deps
-    uses: ./.github/workflows/test-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      nox-version: 2022.8.7
-      gh-actions-python-version: "3.10"
-      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: false
-      workflow-slug: scheduled
-      default-timeout: 360
-
   debian-11:
     name: Debian 11 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2066,7 +2024,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2236,7 +2193,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2265,7 +2221,6 @@ jobs:
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests
       - amazonlinux-2023-arm64-pkg-tests
-      - centos-7-pkg-tests
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - debian-12-pkg-tests

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -692,27 +692,6 @@ jobs:
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
 
-  centos-7-pkg-tests:
-    name: CentOS 7 Package Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-pkgs-onedir
-      - build-ci-deps
-    uses: ./.github/workflows/test-packages-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      pkg-type: rpm
-      nox-version: 2022.8.7
-      python-version: "3.10"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: true
-      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
-
   debian-11-pkg-tests:
     name: Debian 11 Package Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1605,27 +1584,6 @@ jobs:
       workflow-slug: staging
       default-timeout: 180
 
-  centos-7:
-    name: CentOS 7 Test
-    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
-    needs:
-      - prepare-workflow
-      - build-ci-deps
-    uses: ./.github/workflows/test-action-linux.yml
-    with:
-      distro-slug: centos-7
-      nox-session: ci-test-onedir
-      platform: linux
-      arch: x86_64
-      nox-version: 2022.8.7
-      gh-actions-python-version: "3.10"
-      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
-      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.14
-      skip-code-coverage: true
-      workflow-slug: staging
-      default-timeout: 180
-
   debian-11:
     name: Debian 11 Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2362,18 +2320,6 @@ jobs:
             arch: aarch64
           - pkg-type: rpm
             distro: redhat
-            version: "7"
-            arch: x86_64
-          - pkg-type: rpm
-            distro: redhat
-            version: "7"
-            arch: arm64
-          - pkg-type: rpm
-            distro: redhat
-            version: "7"
-            arch: aarch64
-          - pkg-type: rpm
-            distro: redhat
             version: "8"
             arch: x86_64
           - pkg-type: rpm
@@ -2967,7 +2913,6 @@ jobs:
       - amazonlinux-2023
       - amazonlinux-2023-arm64
       - archlinux-lts
-      - centos-7
       - debian-11
       - debian-11-arm64
       - debian-12
@@ -2996,7 +2941,6 @@ jobs:
       - amazonlinux-2-arm64-pkg-tests
       - amazonlinux-2023-pkg-tests
       - amazonlinux-2023-arm64-pkg-tests
-      - centos-7-pkg-tests
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - debian-12-pkg-tests

--- a/changelog/66623.deprecated.md
+++ b/changelog/66623.deprecated.md
@@ -1,0 +1,1 @@
+Drop CentOS 7 support

--- a/changelog/66624.added.md
+++ b/changelog/66624.added.md
@@ -1,0 +1,1 @@
+Build RPM packages with Rocky Linux 9 (instead of CentOS Stream 9)

--- a/changelog/66624.deprecated.md
+++ b/changelog/66624.deprecated.md
@@ -1,0 +1,1 @@
+No longer build RPM packages with CentOS Stream 9

--- a/cicd/golden-images.json
+++ b/cicd/golden-images.json
@@ -49,26 +49,6 @@
     "is_windows": "false",
     "ssh_username": "arch"
   },
-  "centos-7-arm64": {
-    "ami": "ami-0ef52419c91cb0169",
-    "ami_description": "CI Image of CentOS 7 arm64",
-    "ami_name": "salt-project/ci/centos/7/arm64/20240509.1530",
-    "arch": "arm64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "m6g.large",
-    "is_windows": "false",
-    "ssh_username": "centos"
-  },
-  "centos-7": {
-    "ami": "ami-0973c8d1b91dcba5c",
-    "ami_description": "CI Image of CentOS 7 x86_64",
-    "ami_name": "salt-project/ci/centos/7/x86_64/20240509.1530",
-    "arch": "x86_64",
-    "cloudwatch-agent-available": "true",
-    "instance_type": "t3a.large",
-    "is_windows": "false",
-    "ssh_username": "centos"
-  },
   "debian-11-arm64": {
     "ami": "ami-0eff227d9a94d8692",
     "ami_description": "CI Image of Debian 11 arm64",

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -682,8 +682,8 @@ def matrix(
     for transport in ("zeromq", "tcp"):
         if transport == "tcp":
             if distro_slug not in (
-                "centosstream-9",
-                "centosstream-9-arm64",
+                "rockylinux-9",
+                "rockylinux-9-arm64",
                 "photonos-5",
                 "photonos-5-arm64",
                 "ubuntu-22.04",
@@ -831,7 +831,7 @@ def pkg_matrix(
 
         if name == "amazonlinux":
             name = "amazon"
-        elif "centos" in name or name == "rockylinux":
+        elif name == "rockylinux":
             name = "redhat"
         elif "photon" in name:
             name = "photon"
@@ -967,8 +967,8 @@ def get_ci_deps_matrix(ctx: Context):
 
     _matrix = {
         "linux": [
-            {"distro-slug": "centos-7", "arch": "x86_64"},
-            {"distro-slug": "centos-7-arm64", "arch": "arm64"},
+            {"distro-slug": "rockylinux-9", "arch": "x86_64"},
+            {"distro-slug": "rockylinux-9-arm64", "arch": "arm64"},
         ],
         "macos": [
             {"distro-slug": "macos-12", "arch": "x86_64"},
@@ -1031,7 +1031,6 @@ def get_pkg_downloads_matrix(ctx: Context):
     rpm_slugs = (
         "rockylinux",
         "amazonlinux",
-        "centos",
         "fedora",
         "photon",
     )

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -435,7 +435,7 @@ def rpm(
 
     createrepo = shutil.which("createrepo")
     if createrepo is None:
-        container = "ghcr.io/saltstack/salt-ci-containers/packaging:centosstream-9"
+        container = "ghcr.io/saltstack/salt-ci-containers/packaging:rockylinux-9"
         ctx.info(f"Using docker container '{container}' to call 'createrepo'...")
         uid = ctx.run("id", "-u", capture=True).stdout.strip().decode()
         gid = ctx.run("id", "-g", capture=True).stdout.strip().decode()
@@ -493,7 +493,7 @@ def rpm(
         if distro == "amazon":
             distro_name = "Amazon Linux"
         elif distro == "redhat":
-            distro_name = "RHEL/CentOS"
+            distro_name = "RHEL"
         else:
             distro_name = distro.capitalize()
 

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -52,7 +52,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 arch="arm64",
             ),
             Linux(slug="archlinux-lts", display_name="Arch Linux LTS", arch="x86_64"),
-            Linux(slug="centos-7", display_name="CentOS 7", arch="x86_64"),
             Linux(slug="debian-11", display_name="Debian 11", arch="x86_64"),
             Linux(slug="debian-11-arm64", display_name="Debian 11 Arm64", arch="arm64"),
             Linux(slug="debian-12", display_name="Debian 12", arch="x86_64"),
@@ -246,12 +245,6 @@ def generate_workflows(ctx: Context):
                     pkg_type="rpm",
                 ),
                 Linux(
-                    slug="centos-7",
-                    display_name="CentOS 7",
-                    arch="x86_64",
-                    pkg_type="rpm",
-                ),
-                Linux(
                     slug="debian-11",
                     display_name="Debian 11",
                     arch="x86_64",
@@ -425,9 +418,7 @@ def generate_workflows(ctx: Context):
     for slug in sorted(tools.utils.get_golden_images()):
         if slug.endswith("-arm64"):
             continue
-        if not slug.startswith(
-            ("amazonlinux", "rockylinux", "centos", "fedora", "photonos")
-        ):
+        if not slug.startswith(("amazonlinux", "rockylinux", "fedora", "photonos")):
             continue
         os_name, os_version = slug.split("-")
         if os_name == "amazonlinux":

--- a/tools/utils/gh.py
+++ b/tools/utils/gh.py
@@ -219,7 +219,7 @@ def download_pkgs_artifact(
         if slug.startswith(("debian", "ubuntu")):
             artifact_name += f"{arch}-deb"
         elif slug.startswith(
-            ("rockylinux", "amazonlinux", "centos", "fedora", "opensuse", "photonos")
+            ("rockylinux", "amazonlinux", "fedora", "opensuse", "photonos")
         ):
             artifact_name += f"{arch}-rpm"
         else:


### PR DESCRIPTION
### What does this PR do?

- Drop CentOS 7 support
- Replace CentOS Stream 9 container, used for packaging, with Rocky Linux 9

### What issues does this PR fix or reference?

- Fixes #66623
- Fixes #66624

### Previous Behavior

- Test CI/CD against CentOS 7, and publish packages to RHEL 7 repository paths
- Build RPM packages with CentOS Stream 9 for RHEL-based systems

### New Behavior

- No longer test CI/CD against CentOS 7, and no longer publish packages to RHEL 7 repository paths
- Build RPM packages with Rocky Linux 9 for RHEL-based systems

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
