### PR TITLE
[3006.x] Accept 2 as a valid exitcode for the nsis installer

### DIFF
--- a/tests/pytests/pkg/download/test_pkg_download.py
+++ b/tests/pytests/pkg/download/test_pkg_download.py
@@ -496,7 +496,7 @@ def setup_windows(
                 ret = shell.run(
                     "msiexec", "/qn", "/i", str(pkg_path), 'START_MINION=""'
                 )
-            assert ret.returncode == 0, ret
+            assert ret.returncode in (0, 2), ret
 
             log.debug("Removing installed salt-minion service")
             ret = shell.run(
@@ -508,7 +508,7 @@ def setup_windows(
                 "confirm",
                 check=False,
             )
-            assert ret.returncode == 0, ret
+            assert ret.returncode in (0, 2), ret
         else:
             # We are testing the onedir download
             onedir_name = f"salt-{salt_release}-onedir-windows-{arch}.zip"


### PR DESCRIPTION
### What does this PR do?
This is a workaround to the pkg test failures on Windows