### PR TITLE
[3006.x] Allow NamedLoaderContexts to be returned from loaded functions

### DIFF
--- a/changelog/65251.fixed.md
+++ b/changelog/65251.fixed.md
@@ -1,0 +1,1 @@
+Fix config.items when called on minion

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -1257,7 +1257,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self.parent_loader = current_loader
         token = salt.loader.context.loader_ctxvar.set(self)
         try:
-            return _func_or_method(*args, **kwargs)
+            ret = _func_or_method(*args, **kwargs)
+            if isinstance(ret, salt.loader.context.NamedLoaderContext):
+                ret = ret.value()
+            return ret
         finally:
             self.parent_loader = None
             salt.loader.context.loader_ctxvar.reset(token)

--- a/tests/pytests/integration/modules/test_config.py
+++ b/tests/pytests/integration/modules/test_config.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.slow_test
+def test_config_items(salt_cli, salt_minion):
+    ret = salt_cli.run("config.items", minion_tgt=salt_minion.id)
+    assert ret.returncode == 0
+    assert isinstance(ret.data, dict)

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -83,3 +83,16 @@ def test_named_loader_context_name_not_packed(tmp_path):
             match="LazyLoader does not have a packed value for: __not_packed__",
         ):
             loader["mymod.foobar"]()
+
+
+def test_return_named_context_from_loaded_func(tmp_path):
+    opts = {
+        "optimization_order": [0],
+    }
+    contents = """
+    def foobar():
+        return __test__
+    """
+    with pytest.helpers.temp_file("mymod.py", contents, directory=tmp_path):
+        loader = salt.loader.LazyLoader([tmp_path], opts, pack={"__test__": "meh"})
+        assert loader["mymod.foobar"]() == "meh"


### PR DESCRIPTION
It is useful in some cases to return NamedLoaderContexts from loaded functions. Instead of choking or requiring implementers to call the context's value() method before being de-scoped, detect when a NamedLoaderContext has been returned and return the value from the current context.

### What issues does this PR fix or reference?

Fixes: #65251


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

