### PR TITLE
[master] change regex for pkg name match

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -226,7 +226,7 @@ def _check_pkg_version_format(pkg):
             ret["prefix"] = install_req.req.project_name
             ret["version_spec"] = install_req.req.specs
         except Exception:  # pylint: disable=broad-except
-            ret["prefix"] = re.sub("[^A-Za-z0-9.]+", "-", install_req.name)
+            ret["prefix"] = re.sub("[^A-Za-z0-9._]+", "-", install_req.name)
             if hasattr(install_req, "specifier"):
                 specifier = install_req.specifier
             else:


### PR DESCRIPTION
### What does this PR do?
Change the regex to accept underscore as an acceptable symbol in package name.

### What issues does this PR fix or reference?
According to [python normalization rules](https://packaging.python.org/en/latest/specifications/name-normalization/) the underscore (`_`) is allowed symbol in package name. Note the examples there allow for underscore. 

### Previous Behavior
When trying to install package with underscore in the name `with pip.installed`, although the installation is successful, there's a problem with confirming if the package is installed (and always will trigger changes). It doesn't matter if you refer in `pip.installed` to the package with original name (with underscore) or with "normalized" name (with dash), always you have one of the following:

- `Comment: There was no error installing package 'requests_ntlm' although it does not show when calling 'pip.freeze'.`
- `Comment: There was no error installing package 'requests-ntlm' although it does not show when calling 'pip.freeze'.`

Note, the JSON output is with original name:

`{"name": "requests_ntlm", "version": "1.3.0"}`

