### PR TITLE
[3006.x] fix(saltclass): don't lose nested classes and states in recursion

### DIFF
--- a/changelog/58969.fixed.md
+++ b/changelog/58969.fixed.md
@@ -1,0 +1,4 @@
+Issue 58969: Fixes an issue with `saltclass.expand_classes_in_order`
+function where it was losing nested classes states during class
+expansion. The logic now use `salt.utils.odict.OrderedDict` to keep
+the inclusion ordering.

--- a/changelog/63933.fixed.md
+++ b/changelog/63933.fixed.md
@@ -1,0 +1,4 @@
+Issue 63933: Fixes an issue with `saltclass.expanded_dict_from_minion`
+function where it was passing a reference to minion `dict` which was
+overridden by nested classes during class expansion. Copy the node
+definition with `copy.deepcopy` instead of passing a reference.

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -1,3 +1,4 @@
+import copy
 import glob
 import logging
 import os
@@ -362,7 +363,9 @@ def expanded_dict_from_minion(minion_id, salt_data):
         node_dict[minion_id] = {}
 
     # Merge newly found pillars into existing ones
-    dict_merge(salt_data["__pillar__"], node_dict[minion_id].get("pillars", {}))
+    dict_merge(
+        salt_data["__pillar__"], copy.deepcopy(node_dict[minion_id]).get("pillars", {})
+    )
 
     # Get 2 ordered lists:
     # expanded_classes: A list of all the dicts

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -5,6 +5,7 @@ import re
 
 from jinja2 import Environment, FileSystemLoader
 
+import salt.utils.odict
 import salt.utils.path
 import salt.utils.yaml
 
@@ -277,9 +278,27 @@ def expand_classes_glob(classes, salt_data):
     return expanded_classes
 
 
-def expand_classes_in_order(
-    minion_dict, salt_data, seen_classes, expanded_classes, classes_to_expand
-):
+def expand_classes_in_order(minion_dict, salt_data, seen_classes, classes_to_expand):
+    """
+    Expand the list of `classes_to_expand` and return them in the order found
+
+    The return order is `[C, B, A, M, B, L, MINION_ID]` when:
+
+    - minion node include classes `A` and `L`
+    - `A` include class `B`
+    - `B` include class `C`
+    - `L` include class `M` and `B`
+
+    :param dict minion_dict: definition of minion node
+    :param dict salt_data: configuration data
+    :param iterable(str) seen_classes: classes already processed
+    :param iterable(str) classes_to_expand: classes to recursivly expand
+    :return: Expanded classes in proper order
+    :rtype: salt.utils.odict.OrderedDict
+    """
+
+    expanded_classes = salt.utils.odict.OrderedDict()
+
     # Get classes to expand from minion dictionary
     if not classes_to_expand and "classes" in minion_dict:
         classes_to_expand = minion_dict["classes"]
@@ -290,71 +309,37 @@ def expand_classes_in_order(
     for klass in classes_to_expand:
         if klass not in seen_classes:
             seen_classes.append(klass)
-            expanded_classes[klass] = get_class(klass, salt_data)
+            klass_dict = salt.utils.odict.OrderedDict(
+                {klass: get_class(klass, salt_data)}
+            )
             # Fix corner case where class is loaded but doesn't contain anything
-            if expanded_classes[klass] is None:
-                expanded_classes[klass] = {}
+            if klass_dict[klass] is None:
+                klass_dict[klass] = {}
 
             # Merge newly found pillars into existing ones
-            new_pillars = expanded_classes[klass].get("pillars", {})
+            new_pillars = klass_dict[klass].get("pillars", {})
             if new_pillars:
                 dict_merge(salt_data["__pillar__"], new_pillars)
 
-            # Now replace class element in classes_to_expand by expansion
-            if expanded_classes[klass].get("classes"):
-                l_id = classes_to_expand.index(klass)
-                classes_to_expand[l_id:l_id] = expanded_classes[klass]["classes"]
-                expand_classes_in_order(
-                    minion_dict,
+            if "classes" in klass_dict[klass]:
+                nested_classes = expand_classes_in_order(
+                    {},
                     salt_data,
                     seen_classes,
-                    expanded_classes,
-                    classes_to_expand,
-                )
-            else:
-                expand_classes_in_order(
-                    minion_dict,
-                    salt_data,
-                    seen_classes,
-                    expanded_classes,
-                    classes_to_expand,
+                    klass_dict[klass].get("classes", {}),
                 )
 
-    # We may have duplicates here and we want to remove them
-    tmp = []
-    for t_element in classes_to_expand:
-        if t_element not in tmp:
-            tmp.append(t_element)
+                # Put current class after nested classes
+                klass_dict.update(nested_classes)
+                klass_dict.move_to_end(klass)
 
-    classes_to_expand = tmp
+            expanded_classes.update(klass_dict)
 
-    # Now that we've retrieved every class in order,
-    # let's return an ordered list of dicts
-    ord_expanded_classes = []
-    ord_expanded_states = []
-    for ord_klass in classes_to_expand:
-        ord_expanded_classes.append(expanded_classes[ord_klass])
-        # And be smart and sort out states list
-        # Address the corner case where states is empty in a class definition
-        if (
-            "states" in expanded_classes[ord_klass]
-            and expanded_classes[ord_klass]["states"] is None
-        ):
-            expanded_classes[ord_klass]["states"] = {}
+    # Minion dict must be at the end
+    if minion_dict:
+        expanded_classes.update({salt_data["minion_id"]: minion_dict})
 
-        if "states" in expanded_classes[ord_klass]:
-            ord_expanded_states.extend(expanded_classes[ord_klass]["states"])
-
-    # Add our minion dict as final element but check if we have states to process
-    if "states" in minion_dict and minion_dict["states"] is None:
-        minion_dict["states"] = []
-
-    if "states" in minion_dict:
-        ord_expanded_states.extend(minion_dict["states"])
-
-    ord_expanded_classes.append(minion_dict)
-
-    return ord_expanded_classes, classes_to_expand, ord_expanded_states
+    return expanded_classes
 
 
 def expanded_dict_from_minion(minion_id, salt_data):
@@ -382,17 +367,28 @@ def expanded_dict_from_minion(minion_id, salt_data):
     # Get 2 ordered lists:
     # expanded_classes: A list of all the dicts
     # classes_list: List of all the classes
-    expanded_classes, classes_list, states_list = expand_classes_in_order(
-        node_dict[minion_id], salt_data, [], {}, []
-    )
+    expanded_classes = expand_classes_in_order(node_dict[minion_id], salt_data, [], [])
 
     # Here merge the pillars together
     pillars_dict = {}
-    for exp_dict in expanded_classes:
+    states_list = []
+    classes_list = list(expanded_classes.keys())[:-1]
+    classes_values = list(expanded_classes.values())
+    for exp_dict in classes_values:
         if "pillars" in exp_dict:
             dict_merge(pillars_dict, exp_dict)
+        if "states" in exp_dict:
+            states_list.extend(exp_dict["states"])
 
-    return expanded_classes, pillars_dict, classes_list, states_list
+    # Avoid duplicates, keep first
+    state_seen = set()
+    states_list = [
+        state
+        for state in states_list
+        if not (state in state_seen or state_seen.add(state))
+    ]
+
+    return classes_values, pillars_dict, classes_list, states_list
 
 
 def get_pillars(minion_id, salt_data):

--- a/tests/pytests/unit/pillar/test_saltclass.py
+++ b/tests/pytests/unit/pillar/test_saltclass.py
@@ -23,6 +23,8 @@ def temp_saltclass_tree(tmp_path, minion_id):
     nodes_dir.mkdir(parents=True, exist_ok=True)
     default_dir = classes_dir / "default"
     default_dir.mkdir(parents=True, exist_ok=True)
+    users_dir = default_dir / "users"
+    users_dir.mkdir(parents=True, exist_ok=True)
     roles_dir = classes_dir / "roles"
     roles_dir.mkdir(parents=True, exist_ok=True)
     nginx_subdir = roles_dir / "nginx"
@@ -34,6 +36,9 @@ def temp_saltclass_tree(tmp_path, minion_id):
       - default.users
       - default.motd
       - default.empty
+
+    states:
+      - default
 
     pillars:
       default:
@@ -50,6 +55,13 @@ def temp_saltclass_tree(tmp_path, minion_id):
       test_list:
         - a: ${default:network:ntp:srv1}
         - ${default:network:ntp:srv2}
+
+      global_scalar: from default
+      test_dict:
+        a_scalar: from default
+        a_list:
+          - element1
+          - element2
     """
     default_init.write_text(test_list)
 
@@ -57,24 +69,91 @@ def temp_saltclass_tree(tmp_path, minion_id):
     nodes_text = """
     environment: base
 
+    states:
+      - minion_node
+
     classes:
     {% for class in ['default', 'roles.*', 'empty.*'] %}
       - {{ class }}
     {% endfor %}
+
+    pillars:
+      global_scalar: from minion_node
+      test_dict:
+        a_scalar: from minion_node
     """
     minion_node_file.write_text(nodes_text)
 
-    (default_dir / "users.yml").write_text("test: this is a test")
+    (users_dir / "init.yml").write_text(
+        """
+        classes:
+          - default.users.foo
+
+        states:
+          - users
+
+        pillars:
+          default:
+            ntp:
+              srv1: 192.168.20.10
+
+          global_scalar: from users
+          test_dict:
+            a_scalar: from users
+        """
+    )
+    (users_dir / "foo.yml").write_text(
+        """
+        states:
+          - users.foo
+
+        global_scalar: from users.foo
+        users_foo_scalar: from users.foo
+        test_dict:
+          a_scalar: from users.foo
+        """
+    )
     (default_dir / "empty.yml").write_text("test: this is a test")
-    (default_dir / "motd.yml").write_text("test: this is a test")
-    (roles_dir / "app.yml").write_text("test: this is a test")
-    (nginx_subdir / "init.yml").write_text("test: this is a test")
+    (default_dir / "motd.yml").write_text(
+        """
+        states:
+          - motd
+
+        pillars:
+          global_scalar: from motd
+        """
+    )
+    (roles_dir / "app.yml").write_text(
+        """
+        states:
+          - app
+
+        pillars:
+          global_scalar: from app
+        """
+    )
+    (nginx_subdir / "init.yml").write_text(
+        """
+        states:
+          - nginx
+
+        pillars:
+          global_scalar: from nginx
+          nginx_scalar: from nginx
+        """
+    )
 
     return dirname
 
 
-def test_succeeds(temp_saltclass_tree):
+def test_classes_order(temp_saltclass_tree):
+    """
+    Classes must be correctly ordered.
+
+    See: https://github.com/saltstack/salt/issues/58969
+    """
     expected_ret = [
+        "default.users.foo",
         "default.users",
         "default.motd",
         "default.empty",
@@ -105,6 +184,105 @@ def test_list_expansion_succeeds(temp_saltclass_tree):
     try:
         full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
         parsed_ret = full_ret["test_list"]
+    # Fail the test if we hit our NoneType error
+    except TypeError as err:
+        pytest.fail(err)
+    # Else give the parsed content result
+    assert expected_ret == parsed_ret
+
+
+def test_node_override_classes_scalars(temp_saltclass_tree):
+    """
+    Scalars pillars defined in a node definition must override the
+    definition from classes.
+    """
+    expected_ret = "from minion_node"
+    fake_args = {"path": str(temp_saltclass_tree)}
+    fake_pillar = {}
+    fake_minion_id = "fake_id"
+    try:
+        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+        parsed_ret = full_ret["global_scalar"]
+    # Fail the test if we hit our NoneType error
+    except TypeError as err:
+        pytest.fail(err)
+    # Else give the parsed content result
+    assert expected_ret == parsed_ret
+
+
+def test_node_override_classes_scalar_in_dict(temp_saltclass_tree):
+    """
+    Scalars defined in `dict` pillars defined in a node definition must override the
+    same dict definition from classes.
+
+    See: https://github.com/saltstack/salt/issues/63933
+    """
+    expected_ret = "from minion_node"
+    fake_args = {"path": str(temp_saltclass_tree)}
+    fake_pillar = {}
+    fake_minion_id = "fake_id"
+    try:
+        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+        parsed_ret = full_ret["test_dict"]["a_scalar"]
+    # Fail the test if we hit our NoneType error
+    except TypeError as err:
+        pytest.fail(err)
+    # Else give the parsed content result
+    assert expected_ret == parsed_ret
+
+
+def test_node_override_classes_list_in_dict(temp_saltclass_tree):
+    """
+    `list` under a `dict` defined in a node definition must override the
+    same definition from classes.
+
+    See: https://github.com/saltstack/salt/issues/63933
+    """
+    expected_ret = {"srv1": "192.168.10.10", "srv2": "192.168.10.20"}
+    fake_args = {"path": str(temp_saltclass_tree)}
+    fake_pillar = {}
+    fake_minion_id = "fake_id"
+    try:
+        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+        parsed_ret = full_ret["default"]["network"]["ntp"]
+    # Fail the test if we hit our NoneType error
+    except TypeError as err:
+        pytest.fail(err)
+    # Else give the parsed content result
+    assert expected_ret == parsed_ret
+
+
+def test_list_in_dict_no_duplication(temp_saltclass_tree):
+    """
+    `list` under a `dict` in pillar must not be duplicated.
+
+    See:
+    """
+    expected_ret = ["element1", "element2"]
+    fake_args = {"path": str(temp_saltclass_tree)}
+    fake_pillar = {}
+    fake_minion_id = "fake_id"
+    try:
+        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+        parsed_ret = full_ret["test_dict"]["a_list"]
+    # Fail the test if we hit our NoneType error
+    except TypeError as err:
+        pytest.fail(err)
+    # Else give the parsed content result
+    assert expected_ret == parsed_ret
+
+
+def test_nested_classes_has_pillars(temp_saltclass_tree):
+    """
+    pillars defined in nested classes are present
+    """
+    expected_ret = "from nginx"
+    fake_args = {"path": str(temp_saltclass_tree)}
+    fake_pillar = {}
+    fake_minion_id = "fake_id"
+    try:
+        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+        parsed_ret = full_ret["nginx_scalar"]
     # Fail the test if we hit our NoneType error
     except TypeError as err:
         pytest.fail(err)

--- a/tools/precommit/docstrings.py
+++ b/tools/precommit/docstrings.py
@@ -345,7 +345,6 @@ MISSING_DOCSTRINGS = {
         "get_pillars",
         "expand_variables",
         "render_jinja",
-        "expand_classes_in_order",
         "dict_search_and_replace",
         "expanded_dict_from_minion",
         "find_value_to_expand",


### PR DESCRIPTION
### What does this PR do?

This PR keep all the classes and states from recursive expansion of saltclass classes.

### What issues does this PR fix or reference?
Fixes #58969
Fixes #63933

### Previous Behavior

Only states from top level classes were kept.

### New Behavior

All states from all classes are used, in the correct order.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
