### PR TITLE
[master] Handle disconnects from with ZeroMQ and make it re-resolve master IP

### DIFF
--- a/changelog/66760.added.md
+++ b/changelog/66760.added.md
@@ -1,0 +1,1 @@
+Added possibility for the minion to reconnect to the master on it's IP address change with using ZeroMQ

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -79,7 +79,7 @@ elif salt.utils.platform.is_darwin():
 else:
     _DFLT_IPC_MODE = "ipc"
     _DFLT_FQDNS_GRAINS = False
-    _MASTER_TRIES = 1
+    _MASTER_TRIES = -1
     _MASTER_USER = salt.utils.user.get_user()
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1406,7 +1406,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "username": None,
         "password": None,
         "zmq_filtering": False,
-        "zmq_monitor": False,
+        "zmq_monitor": True,
         "cache_sreqs": True,
         "cmd_safe": True,
         "sudo_user": "",

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -325,6 +325,12 @@ class PublishClient(salt.transport.base.PublishClient):
                 master_pub_uri,
             )
             self._socket.connect(master_pub_uri)
+        if (
+            hasattr(self, "_monitor")
+            and self._monitor is not None
+            and disconnect_callback is not None
+        ):
+            self._monitor.disconnect_callback = disconnect_callback
         if connect_callback:
             await connect_callback(True)
 
@@ -1637,6 +1643,12 @@ class ZeroMQSocketMonitor:
         log.debug("ZeroMQ event: %s", evt)
         if evt["event"] == zmq.EVENT_MONITOR_STOPPED:
             self.stop()
+        elif evt["event"] == zmq.EVENT_DISCONNECTED:
+            if (
+                hasattr(self, "disconnect_callback")
+                and self.disconnect_callback is not None
+            ):
+                self.disconnect_callback()
 
     def stop(self):
         if self._socket is None:
@@ -1652,6 +1664,7 @@ class ZeroMQSocketMonitor:
                 pass
         self._socket = None
         self._running.clear()
+        self._monitor_socket.close()
         self._monitor_socket = None
         log.trace("Event monitor done!")
 

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -18,6 +18,7 @@ def salt_minion_retry(salt_master, salt_minion_id):
         "fips_mode": FIPS_TESTRUN,
         "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
         "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
+        "zmq_monitor": False,
     }
     factory = salt_master.salt_minion_daemon(
         random_string("retry-minion-"),

--- a/tests/pytests/scenarios/multimaster/conftest.py
+++ b/tests/pytests/scenarios/multimaster/conftest.py
@@ -157,6 +157,8 @@ def mm_master_2_salt_cli(salt_mm_master_2):
 def _salt_mm_minion_1(_salt_mm_master_1, _salt_mm_master_2):
     config_defaults = {
         "transport": _salt_mm_master_1.config["transport"],
+        "zmq_monitor": False,
+        "master_tries": 1,
     }
 
     mm_master_1_port = _salt_mm_master_1.config["ret_port"]
@@ -218,6 +220,8 @@ def salt_mm_minion_1(_salt_mm_minion_1, salt_mm_master_1, salt_mm_master_2):
 def _salt_mm_minion_2(_salt_mm_master_1, _salt_mm_master_2):
     config_defaults = {
         "transport": _salt_mm_master_1.config["transport"],
+        "zmq_monitor": False,
+        "master_tries": 1,
     }
 
     mm_master_1_port = _salt_mm_master_1.config["ret_port"]

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1640,6 +1640,7 @@ async def test_master_type_failover(minion_opts):
             "master": ["master1", "master2"],
             "__role": "",
             "retry_dns": 0,
+            "master_tries": 1,
         }
     )
 


### PR DESCRIPTION
### What does this PR do?

With `ZeroMQ` transport the `disconnect_callback` was not called and because of it there was no way to re-resolve IP address as `ZeroMQ` socket is trying to reconnect to the master internally, while FQDN to IP resolution was performed before the connect call and IP address is used in the URI of the master to connect to, so in case of changing FQDN to IP assignment of the master there was no way to detect it and react properly.

With this PR the behaviour is changing and `salt.transport.zeromq.ZeroMQSocketMonitor` is used to detect disconnects and `zmq_monitor` config value is changed to `True` by default to make it working.

It seems that it also makes sense to set `master_tries` to `-1` as the default value to make it possible to keep trying to reconnect to the master.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/24871

### Previous Behavior
Minion is getting stuck trying to reconnect to the master using old IP address in case if the IP address of the master has changed in DNS.

### New Behavior
Minion is able to reconnect to the master using its new IP address. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
