### PR TITLE
[3007.x][66799] Update master-cluster.rst Example Config

### DIFF
--- a/doc/topics/tutorials/master-cluster.rst
+++ b/doc/topics/tutorials/master-cluster.rst
@@ -93,6 +93,8 @@ Master Config:
         cluster_pki_dir: /my/gluster/share/pki
         cachedir: /my/gluster/share/cache
         file_roots:
+          base:
             - /my/gluster/share/srv/salt
         pillar_roots:
+          base:
             - /my/gluster/share/srv/pillar


### PR DESCRIPTION
The Master Config example's `file_roots` and `pillar_roots` properties need the `base` property followed by a list of the directory. Otherwise, the Salt master shows an error in the logs.

### What does this PR do?
Updates the documentation of the Master Cluster config.

I had to close https://github.com/saltstack/salt/pull/66822 in order to rebase my branch against 3007.x.

### What issues does this PR fix or reference?
Incorrect example of the Master Cluster config.
Fixes 66799 [DOCS] Documentation Inconsistency

### Previous Behavior
![saltExample](https://github.com/user-attachments/assets/e43694cd-c558-499b-a116-de3f7599f1bb)

### New Behavior
Based on the example of `file_roots` here:
https://docs.saltproject.io/en/latest/ref/configuration/master.html#file-roots

we add `base:` to the config.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
