### PR TITLE
[master] Use token's eauth key if load omits it.

### DIFF
--- a/changelog/66662.changed.md
+++ b/changelog/66662.changed.md
@@ -1,0 +1,1 @@
+Use the "eauth" key from token data, if it isn't present in the "load" dictionary, to support external ACL lookup when using token-based authentication.

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -389,6 +389,12 @@ class LoadAuth:
         # Get auth list from token
         if token and self.opts["keep_acl_in_token"] and "auth_list" in token:
             return token["auth_list"]
+
+        # If eauth is not present in the load, but is in the token, set it in
+        # the load so that we can engage the ACL lookup code inside __get_acl().
+        if "eauth" not in load and "eauth" in token:
+            load["eauth"] = token["eauth"]
+
         # Get acl from eauth module.
         auth_list = self.__get_acl(load)
         if auth_list is not None:

--- a/tests/pytests/unit/auth/test_auth.py
+++ b/tests/pytests/unit/auth/test_auth.py
@@ -41,12 +41,9 @@ def test_static_external_auth_with_eauth_in_token_but_not_in_load():
     can still look up an ACL, via the static "external_auth" option, if it is
     defined.
     """
-    _auth_list = ['.*', '@wheel', '@runner']
+    _auth_list = [".*", "@wheel", "@runner"]
     # The static "external_auth" option is defined.
-    opts = {
-        "external_auth": {"auto": {"foo": _auth_list}},
-        "keep_acl_in_token": False
-    }
+    opts = {"external_auth": {"auto": {"foo": _auth_list}}, "keep_acl_in_token": False}
     auth = salt.auth.LoadAuth(opts)
     # No "eauth" key is defined in the load...
     load = {
@@ -59,14 +56,14 @@ def test_static_external_auth_with_eauth_in_token_but_not_in_load():
         "expire": 1718699466.996583,
         "name": "foo",
         "eauth": "auto",
-        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa"
+        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa",
     }
 
     # Mock __get_acl() as if the `auto` module has not "acl" member.
     # This will force get_auth_list() to check the static "external_auth"
     # option.
     with patch.object(auth, "_LoadAuth__get_acl") as mocked_get_acl:
-        mocked_get_acl.return_value=None
+        mocked_get_acl.return_value = None
         auth_list = auth.get_auth_list(load, token)
         assert auth_list == _auth_list
 
@@ -79,13 +76,10 @@ def test_eauth_acl_module_with_eauth_in_token_but_not_in_load():
     the value of load["eauth"], thereby engaging the external ACL lookup code in
     __get_acl().
     """
-    _auth_list = ['@jobs', '@runner']
+    _auth_list = ["@jobs", "@runner"]
     # The static "external_auth" option is undefined because the server contains
     # a module to perform ACL lookups from an external source.
-    opts = {
-        "external_auth": {},
-        "keep_acl_in_token": False
-    }
+    opts = {"external_auth": {}, "keep_acl_in_token": False}
     auth = salt.auth.LoadAuth(opts)
     # No "eauth" key is defined in the load...
     load = {
@@ -98,12 +92,12 @@ def test_eauth_acl_module_with_eauth_in_token_but_not_in_load():
         "expire": 1718699466.996583,
         "name": "foo",
         "eauth": "auto",
-        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa"
+        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa",
     }
 
     # Mock __get_acl() as if it has successfully looked up an ACL from an
     # external source.
     with patch.object(auth, "_LoadAuth__get_acl") as mocked_get_acl:
-        mocked_get_acl.return_value=_auth_list
+        mocked_get_acl.return_value = _auth_list
         auth_list = auth.get_auth_list(load, token)
         assert auth_list == _auth_list

--- a/tests/pytests/unit/auth/test_auth.py
+++ b/tests/pytests/unit/auth/test_auth.py
@@ -2,6 +2,7 @@ import time
 
 import salt.auth
 import salt.config
+from tests.support.mock import patch
 
 
 def test_cve_2021_3244(tmp_path):

--- a/tests/pytests/unit/auth/test_auth.py
+++ b/tests/pytests/unit/auth/test_auth.py
@@ -31,3 +31,78 @@ def test_cve_2021_3244(tmp_path):
     t_data = auth.get_tok(t_data["token"])
     assert not t_data
     assert not token_file.exists()
+
+
+def test_static_external_auth_with_eauth_in_token_but_not_in_load():
+    """
+    During token-based authorization, we may see the `load` dictionary without
+    an "eauth" key. If the "eauth" key is present in the `token` dictionary, we
+    can still look up an ACL, via the static "external_auth" option, if it is
+    defined.
+    """
+    _auth_list = ['.*', '@wheel', '@runner']
+    # The static "external_auth" option is defined.
+    opts = {
+        "external_auth": {"auto": {"foo": _auth_list}},
+        "keep_acl_in_token": False
+    }
+    auth = salt.auth.LoadAuth(opts)
+    # No "eauth" key is defined in the load...
+    load = {
+        "username": "foo",
+        "password": "foo",
+    }
+    # ...but an "eauth" key is defined in the token.
+    token = {
+        "start": 1718656266.9965827,
+        "expire": 1718699466.996583,
+        "name": "foo",
+        "eauth": "auto",
+        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa"
+    }
+
+    # Mock __get_acl() as if the `auto` module has not "acl" member.
+    # This will force get_auth_list() to check the static "external_auth"
+    # option.
+    with patch.object(auth, "_LoadAuth__get_acl") as mocked_get_acl:
+        mocked_get_acl.return_value=None
+        auth_list = auth.get_auth_list(load, token)
+        assert auth_list == _auth_list
+
+
+def test_eauth_acl_module_with_eauth_in_token_but_not_in_load():
+    """
+    In the case a server is configured to look up ACLs via an external source
+    (e.g. "eauth_acl_module" is defined), "eauth" is defined in the `token`
+    dictionary and not in the `load` dictionary, token["eauth"] will be used as
+    the value of load["eauth"], thereby engaging the external ACL lookup code in
+    __get_acl().
+    """
+    _auth_list = ['@jobs', '@runner']
+    # The static "external_auth" option is undefined because the server contains
+    # a module to perform ACL lookups from an external source.
+    opts = {
+        "external_auth": {},
+        "keep_acl_in_token": False
+    }
+    auth = salt.auth.LoadAuth(opts)
+    # No "eauth" key is defined in the load...
+    load = {
+        "username": "foo",
+        "password": "foo",
+    }
+    # ...but an "eauth" key is defined in the token.
+    token = {
+        "start": 1718656266.9965827,
+        "expire": 1718699466.996583,
+        "name": "foo",
+        "eauth": "auto",
+        "token": "bbbc12ab06aa9e9acf9747127858ee6756377c2edcf8c8176c8fcbc2307e40aa"
+    }
+
+    # Mock __get_acl() as if it has successfully looked up an ACL from an
+    # external source.
+    with patch.object(auth, "_LoadAuth__get_acl") as mocked_get_acl:
+        mocked_get_acl.return_value=_auth_list
+        auth_list = auth.get_auth_list(load, token)
+        assert auth_list == _auth_list


### PR DESCRIPTION
### What does this PR do?

- For token-based authentication, where administrators would also like to write a custom eauth ACL module, this update allows `__get_acl` to check for such a module, either via the `eauth_acl_module` configuration value or fallback to the `eauth` module's `acl` function, if defined.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

If `load["eauth"]` is not defined, `__get_acl()` immediately returns `None`.

### New Behavior

In `get_auth_list()`, if the `"eauth"` key is not present in the `load` dictionary, but _is_ present in the `token` dictionary, the token's `"eauth"` value is added to the `load` dictionary. When `__get_acl()` is called from within `get_auth_list()`, the former can attempt to perform an ACL lookup via the `eauth_acl_module` configuration option or fall back to the eauth module's `acl()` function, if defined.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
