### PR TITLE
[master] rest_cherrypy: accept / force credentials via HTTP header

### DIFF
--- a/changelog/66814.added.md
+++ b/changelog/66814.added.md
@@ -1,0 +1,5 @@
+Added support for credentials via HTTP headers (``X-Forwarded-User``,
+``X-Forwarded-Password``, ``X-Forwarded-Eauth``) in ``rest_cherrypy``,
+enabling reverse proxies to handle authentication and inject credentials
+without modifying the request body. Session tokens are also validated
+against the forwarded identity when these headers are present.

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -256,19 +256,21 @@ cookie. The latter is far more convenient for clients that support cookies.
       {u'return': [{
           ...snip...
       }]}
-      
+
 .. seealso:: You can bypass the session handling via the :py:class:`Run` URL.
 
 
-### Session start and check via custom header
+Session start and check via custom header
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    If one or more custom headers are present ``X-Forwarded-User``,
-   ``X-Forwarded-User`` or ``X-Forwarded-Eauth`` the value will **override** the
+   ``X-Forwarded-Password`` or ``X-Forwarded-Eauth`` the value will **override** the
    corresponding key in the request body.
 
    This allows the use of a reverse proxy that is now able to force certain values,
    without modifications to the request body.
    For example `oauth2 proxy <https://oauth2-proxy.github.io/oauth2-proxy/>` can
-   be used to authenticate against diffent IdPs in conjunction with password driven
+   be used to authenticate against different IdPs in conjunction with password driven
    eauth backends.
 
    Furthermore the session token will be checked against ``username`` and ``eauth``
@@ -923,8 +925,8 @@ def salt_auth_tool():
     Redirect all unauthenticated requests to the login page
     """
     # Redirect to the login page if the header username and eauth of the session differ.
-    # A reverse proxy can force a session via to adhere to given credentials,
-    # to limit misuse of a token gathered from another user. 
+    # A reverse proxy can force a session to adhere to given credentials,
+    # to limit misuse of a token gathered from another user.
     x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User", None)
     x_forwarded_eauth = cherrypy.request.headers.get("X-Forwarded-Eauth", None)
     if x_forwarded_user and x_forwarded_user != cherrypy.session.get("name", None):
@@ -1255,6 +1257,7 @@ def hypermedia_in():
     )
     cherrypy.request.body.processors = ct_in_map
 
+
 def force_header_creds(data):
     """
     Force credentials served by HTTP data into lowdata
@@ -1263,7 +1266,7 @@ def force_header_creds(data):
     authentication and/or force certain parameters.
     """
     # Force credentials if served in HTTP header
-    x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User",None)
+    x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User", None)
     x_forwarded_password = cherrypy.request.headers.get("X-Forwarded-Password", None)
     x_forwarded_eauth = cherrypy.request.headers.get("X-Forwarded-Eauth", None)
     if x_forwarded_user:
@@ -2103,8 +2106,8 @@ class Login(LowDataAdapter):
         cherrypy.response.headers["X-Auth-Token"] = cherrypy.session.id
         cherrypy.session["token"] = token["token"]
         cherrypy.session["timeout"] = (token["expire"] - token["start"]) / 60
-        cherrypy.session["name"] = token["name"] # Save for security checks
-        cherrypy.session["eauth"] = token["eauth"] # Save for security checks
+        cherrypy.session["name"] = token["name"]  # Save for security checks
+        cherrypy.session["eauth"] = token["eauth"]  # Save for security checks
 
         # Grab eauth config for the current backend for the current user
         try:
@@ -2449,15 +2452,19 @@ class Events:
             if resolved_tkn:
                 # We want to make sure that the username has not changed within a session,
                 # if a username is forced via X-Forwarded-User Header.
-                if x_forwarded_user and x_forwarded_user != resolved_tkn.get("name", None):
-                  return False
+                if x_forwarded_user and x_forwarded_user != resolved_tkn.get(
+                    "name", None
+                ):
+                    return False
                 # We want to make sure that the eauth has not changed within a session,
                 # if a eauth is forced via X-Forwarded-Eauth Header.
-                if x_forwarded_eauth and x_forwarded_eauth != resolved_tkn.get("eauth", None):
-                  return False
+                if x_forwarded_eauth and x_forwarded_eauth != resolved_tkn.get(
+                    "eauth", None
+                ):
+                    return False
                 # We want to make sure that the token isn't expired yet.
                 if resolved_tkn.get("expire", 0) > time.time():
-                  return True
+                    return True
 
         # Redirect to the login page if the session hasn't been authed
         return False

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -256,8 +256,25 @@ cookie. The latter is far more convenient for clients that support cookies.
       {u'return': [{
           ...snip...
       }]}
-
+      
 .. seealso:: You can bypass the session handling via the :py:class:`Run` URL.
+
+
+### Session start and check via custom header
+   If one or more custom headers are present ``X-Forwarded-User``,
+   ``X-Forwarded-User`` or ``X-Forwarded-Eauth`` the value will **override** the
+   corresponding key in the request body.
+
+   This allows the use of a reverse proxy that is now able to force certain values,
+   without modifications to the request body.
+   For example `oauth2 proxy <https://oauth2-proxy.github.io/oauth2-proxy/>` can
+   be used to authenticate against diffent IdPs in conjunction with password driven
+   eauth backends.
+
+   Furthermore the session token will be checked against ``username`` and ``eauth``
+   if the headers are present and session handling is used,
+   which limits the use of session tokens to those matching the original
+   login identity.
 
 Usage
 -----
@@ -587,6 +604,9 @@ rest_cherrypy will remain the officially recommended REST API.
 .. __: https://github.com/saltstack/salt/issues/26505
 
 .. |req_token| replace:: a session token from :py:class:`~Login`.
+.. |req_forwarded_user| replace:: user to be used in :py:class:`~Login`, :py:class:`~Run` or checked against in session handling.
+.. |req_forwarded_password| replace:: password to be used in :py:class:`~Login`  or :py:class:`~Run`.
+.. |req_forwarded_eauth| replace:: eauth to be used in :py:class:`~Login`, :py:class:`~Run` or checked against in session handling.
 .. |req_accept| replace:: the desired response format.
 .. |req_ct| replace:: the format of the request body.
 
@@ -902,6 +922,15 @@ def salt_auth_tool():
     """
     Redirect all unauthenticated requests to the login page
     """
+    # Redirect to the login page if the header username and eauth of the session differ.
+    # A reverse proxy can force a session via to adhere to given credentials,
+    # to limit misuse of a token gathered from another user. 
+    x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User", None)
+    x_forwarded_eauth = cherrypy.request.headers.get("X-Forwarded-Eauth", None)
+    if x_forwarded_user and x_forwarded_user != cherrypy.session.get("name", None):
+        raise cherrypy.HTTPError(401)
+    if x_forwarded_eauth and x_forwarded_eauth != cherrypy.session.get("eauth", None):
+        raise cherrypy.HTTPError(401)
     # Redirect to the login page if the session hasn't been authed
     if "token" not in cherrypy.session:
         raise cherrypy.HTTPError(401)
@@ -934,6 +963,9 @@ def cors_tool():
         allowed_headers = [
             "Content-Type",
             "X-Auth-Token",
+            "X-Forwarded-User",
+            "X-Forwarded-Password",
+            "X-Forwarded-Eauth",
             "X-Requested-With",
         ]
 
@@ -1223,6 +1255,24 @@ def hypermedia_in():
     )
     cherrypy.request.body.processors = ct_in_map
 
+def force_header_creds(data):
+    """
+    Force credentials served by HTTP data into lowdata
+
+    This trumps credentials in the POST body, to allow a reverse proxy to handle
+    authentication and/or force certain parameters.
+    """
+    # Force credentials if served in HTTP header
+    x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User",None)
+    x_forwarded_password = cherrypy.request.headers.get("X-Forwarded-Password", None)
+    x_forwarded_eauth = cherrypy.request.headers.get("X-Forwarded-Eauth", None)
+    if x_forwarded_user:
+        data["username"] = x_forwarded_user
+    if x_forwarded_password:
+        data["password"] = x_forwarded_password
+    if x_forwarded_eauth:
+        data["eauth"] = x_forwarded_eauth
+
 
 def lowdata_fmt():
     """
@@ -1246,9 +1296,12 @@ def lowdata_fmt():
         ):  # pylint: disable=unsupported-membership-test
             data["arg"] = [data["arg"]]
 
+        force_header_creds(data)
+
         # Finally, make a Low State and put it in request
         cherrypy.request.lowstate = [data]
     else:
+        force_header_creds(data)
         cherrypy.serving.request.lowstate = data
 
 
@@ -1411,6 +1464,8 @@ class LowDataAdapter:
         .. http:post:: /
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
             :reqheader Content-Type: |req_ct|
 
@@ -1478,6 +1533,8 @@ class Minions(LowDataAdapter):
         .. http:get:: /minions/(mid)
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
 
             :status 200: |200|
@@ -1523,6 +1580,8 @@ class Minions(LowDataAdapter):
         .. http:post:: /minions
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
             :reqheader Content-Type: |req_ct|
 
@@ -1598,6 +1657,8 @@ class Jobs(LowDataAdapter):
             List jobs or show a single job from the job cache.
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
 
             :status 200: |200|
@@ -1719,6 +1780,8 @@ class Keys(LowDataAdapter):
             List all keys or show a specific key
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
 
             :status 200: |200|
@@ -1950,6 +2013,9 @@ class Login(LowDataAdapter):
         .. http:post:: /login
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Password: |req_forwarded_password|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
             :reqheader Content-Type: |req_ct|
 
@@ -2037,6 +2103,8 @@ class Login(LowDataAdapter):
         cherrypy.response.headers["X-Auth-Token"] = cherrypy.session.id
         cherrypy.session["token"] = token["token"]
         cherrypy.session["timeout"] = (token["expire"] - token["start"]) / 60
+        cherrypy.session["name"] = token["name"] # Save for security checks
+        cherrypy.session["eauth"] = token["eauth"] # Save for security checks
 
         # Grab eauth config for the current backend for the current user
         try:
@@ -2230,6 +2298,22 @@ class Run(LowDataAdapter):
                     "token": "<salt eauth token here>"
                 }]'
 
+        **Or** using a custom headers:
+
+        .. code-block:: bash
+
+            curl -sS localhost:8000/run \\
+                -H 'X-Forwarded-User: saltdev' \\
+                -H 'X-Forwarded-Password: saltdev' \\
+                -H 'X-Forwarded-Eauth: auto' \\
+                -H 'Accept: application/x-yaml' \\
+                -H 'Content-type: application/json' \\
+                -d '[{
+                    "client": "local",
+                    "tgt": "*",
+                    "fun": "test.ping"
+                }]'
+
         .. code-block:: text
 
             POST /run HTTP/1.1
@@ -2358,11 +2442,24 @@ class Events:
         # stream, so we're just checking if the token exists not if the token
         # allows access.
         if salt_token:
-            # We want to at least make sure that the token isn't expired yet.
             resolved_tkn = self.resolver.get_token(salt_token)
-            if resolved_tkn and resolved_tkn.get("expire", 0) > time.time():
-                return True
+            x_forwarded_user = cherrypy.request.headers.get("X-Forwarded-User", None)
+            x_forwarded_eauth = cherrypy.request.headers.get("X-Forwarded-Eauth", None)
 
+            if resolved_tkn:
+                # We want to make sure that the username has not changed within a session,
+                # if a username is forced via X-Forwarded-User Header.
+                if x_forwarded_user and x_forwarded_user != resolved_tkn.get("name", None):
+                  return False
+                # We want to make sure that the eauth has not changed within a session,
+                # if a eauth is forced via X-Forwarded-Eauth Header.
+                if x_forwarded_eauth and x_forwarded_eauth != resolved_tkn.get("eauth", None):
+                  return False
+                # We want to make sure that the token isn't expired yet.
+                if resolved_tkn.get("expire", 0) > time.time():
+                  return True
+
+        # Redirect to the login page if the session hasn't been authed
         return False
 
     def GET(self, **kwargs):
@@ -2959,6 +3056,8 @@ class Stats:
         .. http:get:: /stats
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
             :reqheader Accept: |req_accept|
 
             :resheader Content-Type: |res_ct|
@@ -2990,6 +3089,8 @@ class App:
         .. http:get:: /app
 
             :reqheader X-Auth-Token: |req_token|
+            :reqheader X-Forwarded-User: |req_forwarded_user|
+            :reqheader X-Forwarded-Eauth: |req_forwarded_eauth|
 
             :status 200: |200|
             :status 401: |401|

--- a/tests/pytests/unit/netapi/cherrypy/test_header_creds.py
+++ b/tests/pytests/unit/netapi/cherrypy/test_header_creds.py
@@ -1,0 +1,241 @@
+"""
+Tests for rest_cherrypy header credential forwarding (X-Forwarded-User, etc.)
+"""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import salt.netapi.rest_cherrypy.app as cherrypy_app
+from tests.support.mock import MagicMock, patch
+
+
+class MockSession(dict):
+    """A dict subclass that acts as a cherrypy session."""
+
+    id = "test-session-id"
+
+
+def _mock_cherrypy(headers=None, session_data=None):
+    """Helper to create a mock cherrypy object with configurable headers/session."""
+    session = MockSession(session_data or {})
+    mock = MagicMock()
+    mock.session = session
+    mock.request.headers = headers or {}
+    mock.HTTPError = Exception
+    return mock
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {cherrypy_app: {}}
+
+
+# ---------------------------------------------------------------------------
+# force_header_creds
+# ---------------------------------------------------------------------------
+
+
+def test_force_header_creds_overrides_username():
+    """X-Forwarded-User replaces the username in lowdata."""
+    data = {"username": "original", "password": "secret", "eauth": "auto"}
+    mock_cp = _mock_cherrypy(headers={"X-Forwarded-User": "proxy-user"})
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        cherrypy_app.force_header_creds(data)
+    assert data["username"] == "proxy-user"
+    assert data["password"] == "secret"  # unchanged
+    assert data["eauth"] == "auto"  # unchanged
+
+
+def test_force_header_creds_overrides_password():
+    """X-Forwarded-Password replaces the password in lowdata."""
+    data = {"username": "user", "password": "original", "eauth": "auto"}
+    mock_cp = _mock_cherrypy(headers={"X-Forwarded-Password": "proxy-pass"})
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        cherrypy_app.force_header_creds(data)
+    assert data["password"] == "proxy-pass"
+    assert data["username"] == "user"  # unchanged
+
+
+def test_force_header_creds_overrides_eauth():
+    """X-Forwarded-Eauth replaces the eauth in lowdata."""
+    data = {"username": "user", "password": "secret", "eauth": "pam"}
+    mock_cp = _mock_cherrypy(headers={"X-Forwarded-Eauth": "auto"})
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        cherrypy_app.force_header_creds(data)
+    assert data["eauth"] == "auto"
+    assert data["username"] == "user"  # unchanged
+
+
+def test_force_header_creds_overrides_all():
+    """All three X-Forwarded-* headers override all credential fields."""
+    data = {"username": "user", "password": "secret", "eauth": "pam"}
+    mock_cp = _mock_cherrypy(
+        headers={
+            "X-Forwarded-User": "proxy-user",
+            "X-Forwarded-Password": "proxy-pass",
+            "X-Forwarded-Eauth": "auto",
+        }
+    )
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        cherrypy_app.force_header_creds(data)
+    assert data["username"] == "proxy-user"
+    assert data["password"] == "proxy-pass"
+    assert data["eauth"] == "auto"
+
+
+def test_force_header_creds_no_headers():
+    """When no X-Forwarded-* headers are present, lowdata is unchanged."""
+    data = {"username": "user", "password": "secret", "eauth": "pam"}
+    mock_cp = _mock_cherrypy(headers={})
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        cherrypy_app.force_header_creds(data)
+    assert data == {"username": "user", "password": "secret", "eauth": "pam"}
+
+
+# ---------------------------------------------------------------------------
+# salt_auth_tool - session validation against forwarded headers
+# ---------------------------------------------------------------------------
+
+
+def test_salt_auth_tool_accepts_matching_user():
+    """Auth tool passes when session name matches X-Forwarded-User."""
+    mock_cp = _mock_cherrypy(
+        headers={"X-Forwarded-User": "alice"},
+        session_data={"name": "alice", "eauth": "auto", "token": "abc"},
+    )
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        # Should not raise
+        cherrypy_app.salt_auth_tool()
+
+
+def test_salt_auth_tool_rejects_mismatched_user():
+    """Auth tool raises 401 when X-Forwarded-User differs from session name."""
+    mock_cp = _mock_cherrypy(
+        headers={"X-Forwarded-User": "eve"},
+        session_data={"name": "alice", "eauth": "auto", "token": "abc"},
+    )
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        with pytest.raises(Exception):  # cherrypy.HTTPError(401)
+            cherrypy_app.salt_auth_tool()
+
+
+def test_salt_auth_tool_rejects_mismatched_eauth():
+    """Auth tool raises 401 when X-Forwarded-Eauth differs from session eauth."""
+    mock_cp = _mock_cherrypy(
+        headers={"X-Forwarded-Eauth": "pam"},
+        session_data={"name": "alice", "eauth": "auto", "token": "abc"},
+    )
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        with pytest.raises(Exception):  # cherrypy.HTTPError(401)
+            cherrypy_app.salt_auth_tool()
+
+
+def test_salt_auth_tool_no_forwarded_headers():
+    """Auth tool passes normally when no X-Forwarded-* headers are present."""
+    mock_cp = _mock_cherrypy(
+        headers={},
+        session_data={"name": "alice", "eauth": "auto", "token": "abc"},
+    )
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        # Should not raise
+        cherrypy_app.salt_auth_tool()
+
+
+# ---------------------------------------------------------------------------
+# Events._is_valid_token - forwarded header checks
+# ---------------------------------------------------------------------------
+
+
+class MockResolver:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_token(self, token):
+        return None
+
+
+class MockCherryPyForEvents:
+    """Mock cherrypy suitable for Events._is_valid_token tests."""
+
+    serving = SimpleNamespace(session=MagicMock(cache={}))
+    config = {"saltopts": {}}
+
+    def __init__(self, forwarded_user=None, forwarded_eauth=None):
+        self._headers = {}
+        if forwarded_user is not None:
+            self._headers["X-Forwarded-User"] = forwarded_user
+        if forwarded_eauth is not None:
+            self._headers["X-Forwarded-Eauth"] = forwarded_eauth
+        self.request = SimpleNamespace(
+            headers=SimpleNamespace(
+                get=lambda key, default=None: self._headers.get(key, default)
+            )
+        )
+
+
+def test_is_valid_token_forwarded_user_matches():
+    """Token is valid when X-Forwarded-User matches the token's name."""
+    mock_cp = MockCherryPyForEvents(forwarded_user="alice")
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        with patch("salt.auth.Resolver", MockResolver):
+            with patch(
+                "salt.netapi.rest_cherrypy.app._lookup_session_data",
+                return_value={"token": "ABCDEF"},
+            ):
+                events = cherrypy_app.Events()
+                with patch.object(
+                    events.resolver,
+                    "get_token",
+                    return_value={
+                        "expire": time.time() + 60,
+                        "name": "alice",
+                        "eauth": "auto",
+                    },
+                ):
+                    assert events._is_valid_token("ABCDEF")
+
+
+def test_is_valid_token_forwarded_user_mismatch():
+    """Token is invalid when X-Forwarded-User does not match the token's name."""
+    mock_cp = MockCherryPyForEvents(forwarded_user="eve")
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        with patch("salt.auth.Resolver", MockResolver):
+            with patch(
+                "salt.netapi.rest_cherrypy.app._lookup_session_data",
+                return_value={"token": "ABCDEF"},
+            ):
+                events = cherrypy_app.Events()
+                with patch.object(
+                    events.resolver,
+                    "get_token",
+                    return_value={
+                        "expire": time.time() + 60,
+                        "name": "alice",
+                        "eauth": "auto",
+                    },
+                ):
+                    assert not events._is_valid_token("ABCDEF")
+
+
+def test_is_valid_token_forwarded_eauth_mismatch():
+    """Token is invalid when X-Forwarded-Eauth does not match the token's eauth."""
+    mock_cp = MockCherryPyForEvents(forwarded_eauth="pam")
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", mock_cp):
+        with patch("salt.auth.Resolver", MockResolver):
+            with patch(
+                "salt.netapi.rest_cherrypy.app._lookup_session_data",
+                return_value={"token": "ABCDEF"},
+            ):
+                events = cherrypy_app.Events()
+                with patch.object(
+                    events.resolver,
+                    "get_token",
+                    return_value={
+                        "expire": time.time() + 60,
+                        "name": "alice",
+                        "eauth": "auto",
+                    },
+                ):
+                    assert not events._is_valid_token("ABCDEF")


### PR DESCRIPTION
The acceptance of HTTP headers opens the possibility to either set or force credentials for a session.
A reverse proxy, can handle authentication and
inject the custom headers X-Forwarded-User, X-Forwarded-Password and/or X-Forwarded-Eauth. In general, these headers can work in conjunction with the eauth sharedsecret / rest / auto methods to externalize and flexibilize authentication, without raising code complexity for new or niche authentication methods inside salt.

### What does this PR do?
This PR enables rest_cherrypy to gather credentials via HTTP headers, that may be set by reverse proxy, to use them for session creation or session checking.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/22046

### Previous Behavior
Credentials are only allowed via request body.

### New Behavior
Credentials are allowed via request body and http header.
Prevalence is http header over request body values.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
