### PR TITLE
[3006.x] Falsey cmd.script input/output

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2689,11 +2689,15 @@ def script(
 
     :param str args: String of command line args to pass to the script. Only
         used if no args are specified as part of the `name` argument. To pass a
-        string containing spaces in YAML, you will need to doubly-quote it:
+        string containing spaces in YAML, you will need to doubly-quote it.
+        Additionally, if you need to pass falsey values (e.g., "0", "", "False"),
+        you should doubly-quote them to ensure they are correctly interpreted:
 
         .. code-block:: bash
 
             salt myminion cmd.script salt://foo.sh "arg1 'arg two' arg3"
+            salt myminion cmd.script salt://foo.sh "''0''"
+            salt myminion cmd.script salt://foo.sh "''False''"
 
     :param str cwd: The directory from which to execute the command. Defaults
         to the directory returned from Python's tempfile.mkstemp.
@@ -2834,6 +2838,10 @@ def script(
         present in the ``stdin`` value to newlines.
 
       .. versionadded:: 2019.2.0
+
+    :return: The return value of the script execution, including stdout, stderr,
+        and the exit code. If the script returns a falsey string value, it should be
+        doubly-quoted to ensure it is correctly interpreted by Salt.
 
     CLI Example:
 

--- a/tests/pytests/integration/modules/test_cmdmod.py
+++ b/tests/pytests/integration/modules/test_cmdmod.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import pytest
 
 
@@ -25,29 +22,3 @@ def test_long_stdout(salt_cli, salt_minion):
     )
     assert ret.returncode == 0
     assert len(ret.data.strip()) == len(echo_str)
-
-
-@pytest.fixture()
-def test_script_path():
-    """
-    Create a temporary shell script that echoes its arguments.
-
-    This fixture sets up a temporary shell script, makes it executable,
-    and yields the path to the script for use in tests. After the test
-    completes, the temporary file is automatically removed.
-
-    Yields:
-        str: The path to the temporary shell script.
-    """
-    script_content = "#!/bin/bash\necho $*"
-
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix="-salt_echo_num.sh"
-    ) as temp_script:
-        temp_script.write(script_content)
-        temp_script_path = temp_script.name
-
-        # Make the script executable
-        os.chmod(temp_script_path, 0o755)
-
-        yield temp_script_path

--- a/tests/pytests/integration/modules/test_cmdmod.py
+++ b/tests/pytests/integration/modules/test_cmdmod.py
@@ -1,4 +1,6 @@
 import pytest
+import tempfile
+import os
 
 
 @pytest.fixture(scope="module")
@@ -22,3 +24,58 @@ def test_long_stdout(salt_cli, salt_minion):
     )
     assert ret.returncode == 0
     assert len(ret.data.strip()) == len(echo_str)
+
+
+@pytest.fixture()
+def test_script_path():
+    """
+    Create a temporary shell script that echoes its arguments.
+    
+    This fixture sets up a temporary shell script, makes it executable,
+    and yields the path to the script for use in tests. After the test
+    completes, the temporary file is automatically removed.
+    
+    Yields:
+        str: The path to the temporary shell script.
+    """
+    script_content = "#!/bin/bash\necho $*"
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='-salt_echo_num.sh') as temp_script:
+        temp_script.write(script_content)
+        temp_script_path = temp_script.name
+    
+        # Make the script executable
+        os.chmod(temp_script_path, 0o755)  
+        
+
+        yield temp_script_path
+
+
+def test_script_with_falsey_args(subtests, salt_call_cli, test_script_path):
+    """
+    Test `cmd.script` with various falsey arguments to ensure correct handling.
+    
+    This test runs the temporary shell script with a variety of arguments
+    that evaluate to false in Python. It uses subtests to individually test
+    each falsey argument and checks that the script outputs the argument correctly.
+    
+    Args:
+        subtests (SubTests): The subtests fixture for running parameterized tests.
+        salt_call_cli (SaltCallCLI): The salt CLI fixture for running salt commands.
+        test_script_path (str): The path to the temporary shell script.
+    """
+    # List of values to test that evaluate to `False` when used in python conditionals
+    falsey_values = ["0", "", "''", "\"\"", "()", "[]", "{}", "False", "None"]
+
+    for value in falsey_values:
+        expected_output = str(value).strip('"').strip("'")
+        with subtests.test(f"The script should print '{expected_output}' for input '{value}'", value=value):
+            # Run the script with the current falsey value as an argument
+            ret = salt_call_cli.run("--local", "cmd.script", f"file://{test_script_path}", str(value))
+
+            # Check that the script ran successfully and printed the expected output
+            assert ret.returncode == 0, f"The script failed to run with argument: {value}"
+
+            # Verify that the script's output matches the expected output
+            assert expected_output in ret.json["stdout"]
+            

--- a/tests/pytests/integration/modules/test_cmdmod.py
+++ b/tests/pytests/integration/modules/test_cmdmod.py
@@ -1,6 +1,7 @@
-import pytest
-import tempfile
 import os
+import tempfile
+
+import pytest
 
 
 @pytest.fixture(scope="module")
@@ -30,52 +31,23 @@ def test_long_stdout(salt_cli, salt_minion):
 def test_script_path():
     """
     Create a temporary shell script that echoes its arguments.
-    
+
     This fixture sets up a temporary shell script, makes it executable,
     and yields the path to the script for use in tests. After the test
     completes, the temporary file is automatically removed.
-    
+
     Yields:
         str: The path to the temporary shell script.
     """
     script_content = "#!/bin/bash\necho $*"
 
-    with tempfile.NamedTemporaryFile(mode='w', suffix='-salt_echo_num.sh') as temp_script:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix="-salt_echo_num.sh"
+    ) as temp_script:
         temp_script.write(script_content)
         temp_script_path = temp_script.name
-    
+
         # Make the script executable
-        os.chmod(temp_script_path, 0o755)  
-        
+        os.chmod(temp_script_path, 0o755)
 
         yield temp_script_path
-
-
-def test_script_with_falsey_args(subtests, salt_call_cli, test_script_path):
-    """
-    Test `cmd.script` with various falsey arguments to ensure correct handling.
-    
-    This test runs the temporary shell script with a variety of arguments
-    that evaluate to false in Python. It uses subtests to individually test
-    each falsey argument and checks that the script outputs the argument correctly.
-    
-    Args:
-        subtests (SubTests): The subtests fixture for running parameterized tests.
-        salt_call_cli (SaltCallCLI): The salt CLI fixture for running salt commands.
-        test_script_path (str): The path to the temporary shell script.
-    """
-    # List of values to test that evaluate to `False` when used in python conditionals
-    falsey_values = ["0", "", "''", "\"\"", "()", "[]", "{}", "False", "None"]
-
-    for value in falsey_values:
-        expected_output = str(value).strip('"').strip("'")
-        with subtests.test(f"The script should print '{expected_output}' for input '{value}'", value=value):
-            # Run the script with the current falsey value as an argument
-            ret = salt_call_cli.run("--local", "cmd.script", f"file://{test_script_path}", str(value))
-
-            # Check that the script ran successfully and printed the expected output
-            assert ret.returncode == 0, f"The script failed to run with argument: {value}"
-
-            # Verify that the script's output matches the expected output
-            assert expected_output in ret.json["stdout"]
-            


### PR DESCRIPTION
### What does this PR do?
Adds documentation to `cmd.script` module making it clear how to pass or return a single falsey string value (e.g. "0", "False", "None", "()", "{}",  "[]").   Similar to the existing documentation around passing space characters in `cmd.script` args, falsey values must be double quoted (e.g. "''0''", "''False''", "''None''", "''*(''", "''{}''", "''[]''").

### What issues does this PR fix or reference?
Fixes #66145

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
