### PR TITLE
[3006.x] Fix win_wua to handle empty CDispatch objects

### DIFF
--- a/changelog/66718.fixed.md
+++ b/changelog/66718.fixed.md
@@ -1,0 +1,2 @@
+Fixed ``win_wua.available`` when some of the update objects are empty CDispatch
+objects. The ``available`` function no longer crashes

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -528,14 +528,18 @@ class WindowsUpdateAgent:
         found = updates.updates
 
         for update in self._updates:
+            # Some update objects seem to be empty or undefined. Those will be
+            # exposed here if they are missing these attributes
+            try:
+                if salt.utils.data.is_true(update.IsHidden) and skip_hidden:
+                    continue
 
-            if salt.utils.data.is_true(update.IsHidden) and skip_hidden:
-                continue
+                if salt.utils.data.is_true(update.IsInstalled) and skip_installed:
+                    continue
 
-            if salt.utils.data.is_true(update.IsInstalled) and skip_installed:
-                continue
-
-            if salt.utils.data.is_true(update.IsMandatory) and skip_mandatory:
+                if salt.utils.data.is_true(update.IsMandatory) and skip_mandatory:
+                    continue
+            except AttributeError:
                 continue
 
             # Windows 10 build 2004 introduced some problems with the

--- a/tests/pytests/unit/utils/test_win_update.py
+++ b/tests/pytests/unit/utils/test_win_update.py
@@ -1,12 +1,50 @@
 import pytest
 
+try:
+    import win32com.client
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
 import salt.utils.win_update as win_update
 from tests.support.mock import MagicMock, patch
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_unless_on_windows,
+    pytest.mark.skipif(not HAS_WIN32, reason="Requires Win32 libraries"),
 ]
+
+
+def test_available_no_updates():
+    """
+    Test installed when there are no updates on the system
+    """
+    with patch("salt.utils.winapi.Com", autospec=True), patch(
+        "win32com.client.Dispatch", autospec=True
+    ), patch.object(win_update.WindowsUpdateAgent, "refresh", autospec=True):
+        wua = win_update.WindowsUpdateAgent(online=False)
+        wua._updates = []
+
+        available_updates = wua.available()
+
+        assert available_updates.updates.Add.call_count == 0
+
+
+def test_available_no_updates_empty_objects():
+    """
+    Test installed when there are no updates on the system
+    """
+    with patch("salt.utils.winapi.Com", autospec=True), patch(
+        "win32com.client.Dispatch", autospec=True
+    ), patch.object(win_update.WindowsUpdateAgent, "refresh", autospec=True):
+        wua = win_update.WindowsUpdateAgent(online=False)
+        wua._updates = [win32com.client.CDispatch, win32com.client.CDispatch]
+
+        available_updates = wua.available()
+
+        assert available_updates.updates.Add.call_count == 0
 
 
 def test_installed_no_updates():


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the ``win_wua.available`` function when there are no updates to install. The update searcher still returns some empty CDispatch objects. These are now skipped.

### What issues does this PR fix or reference?
Fixes #66718 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes