### PR TITLE
[master] firewalld: normalize rich rules before comparison to avoid problems with states

### DIFF
--- a/changelog/61235.fixed.md
+++ b/changelog/61235.fixed.md
@@ -1,0 +1,1 @@
+- firewalld: normalize new rich rules before comparing to old ones

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -377,6 +377,21 @@ def service(name, ports=None, protocols=None):
 
 
 def _normalize_rich_rules(rich_rules):
+    """
+    Make sure rich rules are normalized and attributes
+    are quoted with double quotes so it matches the output
+    from firewall-cmd
+
+    Example:
+
+    rule family="ipv4" source address="192.168.0.0/16" port port=22 protocol=tcp accept
+    rule family="ipv4" source address="192.168.0.0/16" port port='22' protocol=tcp accept
+    rule family='ipv4' source address='192.168.0.0/16' port port='22' protocol=tcp accept
+
+    normalized to:
+
+    rule family="ipv4" source address="192.168.0.0/16" port port="22" protocol="tcp" accept
+    """
     normalized_rules = []
     for rich_rule in rich_rules:
         normalized_rule = ""

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -376,6 +376,27 @@ def service(name, ports=None, protocols=None):
     return ret
 
 
+def _normalize_rich_rules(rich_rules):
+    normalized_rules = []
+    for rich_rule in rich_rules:
+        normalized_rule = ""
+        for cmd in rich_rule.split(" "):
+            cmd_components = cmd.split("=", 1)
+            if len(cmd_components) == 2:
+                assigned_component = cmd_components[1]
+                if not assigned_component.startswith(
+                    '"'
+                ) and not assigned_component.endswith('"'):
+                    if assigned_component.startswith(
+                        "'"
+                    ) and assigned_component.endswith("'"):
+                        assigned_component = assigned_component[1:-1]
+                    cmd_components[1] = f'"{assigned_component}"'
+            normalized_rule = f"{normalized_rule} {'='.join(cmd_components)}"
+        normalized_rules.append(normalized_rule.lstrip())
+    return normalized_rules
+
+
 def _present(
     name,
     block_icmp=None,
@@ -767,6 +788,7 @@ def _present(
 
     if rich_rules or prune_rich_rules:
         rich_rules = rich_rules or []
+        rich_rules = _normalize_rich_rules(rich_rules)
         try:
             _current_rich_rules = __salt__["firewalld.get_rich_rules"](
                 name, permanent=True

--- a/tests/pytests/unit/states/test_firewalld.py
+++ b/tests/pytests/unit/states/test_firewalld.py
@@ -59,3 +59,54 @@ def test_masquerade():
             "comment": "'public' is already in the desired state.",
             "name": "public",
         }
+
+
+@pytest.mark.parametrize(
+    "rich_rule",
+    [
+        (
+            [
+                'rule family="ipv4" source address="192.168.0.0/16" port port=22 protocol=tcp accept'
+            ]
+        ),
+        (
+            [
+                'rule family="ipv4" source address="192.168.0.0/16" port port=\'22\' protocol=tcp accept'
+            ]
+        ),
+        (
+            [
+                "rule family='ipv4' source address='192.168.0.0/16' port port='22' protocol=tcp accept"
+            ]
+        ),
+    ],
+)
+def test_present_rich_rules_normalized(rich_rule):
+    firewalld_reload_rules = MagicMock(return_value={})
+    firewalld_rich_rules = [
+        'rule family="ipv4" source address="192.168.0.0/16" port port="22" protocol="tcp" accept',
+    ]
+
+    firewalld_get_zones = MagicMock(
+        return_value=[
+            "block",
+            "public",
+        ]
+    )
+    firewalld_get_masquerade = MagicMock(return_value=True)
+    firewalld_get_rich_rules = MagicMock(return_value=firewalld_rich_rules)
+
+    __salt__ = {
+        "firewalld.reload_rules": firewalld_reload_rules,
+        "firewalld.get_zones": firewalld_get_zones,
+        "firewalld.get_masquerade": firewalld_get_masquerade,
+        "firewalld.get_rich_rules": firewalld_get_rich_rules,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.present("public", rich_rules=rich_rule)
+        assert ret == {
+            "changes": {},
+            "result": True,
+            "comment": "'public' is already in the desired state.",
+            "name": "public",
+        }


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with `firewalld` state module, where provided rich rules are not normalized before its comparison with the existing ones in the system.

Without this normalization, the state might not behave as expected since provided rules might not match with the existing one, even being the same rule.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/61235

### Previous Behavior
Given an SLS like:

```
my_rules:
  firewalld.present:
    - name: public
    - prune_rich_rules: True
    - rich_rules:
      - rule family="ipv4" source address="192.168.1.0/32" port port=222 protocol=tcp accept
      - rule family="ipv4" source address="192.168.1.0/32" port port=222 protocol=udp accept
```

I always gets the following when applying the state (as the rules are not matching):

```
local:
----------
          ID: my_rules
    Function: firewalld.present
        Name: public
      Result: True
     Comment: 'public' was configured.
     Started: 16:53:48.295896
    Duration: 1797.608 ms
     Changes:   
              ----------
              rich_rules:
                  ----------
                  new:
                      - rule family="ipv4" source address="192.168.1.0/32" port port=222 protocol=tcp accept
                      - rule family="ipv4" source address="192.168.1.0/32" port port=222 protocol=udp accept
                  old:
                      - rule family="ipv4" source address="192.168.1.0/32" port port="222" protocol="udp" accept
                      - rule family="ipv4" source address="192.168.1.0/32" port port="222" protocol="tcp" accept

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   1.798 s
```

### New Behavior
Now, the rules are matching so, no chances are done if I apply the state several times:

```
local:
----------
          ID: another
    Function: firewalld.present
        Name: public
      Result: True
     Comment: 'public' is already in the desired state.
     Started: 16:56:09.127409
    Duration: 602.283 ms
     Changes:   

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time: 602.283 ms
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
