### PR TITLE
[3006.x] Use FullArgSpec as ArgSpec is deprecated

### DIFF
--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -3,7 +3,7 @@
 """
 
 import logging
-from inspect import ArgSpec
+from inspect import FullArgSpec
 
 import salt.states.module as module
 from tests.support.mixins import LoaderModuleMockMixin
@@ -116,11 +116,25 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
 
     @classmethod
     def setUpClass(cls):
-        cls.aspec = ArgSpec(
-            args=["hello", "world"], varargs=None, keywords=None, defaults=False
+        cls.aspec = FullArgSpec(
+            args=["hello", "world"],
+            varargs=None,
+            varkw=None,
+            defaults=False,
+            kwonlyargs=None,
+            kwonlydefaults=None,
+            annotations=None,
         )
 
-        cls.bspec = ArgSpec(args=[], varargs="names", keywords="kwargs", defaults=None)
+        cls.bspec = FullArgSpec(
+            args=[],
+            varargs="names",
+            varkw=None,
+            defaults=None,
+            kwonlyargs="kwargs",
+            kwonlydefaults=None,
+            annotations=None,
+        )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
See title. No changelog since this is just a simple fix in the test suite. #65162