### PR TITLE
[3007.x] transport: tcp check that pull_path exists before chmod

### DIFF
--- a/changelog/66931.fixed.md
+++ b/changelog/66931.fixed.md
@@ -1,0 +1,4 @@
+transports.tcp: ensure pull path is being used before attempting chmod.
+The fix prevents an unnecessary traceback when the TCP transport is
+not using unix sockets. No functionaly has changed as the traceback
+occurs when an async task was about to exit anyway.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1455,7 +1455,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         # Securely create socket
         with salt.utils.files.set_umask(0o177):
             self.pull_sock.start()
-            os.chmod(self.pull_path, self.pull_path_perms)
+            if self.pull_path:
+                os.chmod(self.pull_path, self.pull_path_perms)
 
     def pre_fork(self, process_manager):
         """


### PR DESCRIPTION
### What does this PR do?
Check that pull_path is used before attempting to chmod. This was an oversight in the patch to open up the socket permissions. I'm not entirely sure how this doesn't break tests / functionality.. but whatever. The fix removes a traceback, which is good I suppose.

I'm not actually sure what kind of tests would be needed ... since the current tests seem not to have caught this?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
I noticed this traceback in some testing artifacts:
```
14:06:15,138 [tornado.application                                                             :758 ][ERROR   ][PublishServer(268624)] Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOLoop object at 0x7f83475315e0>>, <Task finished name='Task-10' coro=<PublishServer.publisher() done, defined at /home/sdaniele3/salt/salt/transport/tcp.py:1372> exception=TypeError('chmod: path should be string, bytes, os.PathLike or integer, not NoneType')>)
Traceback (most recent call last):
  File "/home/sdaniele3/salt/.nox/test-parametrized-3-crypto-none-transport-zeromq-coverage-false/lib64/python3.9/site-packages/tornado/ioloop.py", line 738, in _run_callback
    ret = callback()
  File "/home/sdaniele3/salt/.nox/test-parametrized-3-crypto-none-transport-zeromq-coverage-false/lib64/python3.9/site-packages/tornado/ioloop.py", line 762, in _discard_future_result
    future.result()
  File "/home/sdaniele3/salt/salt/transport/tcp.py", line 1438, in publisher
    os.chmod(self.pull_path, self.pull_path_perms)
TypeError: chmod: path should be string, bytes, os.PathLike or integer, not NoneType
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated
