### PR TITLE
[3006.x] Corrected missed line in branch 3006.x when backporting from PR 61620 and 65044

### DIFF
--- a/changelog/66683.fixed.md
+++ b/changelog/66683.fixed.md
@@ -1,0 +1,1 @@
+Corrected missed line in branch 3006.x when backporting from PR 61620 and 65044

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -327,7 +327,7 @@ def new_set(name=None, set_type=None, family="ipv4", comment=False, **kwargs):
 
     # Family only valid for certain set types
     if "family" in _CREATE_OPTIONS[set_type]:
-        cmd.extend(["family", cmd, ipset_family])
+        cmd.extend(["family", ipset_family])
 
     if comment:
         cmd.append("comment")


### PR DESCRIPTION
### What does this PR do?
Corrected missed line in branch 3006.x when backporting from PR 61620 and 65044

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66683


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
