### PR TITLE
[master] Fix Python3.13 compatibility regarding urllib.parse module

### DIFF
--- a/changelog/66898.fixed.md
+++ b/changelog/66898.fixed.md
@@ -1,0 +1,1 @@
+Fixed Python 3.13 compatibility regarding urllib.parse module

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -4,7 +4,7 @@ URL utils
 
 import re
 import sys
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, urlunsplit
 
 import salt.utils.data
 import salt.utils.path
@@ -46,8 +46,7 @@ def create(path, saltenv=None):
     path = salt.utils.data.decode(path)
 
     query = f"saltenv={saltenv}" if saltenv else ""
-    url = salt.utils.data.decode(urlunparse(("file", "", path, "", query, "")))
-    return "salt://{}".format(url[len("file:///") :])
+    return f'salt://{salt.utils.data.decode(urlunsplit(("", "", path, query, "")))}'
 
 
 def is_escaped(url):


### PR DESCRIPTION
### What does this PR do?

Python 3.13 fixed handling relative paths in `urllib.parse` module. Specifically, relative file URL is now constructed as `file:path` instead of converting it to absolute `file:///path`. This breaks `salt.utils.url.create` which expects `file:///` specifically. The mismatch results in for example changing `salt://top.sls` into `salt://.sls` and thus not finding the top file.

Fix this by handling both prefixes.

Relevant python change: https://github.com/python/cpython/issues/85110

### What issues does this PR fix or reference?
Fixes: #66898

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated (current tests in tests/unit/utils/test_url.py are enough when will start running on Python 3.13)

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
