### PR TITLE
[master] Add onlyifrunning option for Service Beacon

### DIFF
--- a/changelog/66809.added.md
+++ b/changelog/66809.added.md
@@ -1,0 +1,1 @@
+Added support in service Beacon for only fire matching configured running state

--- a/salt/beacons/service.py
+++ b/salt/beacons/service.py
@@ -76,6 +76,12 @@ def beacon(config):
     event when the minion is reload. Applicable only when `onchangeonly` is True.
     The default is True.
 
+    `is_running_state`: This boolean parameter controls when the beacon will
+    fire based on the service's running state. If `is_running_state` is set to
+    `True`, the beacon will fire only when the service is running. If
+    `is_running_state` is set to `False`, the beacon will fire only when the
+    service is not running.
+
     `uncleanshutdown`: If `uncleanshutdown` is present it should point to the
     location of a pid file for the service.  Most services will not clean up
     this pid file if they are shutdown uncleanly (e.g. via `kill -9`) or if they
@@ -141,6 +147,15 @@ def beacon(config):
             ret_dict[service]["uncleanshutdown"] = (
                 True if os.path.exists(filename) else False
             )
+
+        # If is_running_state does not match the current running state, skip it
+        if (
+            "is_running_state" in service_config
+            and isinstance(service_config["is_running_state"], bool)
+            and service_config["is_running_state"] != ret_dict[service]["running"]
+        ):
+            continue
+
         if "onchangeonly" in service_config and service_config["onchangeonly"] is True:
             if service not in LAST_STATUS:
                 LAST_STATUS[service] = ret_dict[service]

--- a/tests/pytests/unit/beacons/test_service.py
+++ b/tests/pytests/unit/beacons/test_service.py
@@ -195,3 +195,37 @@ def test_service_not_running():
                 "salt-master": {"running": False},
             }
         ]
+
+
+def test_service_matching_is_running_state():
+    with patch.dict(
+        service_beacon.__salt__, {"service.status": MagicMock(return_value=False)}
+    ):
+        config = [{"services": {"salt-master": {"is_running_state": True}}}]
+
+        ret = service_beacon.validate(config)
+
+        assert ret == (True, "Valid beacon configuration")
+
+        ret = service_beacon.beacon(config)
+
+        assert ret == []
+
+        config = [
+            {
+                "services": {
+                    "salt-master": {"is_running_state": False},
+                    "salt-minion": {"is_running_state": True},
+                }
+            }
+        ]
+
+        ret = service_beacon.beacon(config)
+
+        assert ret == [
+            {
+                "service_name": "salt-master",
+                "tag": "salt-master",
+                "salt-master": {"running": False},
+            }
+        ]


### PR DESCRIPTION
With this option it's able to only fire events that match the running state

### What does this PR do?
I added this change because I don't want my Salt master being overloaded with events I'm not interested in. In my case I only would receive an event when the service is stopped. Without this change the event bus is, for all connected minions, overloaded with events about the running services which I will ignore. This will filter these events from the beacon directly.

### What issues does this PR fix or reference?


### Previous Behavior
Without this option it will fire the event without filtering the running state

### New Behavior
It allows the user to configure that an event should only be fired when the running state is matched with what's configured per service.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.