### PR TITLE
[master] salt.channel.server.handle_message: be more defensive

### DIFF
--- a/changelog/66909.fixed.md
+++ b/changelog/66909.fixed.md
@@ -1,0 +1,1 @@
+make salt.channel.server.handle_message codepath more defensive

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -141,7 +141,7 @@ class ReqServerChannel:
             or "enc" not in payload
             or "load" not in payload
         ):
-            log.warn("bad load received on socket")
+            log.warning("bad load received on socket")
             return "bad load"
         try:
             version = int(payload.get("version", 0))
@@ -177,9 +177,8 @@ class ReqServerChannel:
         # TODO helper functions to normalize payload?
         if not isinstance(payload, dict) or not isinstance(payload.get("load"), dict):
             log.error(
-                "payload and load must be a dict. Payload was: %s and load was %s",
+                "payload and load must be a dict. Payload was: %s",
                 payload,
-                payload.get("load"),
             )
             return "payload and load must be a dict"
 
@@ -195,11 +194,6 @@ class ReqServerChannel:
         sign_messages = False
         if version > 1:
             sign_messages = True
-
-        # intercept the "_auth" commands, since the main daemon shouldn't know
-        # anything about our key auth
-        if payload["enc"] == "clear" and payload.get("load", {}).get("cmd") == "_auth":
-            return self._auth(payload["load"], sign_messages, version)
 
         if payload["enc"] == "aes":
             nonce = None
@@ -240,37 +234,47 @@ class ReqServerChannel:
 
         # TODO: test
         try:
+            # intercept the "_auth" commands, since the main daemon shouldn't know
+            # anything about our key auth
+            if (
+                payload["enc"] == "clear"
+                and payload.get("load", {}).get("cmd") == "_auth"
+            ):
+                return self._auth(payload["load"], sign_messages, version)
+
             # Take the payload_handler function that was registered when we created the channel
             # and call it, returning control to the caller until it completes
+
             ret, req_opts = await self.payload_handler(payload)
+
+            req_fun = req_opts.get("fun", "send")
+            if req_fun == "send_clear":
+                return ret
+            elif req_fun == "send":
+                if version > 2:
+                    return salt.crypt.Crypticle(self.opts, self.session_key(id_)).dumps(
+                        ret, nonce
+                    )
+                else:
+                    return self.crypticle.dumps(ret, nonce)
+            elif req_fun == "send_private":
+                return self._encrypt_private(
+                    ret,
+                    req_opts["key"],
+                    req_opts["tgt"],
+                    nonce,
+                    sign_messages,
+                    payload.get("enc_algo", salt.crypt.OAEP_SHA1),
+                    payload.get("sig_algo", salt.crypt.PKCS1v15_SHA1),
+                )
+            log.error("Unknown req_fun %s", req_fun)
+            # always attempt to return an error to the minion
+            return "Server-side exception handling payload"
+
         except Exception as e:  # pylint: disable=broad-except
             # always attempt to return an error to the minion
             log.error("Some exception handling a payload from minion", exc_info=True)
             return "Some exception handling minion payload"
-
-        req_fun = req_opts.get("fun", "send")
-        if req_fun == "send_clear":
-            return ret
-        elif req_fun == "send":
-            if version > 2:
-                return salt.crypt.Crypticle(self.opts, self.session_key(id_)).dumps(
-                    ret, nonce
-                )
-            else:
-                return self.crypticle.dumps(ret, nonce)
-        elif req_fun == "send_private":
-            return self._encrypt_private(
-                ret,
-                req_opts["key"],
-                req_opts["tgt"],
-                nonce,
-                sign_messages,
-                payload.get("enc_algo", salt.crypt.OAEP_SHA1),
-                payload.get("sig_algo", salt.crypt.PKCS1v15_SHA1),
-            )
-        log.error("Unknown req_fun %s", req_fun)
-        # always attempt to return an error to the minion
-        return "Server-side exception handling payload"
 
     def _encrypt_private(
         self,

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -760,7 +760,7 @@ class ReqServerChannel:
         # and an empty request comes in
         try:
             pub = salt.crypt.PublicKey.from_str(key["pub"])
-        except salt.crypt.InvalidKeyError as err:
+        except Exception as err:  # pylint: disable=broad-except
             log.error(
                 'Corrupt or missing public key "%s": %s',
                 load["id"],

--- a/tests/pytests/unit/channel/test_server.py
+++ b/tests/pytests/unit/channel/test_server.py
@@ -13,6 +13,7 @@ import salt.utils.event
 import salt.utils.files
 import salt.utils.stringutils
 from salt.master import SMaster
+from tests.support.mock import AsyncMock, MagicMock, patch
 
 
 @pytest.fixture
@@ -382,3 +383,117 @@ def test_handle_message_version_extraction(auth_master_opts):
 # Note: The remaining security bypasses (token, TTL, ID mismatch, session keys)
 # are already tested via the parametrized downgrade tests above and the
 # functional tests. The key regression test is ensuring old versions are rejected.
+async def test_handle_message_exceptions(temp_salt_master):
+    """
+    test exceptions are handled cleanly in handle_message
+    """
+    opts = dict(temp_salt_master.config.copy())
+    req = server.ReqServerChannel(opts, None)
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(side_effect=OSError()),
+    ):
+        ret = await req.handle_message({})
+        assert ret == "bad load"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value="foobar"),
+    ):
+        ret = await req.handle_message({})
+        assert ret == "bad load"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value={"load": {"id": "foo\0"}}),
+    ):
+        ret = await req.handle_message({"version": 3, "enc": "clear", "load": {}})
+        assert ret == "bad load: id contains a null byte"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value={"load": {"id": None}}),
+    ):
+        ret = await req.handle_message({"version": 3, "enc": "clear", "load": {}})
+        assert ret == "bad load: id None is not a string"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(
+            return_value={"version": 3, "enc": "clear", "load": {"cmd": "_auth"}}
+        ),
+    ):
+        with patch(
+            "salt.channel.server.ReqServerChannel._auth",
+            MagicMock(side_effect=OSError()),
+        ):
+            ret = await req.handle_message({"version": 3, "enc": "clear", "load": {}})
+            assert ret == "Some exception handling minion payload"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(
+            return_value={"version": 3, "enc": "clear", "load": {"cmd": "not_auth"}}
+        ),
+    ):
+        with patch(
+            "salt.channel.server.ReqServerChannel.payload_handler",
+            MagicMock(side_effect=OSError()),
+            create=True,
+        ):
+            ret = await req.handle_message({"version": 3, "enc": "clear", "load": {}})
+            assert ret == "Some exception handling minion payload"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value={"enc": "clear", "load": {"cmd": "not_auth"}}),
+    ):
+        with patch(
+            "salt.channel.server.ReqServerChannel.payload_handler",
+            AsyncMock(return_value=(None, {"fun": "send"})),
+            create=True,
+        ):
+            crypticle = MagicMock()
+            with patch.object(req, "crypticle", crypticle, create=True):
+                crypticle.dumps = MagicMock(side_effect=OSError())
+                ret = await req.handle_message(
+                    {"version": 3, "enc": "clear", "load": {}}
+                )
+                assert ret == "Some exception handling minion payload"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value={"enc": "clear", "load": {"cmd": "not_auth"}}),
+    ):
+        with patch(
+            "salt.channel.server.ReqServerChannel.payload_handler",
+            AsyncMock(
+                return_value=(None, {"fun": "send_private", "key": None, "tgt": None})
+            ),
+            create=True,
+        ):
+            with patch.object(
+                req, "_encrypt_private", MagicMock(side_effect=OSError()), create=True
+            ):
+                ret = await req.handle_message(
+                    {"version": 3, "enc": "clear", "load": {}}
+                )
+                assert ret == "Some exception handling minion payload"
+
+    with patch(
+        "salt.channel.server.ReqServerChannel._decode_payload",
+        MagicMock(return_value={"enc": "clear", "load": {"cmd": "not_auth"}}),
+    ):
+        with patch(
+            "salt.channel.server.ReqServerChannel.payload_handler",
+            AsyncMock(return_value=(None, {"fun": "foobar", "key": None, "tgt": None})),
+            create=True,
+        ):
+            with patch.object(
+                req, "_encrypt_private", MagicMock(side_effect=OSError()), create=True
+            ):
+                ret = await req.handle_message(
+                    {"version": 3, "enc": "clear", "load": {}}
+                )
+                assert ret == "Server-side exception handling payload"


### PR DESCRIPTION
### What does this PR do?
it's possible _encrypt_private can throw depending on what key backend is used; so we should guard against any possible unhandled exceptions in this critical codepath. We already do this when wrapping the payload_handler, so we just move the other code in the same try.

I've also added some tests to cover different scenarios in handle_message as its untested atm.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
