### PR TITLE
[3006.x] Skip pkg tests that need new golden image

### DIFF
--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -249,10 +249,13 @@ def test_pkg_002_installed_with_version(PKG_TARGETS, states, latest_version):
 
 @pytest.mark.requires_salt_states("pkg.installed", "pkg.removed")
 @pytest.mark.slow_test
-def test_pkg_003_installed_multipkg(caplog, PKG_TARGETS, modules, states):
+def test_pkg_003_installed_multipkg(caplog, PKG_TARGETS, modules, states, grains):
     """
     This is a destructive test as it installs and then removes two packages
     """
+    if grains["os_family"] == "Arch":
+        pytest.skip("Arch needs refresh_db logic added to golden image")
+
     version = modules.pkg.version(*PKG_TARGETS)
 
     # If this assert fails, we need to find new targets, this test needs to
@@ -274,10 +277,14 @@ def test_pkg_003_installed_multipkg(caplog, PKG_TARGETS, modules, states):
 @pytest.mark.usefixtures("VERSION_SPEC_SUPPORTED")
 @pytest.mark.requires_salt_states("pkg.installed", "pkg.removed")
 @pytest.mark.slow_test
-def test_pkg_004_installed_multipkg_with_version(PKG_TARGETS, latest_version, states):
+def test_pkg_004_installed_multipkg_with_version(
+    PKG_TARGETS, latest_version, states, grains
+):
     """
     This is a destructive test as it installs and then removes two packages
     """
+    if grains["os_family"] == "Arch":
+        pytest.skip("Arch needs refresh_db logic added to golden image")
     version = latest_version(PKG_TARGETS[0])
 
     # If this assert fails, we need to find new targets, this test needs to
@@ -886,6 +893,7 @@ def test_pkg_cap_003_installed_multipkg_with_version(
     latest_version,
     modules,
     states,
+    grains,
 ):
     """
     This is a destructive test as it installs and then removes two packages


### PR DESCRIPTION
### What does this PR do?

Skip test that needs new golden image until we resolve the issues preventing golden image creation.