### PR TITLE
[3006.x] Fix error in test suite teardown

### DIFF
--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -65,7 +65,11 @@ class DeferredStreamHandler(StreamHandler):
                 super().handle(record)
             finally:
                 self.__emitting = False
-        super().flush()
+        # Seeing an exception from calling flush on a closed file in the test
+        # suite. Handling this condition for now but this seems to be
+        # indicitive of an un-clean teardown at some point.
+        if not self.stream.closed:
+            super().flush()
 
     def sync_with_handlers(self, handlers=()):
         """


### PR DESCRIPTION
The error seen was:
```
Exception ignored in atexit callback: <bound method DeferredStreamHandler.flush of <DeferredStreamHandler <_io.FileIO [closed]> (WARNING)>>
Traceback (most recent call last):
  File "/home/dan/src/salt/salt/_logging/handlers.py", line 68, in flush
    super().flush()
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1084, in flush
    self.stream.flush()
ValueError: I/O operation on closed file.
```

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
