### PR TITLE
[3006.x] Upgrade relenv to 0.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-salt-onedir:
@@ -432,7 +432,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-pkgs-onedir:
@@ -445,7 +445,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "onedir"
 
@@ -459,7 +459,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "src"
   build-ci-deps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -470,7 +470,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-salt-onedir:
@@ -486,7 +486,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-pkgs-onedir:
@@ -499,7 +499,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "onedir"
       environment: nightly
@@ -517,7 +517,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "src"
       environment: nightly

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -455,7 +455,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-salt-onedir:
@@ -471,7 +471,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-pkgs-onedir:
@@ -484,7 +484,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "onedir"
 
@@ -498,7 +498,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "src"
   build-ci-deps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -455,7 +455,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-salt-onedir:
@@ -471,7 +471,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
 
   build-pkgs-onedir:
@@ -484,7 +484,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "onedir"
       environment: staging
@@ -502,7 +502,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.16.1"
+      relenv-version: "0.17.0"
       python-version: "3.10.14"
       source: "src"
       environment: staging

--- a/changelog/66663.fixed.md
+++ b/changelog/66663.fixed.md
@@ -1,0 +1,1 @@
+Upgrade relenv to 0.17.0 (https://github.com/saltstack/relenv/blob/v0.17.0/CHANGELOG.md)

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.14"
-relenv_version: "0.16.1"
+relenv_version: "0.17.0"
 mandatory_os_slugs:
   - rockylinux-9
   - amazonlinux-2023-arm64


### PR DESCRIPTION
### What does this PR do?

Upgrade relenv to 0.17.0:

- Upgrade python 3.11 to 3.11.9
- Upgrade python 3.12 to 3.12.4
- Upgrade openssl to 3.2.2
- Upgrade XZ to 5.6.2
- Upgrade SQLite to 3460000
- Use sha1 for download checksums intead of md5

### What issues does this PR fix or reference?
Fixes #66663


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated
