### PR TITLE
[master] Fix options parsing of highstate returner

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -164,7 +164,7 @@ def _options_browser(cfg, ret_config, defaults, virtualname, options):
         # default place for the option in the config
         value = _fetch_option(cfg, ret_config, virtualname, options[option])
 
-        if value:
+        if value != "":
             yield option, value
             continue
 


### PR DESCRIPTION
### What does this PR do?
Fix Issue #66816

### What issues does this PR fix or reference?
Fixes #66816

### Previous Behavior
Highstate returner doesn't take in configuration of some "report_" options

### New Behavior
Now the returner use configuration of options report_failures, report_changes and report_everything and send report accordingly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
