### PR TITLE
[3006.x] fix #66686: don't fail for InvalidVersion, instead drop the version as-if it was never there

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1696,11 +1696,18 @@ def list_all_versions(
     for line in result["stdout"].splitlines():
         match = regex.search(line)
         if match:
-            versions = [
-                v for v in match.group(1).split(", ") if v and excludes.match(v)
-            ]
-            versions.sort(key=pkg_resources.parse_version)
-            break
+            versions = []
+            for v in match.group(1).split(", "):
+                if v and excludes.match(v):
+                    try:
+                        pkg_resources.parse_version(v)
+
+                    except pkg_resources.extern.packaging.version.InvalidVersion as e:
+                        logger.info(f"{e} for package {pkg}, skipping this version...")
+                        continue
+
+                    versions.append(v)
+
     if not versions:
         return None
 


### PR DESCRIPTION
### What does this PR do?
Add "support" for InvalidVersion: ignore the version instead of failing completly

### What issues does this PR fix or reference?
Fixes #66686 

### Previous Behavior
Failure when listing all version of a package when there is an InvalidVersion

### New Behavior
State pass, but ignore if there is an InvalidVersion, and add a INFO log about this

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
