### PR TITLE
[master] [DOCS] fix jinja.import_json module docstr

### DIFF
--- a/salt/modules/jinja.py
+++ b/salt/modules/jinja.py
@@ -100,7 +100,7 @@ def import_json(path):
 
     .. code-block:: bash
 
-        salt myminion jinja.import_JSON myformula/foo.json
+        salt myminion jinja.import_json myformula/foo.json
     """
     tmplstr = textwrap.dedent(
         """\


### PR DESCRIPTION
### What does this PR do?
Minor. In the doc string of the `jinja.import_json` module, the given example stated `import_JSON` instead of `import_json`.  The function can't be called with the capital letters.

### What issues does this PR fix or reference?
none.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
