### PR TITLE
[3006.x] Fix pkg.removed with multiple versions on Windows

### DIFF
--- a/changelog/61001.fixed.md
+++ b/changelog/61001.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue uninstalling packages on Windows using pkg.removed where there
+are multiple versions of the same software installed

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2883,9 +2883,14 @@ def _uninstall(
         }
 
     try:
-        pkg_params = __salt__["pkg_resource.parse_targets"](
-            name, pkgs, normalize=normalize, version=version, **kwargs
-        )[0]
+        if salt.utils.platform.is_windows():
+            pkg_params = __salt__["pkg_resource.parse_targets"](
+                name, pkgs, normalize=normalize, version=version, **kwargs
+            )[0]
+        else:
+            pkg_params = __salt__["pkg_resource.parse_targets"](
+                name, pkgs, normalize=normalize
+            )[0]
     except MinionError as exc:
         return {
             "name": name,

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2883,14 +2883,9 @@ def _uninstall(
         }
 
     try:
-        if salt.utils.platform.is_windows():
-            pkg_params = __salt__["pkg_resource.parse_targets"](
-                name, pkgs, normalize=normalize, version=version, **kwargs
-            )[0]
-        else:
-            pkg_params = __salt__["pkg_resource.parse_targets"](
-                name, pkgs, normalize=normalize
-            )[0]
+        pkg_params = __salt__["pkg_resource.parse_targets"](
+            name, pkgs, normalize=normalize, version=version, **kwargs
+        )[0]
     except MinionError as exc:
         return {
             "name": name,

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2884,7 +2884,7 @@ def _uninstall(
 
     try:
         pkg_params = __salt__["pkg_resource.parse_targets"](
-            name, pkgs, normalize=normalize
+            name, pkgs, normalize=normalize, version=version, **kwargs
         )[0]
     except MinionError as exc:
         return {
@@ -2951,7 +2951,7 @@ def _uninstall(
     new = __salt__["pkg.list_pkgs"](versions_as_list=True, **kwargs)
     failed = []
     for param in pkg_params:
-        if __grains__["os_family"] in ["Suse", "RedHat"]:
+        if __grains__["os_family"] in ["Suse", "RedHat", "Windows"]:
             # Check if the package version set to be removed is actually removed:
             if param in new and not pkg_params[param]:
                 failed.append(param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1381,9 +1381,7 @@ def sshd_server(salt_factories, sshd_config_dir, salt_master, grains):
         "X11DisplayOffset": "10",
         "PrintMotd": "no",
         "PrintLastLog": "yes",
-        # https://unix.stackexchange.com/a/616355
-        "ServerAliveInterval": "20",
-        "TCPKeepAlive": "no",
+        "TCPKeepAlive": "yes",
         "AcceptEnv": "LANG LC_*",
         "UsePAM": "yes",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1381,7 +1381,9 @@ def sshd_server(salt_factories, sshd_config_dir, salt_master, grains):
         "X11DisplayOffset": "10",
         "PrintMotd": "no",
         "PrintLastLog": "yes",
-        "TCPKeepAlive": "yes",
+        # https://unix.stackexchange.com/a/616355
+        "ServerAliveInterval": "20",
+        "TCPKeepAlive": "no",
         "AcceptEnv": "LANG LC_*",
         "UsePAM": "yes",
     }

--- a/tests/pytests/functional/conftest.py
+++ b/tests/pytests/functional/conftest.py
@@ -4,6 +4,8 @@ import shutil
 import pytest
 from saltfactories.utils.functional import Loaders
 
+import salt.utils.platform
+
 log = logging.getLogger(__name__)
 
 
@@ -70,6 +72,17 @@ def minion_opts(
             },
         }
     )
+
+    if salt.utils.platform.is_windows():
+        # We need to setup winrepo on Windows
+        minion_config_overrides.update(
+            {
+                "winrepo_source_dir": "salt://winrepo_ng",
+                "winrepo_dir_ng": str(state_tree / "winrepo_ng"),
+                "winrepo_dir": str(state_tree / "winrepo"),
+            }
+        )
+
     factory = salt_factories.salt_minion_daemon(
         minion_id,
         defaults=minion_config_defaults or None,

--- a/tests/pytests/functional/conftest.py
+++ b/tests/pytests/functional/conftest.py
@@ -1,10 +1,9 @@
 import logging
 import shutil
+import sys
 
 import pytest
 from saltfactories.utils.functional import Loaders
-
-import salt.utils.platform
 
 log = logging.getLogger(__name__)
 
@@ -73,8 +72,8 @@ def minion_opts(
         }
     )
 
-    if salt.utils.platform.is_windows():
-        # We need to setup winrepo on Windows
+    if sys.platform.startswith("win"):
+        # We need to set up winrepo on Windows
         minion_config_overrides.update(
             {
                 "winrepo_source_dir": "salt://winrepo_ng",

--- a/tests/pytests/functional/modules/test_win_pkg.py
+++ b/tests/pytests/functional/modules/test_win_pkg.py
@@ -29,7 +29,7 @@ def pkg(modules):
 
 def test_refresh_db(pkg, pkg_def_contents, state_tree, minion_opts):
     assert len(pkg.get_package_info("my-software")) == 0
-    repo_dir = state_tree / "win" / "repo-ng"
+    repo_dir = state_tree / "winrepo_ng"
     with pytest.helpers.temp_file("my-software.sls", pkg_def_contents, repo_dir):
         pkg.refresh_db()
     assert len(pkg.get_package_info("my-software")) == 1

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -111,14 +111,14 @@ def PKG_CAP_TARGETS(grains):
 @pytest.fixture
 def PKG_32_TARGETS(grains):
     _PKG_32_TARGETS = []
-    if grains["os"] == "Windows":
-        _PKG_32_TARGETS = ["npp", "nsis"]
-    elif grains["os_family"] == "RedHat" and grains["oscodename"] != "Photon":
+    if grains["os_family"] == "RedHat" and grains["oscodename"] != "Photon":
         if grains["os"] == "CentOS":
             if grains["osmajorrelease"] == 5:
                 _PKG_32_TARGETS = ["xz-devel.i386"]
             else:
                 _PKG_32_TARGETS.append("xz-devel.i686")
+    elif grains["os"] == "Windows":
+        _PKG_32_TARGETS = ["npp", "nsis"]
     if not _PKG_32_TARGETS:
         pytest.skip("No 32 bit packages have been specified for testing")
     return _PKG_32_TARGETS


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `pkg.removed` when removing a package that has multiple versions installed on Windows.
Also fixes some of the package tests to work on Windows by setting up winrepo with the test suite paths.

### What issues does this PR fix or reference?
Fixes #61001 

### Previous Behavior
The software would be removed but would report a failure

### New Behavior
The state now finishes successfully

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes