### PR TITLE
[3006.x] file.replace and file.search work properly with /proc files

### DIFF
--- a/changelog/63102.fixed.md
+++ b/changelog/63102.fixed.md
@@ -1,0 +1,1 @@
+file.replace and file.search work properly with /proc files

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2539,7 +2539,7 @@ def replace(
                 r_data = mmap.mmap(r_file.fileno(), 0, access=mmap.ACCESS_READ)
             except (ValueError, OSError):
                 # size of file in /proc is 0, but contains data
-                r_data = salt.utils.stringutils.to_bytes("".join(r_file))
+                r_data = b"".join(r_file)
             if search_only:
                 # Just search; bail as early as a match is found
                 if re.search(cpattern, r_data):

--- a/tests/pytests/unit/modules/file/test_file_block_replace.py
+++ b/tests/pytests/unit/modules/file/test_file_block_replace.py
@@ -48,6 +48,7 @@ def configure_loader_modules():
             "__grains__": grains,
             "__utils__": {
                 "files.is_binary": MagicMock(return_value=False),
+                "files.is_text": salt.utils.files.is_text,
                 "files.get_encoding": MagicMock(return_value="utf-8"),
                 "stringutils.get_diff": salt.utils.stringutils.get_diff,
             },
@@ -546,3 +547,17 @@ def test_unfinished_block_exception(multiline_file):
             content="foobar",
             backup=False,
         )
+
+
+def test_search_proc_file():
+    """
+    Test that searching content in a /proc file does not raise a TypeError
+    and handles bytes correctly.
+    """
+    proc_file_path = "/proc/cpuinfo"
+
+    if not os.path.exists(proc_file_path):
+        pytest.skip(f"{proc_file_path} not available")
+
+    match_found = filemod.search(proc_file_path, "processor")
+    assert match_found, "Failed to find 'processor' in /proc/cpuinfo"


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where file.replace and file.search do not work with /proc files in Python 3. The issue was caused by attempting to join bytes objects, which is not allowed in Python 3. The fix involves correctly handling bytes when reading from files in the /proc directory.

### What issues does this PR fix or reference?
Fixes #63102

### Previous Behavior
Attempting to use file.replace or file.search on files in the /proc directory resulted in a TypeError because the code tried to join bytes objects, which is not allowed in Python 3.

### New Behavior
The code now correctly handles bytes when reading from files in the /proc directory, preventing the TypeError and ensuring that file.replace and file.search work as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes