### PR TITLE
[master] Make tests compatible with venv bundle

### DIFF
--- a/changelog/66703.changed.md
+++ b/changelog/66703.changed.md
@@ -1,0 +1,1 @@
+- Make test_pip and test_fileserver tests compatible with venv execution

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -5,14 +5,9 @@ from textwrap import dedent
 import pytest
 
 import salt.modules.pip as pip
-import salt.utils.files
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
-
-TARGET = []
-if os.environ.get("VENV_PIP_TARGET"):
-    TARGET = ["--target", os.environ.get("VENV_PIP_TARGET")]
 
 
 class FakeFopen:
@@ -64,6 +59,14 @@ def configure_loader_modules():
     return {pip: {"__salt__": {"cmd.which_bin": lambda _: "pip"}}}
 
 
+@pytest.fixture
+def venv_target():
+    target = []
+    if os.environ.get("VENV_PIP_TARGET"):
+        target = ["--target", os.environ.get("VENV_PIP_TARGET")]
+    return target
+
+
 def test__pip_bin_env():
     ret = pip._pip_bin_env(None, "C:/Users/ch44d/Documents/salt/tests/pip.exe")
     if salt.utils.platform.is_windows():
@@ -91,7 +94,7 @@ def python_binary():
     return binary
 
 
-def test_install_frozen_app(python_binary):
+def test_install_frozen_app(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch("sys.frozen", True, create=True):
@@ -101,7 +104,7 @@ def test_install_frozen_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
-                    *TARGET,
+                    *venv_target,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -113,7 +116,7 @@ def test_install_frozen_app(python_binary):
                 )
 
 
-def test_install_source_app(python_binary):
+def test_install_source_app(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch("sys.frozen", False, create=True):
@@ -123,7 +126,7 @@ def test_install_source_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
-                    *TARGET,
+                    *venv_target,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -135,7 +138,7 @@ def test_install_source_app(python_binary):
                 )
 
 
-def test_fix4361(python_binary):
+def test_fix4361(python_binary, venv_target):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(requirements="requirements.txt")
@@ -144,7 +147,7 @@ def test_fix4361(python_binary):
             "install",
             "--requirement",
             "requirements.txt",
-            *TARGET,
+            *venv_target,
         ]
         mock.assert_called_with(
             expected_cmd,
@@ -165,13 +168,13 @@ def test_install_editable_without_egg_fails():
         )
 
 
-def test_install_multiple_editable(python_binary):
+def test_install_multiple_editable(python_binary, venv_target):
     editables = [
         "git+https://github.com/saltstack/istr.git@v1.0.1#egg=iStr",
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install", *TARGET]
+    expected = [*python_binary, "install", *venv_target]
     for item in editables:
         expected.extend(["--editable", item])
 
@@ -200,14 +203,14 @@ def test_install_multiple_editable(python_binary):
         )
 
 
-def test_install_multiple_pkgs_and_editables(python_binary):
+def test_install_multiple_pkgs_and_editables(python_binary, venv_target):
     pkgs = ["pep8", "salt"]
     editables = [
         "git+https://github.com/saltstack/istr.git@v1.0.1#egg=iStr",
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install", *TARGET]
+    expected = [*python_binary, "install", *venv_target]
     expected.extend(pkgs)
     for item in editables:
         expected.extend(["--editable", item])
@@ -243,7 +246,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             pkgs[0],
             "--editable",
             editables[0],
@@ -257,7 +260,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         )
 
 
-def test_issue5940_install_multiple_pip_mirrors(python_binary):
+def test_issue5940_install_multiple_pip_mirrors(python_binary, venv_target):
     """
     test multiple pip mirrors.  This test only works with pip < 7.0.0
     """
@@ -271,7 +274,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
         expected = [*python_binary, "install", "--use-mirrors"]
         for item in mirrors:
             expected.extend(["--mirrors", item])
-        expected = [*expected, *TARGET, "pep8"]
+        expected = [*expected, *venv_target, "pep8"]
 
         # Passing mirrors as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -303,7 +306,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
             "--use-mirrors",
             "--mirrors",
             mirrors[0],
-            *TARGET,
+            *venv_target,
             "pep8",
         ]
 
@@ -320,7 +323,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
             )
 
 
-def test_install_with_multiple_find_links(python_binary):
+def test_install_with_multiple_find_links(python_binary, venv_target):
     find_links = [
         "http://g.pypi.python.org",
         "http://c.pypi.python.org",
@@ -331,7 +334,7 @@ def test_install_with_multiple_find_links(python_binary):
     expected = [*python_binary, "install"]
     for item in find_links:
         expected.extend(["--find-links", item])
-    expected = [*expected, *TARGET, pkg]
+    expected = [*expected, *venv_target, pkg]
 
     # Passing mirrors as a list
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -374,7 +377,7 @@ def test_install_with_multiple_find_links(python_binary):
         "install",
         "--find-links",
         find_links[0],
-        *TARGET,
+        *venv_target,
         pkg,
     ]
 
@@ -429,7 +432,7 @@ def test_install_failed_cached_requirements():
         assert "my_test_reqs" in ret["comment"]
 
 
-def test_install_cached_requirements_used(python_binary):
+def test_install_cached_requirements_used(python_binary, venv_target):
     with patch("salt.modules.pip._get_cached_requirements") as get_cached_requirements:
         get_cached_requirements.return_value = "my_cached_reqs"
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -440,7 +443,7 @@ def test_install_cached_requirements_used(python_binary):
                 "install",
                 "--requirement",
                 "my_cached_reqs",
-                *TARGET,
+                *venv_target,
             ]
             mock.assert_called_with(
                 expected,
@@ -485,7 +488,9 @@ def test_install_venv():
             )
 
 
-def test_install_log_argument_in_resulting_command(python_binary, tmp_path):
+def test_install_log_argument_in_resulting_command(
+    python_binary, tmp_path, venv_target
+):
     with patch("os.access") as mock_path:
         pkg = "pep8"
         log_path = str(tmp_path / "pip-install.log")
@@ -497,7 +502,7 @@ def test_install_log_argument_in_resulting_command(python_binary, tmp_path):
                 "install",
                 "--log",
                 log_path,
-                *TARGET,
+                *venv_target,
                 pkg,
             ]
             mock.assert_called_with(
@@ -520,7 +525,7 @@ def test_non_writeable_log():
             pytest.raises(IOError, pip.install, pkg, log=log_path)
 
 
-def test_install_timeout_argument_in_resulting_command(python_binary):
+def test_install_timeout_argument_in_resulting_command(python_binary, venv_target):
     # Passing an int
     pkg = "pep8"
     expected = [*python_binary, "install", "--timeout"]
@@ -528,7 +533,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout=10)
         mock.assert_called_with(
-            expected + [10, *TARGET, pkg],
+            expected + [10, *venv_target, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -540,7 +545,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout="10")
         mock.assert_called_with(
-            expected + ["10", *TARGET, pkg],
+            expected + ["10", *venv_target, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -553,7 +558,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
         pytest.raises(ValueError, pip.install, pkg, timeout="a")
 
 
-def test_install_index_url_argument_in_resulting_command(python_binary):
+def test_install_index_url_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     index_url = "http://foo.tld"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -564,7 +569,7 @@ def test_install_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--index-url",
             index_url,
-            *TARGET,
+            *venv_target,
             pkg,
         ]
         mock.assert_called_with(
@@ -576,7 +581,9 @@ def test_install_index_url_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_extra_index_url_argument_in_resulting_command(python_binary):
+def test_install_extra_index_url_argument_in_resulting_command(
+    python_binary, venv_target
+):
     pkg = "pep8"
     extra_index_url = "http://foo.tld"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -587,7 +594,7 @@ def test_install_extra_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--extra-index-url",
             extra_index_url,
-            *TARGET,
+            *venv_target,
             pkg,
         ]
         mock.assert_called_with(
@@ -599,12 +606,12 @@ def test_install_extra_index_url_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_no_index_argument_in_resulting_command(python_binary):
+def test_install_no_index_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_index=True)
-        expected = [*python_binary, "install", "--no-index", *TARGET, pkg]
+        expected = [*python_binary, "install", "--no-index", *venv_target, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -614,13 +621,13 @@ def test_install_no_index_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_build_argument_in_resulting_command(python_binary):
+def test_install_build_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     build = "/tmp/foo"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, build=build)
-        expected = [*python_binary, "install", "--build", build, *TARGET, pkg]
+        expected = [*python_binary, "install", "--build", build, *venv_target, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -646,7 +653,7 @@ def test_install_target_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_download_argument_in_resulting_command(python_binary):
+def test_install_download_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     download = "/tmp/foo"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -655,7 +662,7 @@ def test_install_download_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             "--download",
             download,
             pkg,
@@ -669,12 +676,12 @@ def test_install_download_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_no_download_argument_in_resulting_command(python_binary):
+def test_install_no_download_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_download=True)
-        expected = [*python_binary, "install", *TARGET, "--no-download", pkg]
+        expected = [*python_binary, "install", *venv_target, "--no-download", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -684,7 +691,9 @@ def test_install_no_download_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_download_cache_dir_arguments_in_resulting_command(python_binary):
+def test_install_download_cache_dir_arguments_in_resulting_command(
+    python_binary, venv_target
+):
     pkg = "pep8"
     cache_dir_arg_mapping = {
         "1.5.6": "--download-cache",
@@ -701,7 +710,7 @@ def test_install_download_cache_dir_arguments_in_resulting_command(python_binary
                 expected = [
                     *python_binary,
                     "install",
-                    *TARGET,
+                    *venv_target,
                     cmd_arg,
                     download_cache,
                     pkg,
@@ -725,13 +734,13 @@ def test_install_download_cache_dir_arguments_in_resulting_command(python_binary
                 )
 
 
-def test_install_source_argument_in_resulting_command(python_binary):
+def test_install_source_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     source = "/tmp/foo"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, source=source)
-        expected = [*python_binary, "install", *TARGET, "--source", source, pkg]
+        expected = [*python_binary, "install", *venv_target, "--source", source, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -741,7 +750,9 @@ def test_install_source_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_exists_action_argument_in_resulting_command(python_binary):
+def test_install_exists_action_argument_in_resulting_command(
+    python_binary, venv_target
+):
     pkg = "pep8"
     for action in ("s", "i", "w", "b"):
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -750,7 +761,7 @@ def test_install_exists_action_argument_in_resulting_command(python_binary):
             expected = [
                 *python_binary,
                 "install",
-                *TARGET,
+                *venv_target,
                 "--exists-action",
                 action,
                 pkg,
@@ -769,11 +780,13 @@ def test_install_exists_action_argument_in_resulting_command(python_binary):
         pytest.raises(CommandExecutionError, pip.install, pkg, exists_action="d")
 
 
-def test_install_install_options_argument_in_resulting_command(python_binary):
+def test_install_install_options_argument_in_resulting_command(
+    python_binary, venv_target
+):
     install_options = ["--exec-prefix=/foo/bar", "--install-scripts=/foo/bar/bin"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install", *TARGET]
+    expected = [*python_binary, "install", *venv_target]
     for item in install_options:
         expected.extend(["--install-option", item])
     expected.append(pkg)
@@ -809,7 +822,7 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             "--install-option",
             install_options[0],
             pkg,
@@ -823,11 +836,13 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_global_options_argument_in_resulting_command(python_binary):
+def test_install_global_options_argument_in_resulting_command(
+    python_binary, venv_target
+):
     global_options = ["--quiet", "--no-user-cfg"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install", *TARGET]
+    expected = [*python_binary, "install", *venv_target]
     for item in global_options:
         expected.extend(["--global-option", item])
     expected.append(pkg)
@@ -863,7 +878,7 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             "--global-option",
             global_options[0],
             pkg,
@@ -877,12 +892,12 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_upgrade_argument_in_resulting_command(python_binary):
+def test_install_upgrade_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, upgrade=True)
-        expected = [*python_binary, "install", *TARGET, "--upgrade", pkg]
+        expected = [*python_binary, "install", *venv_target, "--upgrade", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -892,7 +907,9 @@ def test_install_upgrade_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_force_reinstall_argument_in_resulting_command(python_binary):
+def test_install_force_reinstall_argument_in_resulting_command(
+    python_binary, venv_target
+):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
@@ -900,7 +917,7 @@ def test_install_force_reinstall_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             "--force-reinstall",
             pkg,
         ]
@@ -913,7 +930,9 @@ def test_install_force_reinstall_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_ignore_installed_argument_in_resulting_command(python_binary):
+def test_install_ignore_installed_argument_in_resulting_command(
+    python_binary, venv_target
+):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
@@ -921,7 +940,7 @@ def test_install_ignore_installed_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             "--ignore-installed",
             pkg,
         ]
@@ -934,12 +953,12 @@ def test_install_ignore_installed_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_no_deps_argument_in_resulting_command(python_binary):
+def test_install_no_deps_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_deps=True)
-        expected = [*python_binary, "install", *TARGET, "--no-deps", pkg]
+        expected = [*python_binary, "install", *venv_target, "--no-deps", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -949,12 +968,12 @@ def test_install_no_deps_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_no_install_argument_in_resulting_command(python_binary):
+def test_install_no_install_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_install=True)
-        expected = [*python_binary, "install", *TARGET, "--no-install", pkg]
+        expected = [*python_binary, "install", *venv_target, "--no-install", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -964,13 +983,13 @@ def test_install_no_install_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_proxy_argument_in_resulting_command(python_binary):
+def test_install_proxy_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     proxy = "salt-user:salt-passwd@salt-proxy:3128"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, proxy=proxy)
-        expected = [*python_binary, "install", "--proxy", proxy, *TARGET, pkg]
+        expected = [*python_binary, "install", "--proxy", proxy, *venv_target, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -980,7 +999,7 @@ def test_install_proxy_argument_in_resulting_command(python_binary):
         )
 
 
-def test_install_proxy_false_argument_in_resulting_command(python_binary):
+def test_install_proxy_false_argument_in_resulting_command(python_binary, venv_target):
     """
     Checking that there is no proxy set if proxy arg is set to False
     even if the global proxy is set.
@@ -997,7 +1016,7 @@ def test_install_proxy_false_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch.dict(pip.__opts__, config_mock):
             pip.install(pkg, proxy=proxy)
-            expected = [*python_binary, "install", *TARGET, pkg]
+            expected = [*python_binary, "install", *venv_target, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1007,7 +1026,7 @@ def test_install_proxy_false_argument_in_resulting_command(python_binary):
             )
 
 
-def test_install_global_proxy_in_resulting_command(python_binary):
+def test_install_global_proxy_in_resulting_command(python_binary, venv_target):
     """
     Checking that there is proxy set if global proxy is set.
     """
@@ -1028,7 +1047,7 @@ def test_install_global_proxy_in_resulting_command(python_binary):
                 "install",
                 "--proxy",
                 proxy,
-                *TARGET,
+                *venv_target,
                 pkg,
             ]
             mock.assert_called_with(
@@ -1040,7 +1059,9 @@ def test_install_global_proxy_in_resulting_command(python_binary):
             )
 
 
-def test_install_multiple_requirements_arguments_in_resulting_command(python_binary):
+def test_install_multiple_requirements_arguments_in_resulting_command(
+    python_binary, venv_target
+):
     with patch("salt.modules.pip._get_cached_requirements") as get_cached_requirements:
         cached_reqs = ["my_cached_reqs-1", "my_cached_reqs-2"]
         get_cached_requirements.side_effect = cached_reqs
@@ -1049,7 +1070,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
         expected = [*python_binary, "install"]
         for item in cached_reqs:
             expected.extend(["--requirement", item])
-        expected.extend(TARGET)
+        expected.extend(venv_target)
 
         # Passing option as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -1086,7 +1107,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
                 "install",
                 "--requirement",
                 cached_reqs[0],
-                *TARGET,
+                *venv_target,
             ]
             mock.assert_called_with(
                 expected,
@@ -1097,7 +1118,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
             )
 
 
-def test_install_extra_args_arguments_in_resulting_command(python_binary):
+def test_install_extra_args_arguments_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
@@ -1107,7 +1128,7 @@ def test_install_extra_args_arguments_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
-            *TARGET,
+            *venv_target,
             pkg,
             "--latest-pip-kwarg",
             "param",
@@ -1611,7 +1632,7 @@ def test_is_installed_false(python_binary):
             assert not ret
 
 
-def test_install_pre_argument_in_resulting_command(python_binary):
+def test_install_pre_argument_in_resulting_command(python_binary, venv_target):
     pkg = "pep8"
     # Lower than 1.4 versions don't end up with `--pre` in the resulting output
     mock = MagicMock(
@@ -1623,7 +1644,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch("salt.modules.pip.version", MagicMock(return_value="1.3")):
             pip.install(pkg, pre_releases=True)
-            expected = [*python_binary, "install", *TARGET, pkg]
+            expected = [*python_binary, "install", *venv_target, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1639,7 +1660,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     ):
         with patch("salt.modules.pip._get_pip_bin", MagicMock(return_value=["pip"])):
             pip.install(pkg, pre_releases=True)
-            expected = ["pip", "install", *TARGET, "--pre", pkg]
+            expected = ["pip", "install", *venv_target, "--pre", pkg]
             mock_run_all.assert_called_with(
                 expected,
                 saltenv="base",


### PR DESCRIPTION
### What does this PR do?

In this PR, I'm modifying two tests that currently fail when we execute them from a virtual environment.

- In the `test_pip` test, pip adds target since we're in a venv.
- In the `test_fileserver` tests, we need additional `optimization_order` level for the same reason.

Related PR for community test: https://github.com/saltstack/salt/pull/66704

None of the changes should affect test execution without venv. 

### What issues does this PR fix or reference?

### Previous Behavior
Tests fail due to different deployment method.

### New Behavior
Tests pass in any deployment method.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
