### PR TITLE
[3006.x] Use older Linux OS for wider CI deps compatibility

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -967,8 +967,8 @@ def get_ci_deps_matrix(ctx: Context):
 
     _matrix = {
         "linux": [
-            {"distro-slug": "rockylinux-9", "arch": "x86_64"},
-            {"distro-slug": "rockylinux-9-arm64", "arch": "arm64"},
+            {"distro-slug": "amazonlinux-2", "arch": "x86_64"},
+            {"distro-slug": "amazonlinux-2-arm64", "arch": "arm64"},
         ],
         "macos": [
             {"distro-slug": "macos-12", "arch": "x86_64"},


### PR DESCRIPTION
### What does this PR do?

Previously merged PR,  #66625, introduced some problems when it comes to generated CI dependencies. CentOS 7 was originally used to generate the oldest, widest compatible range of dependencies to be used in CI across Linux operating systems. The deprecation of CentOS 7, replaced by Rocky Linux 9 when it came to the CI dependency generated step, resulted in incompatibilities across certain Linux operating systems.

This PR looks to use the oldest Linux OS to build CI dependencies for wider compatibility. This only impacts CI, not a bug in Salt itself.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Tests written/updated

### Commits signed with GPG?
Yes
