### PR TITLE
[master] Datetime utcnow

### DIFF
--- a/changelog/65604.fixed.md
+++ b/changelog/65604.fixed.md
@@ -1,0 +1,1 @@
+Fixed some instances of deprecated datetime.datetime.utcnow()

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2992,12 +2992,12 @@ def ip_fqdn():
         if not ret["ipv" + ipv_num]:
             ret[key] = []
         else:
-            start_time = datetime.datetime.utcnow()
+            start_time = datetime.datetime.now(tz=datetime.timezone.utc)
             try:
                 info = socket.getaddrinfo(_fqdn, None, socket_type)
                 ret[key] = list({item[4][0] for item in info})
             except (OSError, UnicodeError):
-                timediff = datetime.datetime.utcnow() - start_time
+                timediff = datetime.datetime.now(tz=datetime.timezone.utc) - start_time
                 if timediff.seconds > 5 and __opts__["__role"] == "master":
                     log.warning(
                         'Unable to find IPv%s record for "%s" causing a %s '

--- a/salt/state.py
+++ b/salt/state.py
@@ -164,11 +164,9 @@ def _calculate_fake_duration() -> tuple[str, float]:
     Generate a NULL duration for when states do not run
     but we want the results to be consistent.
     """
-    utc_start_time = datetime.datetime.utcnow()
-    local_start_time = utc_start_time - (
-        datetime.datetime.utcnow() - datetime.datetime.now()
-    )
-    utc_finish_time = datetime.datetime.utcnow()
+    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    local_start_time = utc_start_time.astimezone()
+    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
     start_time = local_start_time.time().isoformat()
     delta = utc_finish_time - utc_start_time
     # duration in milliseconds.microseconds
@@ -2022,7 +2020,7 @@ class State:
             instance.states.inject_globals = inject_globals
         # we need to re-record start/end duration here because it is impossible to
         # correctly calculate further down the chain
-        utc_start_time = datetime.datetime.utcnow()
+        utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
         instance.format_slots(cdata)
         tag = _gen_tag(low)
@@ -2042,10 +2040,9 @@ class State:
                 "comment": f"An exception occurred in this state: {trb}",
             }
 
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
-        local_finish_time = utc_finish_time - timezone_delta
-        local_start_time = utc_start_time - timezone_delta
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        local_finish_time = utc_finish_time.astimezone()
+        local_start_time = utc_start_time.astimezone()
         ret["start_time"] = local_start_time.time().isoformat()
         delta = utc_finish_time - utc_start_time
         # duration in milliseconds.microseconds
@@ -2075,8 +2072,8 @@ class State:
                         *cdata["args"], **cdata["kwargs"]
                     )
 
-                    utc_start_time = datetime.datetime.utcnow()
-                    utc_finish_time = datetime.datetime.utcnow()
+                    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+                    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
                     delta = utc_finish_time - utc_start_time
                     duration = (delta.seconds * 1000000 + delta.microseconds) / 1000.0
                     retry_ret["duration"] = duration
@@ -2161,10 +2158,8 @@ class State:
         Call a state directly with the low data structure, verify data
         before processing.
         """
-        utc_start_time = datetime.datetime.utcnow()
-        local_start_time = utc_start_time - (
-            datetime.datetime.utcnow() - datetime.datetime.now()
-        )
+        utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        local_start_time = utc_start_time.astimezone()
         low_name = low.get("name")
         log_low_name = low_name.strip() if isinstance(low_name, str) else low_name
         log.info(
@@ -2359,10 +2354,9 @@ class State:
         self.__run_num += 1
         format_log(ret)
         self.check_refresh(low, ret)
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
-        local_finish_time = utc_finish_time - timezone_delta
-        local_start_time = utc_start_time - timezone_delta
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        local_finish_time = utc_finish_time.astimezone()
+        local_start_time = utc_start_time.astimezone()
         ret["start_time"] = local_start_time.time().isoformat()
         delta = utc_finish_time - utc_start_time
         # duration in milliseconds.microseconds

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -16,7 +16,7 @@ def _utc_now():
     """
     Helper method so tests do not have to patch the built-in method.
     """
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def gen_jid(opts):

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -130,7 +130,10 @@ def parse_pkginfo(line, osarch=None):
 
     if install_time not in ("(none)", "0"):
         install_date = (
-            datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
+            datetime.datetime.fromtimestamp(
+                int(install_time), datetime.timezone.utc
+            ).isoformat()
+            + "Z"
         )
         install_date_time_t = int(install_time)
     else:

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import textwrap
 import uuid
+import warnings
 from collections import namedtuple
 
 import pytest
@@ -2452,7 +2453,8 @@ def _run_fqdn_tests(
         salt.utils.network, "ip_addrs6", MagicMock(return_value=net_ip6_mock)
     ), patch.object(
         core.socket, "getaddrinfo", side_effect=_getaddrinfo
-    ):
+    ), warnings.catch_warnings():
+        warnings.simplefilter("error")
         get_fqdn = core.ip_fqdn()
         ret_keys = ["fqdn_ip4", "fqdn_ip6", "ipv4", "ipv6"]
         for key in ret_keys:

--- a/tests/pytests/unit/state/test_state_basic.py
+++ b/tests/pytests/unit/state/test_state_basic.py
@@ -2,6 +2,7 @@
 Test functions in state.py that are not a part of a class
 """
 
+import warnings
 from collections import OrderedDict
 
 import pytest
@@ -140,8 +141,11 @@ def test_state_args_id_not_high():
             ),
         ]
     )
-    ret = salt.state.state_args(id_, state, high)
-    assert ret == set()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        salt.utils.jid.gen_jid({})
+        ret = salt.state.state_args(id_, state, high)
+        assert ret == set()
 
 
 def test_state_args_state_not_high():

--- a/tests/unit/utils/test_jid.py
+++ b/tests/unit/utils/test_jid.py
@@ -4,6 +4,7 @@ Tests for salt.utils.jid
 
 import datetime
 import os
+import warnings
 
 import salt.utils.jid
 from tests.support.mock import patch
@@ -49,3 +50,8 @@ class JidTestCase(TestCase):
             self.assertEqual(
                 str(no_opts), "gen_jid() missing 1 required positional argument: 'opts'"
             )
+
+    def test_deprecation_65604(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            salt.utils.jid.gen_jid({})


### PR DESCRIPTION
### What does this PR do?

This removes some usage of deprecated datetime.datetime.utcnow() and replaces them with timezone-aware objects, while not changing the actual behavior.

### What issues does this PR fix or reference?
Partial fix for https://github.com/saltstack/salt/issues/65604

This is complementary to https://github.com/saltstack/salt/pull/66042

### Previous Behavior

Salt logs warnings like:
```
/usr/lib/python3.12/site-packages/salt/utils/jid.py:19: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

### New Behavior

No warning.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
