### PR TITLE
[3006.x] Fix bash-completion for Debian packages

### DIFF
--- a/changelog/66560.fixed.md
+++ b/changelog/66560.fixed.md
@@ -1,0 +1,1 @@
+Fixed bash-completion in Debian / Ubuntu packages.

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -4,7 +4,7 @@ DH_VERBOSE = 1
 .PHONY: override_dh_strip
 
 %:
-	dh $@
+	dh $@ --with=bash_completion
 
 # dh_auto_clean tries to invoke distutils causing failures.
 override_dh_auto_clean:

--- a/pkg/debian/salt-common.bash-completion
+++ b/pkg/debian/salt-common.bash-completion
@@ -1,0 +1,1 @@
+pkg/common/salt.bash salt

--- a/pkg/debian/salt-common.install
+++ b/pkg/debian/salt-common.install
@@ -3,7 +3,6 @@ pkg/common/fish-completions/salt-cp.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-call.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-syndic.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt_common.fish /usr/share/fish/vendor_completions.d
-pkg/common/salt.bash /usr/share/bash-completions/completions/salt-common.bash
 pkg/common/fish-completions/salt-minion.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-key.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-master.fish /usr/share/fish/vendor_completions.d

--- a/pkg/debian/salt-common.links
+++ b/pkg/debian/salt-common.links
@@ -1,2 +1,5 @@
 opt/saltstack/salt/salt-pip /usr/bin/salt-pip
 opt/saltstack/salt/salt-call /usr/bin/salt-call
+usr/share/bash-completion/completions/salt usr/share/bash-completion/completions/salt-call
+usr/share/bash-completion/completions/salt usr/share/bash-completion/completions/salt-cp
+usr/share/bash-completion/completions/salt usr/share/bash-completion/completions/salt-key

--- a/tests/pytests/pkg/integration/test_bash_completion.py
+++ b/tests/pytests/pkg/integration/test_bash_completion.py
@@ -1,0 +1,19 @@
+import pathlib
+
+
+def test_bash_completion_installed(grains):
+    # This test specifically checks for a regression of #66560.
+    if grains.get("os_family") == "Debian":
+        completions_dir = pathlib.Path("/usr/share/bash-completion/completions")
+        for exec_name in ("salt", "salt-call", "salt-cp", "salt-key"):
+            # Bash-completion finds the completion when it is installed as
+            # <command>, <command>.bash, or _<command>, so we test all three
+            # variants before failing.
+            completion_file1 = completions_dir / exec_name
+            completion_file2 = completions_dir / f"{exec_name}.bash"
+            completion_file3 = completions_dir / f"_{exec_name}"
+            assert (
+                completion_file1.exists()
+                or completion_file2.exists()
+                or completion_file3.exists()
+            )


### PR DESCRIPTION
### What does this PR do?

This PR fixes a packaging issue that caused bash-completion not to work when installing Salt via the Debian packages.

### What issues does this PR fix or reference?
Fixes #66560.

### Previous Behavior
The file containing the completions was installed in the wrong directory (`/usr/share/bash_completions/completions` instead of `/usr/share/bash_completion/completions`) and symbolic links for `salt-call`, `salt-cp`, and `salt-key` were missing.

### New Behavior
The install location of the bash-completion script has been changed to `/usr/share/bash_completion/completions/salt` and symlinks for `salt-call`, `salt-cp`, and `salt-key` have been added. This means that Bash now uses the completions when hitting tab for one of the supported commands.


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No
