### PR TITLE
[community-extensions] Remove & Purge specific version pkg in zypperpkg

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1979,13 +1979,13 @@ def upgrade(
     return ret
 
 
-def _uninstall(name=None, pkgs=None, root=None):
+def _uninstall(name=None, pkgs=None, version=None, root=None):
     """
     Remove and purge do identical things but with different Zypper commands,
     this function performs the common logic.
     """
     try:
-        pkg_params = __salt__["pkg_resource.parse_targets"](name, pkgs)[0]
+        pkg_params = __salt__["pkg_resource.parse_targets"](name, pkgs, version=version)[0]
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -2063,7 +2063,7 @@ def normalize_name(name):
 
 
 def remove(
-    name=None, pkgs=None, root=None, **kwargs
+    name=None, pkgs=None, version=None, root=None, **kwargs
 ):  # pylint: disable=unused-argument
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -2113,10 +2113,10 @@ def remove(
 
     Can now remove also PTF packages which require a different handling in the backend.
     """
-    return _uninstall(name=name, pkgs=pkgs, root=root)
+    return _uninstall(name=name, pkgs=pkgs, version=version, root=root)
 
 
-def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-argument
+def purge(name=None, pkgs=None, version=None, root=None, **kwargs):  # pylint: disable=unused-argument
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -2161,7 +2161,7 @@ def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-
         salt '*' pkg.purge <package1>,<package2>,<package3>
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     """
-    return _uninstall(name=name, pkgs=pkgs, root=root)
+    return _uninstall(name=name, pkgs=pkgs, version=version, root=root)
 
 
 def list_holds(pattern=None, full=True, root=None, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Add param "version" to _uninstall() remove() & purge() in zypperpkg to allow remove the package with the specific version, do not remove all packages with different versions.

### What issues does this PR fix or reference?

Fixes: https://github.com/openSUSE/salt/issues/658
Reference: https://github.com/saltstack/salt/commit/585145f4b382508ef7a6cc6f1cb33697b9a606b8

Got the param "version" from parse_targets **kwargs, and pass it to the "zypper remove" command.

Also need the https://github.com/saltstack/salt/pull/66714 in master branch for pkg.py, to check in the pkg list with the specific version after the "zypper remove" run successfully.

### Previous Behavior

salt.states.apply pkg.removed in zypperpkg will remove all packages with different versions when you have a specific version defined in sls file. 

### New Behavior

module zypperpkg will remove the specific version of the package only when the version defined in sls file.

### Commits signed with GPG?
Yes
