### PR TITLE
[master] Do not use deprecated ssl.PROTOCOL_TLS

### DIFF
--- a/changelog/66767.changed.md
+++ b/changelog/66767.changed.md
@@ -1,0 +1,3 @@
+Do not use `ssl.PROTOCOL_TLS` which has been
+[deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+Python 3.10 will be removed in the future.

--- a/salt/transport/base.py
+++ b/salt/transport/base.py
@@ -510,13 +510,14 @@ def ssl_context(ssl_options, server_side=False):
     backwards compatability older ssl config settings but adds verify_locations
     and verify_flags options.
     """
-    default_version = ssl.PROTOCOL_TLS
     if server_side:
         default_version = ssl.PROTOCOL_TLS_SERVER
         purpose = ssl.Purpose.CLIENT_AUTH
     elif server_side is not None:
         default_version = ssl.PROTOCOL_TLS_CLIENT
         purpose = ssl.Purpose.SERVER_AUTH
+    else:
+        raise ValueError("server_side must be True or False")
     # Use create_default_context to start with what Python considers resonably
     # secure settings.
     context = ssl.create_default_context(purpose)

--- a/tests/pytests/unit/transport/test_base.py
+++ b/tests/pytests/unit/transport/test_base.py
@@ -76,3 +76,9 @@ def test_ssl_context_opts(mock):
     assert ssl.VerifyMode.CERT_OPTIONAL == ctx.verify_mode
     assert ctx.check_hostname
     assert ssl.VerifyFlags.VERIFY_CRL_CHECK_CHAIN & ctx.verify_flags
+
+
+def test_ssl_context_server_side_none_raises_error():
+    """Test that server_side=None raises ValueError."""
+    with pytest.raises(ValueError, match="server_side must be True or False"):
+        salt.transport.base.ssl_context({}, server_side=None)


### PR DESCRIPTION
This has been deprecated in Python 3.10[1] and will be removed in the
future.

[1] https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
