### PR TITLE
[master] Check `master_alive_interval` on modifying schedule job

### DIFF
--- a/changelog/66757.fixed.md
+++ b/changelog/66757.fixed.md
@@ -1,0 +1,1 @@
+Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3028,7 +3028,10 @@ class Minion(MinionBase):
                     log.info("Minion is ready to receive requests!")
 
                     # update scheduled job to run with the new master addr
-                    if self.opts["transport"] != "tcp":
+                    if (
+                        self.opts["transport"] != "tcp"
+                        and self.opts["master_alive_interval"] > 0
+                    ):
                         schedule = {
                             "function": "status.master",
                             "seconds": self.opts["master_alive_interval"],
@@ -3077,7 +3080,10 @@ class Minion(MinionBase):
                 self.connected = True
                 # modify the __master_alive job to only fire,
                 # if the connection is lost again
-                if self.opts["transport"] != "tcp":
+                if (
+                    self.opts["transport"] != "tcp"
+                    and self.opts["master_alive_interval"] > 0
+                ):
                     schedule = {
                         "function": "status.master",
                         "seconds": self.opts["master_alive_interval"],


### PR DESCRIPTION
### What does this PR do?

Looks like there is a part of condition is missing with https://github.com/saltstack/salt/pull/30488
As the result schedule jobs could be created with 1 second interval even if `master_alive_interval` was not specified.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/24871

### Previous Behavior
Unnecessary schedule job could be created while not really expected.

### New Behavior
No unnecessary schedule job creation.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
