### PR TITLE
[3007.x] transports: fix and normalize PublishServer method signatures

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -930,7 +930,7 @@ class PubServerChannel:
 
         # If topics are upported, target matching has to happen master side
         match_targets = ["pcre", "glob", "list"]
-        if self.transport.topic_support and load["tgt_type"] in match_targets:
+        if self.transport.topic_support() and load["tgt_type"] in match_targets:
             # add some targeting stuff for lists only (for now)
             if load["tgt_type"] == "list":
                 int_payload["topic_lst"] = load["tgt"]

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1075,7 +1075,7 @@ class MasterPubServerChannel:
         finally:
             self.close()
 
-    async def handle_pool_publish(self, payload, _):
+    async def handle_pool_publish(self, payload):
         """
         Handle incomming events from cluster peer.
         """

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -4,6 +4,8 @@ import os
 import ssl
 import traceback
 import warnings
+from abc import ABC
+from abc import abstractmethod
 
 import salt.utils.stringutils
 
@@ -353,12 +355,13 @@ class DaemonizedRequestServer(RequestServer):
         raise NotImplementedError
 
 
-class PublishServer:
+class PublishServer(ABC):
     """
     The PublishServer publishes messages to PublishClients or to a borker
     service.
     """
 
+    @abstractmethod
     def publish(self, payload, **kwargs):
         """
         Publish "load" to minions. This send the load to the publisher daemon
@@ -374,9 +377,23 @@ class DaemonizedPublishServer(PublishServer):
     PublishServer that has a daemon associated with it.
     """
 
-    def pre_fork(self, process_manager):
+    @abstractmethod
+    def __init__(
+        self,
+        opts,
+        pub_host=None,
+        pub_port=None,
+        pub_path=None,
+        pull_host=None,
+        pull_port=None,
+        pull_path=None,
+        pull_path_perms=0o600,
+        pub_path_perms=0o600,
+        ssl=None,
+    ):
         raise NotImplementedError
 
+    @abstractmethod
     def publish_daemon(
         self,
         publish_payload,
@@ -395,6 +412,32 @@ class DaemonizedPublishServer(PublishServer):
                                               notify the channel a client is no
                                               longer present
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def pre_fork(self, process_manager):
+        raise NotImplementedError
+
+    @abstractmethod
+    def publisher(
+        self,
+        publish_payload,
+        presence_callback=None,
+        remove_presence_callback=None,
+        io_loop=None,
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def publish_payload(self, payload, topic_list=None):
+        raise NotImplementedError
+
+    @abstractmethod
+    def publish(self, payload, **kwargs):
+        raise NotImplementedError
+
+    @abstractmethod
+    def connect(self, timeout=None):
         raise NotImplementedError
 
 

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -121,7 +121,7 @@ def publish_server(opts, **kwargs):
 
     if not transcls.support_ssl():
         if "ssl" in kwargs:
-            log.warning(f"SSL is not supported for transport: {ttype}")
+            log.warning("SSL is not supported for transport: %s", ttype)
             kwargs.pop("ssl")
     return transcls(opts, **kwargs)
 

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -406,6 +406,11 @@ class DaemonizedPublishServer(PublishServer):
         raise NotImplementedError
 
     @abstractmethod
+    def topic_support(self):
+        """If the transport supports topics."""
+        raise NotImplementedError
+
+    @abstractmethod
     def publish_daemon(
         self,
         publish_payload,

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -4,8 +4,7 @@ import os
 import ssl
 import traceback
 import warnings
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 import salt.utils.stringutils
 

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -419,7 +419,7 @@ class DaemonizedPublishServer(PublishServer):
         raise NotImplementedError
 
     @abstractmethod
-    def publisher(
+    async def publisher(
         self,
         publish_payload,
         presence_callback=None,
@@ -429,7 +429,7 @@ class DaemonizedPublishServer(PublishServer):
         raise NotImplementedError
 
     @abstractmethod
-    def publish_payload(self, payload, topic_list=None):
+    async def publish_payload(self, payload, topic_list=None):
         raise NotImplementedError
 
     @abstractmethod

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -119,7 +119,7 @@ def publish_server(opts, **kwargs):
     else:
         raise Exception(f"Transport type not found: {ttype}")
 
-    if not transcls.support_ssl:
+    if not transcls.support_ssl():
         if "ssl" in kwargs:
             log.warning(f"SSL is not supported for transport: {ttype}")
             kwargs.pop("ssl")
@@ -399,10 +399,9 @@ class DaemonizedPublishServer(PublishServer):
     ):
         raise NotImplementedError
 
-    @property
     @classmethod
     @abstractmethod
-    def support_ssl(self):
+    def support_ssl(cls):
         """If the transport supports SSL then this should be True."""
         raise NotImplementedError
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1487,8 +1487,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             name=self.__class__.__name__,
         )
 
-    async def publish_payload(self, payload, *args):
-        return await self.pub_server.publish_payload(payload)
+    async def publish_payload(self, payload, topic_list=None):
+        return await self.pub_server.publish_payload(payload, topic_list)
 
     def connect(self, timeout=None):
         self.pub_sock = salt.utils.asynchronous.SyncWrapper(

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1222,25 +1222,6 @@ class TCPPuller:
         See https://tornado.readthedocs.io/en/latest/iostream.html#tornado.iostream.IOStream
         for additional details.
         """
-
-        async def _null(msg):
-            return
-
-        def write_callback(stream, header):
-            if header.get("mid"):
-
-                async def return_message(msg):
-                    pack = salt.transport.frame.frame_msg_ipc(
-                        msg,
-                        header={"mid": header["mid"]},
-                        raw_body=True,
-                    )
-                    await stream.write(pack)
-
-                return return_message
-            else:
-                return _null
-
         unpacker = salt.utils.msgpack.Unpacker(raw=False)
         while not stream.closed():
             try:
@@ -1251,7 +1232,6 @@ class TCPPuller:
                     self.io_loop.spawn_callback(
                         self.payload_handler,
                         body,
-                        write_callback(stream, framed_msg["head"]),
                     )
             except tornado.iostream.StreamClosedError:
                 if self.path:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1299,6 +1299,9 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
     Tornado based TCP PublishServer
     """
 
+    # Required from DaemonizedPublishServer
+    support_ssl = True
+
     # TODO: opts!
     # Based on default used in tornado.netutil.bind_sockets()
     backlog = 128
@@ -1320,8 +1323,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         pull_path=None,
         pull_path_perms=0o600,
         pub_path_perms=0o600,
-        ssl=None,
         started=None,
+        ssl=None,
     ):
         self.opts = opts
         self.pub_sock = None

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1344,8 +1344,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         # Required from DaemonizedPublishServer
         return True
 
-    @property
     def topic_support(self):
+        # Required from DaemonizedPublishServer
         return not self.opts.get("order_masters", False)
 
     def __setstate__(self, state):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1299,9 +1299,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
     Tornado based TCP PublishServer
     """
 
-    # Required from DaemonizedPublishServer
-    support_ssl = True
-
     # TODO: opts!
     # Based on default used in tornado.netutil.bind_sockets()
     backlog = 128
@@ -1341,6 +1338,11 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             self.started = multiprocessing.Event()
         else:
             self.started = started
+
+    @classmethod
+    def support_ssl(cls):
+        # Required from DaemonizedPublishServer
+        return True
 
     @property
     def topic_support(self):

--- a/salt/transport/ws.py
+++ b/salt/transport/ws.py
@@ -240,9 +240,6 @@ class PublishClient(salt.transport.base.PublishClient):
 class PublishServer(salt.transport.base.DaemonizedPublishServer):
     """ """
 
-    # Required from DaemonizedPublishServer
-    support_ssl = True
-
     # TODO: opts!
     # Based on default used in tornado.netutil.bind_sockets()
     backlog = 128
@@ -287,6 +284,11 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             self.started = multiprocessing.Event()
         else:
             self.started = started
+
+    @classmethod
+    def support_ssl(cls):
+        # Required from DaemonizedPublishServer
+        return True
 
     @property
     def topic_support(self):

--- a/salt/transport/ws.py
+++ b/salt/transport/ws.py
@@ -240,6 +240,9 @@ class PublishClient(salt.transport.base.PublishClient):
 class PublishServer(salt.transport.base.DaemonizedPublishServer):
     """ """
 
+    # Required from DaemonizedPublishServer
+    support_ssl = True
+
     # TODO: opts!
     # Based on default used in tornado.netutil.bind_sockets()
     backlog = 128
@@ -262,8 +265,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         pull_path=None,
         pull_path_perms=0o600,
         pub_path_perms=0o600,
-        ssl=None,
         started=None,
+        ssl=None,
     ):
         self.opts = opts
         self.pub_host = pub_host

--- a/salt/transport/ws.py
+++ b/salt/transport/ws.py
@@ -290,8 +290,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         # Required from DaemonizedPublishServer
         return True
 
-    @property
     def topic_support(self):
+        # Required from DaemonizedPublishServer
         return not self.opts.get("order_masters", False)
 
     def __setstate__(self, state):

--- a/salt/transport/ws.py
+++ b/salt/transport/ws.py
@@ -434,7 +434,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             )
         self._connecting = None
 
-    def connect(self):
+    def connect(self, timeout=None):
         log.debug("Connect pusher %s", self.pull_path)
         if self._connecting is None:
             self._connecting = asyncio.create_task(self._connect())
@@ -451,8 +451,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         self.pub_writer.write(salt.payload.dumps(payload, use_bin_type=True))
         await self.pub_writer.drain()
 
-    async def publish_payload(self, package, *args):
-        payload = salt.payload.dumps(package, use_bin_type=True)
+    async def publish_payload(self, payload, topic_list=None):
+        payload = salt.payload.dumps(payload, use_bin_type=True)
         for ws in list(self.clients):
             try:
                 await ws.send_bytes(payload)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -837,9 +837,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
     Encapsulate synchronous operations for a publisher channel
     """
 
-    # Required from DaemonizedPublishServer
-    support_ssl = False
-
     async_methods = [
         "publish",
     ]
@@ -887,6 +884,11 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             self.started = multiprocessing.Event()
         else:
             self.started = started
+
+    @classmethod
+    def support_ssl(cls):
+        # Required from DaemonizedPublishServer
+        return False
 
     def __repr__(self):
         return f"<PublishServer pub_uri={self.pub_uri} pull_uri={self.pull_uri} at {hex(id(self))}>"
@@ -1090,12 +1092,12 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             self.connect()
         await self.sock.send(payload)
 
+    def __enter__(self):
+        return self
+
     @property
     def topic_support(self):
         return self.opts.get("zmq_filtering", False)
-
-    def __enter__(self):
-        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -890,6 +890,10 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         # Required from DaemonizedPublishServer
         return False
 
+    def topic_support(self):
+        # Required from DaemonizedPublishServer
+        return self.opts.get("zmq_filtering", False)
+
     def __repr__(self):
         return f"<PublishServer pub_uri={self.pub_uri} pull_uri={self.pull_uri} at {hex(id(self))}>"
 
@@ -1094,10 +1098,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
 
     def __enter__(self):
         return self
-
-    @property
-    def topic_support(self):
-        return self.opts.get("zmq_filtering", False)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -856,6 +856,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         pull_path_perms=0o600,
         pub_path_perms=0o600,
         started=None,
+        ssl=None,
     ):
         self.opts = opts
         self.pub_host = pub_host
@@ -968,7 +969,13 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
                 )
         return pull_sock, pub_sock, monitor
 
-    async def publisher(self, publish_payload, io_loop=None):
+    async def publisher(
+        self,
+        publish_payload,
+        presence_callback=None,
+        remove_presence_callback=None,
+        io_loop=None,
+    ):
         if io_loop is None:
             io_loop = tornado.ioloop.IOLoop.current()
         self.daemon_context = zmq.asyncio.Context()

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -837,6 +837,9 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
     Encapsulate synchronous operations for a publisher channel
     """
 
+    # Required from DaemonizedPublishServer
+    support_ssl = False
+
     async_methods = [
         "publish",
     ]
@@ -856,7 +859,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         pull_path_perms=0o600,
         pub_path_perms=0o600,
         started=None,
-        ssl=None,
     ):
         self.opts = opts
         self.pub_host = pub_host

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -916,7 +916,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         run in a thread or process as it creates and runs its own ioloop.
         """
         ioloop = tornado.ioloop.IOLoop()
-        ioloop.add_callback(self.publisher, publish_payload, ioloop=ioloop)
+        ioloop.add_callback(self.publisher, publish_payload, io_loop=ioloop)
         try:
             ioloop.start()
         finally:
@@ -968,9 +968,9 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
                 )
         return pull_sock, pub_sock, monitor
 
-    async def publisher(self, publish_payload, ioloop=None):
-        if ioloop is None:
-            ioloop = tornado.ioloop.IOLoop.current()
+    async def publisher(self, publish_payload, io_loop=None):
+        if io_loop is None:
+            io_loop = tornado.ioloop.IOLoop.current()
         self.daemon_context = zmq.asyncio.Context()
         (
             self.daemon_pull_sock,

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -920,17 +920,17 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         This method represents the Publish Daemon process. It is intended to be
         run in a thread or process as it creates and runs its own ioloop.
         """
-        ioloop = tornado.ioloop.IOLoop()
-        ioloop.add_callback(self.publisher, publish_payload, io_loop=ioloop)
+        io_loop = tornado.ioloop.IOLoop()
+        io_loop.add_callback(self.publisher, publish_payload, io_loop=io_loop)
         try:
-            ioloop.start()
+            io_loop.start()
         finally:
             self.close()
 
-    def _get_sockets(self, context, ioloop):
+    def _get_sockets(self, context, io_loop):
         pub_sock = context.socket(zmq.PUB)
         monitor = ZeroMQSocketMonitor(pub_sock)
-        monitor.start_io_loop(ioloop)
+        monitor.start_io_loop(io_loop)
         _set_tcp_keepalive(pub_sock, self.opts)
         self.dpub_sock = pub_sock  # = zmq.eventloop.zmqstream.ZMQStream(pub_sock)
         # if 2.1 >= zmq < 3.0, we only have one HWM setting
@@ -987,7 +987,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             self.daemon_pull_sock,
             self.daemon_pub_sock,
             self.daemon_monitor,
-        ) = self._get_sockets(self.daemon_context, ioloop)
+        ) = self._get_sockets(self.daemon_context, io_loop)
         self.started.set()
         while True:
             try:

--- a/tests/pytests/functional/transport/tcp/test_pub_server.py
+++ b/tests/pytests/functional/transport/tcp/test_pub_server.py
@@ -16,14 +16,14 @@ async def test_pub_channel(master_opts, minion_opts, io_loop):
     master_opts["transport"] = "tcp"
     minion_opts.update(master_ip="127.0.0.1", transport="tcp")
 
-    server = salt.transport.tcp.TCPPublishServer(
+    server = salt.transport.tcp.PublishServer(
         master_opts,
         pub_host="127.0.0.1",
         pub_port=master_opts["publish_port"],
         pull_path=os.path.join(master_opts["sock_dir"], "publish_pull.ipc"),
     )
 
-    client = salt.transport.tcp.TCPPubClient(
+    client = salt.transport.tcp.PublishClient(
         minion_opts,
         io_loop,
         host="127.0.0.1",
@@ -34,7 +34,7 @@ async def test_pub_channel(master_opts, minion_opts, io_loop):
 
     publishes = []
 
-    async def publish_payload(payload, callback):
+    async def publish_payload(payload):
         await server.publish_payload(payload)
         payloads.append(payload)
 

--- a/tests/pytests/functional/transport/zeromq/test_pub_server_channel.py
+++ b/tests/pytests/functional/transport/zeromq/test_pub_server_channel.py
@@ -264,7 +264,7 @@ async def test_pub_channel(master_opts, io_loop):
     io_loop.add_callback(
         server.publisher,
         publish_payload,
-        ioloop=io_loop,
+        io_loop=io_loop,
     )
 
     await asyncio.sleep(3)
@@ -302,7 +302,7 @@ async def test_pub_channel_filtering(master_opts, io_loop):
     io_loop.add_callback(
         server.publisher,
         publish_payload,
-        ioloop=io_loop,
+        io_loop=io_loop,
     )
 
     await asyncio.sleep(3)
@@ -338,7 +338,7 @@ async def test_pub_channel_filtering_topic(master_opts, io_loop):
     io_loop.add_callback(
         server.publisher,
         publish_payload,
-        ioloop=io_loop,
+        io_loop=io_loop,
     )
 
     await asyncio.sleep(3)

--- a/tests/pytests/unit/transport/test_base.py
+++ b/tests/pytests/unit/transport/test_base.py
@@ -2,8 +2,6 @@
 Unit tests for salt.transport.base.
 """
 
-import importlib
-import inspect
 import ssl
 
 import pytest
@@ -14,19 +12,6 @@ from tests.support.mock import patch
 pytestmark = [
     pytest.mark.core_test,
 ]
-
-
-@pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
-def test_transport_publisher_has_required_args(kind):
-    # The publisher method on a transport PublishServer requires the following arguments
-    required_args = [
-        "publish_payload",
-        "io_loop",
-    ]
-    transport_mod = importlib.import_module(f"salt.transport.{kind}")
-    method_sig = inspect.signature(transport_mod.PublishServer.publisher)
-    for rarg in required_args:
-        assert rarg in method_sig.parameters
 
 
 def test_unclosed_warning():

--- a/tests/pytests/unit/transport/test_base.py
+++ b/tests/pytests/unit/transport/test_base.py
@@ -2,6 +2,8 @@
 Unit tests for salt.transport.base.
 """
 
+import importlib
+import inspect
 import ssl
 
 import pytest
@@ -12,6 +14,19 @@ from tests.support.mock import patch
 pytestmark = [
     pytest.mark.core_test,
 ]
+
+
+@pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
+def test_transport_publisher_has_required_args(kind):
+    # The publisher method on a transport PublishServer requires the following arguments
+    required_args = [
+        'publish_payload',
+        'io_loop',
+    ]
+    transport_mod = importlib.import_module('salt.transport.{0}'.format(kind))
+    method_sig = inspect.signature(transport_mod.PublishServer.publisher)
+    for rarg in required_args:
+        assert rarg in method_sig.parameters
 
 
 def test_unclosed_warning():

--- a/tests/pytests/unit/transport/test_base.py
+++ b/tests/pytests/unit/transport/test_base.py
@@ -20,10 +20,10 @@ pytestmark = [
 def test_transport_publisher_has_required_args(kind):
     # The publisher method on a transport PublishServer requires the following arguments
     required_args = [
-        'publish_payload',
-        'io_loop',
+        "publish_payload",
+        "io_loop",
     ]
-    transport_mod = importlib.import_module('salt.transport.{0}'.format(kind))
+    transport_mod = importlib.import_module(f"salt.transport.{kind}")
     method_sig = inspect.signature(transport_mod.PublishServer.publisher)
     for rarg in required_args:
         assert rarg in method_sig.parameters

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -1,0 +1,32 @@
+"""
+Unit tests for salt transports PublishServer.
+"""
+
+import importlib
+import inspect
+
+import pytest
+
+import salt.transport.base
+
+
+@pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
+def test_transport_publishserver_has_abstractmethods(kind):
+    transport_mod = importlib.import_module(f"salt.transport.{kind}")
+    abstractmethods = sorted(salt.transport.base.DaemonizedPublishServer.__abstractmethods__)
+    implemented = []
+    for methodname in abstractmethods:
+        method = getattr(transport_mod.PublishServer, methodname)
+        if not getattr(method, '__isabstractmethod__', False):
+            implemented.append(methodname)
+    assert implemented == abstractmethods
+
+@pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
+@pytest.mark.parametrize("method", salt.transport.base.DaemonizedPublishServer.__abstractmethods__)
+def test_transport_publishserver_has_method_signatures(kind, method):
+    transport_mod = importlib.import_module(f"salt.transport.{kind}")
+    method_sig = inspect.signature(getattr(transport_mod.PublishServer, method))
+    required_sig = inspect.signature(getattr(salt.transport.base.DaemonizedPublishServer, method))
+    # This print "OK" when it errors, but you have to dig through the message to find the
+    # difference. It may make more sense to create a easier to digest datastructure (list/dict).
+    assert method_sig == required_sig

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -41,7 +41,7 @@ def test_transport_publishserver_has_method_signatures(kind, method):
         # found on the Base class are on the child class and ignore any extras.
         method_params = list(method_sig.parameters.items())
         required_params = list(required_sig.parameters.items())
-        assert method_params[ :len(required_params)] == required_params
+        assert method_params[: len(required_params)] == required_params
     else:
         # This print "OK" when it errors, but you have to dig through the message to find the
         # difference. It may make more sense to create a easier to digest datastructure (list/dict).

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -13,20 +13,26 @@ import salt.transport.base
 @pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
 def test_transport_publishserver_has_abstractmethods(kind):
     transport_mod = importlib.import_module(f"salt.transport.{kind}")
-    abstractmethods = sorted(salt.transport.base.DaemonizedPublishServer.__abstractmethods__)
+    abstractmethods = sorted(
+        salt.transport.base.DaemonizedPublishServer.__abstractmethods__
+    )
     implemented = []
     for methodname in abstractmethods:
         method = getattr(transport_mod.PublishServer, methodname)
-        if not getattr(method, '__isabstractmethod__', False):
+        if not getattr(method, "__isabstractmethod__", False):
             implemented.append(methodname)
     assert implemented == abstractmethods
 
 @pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
-@pytest.mark.parametrize("method", salt.transport.base.DaemonizedPublishServer.__abstractmethods__)
+@pytest.mark.parametrize(
+    "method", salt.transport.base.DaemonizedPublishServer.__abstractmethods__
+)
 def test_transport_publishserver_has_method_signatures(kind, method):
     transport_mod = importlib.import_module(f"salt.transport.{kind}")
     method_sig = inspect.signature(getattr(transport_mod.PublishServer, method))
-    required_sig = inspect.signature(getattr(salt.transport.base.DaemonizedPublishServer, method))
+    required_sig = inspect.signature(
+        getattr(salt.transport.base.DaemonizedPublishServer, method)
+    )
     # This print "OK" when it errors, but you have to dig through the message to find the
     # difference. It may make more sense to create a easier to digest datastructure (list/dict).
     assert method_sig == required_sig

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -34,6 +34,15 @@ def test_transport_publishserver_has_method_signatures(kind, method):
     required_sig = inspect.signature(
         getattr(salt.transport.base.DaemonizedPublishServer, method)
     )
-    # This print "OK" when it errors, but you have to dig through the message to find the
-    # difference. It may make more sense to create a easier to digest datastructure (list/dict).
-    assert method_sig == required_sig
+    if method == '__init__':
+        # Treat init slightly differently. All other methods are generic and should have identical
+        # signatures. The __init__ function is called by the factory method which is expected to have
+        # knowledge of what parameters are available. Therefore we only check that the arguments
+        # found on the Base class are on the child class and ignore any extras.
+        method_params = list(method_sig.parameters.items())
+        required_params = list(required_sig.parameters.items())
+        assert method_params[:len(required_params)] == required_params
+    else:
+        # This print "OK" when it errors, but you have to dig through the message to find the
+        # difference. It may make more sense to create a easier to digest datastructure (list/dict).
+        assert method_sig == required_sig

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -23,6 +23,7 @@ def test_transport_publishserver_has_abstractmethods(kind):
             implemented.append(methodname)
     assert implemented == abstractmethods
 
+
 @pytest.mark.parametrize("kind", salt.transport.base.TRANSPORTS)
 @pytest.mark.parametrize(
     "method", salt.transport.base.DaemonizedPublishServer.__abstractmethods__

--- a/tests/pytests/unit/transport/test_publish_server.py
+++ b/tests/pytests/unit/transport/test_publish_server.py
@@ -34,14 +34,14 @@ def test_transport_publishserver_has_method_signatures(kind, method):
     required_sig = inspect.signature(
         getattr(salt.transport.base.DaemonizedPublishServer, method)
     )
-    if method == '__init__':
+    if method == "__init__":
         # Treat init slightly differently. All other methods are generic and should have identical
         # signatures. The __init__ function is called by the factory method which is expected to have
         # knowledge of what parameters are available. Therefore we only check that the arguments
         # found on the Base class are on the child class and ignore any extras.
         method_params = list(method_sig.parameters.items())
         required_params = list(required_sig.parameters.items())
-        assert method_params[:len(required_params)] == required_params
+        assert method_params[ :len(required_params)] == required_params
     else:
         # This print "OK" when it errors, but you have to dig through the message to find the
         # difference. It may make more sense to create a easier to digest datastructure (list/dict).


### PR DESCRIPTION
the arguments to publish, specifically io_loop, needs to be consistant across the different transports. This argument was not consistant and caused exceptions.