### PR TITLE
[3006.x] fix yaml output

### DIFF
--- a/changelog/66783.fixed.md
+++ b/changelog/66783.fixed.md
@@ -1,0 +1,1 @@
+fix yaml output

--- a/salt/state.py
+++ b/salt/state.py
@@ -51,7 +51,7 @@ from salt.exceptions import CommandExecutionError, SaltRenderError, SaltReqTimeo
 from salt.serializers.msgpack import deserialize as msgpack_deserialize
 from salt.serializers.msgpack import serialize as msgpack_serialize
 from salt.template import compile_template, compile_template_str
-from salt.utils.odict import DefaultOrderedDict, OrderedDict
+from salt.utils.odict import DefaultOrderedDict, HashableOrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -125,11 +125,6 @@ STATE_RUNTIME_KEYWORDS = frozenset(
 STATE_INTERNAL_KEYWORDS = STATE_REQUISITE_KEYWORDS.union(
     STATE_REQUISITE_IN_KEYWORDS
 ).union(STATE_RUNTIME_KEYWORDS)
-
-
-class HashableOrderedDict(OrderedDict):
-    def __hash__(self):
-        return id(self)
 
 
 def split_low_tag(tag):

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -62,3 +62,8 @@ class DefaultOrderedDict(OrderedDict):
         return "DefaultOrderedDict({}, {})".format(
             self.default_factory, super().__repr__()
         )
+
+
+class HashableOrderedDict(OrderedDict):
+    def __hash__(self):
+        return id(self)

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -13,7 +13,7 @@ import collections
 import yaml  # pylint: disable=blacklisted-import
 
 import salt.utils.context
-from salt.utils.odict import OrderedDict
+from salt.utils.odict import HashableOrderedDict, OrderedDict
 
 try:
     from yaml import CDumper as Dumper
@@ -71,7 +71,9 @@ def represent_undefined(dumper, data):
 
 
 OrderedDumper.add_representer(OrderedDict, represent_ordereddict)
+OrderedDumper.add_representer(HashableOrderedDict, represent_ordereddict)
 SafeOrderedDumper.add_representer(OrderedDict, represent_ordereddict)
+SafeOrderedDumper.add_representer(HashableOrderedDict, represent_ordereddict)
 SafeOrderedDumper.add_representer(None, represent_undefined)
 
 OrderedDumper.add_representer(

--- a/tests/unit/utils/test_yamldumper.py
+++ b/tests/unit/utils/test_yamldumper.py
@@ -2,7 +2,11 @@
     Unit tests for salt.utils.yamldumper
 """
 
+from collections import OrderedDict, defaultdict
+
 import salt.utils.yamldumper
+from salt.utils.context import NamespacedDictWrapper
+from salt.utils.odict import HashableOrderedDict
 from tests.support.unit import TestCase
 
 
@@ -34,4 +38,81 @@ class YamlDumperTestCase(TestCase):
         assert (
             salt.utils.yamldumper.safe_dump(data, default_flow_style=False)
             == "foo: bar\n"
+        )
+
+    def test_yaml_ordered_dump(self):
+        """
+        Test yaml.dump with OrderedDict
+        """
+        data = OrderedDict([("foo", "bar"), ("baz", "qux")])
+        exp_yaml = "{foo: bar, baz: qux}\n"
+        assert (
+            salt.utils.yamldumper.dump(data, Dumper=salt.utils.yamldumper.OrderedDumper)
+            == exp_yaml
+        )
+
+    def test_yaml_safe_ordered_dump(self):
+        """
+        Test yaml.safe_dump with OrderedDict
+        """
+        data = OrderedDict([("foo", "bar"), ("baz", "qux")])
+        exp_yaml = "{foo: bar, baz: qux}\n"
+        assert salt.utils.yamldumper.safe_dump(data) == exp_yaml
+
+    def test_yaml_indent_safe_ordered_dump(self):
+        """
+        Test yaml.dump with IndentedSafeOrderedDumper
+        """
+        data = OrderedDict([("foo", ["bar", "baz"]), ("qux", "quux")])
+        exp_yaml = "foo:\n- bar\n- baz\nqux: quux\n"
+        assert (
+            salt.utils.yamldumper.dump(
+                data,
+                Dumper=salt.utils.yamldumper.IndentedSafeOrderedDumper,
+                default_flow_style=False,
+            )
+            == exp_yaml
+        )
+
+    def test_yaml_defaultdict_dump(self):
+        """
+        Test yaml.dump with defaultdict
+        """
+        data = defaultdict(list)
+        data["foo"].append("bar")
+        exp_yaml = "foo: [bar]\n"
+        assert salt.utils.yamldumper.safe_dump(data) == exp_yaml
+
+    def test_yaml_namespaced_dict_wrapper_dump(self):
+        """
+        Test yaml.dump with NamespacedDictWrapper
+        """
+        data = NamespacedDictWrapper({"test": {"foo": "bar"}}, "test")
+        exp_yaml = (
+            "!!python/object/new:salt.utils.context.NamespacedDictWrapper\n"
+            "dictitems: {foo: bar}\n"
+            "state:\n"
+            "  _NamespacedDictWrapper__dict:\n"
+            "    test: {foo: bar}\n"
+            "  pre_keys: !!python/tuple [test]\n"
+        )
+        assert salt.utils.yamldumper.dump(data) == exp_yaml
+
+    def test_yaml_undefined_dump(self):
+        """
+        Test yaml.safe_dump with None
+        """
+        data = {"foo": None}
+        exp_yaml = "{foo: null}\n"
+        assert salt.utils.yamldumper.safe_dump(data) == exp_yaml
+
+    def test_yaml_hashable_ordered_dict_dump(self):
+        """
+        Test yaml.dump with HashableOrderedDict
+        """
+        data = HashableOrderedDict([("foo", "bar"), ("baz", "qux")])
+        exp_yaml = "{foo: bar, baz: qux}\n"
+        assert (
+            salt.utils.yamldumper.dump(data, Dumper=salt.utils.yamldumper.OrderedDumper)
+            == exp_yaml
         )


### PR DESCRIPTION
In b9be2de, OrderedDict was replaced with HashableOrderedDict. Add logic to yamldumper to handle the new type.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes #66594 

### Previous Behavior

```
% sudo salt-call state.show_sls salt.netbox-download --out=yaml
local: NULL
%
```

### New Behavior

```
% sudo salt-call state.show_sls salt.netbox-download --out=yaml
local:
  salt.netbox-download_manage_file_netbox-download.sh:
    file:
    - name: /bootstrap/netbox-download.sh
    - source: salt://salt/netbox-download/files/netbox-download.sh
    - mode: '0755'
    - managed
    - order: 10002
...
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
