### PR TITLE
[master] Don't crash if dmesg contains non-utf8 characters

### DIFF
--- a/changelog/66764.fixed.md
+++ b/changelog/66764.fixed.md
@@ -1,0 +1,1 @@
+Fix a crash on startup on FreeBSD when /var/run/dmesg.boot contains non-UTF8 characters.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -460,7 +460,9 @@ def _bsd_cpudata(osdata):
     if osdata["kernel"] == "FreeBSD" and os.path.isfile("/var/run/dmesg.boot"):
         grains["cpu_flags"] = []
         # TODO: at least it needs to be tested for BSD other then FreeBSD
-        with salt.utils.files.fopen("/var/run/dmesg.boot", "r") as _fp:
+        with salt.utils.files.fopen(
+            "/var/run/dmesg.boot", "r", encoding="utf8", errors="ignore"
+        ) as _fp:
             cpu_here = False
             for line in _fp:
                 if line.startswith("CPU: "):

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -4958,6 +4958,54 @@ em0: link state changed to UP"""
                     ]
 
 
+def test__bsd_cpudata_freebsd_non_utf8(tmp_path):
+    """
+    Regression test for #66764.
+
+    /var/run/dmesg.boot can contain non-UTF-8 bytes (e.g. when a connected
+    device exposes a serial number with non-UTF-8 characters). Loading the
+    "cpu_flags" grain on FreeBSD must not raise UnicodeDecodeError in that
+    case; the offending bytes should be skipped and the readable CPU
+    features still extracted.
+    """
+    boot = tmp_path / "dmesg.boot"
+    # The CPU: line contains non-UTF-8 bytes (0xff, 0xfe) that would crash
+    # a strict utf-8 decode. The Features= line is valid ASCII and must
+    # still be parsed.
+    boot.write_bytes(
+        b"CPU: Intel(R) Test CPU \xff\xfe garbage\n"
+        b'  Origin="GenuineIntel"\n'
+        b"  Features=0x1<FPU,VME,DE>\n"
+        b"real memory = 0\n"
+    )
+
+    osdata = {"kernel": "FreeBSD"}
+    mock_cmd_run = ["1", "amd64", "Intel(R) Test CPU"]
+
+    # Delegate to the real open() so the encoding/errors kwargs added by
+    # the fix are actually exercised against the non-UTF-8 bytes on disk.
+    # Using open() directly here (rather than salt.utils.files.fopen) is
+    # intentional: salt.utils.files.fopen is what we are patching.
+    def _real_fopen(_path, *args, **kwargs):
+        return open(  # pylint: disable=resource-leakage,unspecified-encoding
+            str(boot), *args, **kwargs
+        )
+
+    with patch("salt.utils.path.which", return_value="/sbin/sysctl"):
+        with patch.dict(
+            core.__salt__,
+            {"cmd.run": MagicMock(side_effect=mock_cmd_run)},
+        ):
+            with patch("os.path.isfile", return_value=True):
+                with patch("salt.utils.files.fopen", side_effect=_real_fopen):
+                    # The pre-fix code raised UnicodeDecodeError here.
+                    ret = core._bsd_cpudata(osdata)
+
+    assert "cpu_flags" in ret
+    assert ret["cpu_flags"] == ["FPU", "VME", "DE"]
+    assert ret["num_cpus"] == 1
+
+
 def test__bsd_cpudata_netbsd():
     """
     test _bsd_cpudata for NetBSD


### PR DESCRIPTION
On FreeBSD Salt scrapes /var/run/dmesg.boot to set the "cpu_flags" grain.  But it's possible for that file to contain non-UTF-8 characters. Skipping over such characters is better than crashing.

### What does this PR do?

Fixes a crash on startup on FreeBSD systems if non-UTF8 data is present in /var/run/dmesg.boot . That can happen, for example, if a connected SAS device has a serial number containing non-UTF8 characters.

### Previous Behavior
On such systems, Salt would crash on startup with an error like this:
```
2022-06-30 13:54:03,038 [salt.log.setup   :911 ][ERROR   ][25928] An un-handled exception was caught by salt's global exception handler:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 470: invalid start byte
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 33, in <module>
    sys.exit(load_entry_point('salt==3004', 'console_scripts', 'salt-call')())
  File "/usr/local/lib/python3.8/site-packages/salt/scripts.py", line 432, in salt_call
    client.run()
  File "/usr/local/lib/python3.8/site-packages/salt/cli/call.py", line 45, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 55, in factory
    return ZeroMQCaller(opts, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 319, in _init_
    super()._init_(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 79, in _init_
    self.minion = salt.minion.SMinion(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/minion.py", line 926, in _init_
    opts["grains"] = salt.loader.grains(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/_init_.py", line 909, in grains
    ret = funcs[key]()
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 149, in _call_
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 1201, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 1216, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/grains/core.py", line 2251, in os_data
    grains.update(_bsd_cpudata(grains))
  File "/usr/local/lib/python3.8/site-packages/salt/grains/core.py", line 412, in _bsd_cpudata
    for line in _fp:
  File "/usr/local/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 470: invalid start byte
```

### New Behavior
Salt will skip over the illegal bytes in /var/run/dmesg.boot .

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes