### PR TITLE
Python 3.12: fix for urlunparse() not returning properly-prefixed file:/// URLs

### DIFF
--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -47,6 +47,9 @@ def create(path, saltenv=None):
 
     query = f"saltenv={saltenv}" if saltenv else ""
     url = salt.utils.data.decode(urlunparse(("file", "", path, "", query, "")))
+    if url.startswith("file:") and not url.startswith("file:/"):
+        # Workaround for urlunparse not returning a full file:/// in Python 3.12.
+        url = "file:///" + url[len("file:") :]
     return "salt://{}".format(url[len("file:///") :])
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes `salt:///` URL handling.

Issue spotted when using `file.template` and Salt-SSH.  This issue caused the relative portion of the URL to be truncated two characters in the front, which caused the template files affected not being found by the minion.

Technically, a `file:path/to/file` URL is legal (although quite nonsensical), but since we know this `create()` function only gets paths that are absolute (or, rather, always relative to a specific root path), it's OK for us to do this.  Even the `return` line of the function betrays this by adding prefix `salt:///`.

### What issues does this PR fix or reference?

None known, so far it is original bug.

### Previous Behavior

This used to work.

### New Behavior

This does not work in 3007.1 anymore.

### Merge requirements satisfied?

Sorry, I just want to fix this issue, I don't have time for these requirements.  If someone else wants to adopt this change, good, please go ahead and steal the change — you are hereby authorized to do so, you don't even have to credit me (but it would be nice if I was).  If not, Salt-SSH can stay broken and I can live with my patch locally forever.  If you need a towncrier change log entry, please just push that to the branch.