### PR TITLE
[master] fix(nacl): Update `generate pk using the sk` procedure

### DIFF
--- a/changelog/66900.fixed.md
+++ b/changelog/66900.fixed.md
@@ -1,0 +1,1 @@
+Fix the procedure of create `pk` from `sk` of `keygen` function in `salt.utils.nacl` file. The old code, could not generate the correct value of `pk`.

--- a/salt/utils/nacl.py
+++ b/salt/utils/nacl.py
@@ -182,9 +182,9 @@ def keygen(sk_file=None, pk_file=None, **kwargs):
         with salt.utils.files.fopen(sk_file, "rb") as keyf:
             sk = salt.utils.stringutils.to_unicode(keyf.read()).rstrip("\n")
             sk = base64.b64decode(sk)
-        kp = nacl.public.PublicKey(sk)
+        kp = nacl.public.PrivateKey(sk)
         with salt.utils.files.fopen(pk_file, "wb") as keyf:
-            keyf.write(base64.b64encode(kp.encode()))
+            keyf.write(base64.b64encode(kp.public_key.encode()))
         return f"saved pk_file: {pk_file}"
 
     kp = nacl.public.PublicKey.generate()


### PR DESCRIPTION
### What does this PR do?

Fix the `generate pk using the sk` procedure in `genkey` function of the `salt.utils.nacl` file.

### What issues does this PR fix or reference?
Fixes #66900

### Previous Behavior

Generate the wrong `pk` value because it's the same as `sk`.

### New Behavior

Generate the correct `pk` value.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
