### PR TITLE
[master] Convert stdin string to bytes regardless of stdin_raw_newlines

### DIFF
--- a/changelog/62501.fixed.md
+++ b/changelog/62501.fixed.md
@@ -1,0 +1,1 @@
+Convert stdin string to bytes regardless of stdin_raw_newlines

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -33,9 +33,8 @@ class TimedProc:
             if not self.stdin_raw_newlines:
                 # Translate a newline submitted as '\n' on the CLI to an actual
                 # newline character.
-                self.stdin = salt.utils.stringutils.to_bytes(
-                    self.stdin.replace("\\n", "\n")
-                )
+                self.stdin = self.stdin.replace("\\n", "\n")
+            self.stdin = salt.utils.stringutils.to_bytes(self.stdin)
             kwargs["stdin"] = subprocess.PIPE
 
         if not self.with_communicate:

--- a/tests/pytests/functional/modules/test_cmdmod.py
+++ b/tests/pytests/functional/modules/test_cmdmod.py
@@ -106,6 +106,8 @@ def test_run(cmdmod, grains):
         == "func-tests-minion-opts"
     )
     assert cmdmod.run("grep f", stdin="one\ntwo\nthree\nfour\nfive\n") == "four\nfive"
+    assert cmdmod.run("cat", stdin="one\\ntwo", stdin_raw_newlines=False) == "one\ntwo"
+    assert cmdmod.run("cat", stdin="one\\ntwo", stdin_raw_newlines=True) == "one\\ntwo"
     assert cmdmod.run('echo "a=b" | sed -e s/=/:/g', python_shell=True) == "a:b"
 
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes issue #62501 

### Previous Behavior
The following error was thrown when running cmd.run with a str passed via stdin and stdin_raw_newlines=True

`Passed invalid arguments to cmd.run: memoryview: a bytes-like object is required, not 'str'`

### New Behavior

String also gets converted to bytes when stdin_raw_newlines=True, so no error is thrown

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
