### PR TITLE
[3006.x]Manage symlinks after dirs and files

### DIFF
--- a/changelog/64630.fixed.md
+++ b/changelog/64630.fixed.md
@@ -1,0 +1,3 @@
+Fixed an intermittent issue with file.recurse where the state would
+report failure even on success. Makes sure symlinks are created
+after the target file is created

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -325,7 +325,7 @@ def file_hash(load, fnd):
 
 def _file_lists(load, form):
     """
-    Return a dict containing the file lists for files, dirs, emtydirs and symlinks
+    Return a dict containing the file lists for files, dirs, empty dirs and symlinks
     """
     if "env" in load:
         # "env" is not supported; Use "saltenv".

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4668,12 +4668,16 @@ def recurse(
         name, source, keep_symlinks, include_pat, exclude_pat, maxdepth, include_empty
     )
 
+    for dirname in mng_dirs:
+        manage_directory(dirname)
+    for dest, src in mng_files:
+        manage_file(dest, src, replace)
     for srelpath, ltarget in mng_symlinks:
         _ret = symlink(
             os.path.join(name, srelpath),
             ltarget,
             makedirs=True,
-            force=force_symlinks,
+            force=force_symlinks or keep_symlinks,
             user=user,
             group=group,
             mode=sym_mode,
@@ -4681,10 +4685,6 @@ def recurse(
         if not _ret:
             continue
         merge_ret(os.path.join(name, srelpath), _ret)
-    for dirname in mng_dirs:
-        manage_directory(dirname)
-    for dest, src in mng_files:
-        manage_file(dest, src, replace)
 
     if clean:
         # TODO: Use directory(clean=True) instead

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -568,7 +568,7 @@ def _gen_recurse_managed_files(
         for file_dest, file_src in managed_files:
             # We need to convert relpath to fullpath. We're using pathlib to
             # be platform-agnostic
-            symlink_full_path = pathlib.Path(f"{name}\\{link_src_relpath}")
+            symlink_full_path = pathlib.Path(f"{name}{os.sep}{link_src_relpath}")
             file_dest_full_path = pathlib.Path(file_dest)
             if symlink_full_path == file_dest_full_path:
                 new_managed_files.append(

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -563,7 +563,7 @@ def _gen_recurse_managed_files(
     # Now let's move all the symlinks to the end
     for symlink in managed_symlinks:
         for file in managed_files:
-            if file[0].endswith(symlink[0]):
+            if file[0].endswith(os.sep + symlink[0]):
                 new_managed_files.append(
                     new_managed_files.pop(new_managed_files.index(file))
                 )
@@ -4443,18 +4443,26 @@ def recurse(
                                 or immediate subdirectories
 
     keep_symlinks
-        Keep symlinks when copying from the source. This option will cause
-        the copy operation to terminate at the symlink. If desire behavior
-        similar to rsync, then set this to True. This option is not taken
-        in account if ``fileserver_followsymlinks`` is set to False.
+
+        Determines how symbolic links (symlinks) are handled during the copying
+        process. When set to ``True``, the copy operation will copy the symlink
+        itself, rather than the file or directory it points to. When set to
+        ``False``, the operation will follow the symlink and copy the target
+        file or directory. If you want behavior similar to rsync, set this
+        option to ``True``.
+
+        However, if the ``fileserver_followsymlinks`` option is set to ``False``,
+        the ``keep_symlinks`` setting will be ignored, and symlinks will not be
+        copied at all.
 
     force_symlinks
-        Force symlink creation. This option will force the symlink creation.
-        If a file or directory is obstructing symlink creation it will be
-        recursively removed so that symlink creation can proceed. This
-        option is usually not needed except in special circumstances. This
-        option is not taken in account if ``fileserver_followsymlinks`` is
-        set to False.
+
+        Controls the creation of symlinks when using ``keep_symlinks``. When set
+        to ``True``, it forces the creation of symlinks by removing any existing
+        files or directories that might be obstructing their creation. This
+        removal is done recursively if a directory is blocking the symlink. This
+        option is only used when ``keep_symlinks`` is passed and is ignored if
+        ``fileserver_followsymlinks`` is set to ``False``.
 
     win_owner
         The owner of the symlink and directories if ``makedirs`` is True. If

--- a/tests/pytests/unit/states/file/test_recurse.py
+++ b/tests/pytests/unit/states/file/test_recurse.py
@@ -1,0 +1,42 @@
+import logging
+import pathlib
+
+import pytest
+
+import salt.states.file as filestate
+from tests.support.mock import MagicMock, patch
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {filestate: {"__salt__": {}, "__opts__": {}, "__env__": "base"}}
+
+
+def test__gen_recurse_managed_files():
+    """
+    Test _gen_recurse_managed_files to make sure it puts symlinks at the end of the list of files.
+    """
+    target_dir = pathlib.Path("\\some\\path\\target")
+    cp_list_master = MagicMock(
+        return_value=[
+            "target/symlink",
+            "target/just_a_file.txt",
+            "target/not_a_symlink/symlink",
+            "target/notasymlink",
+        ],
+    )
+    cp_list_master_symlinks = MagicMock(
+        return_value={"target/symlink": f"{target_dir}\\not_a_symlink\\symlink"}
+    )
+    patch_salt = {
+        "cp.list_master": cp_list_master,
+        "cp.list_master_symlinks": cp_list_master_symlinks,
+    }
+    with patch.dict(filestate.__salt__, patch_salt):
+        files, dirs, links, keep = filestate._gen_recurse_managed_files(
+            name=str(target_dir), source=f"salt://{target_dir.name}", keep_symlinks=True
+        )
+    expected = ("\\some\\path\\target\\symlink", "salt://target/symlink?saltenv=base")
+    assert files[-1] == expected

--- a/tests/pytests/unit/states/file/test_recurse.py
+++ b/tests/pytests/unit/states/file/test_recurse.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 
 import pytest
@@ -18,7 +19,7 @@ def test__gen_recurse_managed_files():
     """
     Test _gen_recurse_managed_files to make sure it puts symlinks at the end of the list of files.
     """
-    target_dir = pathlib.Path("\\some\\path\\target")
+    target_dir = pathlib.Path(f"{os.sep}some{os.sep}path{os.sep}target")
     cp_list_master = MagicMock(
         return_value=[
             "target/symlink",
@@ -28,7 +29,9 @@ def test__gen_recurse_managed_files():
         ],
     )
     cp_list_master_symlinks = MagicMock(
-        return_value={"target/symlink": f"{target_dir}\\not_a_symlink\\symlink"}
+        return_value={
+            "target/symlink": f"{target_dir}{os.sep}not_a_symlink{os.sep}symlink"
+        }
     )
     patch_salt = {
         "cp.list_master": cp_list_master,
@@ -38,5 +41,8 @@ def test__gen_recurse_managed_files():
         files, dirs, links, keep = filestate._gen_recurse_managed_files(
             name=str(target_dir), source=f"salt://{target_dir.name}", keep_symlinks=True
         )
-    expected = ("\\some\\path\\target\\symlink", "salt://target/symlink?saltenv=base")
+    expected = (
+        f"{os.sep}some{os.sep}path{os.sep}target{os.sep}symlink",
+        "salt://target/symlink?saltenv=base",
+    )
     assert files[-1] == expected


### PR DESCRIPTION
### What does this PR do?
Fix intermittent issue with ``file.recurse`` and symlinks.

### What issues does this PR fix or reference?
Fixes #64630 

### Previous Behavior
The state would fail saying that the file was missing.
There seems to be a race condition where it is comparing the hash of the symlinked target file before it is present.

### New Behavior
The state finishes successfully. It does the symlink hashing last to make sure the target files are present.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes