### PR TITLE
[master] Fix the SELinux context for Salt Minion service

### DIFF
--- a/changelog/66779.fixed.md
+++ b/changelog/66779.fixed.md
@@ -1,0 +1,1 @@
+Fix the SELinux context for Salt Minion service to "unconfined_t"

--- a/pkg/common/salt-minion.service
+++ b/pkg/common/salt-minion.service
@@ -9,6 +9,7 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/deb/salt-minion.service
+++ b/pkg/old/deb/salt-minion.service
@@ -8,6 +8,7 @@ KillMode=process
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service
+++ b/pkg/old/suse/salt-minion.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service.rhel7
+++ b/pkg/old/suse/salt-minion.service.rhel7
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/pytests/pkg/integration/test_systemd_config.py
+++ b/tests/pytests/pkg/integration/test_systemd_config.py
@@ -43,3 +43,18 @@ def test_system_config(grains):
             "systemctl show -p ${config} salt-minion.service", shell=True
         )
         assert ret == expected_retcode
+
+
+@pytest.mark.usefixtures("salt_minion")
+def test_systemd_selinux_config(grains):
+    """
+    Test systemd selinux config
+    """
+    if grains["init"] == "systemd":
+        ret = subprocess.run(
+            "systemctl show -p SELinuxContext salt-minion.service",
+            shell=True,
+            check=False,
+            capture_output=True,
+        )
+        assert "system_u:system_r:unconfined_t:s0" in ret.stdout.decode()


### PR DESCRIPTION
### What does this PR do?

**IMPORTANT:** This error is only seen when `salt-minion` is a service started by systemd, as it gets `unconfined_service_t` context. It doesn't happen if `salt-minion` is executed manually or `salt-call` is used.

**NOTE:** Currently there are no SELinux policies for Salt. Until we have a dedicated SELinux domain for Salt Minion, this PR implements a workaround to this issue.

By default, the Salt Minion systemd service runs as `unconfined_service_t` when SELinux is enabled. This works fine in most cases but generates a problem then trying to transition to an `unconfined_t` domain, i.a. when running `cmd.run env runas=nobody`.

Then we see this denied in audit logs:

```
type=AVC msg=audit(1722870119.142:718): avc:  denied  { transition } for  pid=3421 comm="su" path="/usr/bin/bash" dev="vda3" ino=28565 scontext=system_u:system_r:unconfined_service_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0 tclass=process permissive=0
```

(This happens for "cmd.run" at the time of trying to invoke a shell as a different user to gather the environment variables from this particular user)

The issue produces an ERROR message in the Salt logs but the command execution usually works fine (as long as your command is not relying on any of the missing environment variables, as they are not really in place at the time of executing the command)

Fixing the SELinuxContext for the Salt Minion systemd service to a general `unconfined_t` workarounds this situation.

SELinuxContext attribute was added on systemd version 209. If SELinux is disabled or not installed, then this directive is just ignored: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#SELinuxContext=

When systemd version is lower than 209, like in an old CentOS 7.0, having a service with `SELinuxContext` directive will produces this message in the journal at "daemon-reload":
```
systemd[1]: [/usr/lib/systemd/system/firewalld.service:17] Unknown lvalue 'SELinuxContext' in section 'Service'
```
But it does not produce any error and the service is able to start.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66779

### Previous Behavior
```console
minion # su -c env nobody
[... all expected environment variables ...]

master # salt MINION cmd.run env runas=nobody
[... NOT all expected environment variables ..]
```

An ERROR message is produced in the Salt logs and denied AVC  message on `/var/log/audit.log`.

### New Behavior
```console
minion # su -c env nobody
[... all expected environment variables ...]

master # salt MINION cmd.run env runas=nobody
[... all expected environment variables ...]
``` 

No denied message or error seen.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
