### PR TITLE
[master] Suppress error output for missing sysrc variables on FreeBSD

### DIFF
--- a/changelog/66652.changed.md
+++ b/changelog/66652.changed.md
@@ -1,0 +1,1 @@
+Suppress error messages when retrieving undefined sysrc variables on FreeBSD

--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -49,9 +49,8 @@ def get(**kwargs):
     else:
         cmd += " -a"
 
-    sysrcs = __salt__["cmd.run"](cmd)
+    sysrcs = __salt__["cmd.run"](cmd=cmd, output_loglevel="quiet")
     if "sysrc: unknown variable" in sysrcs:
-        # raise CommandExecutionError(sysrcs)
         return None
 
     ret = {}


### PR DESCRIPTION
### What does this PR do?
Suppress error output for missing sysrc variables on FreeBSD
This condition is expected and handled by the code, so there is no need to write error logs when it happens.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
If the `sysrc.get` module was called for a sysrc variable that did not exist, several lines of error message would be written to the log/console.
```
$ sudo salt-call sysrc.get name=example
[ERROR   ] Command 'sysrc' failed with return code: 1
[ERROR   ] stdout: sysrc: unknown variable 'example'
[ERROR   ] retcode: 1
[ERROR   ] Command 'sysrc' failed with return code: 1
[ERROR   ] output: sysrc: unknown variable 'example'
local:
    None
```
This is condition is accounted for by the code, which return the correct value of `None`, so there is no value in displaying the errors.

### New Behavior
The error messages are suppressed.
```
$ sudo salt-call sysrc.get name=example
local:
    None
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
