### PR TITLE
[3006.x] Raise exception when bad pillar data is encountered

### DIFF
--- a/changelog/66702.security.md
+++ b/changelog/66702.security.md
@@ -1,0 +1,2 @@
+CVE-2024-37088 salt-call will fail with exit code 1 if bad pillar data is
+encountered.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -196,6 +196,15 @@ class RemotePillarMixin:
         log.trace("ext_pillar_extra_data = %s", extra_data)
         return extra_data
 
+    def validate_return(self, data):
+        if not isinstance(data, dict):
+            msg = "Got a bad pillar from master, type {}, expecting dict: {}".format(
+                type(data).__name__, data
+            )
+            log.error(msg)
+            # raise an exception! Pillar isn't empty, we can't sync it!
+            raise SaltClientError(msg)
+
 
 class AsyncRemotePillar(RemotePillarMixin):
     """
@@ -275,14 +284,7 @@ class AsyncRemotePillar(RemotePillarMixin):
         except Exception:  # pylint: disable=broad-except
             log.exception("Exception getting pillar:")
             raise SaltClientError("Exception getting pillar.")
-
-        if not isinstance(ret_pillar, dict):
-            msg = "Got a bad pillar from master, type {}, expecting dict: {}".format(
-                type(ret_pillar).__name__, ret_pillar
-            )
-            log.error(msg)
-            # raise an exception! Pillar isn't empty, we can't sync it!
-            raise SaltClientError(msg)
+        self.validate_return(ret_pillar)
         raise salt.ext.tornado.gen.Return(ret_pillar)
 
     def destroy(self):
@@ -373,14 +375,7 @@ class RemotePillar(RemotePillarMixin):
         except Exception:  # pylint: disable=broad-except
             log.exception("Exception getting pillar:")
             raise SaltClientError("Exception getting pillar.")
-
-        if not isinstance(ret_pillar, dict):
-            log.error(
-                "Got a bad pillar from master, type %s, expecting dict: %s",
-                type(ret_pillar).__name__,
-                ret_pillar,
-            )
-            return {}
+        self.validate_return(ret_pillar)
         return ret_pillar
 
     def destroy(self):

--- a/tests/pytests/unit/test_pillar.py
+++ b/tests/pytests/unit/test_pillar.py
@@ -1259,3 +1259,43 @@ def test_compile_pillar_disk_cache(master_opts, grains):
                 "mocked_minion": {"base": {"foo": "bar"}, "dev": {"foo": "baz"}}
             }
             assert pillar.cache._dict == expected_cache
+
+
+def test_remote_pillar_bad_return(grains, tmp_pki):
+    opts = {
+        "pki_dir": tmp_pki,
+        "id": "minion",
+        "master_uri": "tcp://127.0.0.1:4505",
+        "__role": "minion",
+        "keysize": 2048,
+        "saltenv": "base",
+        "pillarenv": "base",
+    }
+    pillar = salt.pillar.RemotePillar(opts, grains, "mocked-minion", "dev")
+
+    async def crypted_transfer_mock():
+        return ""
+
+    pillar.channel.crypted_transfer_decode_dictentry = crypted_transfer_mock
+    with pytest.raises(salt.exceptions.SaltClientError):
+        pillar.compile_pillar()
+
+
+async def test_async_remote_pillar_bad_return(grains, tmp_pki):
+    opts = {
+        "pki_dir": tmp_pki,
+        "id": "minion",
+        "master_uri": "tcp://127.0.0.1:4505",
+        "__role": "minion",
+        "keysize": 2048,
+        "saltenv": "base",
+        "pillarenv": "base",
+    }
+    pillar = salt.pillar.AsyncRemotePillar(opts, grains, "mocked-minion", "dev")
+
+    async def crypted_transfer_mock():
+        return ""
+
+    pillar.channel.crypted_transfer_decode_dictentry = crypted_transfer_mock
+    with pytest.raises(salt.exceptions.SaltClientError):
+        await pillar.compile_pillar()


### PR DESCRIPTION
### What does this PR do?

RemotePillar raises an exception on bad data 

If the master returns a bad pillar data response the pillar client
should raise an exception. This changes RemotePillar and
AsyncRemotePillar classes to use the same logic for validating pillar
data from the master. Fixes CVE-2024-37088 by causing salt-call to fail
with a non zero exit code rather than continuing to execute a state when
pillar data rendering fails on the master.

### What issues does this PR fix or reference?
Fixes #66702


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
