### PR TITLE
[DOCS] Update state_top_saltenv docs for cases where minion has explicit saltenv

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2395,7 +2395,11 @@ This option has no default value. Set it to an environment name to ensure that
 :ref:`highstate <running-highstate>`.
 
 .. note::
-    Using this value does not change the merging strategy. For instance, if
+    Minions which have an explicit :conf_minion:`saltenv` set will use that
+    environment's top file, ignoring this master config option.
+
+.. note::
+    Using this option does not change the merging strategy. For instance, if
     :conf_master:`top_file_merging_strategy` is set to ``merge``, and
     :conf_master:`state_top_saltenv` is set to ``foo``, then any sections for
     environments other than ``foo`` in the top file for the ``foo`` environment


### PR DESCRIPTION
In those cases, the explicit saltenv overrides this master config option.

### What does this PR do?

### What issues does this PR fix or reference?

Clarifies the behavior of [state_top_saltenv](https://docs.saltproject.io/en/latest/ref/configuration/master.html#state-top-saltenv).