### PR TITLE
[3006.x] Make tests compatible with venv bundle

### DIFF
--- a/changelog/66596.fixed.md
+++ b/changelog/66596.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue with cmd.run with requirements when the shell is not the
+default

--- a/tests/pytests/functional/utils/yamllint/test_yamllint.py
+++ b/tests/pytests/functional/utils/yamllint/test_yamllint.py
@@ -7,7 +7,7 @@ import salt.utils.versions as versions
 try:
     import salt.utils.yamllint as yamllint
 
-    YAMLLINT_AVAILABLE = True
+    YAMLLINT_AVAILABLE = yamllint.has_yamllint()
 except ImportError:
     YAMLLINT_AVAILABLE = False
 

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -11,8 +11,8 @@ from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
 
 TARGET = []
-if os.environ.get('VENV_PIP_TARGET'):
-    TARGET = ["--target", os.environ.get('VENV_PIP_TARGET')]
+if os.environ.get("VENV_PIP_TARGET"):
+    TARGET = ["--target", os.environ.get("VENV_PIP_TARGET")]
 
 
 class FakeFopen:

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -10,6 +10,10 @@ import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
 
+TARGET = []
+if os.environ.get('VENV_PIP_TARGET'):
+    TARGET = ["--target", os.environ.get('VENV_PIP_TARGET')]
+
 
 class FakeFopen:
     def __init__(self, filename):
@@ -97,6 +101,7 @@ def test_install_frozen_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -118,6 +123,7 @@ def test_install_source_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -138,6 +144,7 @@ def test_fix4361(python_binary):
             "install",
             "--requirement",
             "requirements.txt",
+            *TARGET,
         ]
         mock.assert_called_with(
             expected_cmd,
@@ -164,7 +171,7 @@ def test_install_multiple_editable(python_binary):
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in editables:
         expected.extend(["--editable", item])
 
@@ -200,7 +207,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     expected.extend(pkgs)
     for item in editables:
         expected.extend(["--editable", item])
@@ -236,6 +243,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             pkgs[0],
             "--editable",
             editables[0],
@@ -263,7 +271,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
         expected = [*python_binary, "install", "--use-mirrors"]
         for item in mirrors:
             expected.extend(["--mirrors", item])
-        expected.append("pep8")
+        expected = [*expected, *TARGET, "pep8"]
 
         # Passing mirrors as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -295,6 +303,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
             "--use-mirrors",
             "--mirrors",
             mirrors[0],
+            *TARGET,
             "pep8",
         ]
 
@@ -322,7 +331,7 @@ def test_install_with_multiple_find_links(python_binary):
     expected = [*python_binary, "install"]
     for item in find_links:
         expected.extend(["--find-links", item])
-    expected.append(pkg)
+    expected = [*expected, *TARGET, pkg]
 
     # Passing mirrors as a list
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -365,6 +374,7 @@ def test_install_with_multiple_find_links(python_binary):
         "install",
         "--find-links",
         find_links[0],
+        *TARGET,
         pkg,
     ]
 
@@ -430,6 +440,7 @@ def test_install_cached_requirements_used(python_binary):
                 "install",
                 "--requirement",
                 "my_cached_reqs",
+                *TARGET,
             ]
             mock.assert_called_with(
                 expected,
@@ -486,6 +497,7 @@ def test_install_log_argument_in_resulting_command(python_binary, tmp_path):
                 "install",
                 "--log",
                 log_path,
+                *TARGET,
                 pkg,
             ]
             mock.assert_called_with(
@@ -516,7 +528,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout=10)
         mock.assert_called_with(
-            expected + [10, pkg],
+            expected + [10, *TARGET, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -528,7 +540,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout="10")
         mock.assert_called_with(
-            expected + ["10", pkg],
+            expected + ["10", *TARGET, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -552,6 +564,7 @@ def test_install_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--index-url",
             index_url,
+            *TARGET,
             pkg,
         ]
         mock.assert_called_with(
@@ -574,6 +587,7 @@ def test_install_extra_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--extra-index-url",
             extra_index_url,
+            *TARGET,
             pkg,
         ]
         mock.assert_called_with(
@@ -590,7 +604,7 @@ def test_install_no_index_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_index=True)
-        expected = [*python_binary, "install", "--no-index", pkg]
+        expected = [*python_binary, "install", "--no-index", *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -606,7 +620,7 @@ def test_install_build_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, build=build)
-        expected = [*python_binary, "install", "--build", build, pkg]
+        expected = [*python_binary, "install", "--build", build, *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -641,6 +655,7 @@ def test_install_download_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--download",
             download,
             pkg,
@@ -659,7 +674,7 @@ def test_install_no_download_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_download=True)
-        expected = [*python_binary, "install", "--no-download", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-download", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -686,6 +701,7 @@ def test_install_download_cache_dir_arguments_in_resulting_command(python_binary
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     cmd_arg,
                     download_cache,
                     pkg,
@@ -715,7 +731,7 @@ def test_install_source_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, source=source)
-        expected = [*python_binary, "install", "--source", source, pkg]
+        expected = [*python_binary, "install", *TARGET, "--source", source, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -734,6 +750,7 @@ def test_install_exists_action_argument_in_resulting_command(python_binary):
             expected = [
                 *python_binary,
                 "install",
+                *TARGET,
                 "--exists-action",
                 action,
                 pkg,
@@ -756,7 +773,7 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
     install_options = ["--exec-prefix=/foo/bar", "--install-scripts=/foo/bar/bin"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in install_options:
         expected.extend(["--install-option", item])
     expected.append(pkg)
@@ -792,6 +809,7 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--install-option",
             install_options[0],
             pkg,
@@ -809,7 +827,7 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
     global_options = ["--quiet", "--no-user-cfg"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in global_options:
         expected.extend(["--global-option", item])
     expected.append(pkg)
@@ -845,6 +863,7 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--global-option",
             global_options[0],
             pkg,
@@ -863,7 +882,7 @@ def test_install_upgrade_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, upgrade=True)
-        expected = [*python_binary, "install", "--upgrade", pkg]
+        expected = [*python_binary, "install", *TARGET, "--upgrade", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -881,6 +900,7 @@ def test_install_force_reinstall_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--force-reinstall",
             pkg,
         ]
@@ -901,6 +921,7 @@ def test_install_ignore_installed_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--ignore-installed",
             pkg,
         ]
@@ -918,7 +939,7 @@ def test_install_no_deps_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_deps=True)
-        expected = [*python_binary, "install", "--no-deps", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-deps", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -933,7 +954,7 @@ def test_install_no_install_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_install=True)
-        expected = [*python_binary, "install", "--no-install", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-install", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -949,7 +970,7 @@ def test_install_proxy_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, proxy=proxy)
-        expected = [*python_binary, "install", "--proxy", proxy, pkg]
+        expected = [*python_binary, "install", "--proxy", proxy, *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -976,7 +997,7 @@ def test_install_proxy_false_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch.dict(pip.__opts__, config_mock):
             pip.install(pkg, proxy=proxy)
-            expected = [*python_binary, "install", pkg]
+            expected = [*python_binary, "install", *TARGET, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1007,6 +1028,7 @@ def test_install_global_proxy_in_resulting_command(python_binary):
                 "install",
                 "--proxy",
                 proxy,
+                *TARGET,
                 pkg,
             ]
             mock.assert_called_with(
@@ -1027,6 +1049,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
         expected = [*python_binary, "install"]
         for item in cached_reqs:
             expected.extend(["--requirement", item])
+        expected.extend(TARGET)
 
         # Passing option as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -1063,6 +1086,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
                 "install",
                 "--requirement",
                 cached_reqs[0],
+                *TARGET,
             ]
             mock.assert_called_with(
                 expected,
@@ -1083,6 +1107,7 @@ def test_install_extra_args_arguments_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             pkg,
             "--latest-pip-kwarg",
             "param",
@@ -1599,7 +1624,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch("salt.modules.pip.version", MagicMock(return_value="1.3")):
             pip.install(pkg, pre_releases=True)
-            expected = [*python_binary, "install", pkg]
+            expected = [*python_binary, "install", *TARGET, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1615,7 +1640,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     ):
         with patch("salt.modules.pip._get_pip_bin", MagicMock(return_value=["pip"])):
             pip.install(pkg, pre_releases=True)
-            expected = ["pip", "install", "--pre", pkg]
+            expected = ["pip", "install", *TARGET, "--pre", pkg]
             mock_run_all.assert_called_with(
                 expected,
                 saltenv="base",

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -13,7 +14,7 @@ pytestmark = [
 ]
 
 SALT_CALL_BINARY = "salt-call"
-if os.environ.get("VIRTUAL_ENV"):
+if os.environ.get("VIRTUAL_ENV") and os.environ.get("VIRTUAL_ENV") in sys.executable:
     SALT_CALL_BINARY = f"{os.environ.get('VIRTUAL_ENV')}/bin/salt-call"
 
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import salt.loader.context
@@ -9,6 +10,10 @@ from tests.support.mock import MagicMock, patch
 pytestmark = [
     pytest.mark.skip_on_windows(reason="Not supported on Windows"),
 ]
+
+SALT_CALL_BINARY = "salt-call"
+if os.environ.get('VIRTUAL_ENV'):
+    SALT_CALL_BINARY = f"{os.environ.get('VIRTUAL_ENV')}/bin/salt-call"
 
 
 @pytest.fixture
@@ -381,7 +386,7 @@ def test_call_fails_function():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -413,7 +418,7 @@ def test_call_success_no_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -456,7 +461,7 @@ def test_call_success_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -490,7 +495,7 @@ def test_call_success_parameters():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 import pytest
 
 import salt.loader.context
@@ -12,10 +9,6 @@ from tests.support.mock import MagicMock, patch
 pytestmark = [
     pytest.mark.skip_on_windows(reason="Not supported on Windows"),
 ]
-
-SALT_CALL_BINARY = "salt-call"
-if os.environ.get("VIRTUAL_ENV") and os.environ.get("VIRTUAL_ENV") in sys.executable:
-    SALT_CALL_BINARY = f"{os.environ.get('VIRTUAL_ENV')}/bin/salt-call"
 
 
 @pytest.fixture
@@ -388,7 +381,7 @@ def test_call_fails_function():
                 "--continue",
                 "--quiet",
                 "run",
-                SALT_CALL_BINARY,
+                "salt-call",
                 "--out",
                 "json",
                 "-l",
@@ -420,7 +413,7 @@ def test_call_success_no_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                SALT_CALL_BINARY,
+                "salt-call",
                 "--out",
                 "json",
                 "-l",
@@ -463,7 +456,7 @@ def test_call_success_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                SALT_CALL_BINARY,
+                "salt-call",
                 "--out",
                 "json",
                 "-l",
@@ -497,7 +490,7 @@ def test_call_success_parameters():
                 "--continue",
                 "--quiet",
                 "run",
-                SALT_CALL_BINARY,
+                "salt-call",
                 "--out",
                 "json",
                 "-l",

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import salt.loader.context
@@ -12,7 +13,7 @@ pytestmark = [
 ]
 
 SALT_CALL_BINARY = "salt-call"
-if os.environ.get('VIRTUAL_ENV'):
+if os.environ.get("VIRTUAL_ENV"):
     SALT_CALL_BINARY = f"{os.environ.get('VIRTUAL_ENV')}/bin/salt-call"
 
 

--- a/tests/pytests/unit/modules/test_yaml.py
+++ b/tests/pytests/unit/modules/test_yaml.py
@@ -13,7 +13,7 @@ try:
     import salt.modules.yaml
     import salt.utils.yamllint
 
-    YAMLLINT_AVAILABLE = True
+    YAMLLINT_AVAILABLE = salt.utils.yamllint.has_yamllint()
 except ImportError:
     YAMLLINT_AVAILABLE = False
 

--- a/tests/pytests/unit/test_fileserver.py
+++ b/tests/pytests/unit/test_fileserver.py
@@ -76,7 +76,7 @@ def test_file_server_url_escape(tmp_path):
         "fileserver_backend": ["roots"],
         "extension_modules": "",
         "optimization_order": [
-            0,
+            0, 1
         ],
         "file_roots": {
             "base": [fileroot],
@@ -103,7 +103,7 @@ def test_file_server_serve_url_escape(tmp_path):
         "fileserver_backend": ["roots"],
         "extension_modules": "",
         "optimization_order": [
-            0,
+            0, 1
         ],
         "file_roots": {
             "base": [fileroot],

--- a/tests/pytests/unit/test_fileserver.py
+++ b/tests/pytests/unit/test_fileserver.py
@@ -75,9 +75,7 @@ def test_file_server_url_escape(tmp_path):
     opts = {
         "fileserver_backend": ["roots"],
         "extension_modules": "",
-        "optimization_order": [
-            0, 1
-        ],
+        "optimization_order": [0, 1],
         "file_roots": {
             "base": [fileroot],
         },
@@ -102,9 +100,7 @@ def test_file_server_serve_url_escape(tmp_path):
     opts = {
         "fileserver_backend": ["roots"],
         "extension_modules": "",
-        "optimization_order": [
-            0, 1
-        ],
+        "optimization_order": [0, 1],
         "file_roots": {
             "base": [fileroot],
         },

--- a/tests/pytests/unit/utils/test_msgpack.py
+++ b/tests/pytests/unit/utils/test_msgpack.py
@@ -3,7 +3,7 @@ import pytest
 import salt.utils.msgpack
 from tests.support.mock import MagicMock, patch
 
-
+@pytest.mark.skipif(salt.utils.msgpack.version < (1, 0, 0), reason="Test requires msgpack version >= 1.0.0")
 def test_load_encoding(tmp_path):
     """
     test when using msgpack version >= 1.0.0 we

--- a/tests/pytests/unit/utils/test_msgpack.py
+++ b/tests/pytests/unit/utils/test_msgpack.py
@@ -3,7 +3,11 @@ import pytest
 import salt.utils.msgpack
 from tests.support.mock import MagicMock, patch
 
-@pytest.mark.skipif(salt.utils.msgpack.version < (1, 0, 0), reason="Test requires msgpack version >= 1.0.0")
+
+@pytest.mark.skipif(
+    salt.utils.msgpack.version < (1, 0, 0),
+    reason="Test requires msgpack version >= 1.0.0",
+)
 def test_load_encoding(tmp_path):
     """
     test when using msgpack version >= 1.0.0 we

--- a/tests/pytests/unit/utils/test_pycrypto.py
+++ b/tests/pytests/unit/utils/test_pycrypto.py
@@ -57,21 +57,20 @@ def test_gen_hash_crypt(algorithm, expected):
     """
     Test gen_hash with crypt library
     """
-    with patch("salt.utils.pycrypto.methods", {}):
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=expected["salt"], password=passwd, algorithm=algorithm
-        )
-        assert ret == expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=expected["salt"], password=passwd, algorithm=algorithm
+    )
+    assert ret == expected["hashed"]
 
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=expected["badsalt"], password=passwd, algorithm=algorithm
-        )
-        assert ret != expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=expected["badsalt"], password=passwd, algorithm=algorithm
+    )
+    assert ret != expected["hashed"]
 
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=None, password=passwd, algorithm=algorithm
-        )
-        assert ret != expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=None, password=passwd, algorithm=algorithm
+    )
+    assert ret != expected["hashed"]
 
 
 @pytest.mark.skipif(not salt.utils.pycrypto.HAS_CRYPT, reason="crypt not available")


### PR DESCRIPTION
### What does this PR do?

This PR is a continuation of the following PRs:

- https://github.com/saltstack/salt/pull/66704
- https://github.com/saltstack/salt/pull/66703

I'm creating this PR after feedback from https://github.com/saltstack/salt/pull/66704 to push the code into `3006.x`.

### Explanation for the changes

**test_pip.py**: When we execute the tests from a virtual environment, this test fails, because there's an env variable that instructs pip where to install packages.

**test_fileserver.py**: When executed from a venv, the required `optimization_order` value changes due to different structure of the salt pkg (I believe).

~**test_transactional_update.py**: When we execute the test from a virtual environment, the `salt-call` binary uses a full path to the venv.~ - reverted, not sure why nox's venv doesn't use the full binary path. Will keep downstream only.

**test_msgpack.py**: This test now assumes that the installed `msgpack` has version 1.0.0 or higher. Consequently, I chose to mark the test as skipped in case the msgpack's real version is lower than 1.0.0.

**test_pycrypto.py**: This test was incorrect. If you take a look at https://github.com/m-czernek/salt/blob/master/tests/pytests/unit/utils/test_pycrypto.py#L45, you see that the test should be skipped in case `crypt` is unavailable. However, at https://github.com/m-czernek/salt/blob/master/tests/pytests/unit/utils/test_pycrypto.py#L60, we remove all crypt's methods. The test falls back to `passlib` methods, which is why it currently passes. 

**test_yaml.py** and **test_yamllint.py**: Both tests try to import `salt.utils.yamllint` as a way to check if yamllint is available. However, the module always imports (see https://github.com/saltstack/salt/blob/master/salt/utils/yamllint.py#L5-L12). Consequently, I used the [has_yamllint](https://github.com/saltstack/salt/blob/master/salt/utils/yamllint.py#L17) method to check if yamllint is available for the tests.  

But, we are already covering passlib testing in https://github.com/m-czernek/salt/blob/master/tests/pytests/unit/utils/test_pycrypto.py#L103. Consequently, we can either fix the test to actually test `crypt`, or remove the test as it is duplicated.

**NOTE** that with these changes, test pass _both_ inside _and_ outside of a virtual environment.

My testing is done at https://github.com/openSUSE/salt/pull/662. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
