### PR TITLE
[3006.x] Skip pkg download test on Windows... for now

### DIFF
--- a/tests/pytests/pkg/download/test_pkg_download.py
+++ b/tests/pytests/pkg/download/test_pkg_download.py
@@ -556,6 +556,7 @@ def salt_test_command(request, install_dir):
     return command
 
 
+@pytest.mark.skip_on_windows(reason="This is flaky on Windows")
 @pytest.mark.parametrize("salt_test_command", get_salt_test_commands(), indirect=True)
 def test_download(shell, salt_test_command):
     """


### PR DESCRIPTION
### What does this PR do?
Skips the failing pkg download test on Windows. This is a fallback in case the fix (https://github.com/saltstack/salt/pull/66753) doesn't work
