### PR TITLE
[3006.x] Adjust timeout from 2 to 2 & 1/2 hours for MacOS package tests

### DIFF
--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -105,7 +105,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 181  # 3 Hours - More than this and something is wrong (MacOS needs a little more time)
+    timeout-minutes: 150  # 2 & 1/2 Hours - More than this and something is wrong (MacOS needs a little more time)
     needs:
       - generate-matrix
     strategy:

--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -105,7 +105,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 180  # 3 Hours - More than this and something is wrong (MacOS needs a little more time)
+    timeout-minutes: 181  # 3 Hours - More than this and something is wrong (MacOS needs a little more time)
     needs:
       - generate-matrix
     strategy:

--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -105,7 +105,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 120  # 2 Hours - More than this and something is wrong
+    timeout-minutes: 180  # 3 Hours - More than this and something is wrong (MacOS needs a little more time)
     needs:
       - generate-matrix
     strategy:


### PR DESCRIPTION
### What does this PR do?
Adjusts the timeout for MacOS packages tests which currently are exceeding the allowed 2 hours

### What issues does this PR fix or reference?
Fixes Nightly build for MacOS

### Previous Behavior
Seeing testing canceled due to using 2 hours allotted

### New Behavior
Package tests for MacOS succeed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
