### PR TITLE
[3006.x] Fix 33669: Allow spaces or not in ini.set_option

### DIFF
--- a/changelog/33669.added.md
+++ b/changelog/33669.added.md
@@ -1,0 +1,3 @@
+Issue #33669: Fixes an issue with the ``ini_managed`` execution module
+where it would always wrap the separator with spaces. Adds a new parameter
+named ``no_spaces`` that will not warp the separator with spaces.

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -67,10 +67,10 @@ def set_option(file_name, sections=None, separator="=", encoding=None, no_spaces
             .. versionadded:: 3006.6
 
         no_spaces (bool):
-            A bool value that specifies if the separator will be wrapped with
-            spaces. This parameter was added to have the ability to not wrap the
-            separator with spaces. Default is ``False``, which maintains
-            backwards compatibility.
+            A bool value that specifies that the key/value separator will be
+            wrapped with spaces. This parameter was added to have the ability to
+            not wrap the separator with spaces. Default is ``False``, which
+            maintains backwards compatibility.
 
             .. warning::
                 This will affect all key/value pairs in the ini file, not just

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -72,6 +72,10 @@ def set_option(file_name, sections=None, separator="=", encoding=None, no_spaces
             separator with spaces. Default is ``False``, which maintains
             backwards compatibility.
 
+            .. warning::
+                This will affect all key/value pairs in the ini file, not just
+                the specific value being set.
+
             .. versionadded:: 3006.10
 
     Returns:

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -37,7 +37,7 @@ COM_REGX = re.compile(r"^\s*(#|;)\s*(.*)")
 INDENTED_REGX = re.compile(r"(\s+)(.*)")
 
 
-def set_option(file_name, sections=None, separator="=", encoding=None):
+def set_option(file_name, sections=None, separator="=", encoding=None, no_spaces=False):
     """
     Edit an ini file, replacing one or more sections. Returns a dictionary
     containing the changes made.
@@ -66,6 +66,14 @@ def set_option(file_name, sections=None, separator="=", encoding=None):
 
             .. versionadded:: 3006.6
 
+        no_spaces (bool):
+            A bool value that specifies if the separator will be wrapped with
+            spaces. This parameter was added to have the ability to not wrap the
+            separator with spaces. Default is ``False``, which maintains
+            backwards compatibility.
+
+            .. versionadded:: 3006.10
+
     Returns:
         dict: A dictionary representing the changes made to the ini file
 
@@ -88,7 +96,9 @@ def set_option(file_name, sections=None, separator="=", encoding=None):
     """
 
     sections = sections or {}
-    inifile = _Ini.get_ini_file(file_name, separator=separator, encoding=encoding)
+    inifile = _Ini.get_ini_file(
+        file_name, separator=separator, encoding=encoding, no_spaces=no_spaces
+    )
     changes = inifile.update(sections)
     inifile.flush()
     return changes
@@ -388,20 +398,19 @@ def get_ini(file_name, separator="=", encoding=None):
 
 
 class _Section(OrderedDict):
-    def __init__(self, name, inicontents="", separator="=", commenter="#", no_spaces=False):
+    def __init__(
+        self, name, inicontents="", separator="=", commenter="#", no_spaces=False
+    ):
         super().__init__(self)
         self.name = name
         self.inicontents = inicontents
         self.sep = separator
         self.com = commenter
-        if not no_spaces = 
-            self.sep = ' ' + self.sep + ' '
+        self.no_spaces = no_spaces
 
         opt_regx_prefix = r"(\s*)(.+?)\s*"
         opt_regx_suffix = r"\s*(.*)\s*"
-        self.opt_regx_str = r"{}(\{}){}".format(
-            opt_regx_prefix, self.sep, opt_regx_suffix
-        )
+        self.opt_regx_str = rf"{opt_regx_prefix}(\{self.sep}){opt_regx_suffix}"
         self.opt_regx = re.compile(self.opt_regx_str)
 
     def refresh(self, inicontents=None):
@@ -477,7 +486,11 @@ class _Section(OrderedDict):
             # Ensure the value is either a _Section or a string
             if isinstance(value, (dict, OrderedDict)):
                 sect = _Section(
-                    name=key, inicontents="", separator=self.sep, commenter=self.com
+                    name=key,
+                    inicontents="",
+                    separator=self.sep,
+                    commenter=self.com,
+                    no_spaces=self.no_spaces,
                 )
                 sect.update(value)
                 value = sect
@@ -509,7 +522,7 @@ class _Section(OrderedDict):
         return changes
 
     def gen_ini(self):
-        yield "{0}[{1}]{0}".format(os.linesep, self.name)
+        yield f"{os.linesep}[{self.name}]{os.linesep}"
         sections_dict = OrderedDict()
         for name, value in self.items():
             # Handle Comment Lines
@@ -520,12 +533,19 @@ class _Section(OrderedDict):
                 sections_dict.update({name: value})
             # Key / Value pairs
             else:
-                yield "{}{}{}{}".format(
-                    name,
-                    self.sep,
-                    value,
-                    os.linesep,
-                )
+                # multiple spaces will be a single space
+                if all(c == " " for c in self.sep):
+                    self.sep = " "
+                # Default is to add spaces
+                if self.no_spaces:
+                    if self.sep != " ":
+                        # We only strip whitespace if the delimiter is not a space
+                        self.sep = self.sep.strip()
+                else:
+                    if self.sep != " ":
+                        # We only add spaces if the delimiter itself is not a space
+                        self.sep = f" {self.sep.strip()} "
+                yield f"{name}{self.sep}{value}{os.linesep}"
         for name, value in sections_dict.items():
             yield from value.gen_ini()
 
@@ -558,15 +578,26 @@ class _Section(OrderedDict):
 
 class _Ini(_Section):
     def __init__(
-        self, name, inicontents="", separator="=", commenter="#", encoding=None
+        self,
+        name,
+        inicontents="",
+        separator="=",
+        commenter="#",
+        encoding=None,
+        no_spaces=False,
     ):
         super().__init__(
-            self, inicontents=inicontents, separator=separator, commenter=commenter
+            self,
+            inicontents=inicontents,
+            separator=separator,
+            commenter=commenter,
+            no_spaces=no_spaces,
         )
         self.name = name
         if encoding is None:
             encoding = __salt_system_encoding__
         self.encoding = encoding
+        self.no_spaces = no_spaces
 
     def refresh(self, inicontents=None):
         if inicontents is None:
@@ -613,7 +644,7 @@ class _Ini(_Section):
                 self.name, "w", encoding=self.encoding
             ) as outfile:
                 ini_gen = self.gen_ini()
-                next(ini_gen)
+                next(ini_gen)  # Next to skip the file name
                 ini_gen_list = list(ini_gen)
                 # Avoid writing an initial line separator.
                 if ini_gen_list:
@@ -625,8 +656,10 @@ class _Ini(_Section):
             )
 
     @staticmethod
-    def get_ini_file(file_name, separator="=", encoding=None):
-        inifile = _Ini(file_name, separator=separator, encoding=encoding)
+    def get_ini_file(file_name, separator="=", encoding=None, no_spaces=False):
+        inifile = _Ini(
+            file_name, separator=separator, encoding=encoding, no_spaces=no_spaces
+        )
         inifile.refresh()
         return inifile
 

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -388,12 +388,14 @@ def get_ini(file_name, separator="=", encoding=None):
 
 
 class _Section(OrderedDict):
-    def __init__(self, name, inicontents="", separator="=", commenter="#"):
+    def __init__(self, name, inicontents="", separator="=", commenter="#", no_spaces=False):
         super().__init__(self)
         self.name = name
         self.inicontents = inicontents
         self.sep = separator
         self.com = commenter
+        if not no_spaces = 
+            self.sep = ' ' + self.sep + ' '
 
         opt_regx_prefix = r"(\s*)(.+?)\s*"
         opt_regx_suffix = r"\s*(.*)\s*"
@@ -517,11 +519,10 @@ class _Section(OrderedDict):
             elif isinstance(value, _Section):
                 sections_dict.update({name: value})
             # Key / Value pairs
-            # Adds spaces between the separator
             else:
                 yield "{}{}{}{}".format(
                     name,
-                    f" {self.sep} " if self.sep != " " else self.sep,
+                    self.sep,
                     value,
                     os.linesep,
                 )

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -21,8 +21,61 @@ def __virtual__():
     return __virtualname__ if "ini.set_option" in __salt__ else False
 
 
-def options_present(name, sections=None, separator="=", strict=False):
+def options_present(
+    name, sections=None, separator="=", strict=False, encoding=None, no_spaces=False
+):
     """
+    Set or create a key/value pair in an ``ini`` file. Options present in the
+    ini file and not specified in the sections dict will be untouched, unless
+    the ``strict: True`` flag is used.
+
+    Sections that do not exist will be created.
+
+    Args:
+
+        name (str):
+            The path to the ini file
+
+        sections (dict):
+            A dictionary of sections and key/value pairs that will be used to
+            update the ini file. Other sections and key/value pairs in the ini
+            file will be untouched unless ``strict: True`` is passed.
+
+        separator (str):
+            The character used to separate keys and values. Standard ini files
+            use the "=" character. The default is ``=``.
+
+        strict (bool):
+            A boolean value that specifies that the ``sections`` dictionary
+            contains all settings in the ini file. ``True`` will create an ini
+            file with only the values specified in ``sections``. ``False`` will
+            append or update values in an existing ini file and leave the rest
+            untouched.
+
+        encoding (str):
+            A string value representing encoding of the target ini file. If
+            ``None`` is passed, it uses the system default which is likely
+            ``utf-8``. Default is ``None``
+
+            .. versionadded:: 3006.10
+
+        no_spaces (bool):
+            A bool value that specifies that the key/value separator will be
+            wrapped with spaces. This parameter was added to have the ability to
+            not wrap the separator with spaces. Default is ``False``, which
+            maintains backwards compatibility.
+
+            .. warning::
+                This will affect all key/value pairs in the ini file, not just
+                the specific value being set.
+
+            .. versionadded:: 3006.10
+
+    Returns:
+        dict: A dictionary containing list of changes made
+
+    Example:
+
     .. code-block:: yaml
 
         /home/saltminion/api-paste.ini:
@@ -35,12 +88,6 @@ def options_present(name, sections=None, separator="=", strict=False):
                   secondoption: 'secondvalue'
                 test1:
                   testkey1: 'testval121'
-
-    options present in file and not specified in sections
-    dict will be untouched, unless `strict: True` flag is
-    used
-
-    changes dict will contain the list of changes made
     """
     ret = {
         "name": name,
@@ -58,7 +105,9 @@ def options_present(name, sections=None, separator="=", strict=False):
             for sname, sbody in sections.items():
                 if not isinstance(sbody, (dict, OrderedDict)):
                     options.update({sname: sbody})
-            cur_ini = __salt__["ini.get_ini"](name, separator)
+            cur_ini = __salt__["ini.get_ini"](
+                file_name=name, separator=separator, encoding=encoding
+            )
             original_top_level_opts = {}
             original_sections = {}
             for key, val in cur_ini.items():
@@ -78,7 +127,13 @@ def options_present(name, sections=None, separator="=", strict=False):
                         ret["comment"] += f"Changed key {option}.\n"
                         ret["result"] = None
             else:
-                options_updated = __salt__["ini.set_option"](name, options, separator)
+                options_updated = __salt__["ini.set_option"](
+                    file_name=name,
+                    sections=options,
+                    separator=separator,
+                    encoding=encoding,
+                    no_spaces=no_spaces,
+                )
                 changes.update(options_updated)
             if strict:
                 for opt_to_remove in set(original_top_level_opts).difference(options):
@@ -87,7 +142,11 @@ def options_present(name, sections=None, separator="=", strict=False):
                         ret["result"] = None
                     else:
                         __salt__["ini.remove_option"](
-                            name, None, opt_to_remove, separator
+                            file_name=name,
+                            section=None,
+                            option=opt_to_remove,
+                            separator=separator,
+                            encoding=encoding,
                         )
                         changes.update(
                             {
@@ -119,7 +178,11 @@ def options_present(name, sections=None, separator="=", strict=False):
                             ret["result"] = None
                         else:
                             __salt__["ini.remove_option"](
-                                name, section_name, key_to_remove, separator
+                                file_name=name,
+                                section=section_name,
+                                option=key_to_remove,
+                                separator=separator,
+                                encoding=encoding,
                             )
                             changes[section_name].update({key_to_remove: ""})
                             changes[section_name].update(
@@ -140,7 +203,11 @@ def options_present(name, sections=None, separator="=", strict=False):
                             ret["result"] = None
                 else:
                     options_updated = __salt__["ini.set_option"](
-                        name, {section_name: section_body}, separator
+                        file_name=name,
+                        sections={section_name: section_body},
+                        separator=separator,
+                        encoding=encoding,
+                        no_spaces=no_spaces,
                     )
                     if options_updated:
                         changes[section_name].update(options_updated[section_name])
@@ -148,7 +215,13 @@ def options_present(name, sections=None, separator="=", strict=False):
                         del changes[section_name]
         else:
             if not __opts__["test"]:
-                changes = __salt__["ini.set_option"](name, sections, separator)
+                changes = __salt__["ini.set_option"](
+                    file_name=name,
+                    sections=sections,
+                    separator=separator,
+                    encoding=encoding,
+                    no_spaces=no_spaces,
+                )
     except (OSError, KeyError) as err:
         ret["comment"] = f"{err}"
         ret["result"] = False
@@ -165,8 +238,37 @@ def options_present(name, sections=None, separator="=", strict=False):
     return ret
 
 
-def options_absent(name, sections=None, separator="="):
+def options_absent(name, sections=None, separator="=", encoding=None):
     """
+    Remove a key/value pair from an ini file. Key/value pairs present in the ini
+    file and not specified in sections dict will be untouched.
+
+    Args:
+
+        name (str):
+            The path to the ini file
+
+        sections (dict):
+            A dictionary of sections and key/value pairs that will be removed
+            from the ini file. Other key/value pairs in the ini file will be
+            untouched.
+
+        separator (str):
+            The character used to separate keys and values. Standard ini files
+            use the "=" character. The default is ``=``.
+
+        encoding (str):
+            A string value representing encoding of the target ini file. If
+            ``None`` is passed, it uses the system default which is likely
+            ``utf-8``. Default is ``None``
+
+            .. versionadded:: 3006.10
+
+    Returns:
+        dict: A dictionary containing list of changes made
+
+    Example:
+
     .. code-block:: yaml
 
         /home/saltminion/api-paste.ini:
@@ -178,11 +280,6 @@ def options_absent(name, sections=None, separator="="):
                   - secondoption
                 test1:
                   - testkey1
-
-    options present in file and not specified in sections
-    dict will be untouched
-
-    changes dict will contain the list of changes made
     """
     ret = {
         "name": name,
@@ -196,7 +293,12 @@ def options_absent(name, sections=None, separator="="):
         for section in sections or {}:
             section_name = " in section " + section if section else ""
             try:
-                cur_section = __salt__["ini.get_section"](name, section, separator)
+                cur_section = __salt__["ini.get_section"](
+                    file_name=name,
+                    section=section,
+                    separator=separator,
+                    encoding=encoding,
+                )
             except OSError as err:
                 ret["comment"] = f"{err}"
                 ret["result"] = False
@@ -215,7 +317,13 @@ def options_absent(name, sections=None, separator="="):
                     ret["result"] = None
             else:
                 option = section
-                if not __salt__["ini.get_option"](name, None, option, separator):
+                if not __salt__["ini.get_option"](
+                    file_name=name,
+                    section=None,
+                    option=option,
+                    separator=separator,
+                    encoding=encoding,
+                ):
                     ret["comment"] += f"Key {option} does not exist.\n"
                     continue
                 ret["comment"] += f"Deleted key {option}.\n"
@@ -229,7 +337,11 @@ def options_absent(name, sections=None, separator="="):
         for key in keys:
             try:
                 current_value = __salt__["ini.remove_option"](
-                    name, section, key, separator
+                    file_name=name,
+                    section=section,
+                    option=key,
+                    separator=separator,
+                    encoding=encoding,
                 )
             except OSError as err:
                 ret["comment"] = f"{err}"
@@ -247,8 +359,38 @@ def options_absent(name, sections=None, separator="="):
     return ret
 
 
-def sections_present(name, sections=None, separator="="):
+def sections_present(name, sections=None, separator="=", encoding=None):
     """
+    Add sections to an ini file. This will only create empty sections. To also
+    create key/value pairs, use options_present state.
+
+    Args:
+
+        name (str):
+            The path to the ini file
+
+        sections (dict):
+            A dictionary of sections and key/value pairs that will be used to
+            update the ini file. Only the sections portion is used, key/value
+            pairs are ignored. To also set key/value pairs, use the
+            options_present state.
+
+        separator (str):
+            The character used to separate keys and values. Standard ini files
+            use the "=" character. The default is ``=``.
+
+        encoding (str):
+            A string value representing encoding of the target ini file. If
+            ``None`` is passed, it uses the system default which is likely
+            ``utf-8``. Default is ``None``
+
+            .. versionadded:: 3006.10
+
+    Returns:
+        dict: A dictionary containing list of changes made
+
+    Example:
+
     .. code-block:: yaml
 
         /home/saltminion/api-paste.ini:
@@ -257,12 +399,6 @@ def sections_present(name, sections=None, separator="="):
             - sections:
                 - section_one
                 - section_two
-
-    This will only create empty sections. To also create options, use
-    options_present state
-
-    options present in file and not specified in sections will be deleted
-    changes dict will contain the sections that changed
     """
     ret = {
         "name": name,
@@ -274,7 +410,9 @@ def sections_present(name, sections=None, separator="="):
         ret["result"] = True
         ret["comment"] = ""
         try:
-            cur_ini = __salt__["ini.get_ini"](name, separator)
+            cur_ini = __salt__["ini.get_ini"](
+                file_name=name, separator=separator, encoding=encoding
+            )
         except OSError as err:
             ret["result"] = False
             ret["comment"] = f"{err}"
@@ -293,7 +431,12 @@ def sections_present(name, sections=None, separator="="):
     for section_name in sections or []:
         section_to_update.update({section_name: {}})
     try:
-        changes = __salt__["ini.set_option"](name, section_to_update, separator)
+        changes = __salt__["ini.set_option"](
+            file_name=name,
+            section=section_to_update,
+            separator=separator,
+            encoding=encoding,
+        )
     except OSError as err:
         ret["result"] = False
         ret["comment"] = f"{err}"
@@ -307,8 +450,37 @@ def sections_present(name, sections=None, separator="="):
     return ret
 
 
-def sections_absent(name, sections=None, separator="="):
+def sections_absent(name, sections=None, separator="=", encoding=None):
     """
+    Remove sections from the ini file. All key/value pairs in the section will
+    also be removed.
+
+    Args:
+
+        name (str):
+            The path to the ini file
+
+        sections (dict):
+            A dictionary of sections and key/value pairs that will be used to
+            update the ini file. Other sections and key/value pairs in the ini
+            file will be untouched unless ``strict: True`` is passed.
+
+        separator (str):
+            The character used to separate keys and values. Standard ini files
+            use the "=" character. The default is ``=``.
+
+        encoding (str):
+            A string value representing encoding of the target ini file. If
+            ``None`` is passed, it uses the system default which is likely
+            ``utf-8``. Default is ``None``
+
+            .. versionadded:: 3006.6
+
+    Returns:
+        dict: A dictionary containing list of changes made
+
+    Example:
+
     .. code-block:: yaml
 
         /home/saltminion/api-paste.ini:
@@ -317,9 +489,6 @@ def sections_absent(name, sections=None, separator="="):
             - sections:
                 - test
                 - test1
-
-    options present in file and not specified in sections will be deleted
-    changes dict will contain the sections that changed
     """
     ret = {
         "name": name,
@@ -331,7 +500,9 @@ def sections_absent(name, sections=None, separator="="):
         ret["result"] = True
         ret["comment"] = ""
         try:
-            cur_ini = __salt__["ini.get_ini"](name, separator)
+            cur_ini = __salt__["ini.get_ini"](
+                file_name=name, separator=separator, encoding=encoding
+            )
         except OSError as err:
             ret["result"] = False
             ret["comment"] = f"{err}"
@@ -347,7 +518,9 @@ def sections_absent(name, sections=None, separator="="):
         return ret
     for section in sections or []:
         try:
-            cur_section = __salt__["ini.remove_section"](name, section, separator)
+            cur_section = __salt__["ini.remove_section"](
+                file_name=name, section=section, separator=separator, encoding=encoding
+            )
         except OSError as err:
             ret["result"] = False
             ret["comment"] = f"{err}"


### PR DESCRIPTION
### What does this PR do?
Adds a new option named ``no_spaces`` to the ini.set_option function that allows the user to determine whether the separator (``=``) should be wrapped with spaces or not.

### What issues does this PR fix or reference?
Fixes #33669 

### Previous Behavior
The module always wrapped the separator (`=`) with spaces.

### New Behavior
The user can now choose not to wrap the separator with spaces.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes