### PR TITLE
[3006.x] Remove debug output from shell scripts for packaging

### DIFF
--- a/changelog/66747.fixed.md
+++ b/changelog/66747.fixed.md
@@ -1,0 +1,1 @@
+Remove debug output from shell scripts for packaging

--- a/pkg/debian/salt-api.postinst
+++ b/pkg/debian/salt-api.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-api.preinst
+++ b/pkg/debian/salt-api.preinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-cloud.postinst
+++ b/pkg/debian/salt-cloud.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-master.preinst
+++ b/pkg/debian/salt-master.preinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-minion.postinst
+++ b/pkg/debian/salt-minion.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 

--- a/pkg/debian/salt-minion.preinst
+++ b/pkg/debian/salt-minion.preinst
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 . /usr/share/debconf/confmodule
 


### PR DESCRIPTION
### What does this PR do?
Remove debug output from shell scripts for packaging for Debian/Ubunut

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66747

### Previous Behavior
Installs on Debian/Ubuntu provided debug output

### New Behavior
Installs on Debian/Ubuntu have no  debug output

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
