### PR TITLE
[3006.x] Replace Slack with Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Salt Community Slack
-    url: https://saltstackcommunity.slack.com/
+  - name: Salt Community Discord
+    url: https://discord.com/invite/J7b7EscrAs
     about: Please ask and answer questions here.
   - name: Salt-Users Forum
     url: https://groups.google.com/forum/#!forum/salt-users

--- a/.github/ISSUE_TEMPLATE/tech-debt.md
+++ b/.github/ISSUE_TEMPLATE/tech-debt.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ### Description of the tech debt to be addressed, include links and screenshots
-<!-- Note: Please direct questions to the salt-users google group, IRC or Community Slack. -->
+<!-- Note: Please direct questions to the salt-users google group, IRC or Community Discord. -->
 
 ### Versions Report
 (Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions.)

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -13,7 +13,7 @@ newIssueWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://via.vmw.com/salt-slack)
+    - [Join our Community Discord](https://discord.com/invite/J7b7EscrAs)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)
@@ -39,7 +39,7 @@ newPRWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://via.vmw.com/salt-slack)
+    - [Join our Community Discord](https://discord.com/invite/J7b7EscrAs)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ in a number of ways:
 -  Use Salt and open well-written bug reports.
 -  Join a `working group <https://github.com/saltstack/community>`__.
 -  Answer questions on `irc <https://web.libera.chat/#salt>`__,
-   the `community Slack <https://via.vmw.com/salt-slack>`__,
+   the `community Discord <https://discord.com/invite/J7b7EscrAs>`__,
    the `salt-users mailing
    list <https://groups.google.com/forum/#!forum/salt-users>`__,
    `Server Fault <https://serverfault.com/questions/tagged/saltstack>`__,
@@ -109,7 +109,7 @@ Then activate it:
 
 Sweet! Now you're ready to clone Salt so you can start hacking away! If
 you get stuck at any point, check out the resources at the beginning of
-this guide. IRC and Slack are particularly helpful places to go.
+this guide. IRC and Discord are particularly helpful places to go.
 
 
 Get the source!
@@ -605,7 +605,7 @@ your PR is submitted during the week you should be able to expect some
 kind of communication within that business day. If your tests are
 passing and we're not in a code freeze, ideally your code will be merged
 that week or month. If you haven't heard from your assigned reviewer, ping them
-on GitHub, `irc <https://web.libera.chat/#salt>`__, or Community Slack.
+on GitHub, `irc <https://web.libera.chat/#salt>`__, or Community Discord.
 
 It's likely that your reviewer will leave some comments that need
 addressing - it may be a style change, or you forgot a changelog entry,

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,8 @@ Report bugs or problems using Salt by opening an issue: `<https://github.com/sal
 
 To join our community forum where you can exchange ideas, best practices,
 discuss technical support questions, and talk to project maintainers, join our
-Discord workspace: `Salt Project Community Discord`_
+Discord server: `Salt Project Community Discord`_
+
 
 
 Salt Project documentation

--- a/SUPPORT.rst
+++ b/SUPPORT.rst
@@ -8,10 +8,10 @@ it may take a few moments for someone to reply.
 
 `<https://web.libera.chat/#salt>`_
 
-**SaltStack Slack** - Alongside IRC is our SaltStack Community Slack for the
+**SaltStack Slack** - Alongside IRC is our SaltStack Community Discord for the
 SaltStack Working groups. Use the following link to request an invitation.
 
-`<https://via.vmw.com/salt-slack>`_
+`<https://discord.com/invite/J7b7EscrAs>`_
 
 **Mailing List** - The SaltStack community users mailing list is hosted by
 Google groups. Anyone can post to ask questions about SaltStack products and

--- a/doc/_incl/requisite_incl.rst
+++ b/doc/_incl/requisite_incl.rst
@@ -7,4 +7,4 @@ following the instructions in the
     The Salt Project community can help offer advice and help troubleshoot
     technical issues as you're learning about Salt. One of the best places to
     talk to the community is on the
-    `Salt Project Slack workspace <https://saltstackcommunity.slack.com/>`_.
+    `Salt Project Discord Community <https://discord.com/invite/J7b7EscrAs>`_.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,7 +180,7 @@ rst_prolog = """\
 .. _`salt-users`: https://groups.google.com/forum/#!forum/salt-users
 .. _`salt-announce`: https://groups.google.com/forum/#!forum/salt-announce
 .. _`salt-packagers`: https://groups.google.com/forum/#!forum/salt-packagers
-.. _`salt-slack`: https://via.vmw.com/salt-slack
+.. _`salt-discord`: https://discord.com/invite/J7b7EscrAs
 .. |windownload| raw:: html
 
      <p>Python3 x86: <a

--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -123,4 +123,4 @@ In addition to the mailing lists, SaltStack also provides the following resource
 
 * `SaltStack Security Announcements <https://www.saltstack.com/security-announcements/>`__ landing page
 * `SaltStack Security RSS Feed <http://www.saltstack.com/feed/?post_type=security>`__
-* `SaltStack Community Slack Workspace <http://saltstackcommunity.slack.com/>`__
+* `Salt Project Discord Community <https://discord.com/invite/J7b7EscrAs>`__

--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -222,7 +222,7 @@ repository in your own account on GitHub and notify a SaltStack employee when
 it is ready. We will add you to the Contributors team on the
 `saltstack-formulas`_ organization and help you transfer the repository over.
 Ping a SaltStack employee on IRC (`#salt`_ on LiberaChat), join the
-``#formulas`` channel on the `salt-slack`_ (bridged to ``#saltstack-formulas``
+``#formulas`` channel on the `salt-discord`_ (bridged to ``#saltstack-formulas``
 on LiberaChat) or send an email to the `salt-users`_ mailing list.  Note that
 IRC logs are available at http://ngxbot.nginx.org/logs/%23salt/ and archives
 for FreeNode (up to mid-June 2021) https://logbot-archive.s3.amazonaws.com/freenode/salt.gz

--- a/doc/topics/development/conventions/release.rst
+++ b/doc/topics/development/conventions/release.rst
@@ -46,7 +46,7 @@ example):
 #. Publish the docs.
 #. Create release at `github`_
 #. Update win-repo-ng with new salt versions.
-#. Announce release is live to irc, salt-users, salt-announce and release slack
+#. Announce release is live to irc, salt-users, salt-announce and release discord
    community channel.
 
 
@@ -79,7 +79,7 @@ for a bugfix release.
 #. Publish the docs.
 #. Create release at `github`_
 #. Update win-repo-ng with new salt versions.
-#. Announce release is live to irc, salt-users, salt-announce and release slack channel.
+#. Announce release is live to irc, salt-users, salt-announce and release discord channel.
 
 .. _`github`: https://github.com/saltstack/salt/releases
 .. _`repo.saltproject.io`: https://repo.saltproject.io

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -211,7 +211,7 @@ can be found on GitHub in the `saltstack-formulas`_ collection of repositories.
 If you have any questions, suggestions, or just want to chat with other people
 who are using Salt, we have a very active community and we'd love to hear from
 you. One of the best places to talk to the community is on the
-`Salt Project Slack workspace <https://saltstackcommunity.slack.com/>`_.
+`Salt Project Discord Community <https://discord.com/invite/J7b7EscrAs>`_.
 
 In addition, by continuing to the :ref:`Orchestrate Runner <orchestrate-runner>` docs,
 you can learn about the powerful orchestration of which Salt is capable.


### PR DESCRIPTION
### What does this PR do?

Replace Slack community links with Discord

https://www.reddit.com/r/saltstack/comments/1ecppqn/thoughts_on_the_purge_of_community_extensions/lf1smr8/

Fixes: #66573

### Merge requirements satisfied?

- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No