### PR TITLE
[master] Don't block when evaluating requisites of parallel states

### DIFF
--- a/changelog/59959.fixed.md
+++ b/changelog/59959.fixed.md
@@ -1,0 +1,1 @@
+Fixed requisites by parallel states on parallel states being evaluated synchronously (blocking state execution for other parallel states)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1926,7 +1926,7 @@ def sls_id(id_, mods, test=None, queue=None, state_events=None, **kwargs):
         ret = {}
         for chunk in chunks:
             if chunk.get("__id__", "") == id_:
-                ret.update(st_.state.call_chunk(chunk, {}, chunks))
+                ret.update(st_.state.call_chunk(chunk, {}, chunks)[0])
 
         _set_retcode(ret, highstate=highstate)
         # Work around Windows multiprocessing bug, set __opts__['test'] back to

--- a/salt/state.py
+++ b/salt/state.py
@@ -2688,7 +2688,14 @@ class State:
                 if run_dict_chunk:
                     filtered_run_dict[tag] = run_dict_chunk
             run_dict = filtered_run_dict
-            pending = bool(not self.reconcile_procs(run_dict) and low.get("parallel"))
+
+            if low.get("parallel"):
+                pending = not self.reconcile_procs(run_dict)
+            else:
+                while True:
+                    if self.reconcile_procs(run_dict):
+                        break
+                    time.sleep(0.01)
 
             for chunk in chunks:
                 tag = _gen_tag(chunk)

--- a/salt/state.py
+++ b/salt/state.py
@@ -27,7 +27,7 @@ import site
 import time
 import traceback
 from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import networkx as nx
 
@@ -800,7 +800,7 @@ class State:
         self.global_state_conditions = None
         self.dependency_dag = DependencyGraph()
         # a mapping of state tag (unique id) to the return result dict
-        self.disabled_states: Optional[dict[str, dict[str, Any]]] = None
+        self.disabled_states: dict[str, dict[str, Any]] | None = None
 
     def _match_global_state_conditions(self, full, state, name):
         """
@@ -1458,7 +1458,7 @@ class State:
                 )
 
     def compile_high_data(
-        self, high: dict[str, Any], orchestration_jid: Union[str, int, None] = None
+        self, high: dict[str, Any], orchestration_jid: str | int | None = None
     ) -> tuple[list[LowChunk], list[str]]:
         """
         "Compile" the high data as it is retrieved from the CLI or YAML into
@@ -2022,7 +2022,7 @@ class State:
         self,
         cdata: dict[str, Any],
         low: LowChunk,
-        inject_globals: Optional[dict[Any, Any]],
+        inject_globals: dict[Any, Any] | None,
     ):
         """
         Call the state defined in the given cdata in parallel
@@ -2084,8 +2084,8 @@ class State:
     def call(
         self,
         low: LowChunk,
-        chunks: Optional[Sequence[LowChunk]] = None,
-        running: Optional[dict[str, dict]] = None,
+        chunks: Sequence[LowChunk] | None = None,
+        running: dict[str, dict] | None = None,
         retries: int = 1,
     ):
         """
@@ -2508,7 +2508,7 @@ class State:
     def call_chunks(
         self,
         chunks: Sequence[LowChunk],
-        disabled_states: Optional[dict[str, dict[str, Any]]] = None,
+        disabled_states: dict[str, dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """
         Iterate over a list of chunks and call them, checking for requires.
@@ -2579,7 +2579,7 @@ class State:
             return not running[tag]["result"]
         return False
 
-    def check_pause(self, low: LowChunk) -> Optional[str]:
+    def check_pause(self, low: LowChunk) -> str | None:
         """
         Check to see if this low chunk has been paused
         """
@@ -2787,7 +2787,7 @@ class State:
         return status, reqs
 
     def event(
-        self, chunk_ret: dict, length: int, fire_event: Union[bool, str] = False
+        self, chunk_ret: dict, length: int, fire_event: bool | str = False
     ) -> None:
         """
         Fire an event on the master bus
@@ -3191,8 +3191,8 @@ class State:
         return running
 
     def call_high(
-        self, high: HighData, orchestration_jid: Union[str, int, None] = None
-    ) -> Union[dict, list]:
+        self, high: HighData, orchestration_jid: str | int | None = None
+    ) -> dict | list:
         """
         Process a high data call and ensure the defined states.
         """
@@ -3376,7 +3376,7 @@ class LazyAvailStates:
 
     def __init__(self, hs: BaseHighState):
         self._hs = hs
-        self._avail: dict[Hashable, Optional[list[str]]] = {"base": None}
+        self._avail: dict[Hashable, list[str] | None] = {"base": None}
         self._filled = False
 
     def _fill(self) -> None:

--- a/tests/pytests/functional/modules/state/requisites/test_require.py
+++ b/tests/pytests/functional/modules/state/requisites/test_require.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 
 import pytest
@@ -535,6 +536,69 @@ def test_parallel_state_with_requires(state, state_tree):
         for item in range(1, 10):
             _id = f"cmd_|-blah-{item}_|-sleep 2_|-run"
             assert "__parallel__" in ret[_id]
+
+
+@pytest.mark.skip_on_windows
+def test_parallel_state_with_requires_on_parallel(state, state_tree):
+    """
+    Parallel states requiring other parallel states should not block
+    state execution while waiting on their requisites.
+
+    Issue #59959
+    """
+    sls_contents = """
+        service_a:
+          cmd.run:
+              - name: sleep 2
+              - parallel: True
+
+        service_b1:
+          cmd.run:
+              - name: sleep 5
+              - parallel: True
+              - require:
+                  - service_a
+
+        service_b2:
+          cmd.run:
+              - name: 'true'
+              - parallel: True
+              - require:
+                  - service_b1
+
+        service_c:
+          cmd.run:
+              - name: 'true'
+              - parallel: True
+              - require:
+                  - service_a
+    """
+
+    with pytest.helpers.temp_file("requisite_parallel.sls", sls_contents, state_tree):
+        ret = state.sls(
+            "requisite_parallel",
+            __pub_jid="1",  # Because these run in parallel we need a fake JID)
+        )
+        start_b1 = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_b1_|-sleep 5_|-run"]["start_time"]
+            ),
+        )
+        start_c = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_c_|-true_|-run"]["start_time"]
+            ),
+        )
+        start_diff = start_c - start_b1
+        # Expected order:
+        #   a > (b1, c) > b2
+        # When b2 blocks while waiting for b1, c has to wait for b1 as well.
+        # c should approximately start at the same time as b1 though.
+        assert start_diff < datetime.timedelta(seconds=5)  # b1 sleeps for 5 seconds
+        for state_ret in ret.raw.values():
+            assert "__parallel__" in state_ret
 
 
 def test_issue_59922_conflict_in_name_and_id_for_require_in(state, state_tree):

--- a/tests/pytests/unit/modules/state/test_state.py
+++ b/tests/pytests/unit/modules/state/test_state.py
@@ -107,7 +107,7 @@ class MockState:
             """
             Mock call_chunk method
             """
-            return {"": "ABC"}
+            return {"": "ABC"}, False
 
         @staticmethod
         def call_chunks(data):

--- a/tests/pytests/unit/state/test_state_compiler.py
+++ b/tests/pytests/unit/state/test_state_compiler.py
@@ -853,7 +853,7 @@ def test_call_chunk_sub_state_run(minion_opts):
         with patch("salt.state.State.call", return_value=mock_call_return):
             minion_opts["disabled_requisites"] = ["require"]
             state_obj = salt.state.State(minion_opts)
-            ret = state_obj.call_chunk(low_data, {}, [])
+            ret, _ = state_obj.call_chunk(low_data, {}, [])
             sub_state = ret.get(expected_sub_state_tag)
             assert sub_state
             assert sub_state["__run_num__"] == 1


### PR DESCRIPTION
### What does this PR do?
Evaluates requisites between parallel states less synchronously.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/59959

### Previous Behavior
A state with unmet requisites marked as `parallel` would block state execution until all requisites were met, i.e. its requisites would be evaluated synchronously.

### New Behavior
Execution of a parallel state with unmet requisites is postponed, allowing other parallel states with met dependencies to be started immediately.

This does not implement complete parallelization of requisite checks. The stack of postponed parallel states is iterated over after each single state execution, meaning a non-parallel state in between causes parallel ones whose dependencies finish while it is executing to be started only after it has finished.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes