### PR TITLE
[3006.x] Move grain_opts to subdict to prevent overwriting core grains

### DIFF
--- a/changelog/66784.fixed.md
+++ b/changelog/66784.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue where enabling `grain_opts` in the minion config would cause
+some core grains to be overwritten.

--- a/salt/grains/opts.py
+++ b/salt/grains/opts.py
@@ -11,5 +11,5 @@ def opts():
     if __opts__.get("grain_opts", False) or (
         isinstance(__pillar__, dict) and __pillar__.get("grain_opts", False)
     ):
-        return __opts__
+        return {"opts": __opts__}
     return {}

--- a/tests/pytests/unit/grains/test_opts.py
+++ b/tests/pytests/unit/grains/test_opts.py
@@ -1,0 +1,20 @@
+"""
+tests.pytests.unit.grains.test_opts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import salt.grains.opts as opts
+from tests.support.mock import patch
+
+
+def test_grain_opts_does_not_overwrite_core_grains(tmp_path):
+    """
+    Tests that enabling grain_opts doesn't overwrite the core grains
+
+    See: https://github.com/saltstack/salt/issues/66784
+    """
+    dunder_opts = {"grain_opts": True}
+
+    with patch.object(opts, "__opts__", dunder_opts, create=True):
+        with patch.object(opts, "__pillar__", {}, create=True):
+            assert opts.opts() == {"opts": dunder_opts}


### PR DESCRIPTION
### What does this PR do?

Moves the grains added when `grain_opts: True` is set in the minion config into a subdict.

### What issues does this PR fix or reference?
Fixes #66784

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No