### PR TITLE
[master] Support limiting the number of states running in parallel

### DIFF
--- a/changelog/49301.added.md
+++ b/changelog/49301.added.md
@@ -1,0 +1,1 @@
+Added support for limiting the number of parallel states executing at the same time via `state_max_parallel`

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2358,6 +2358,16 @@ performance is hampered.
 
     state_queue: 2
 
+.. conf_minion:: state_max_parallel
+
+``state_max_parallel``
+----------------------
+
+Default: ``0``
+
+Limit the number of ``parallel: true`` states that can be running at the same time.
+By default, there is no limit.
+
 .. conf_minion:: state_verbose
 
 ``state_verbose``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -404,6 +404,8 @@ VALID_OPTS = immutabletypes.freeze(
         "state_auto_order": bool,
         # Fire events as state chunks are processed by the state compiler
         "state_events": bool,
+        # Limit the number of states that can be running in parallel
+        "state_max_parallel": int,
         # The number of seconds a minion should wait before retry when attempting authentication
         "acceptance_wait_time": float,
         # The number of seconds a minion should wait before giving up during authentication
@@ -1228,6 +1230,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "state_events": False,
         "state_aggregate": False,
         "state_queue": False,
+        "state_max_parallel": 0,
         "snapper_states": False,
         "snapper_states_config": "root",
         "acceptance_wait_time": 10,
@@ -1569,6 +1572,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "state_auto_order": True,
         "state_events": False,
         "state_aggregate": False,
+        "state_max_parallel": 0,
         "search": "",
         "loop_interval": 60,
         "nodegroups": {},

--- a/tests/pytests/functional/modules/state/test_parallel.py
+++ b/tests/pytests/functional/modules/state/test_parallel.py
@@ -1,0 +1,108 @@
+import datetime
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides():
+    return {"state_max_parallel": 2}
+
+
+@pytest.mark.skip_on_windows
+def test_max_parallel(state, state_tree):
+    """
+    Ensure the number of running ``parallel`` states can be limited.
+    """
+    sls_contents = """
+        service_a:
+          cmd.run:
+              - name: sleep 3
+              - parallel: True
+
+        service_b:
+          cmd.run:
+              - name: sleep 3
+              - parallel: True
+
+        service_c:
+          cmd.run:
+              - name: 'true'
+              - parallel: True
+    """
+
+    with pytest.helpers.temp_file("state_max_parallel.sls", sls_contents, state_tree):
+        ret = state.sls(
+            "state_max_parallel",
+            __pub_jid="1",  # Because these run in parallel we need a fake JID)
+        )
+        assert not ret.failed
+        assert all(single.result is True for single in ret)
+        start_a = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_a_|-sleep 3_|-run"]["start_time"]
+            ),
+        )
+        start_c = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_c_|-true_|-run"]["start_time"]
+            ),
+        )
+        start_diff = start_c - start_a
+        # c needs to wait for a or b to finish
+        assert start_diff > datetime.timedelta(seconds=3)
+
+
+@pytest.mark.skip_on_windows
+def test_max_parallel_in_requisites(state, state_tree):
+    """
+    Ensure the number of running ``parallel`` states is respected
+    when a state is started implicitly during a requisite check.
+    """
+    sls_contents = """
+        service_a1:
+          cmd.run:
+              - name: sleep 1.5
+              - parallel: True
+
+        service_a2:
+          cmd.run:
+              - name: sleep 1.5
+              - parallel: True
+
+        service_c:
+          cmd.run:
+              - name: 'true'
+              - parallel: True
+              - require:
+                - service_b
+
+        service_b:
+          cmd.run:
+              - name: sleep 1.5
+              - parallel: True
+    """
+
+    with pytest.helpers.temp_file("state_max_parallel_2.sls", sls_contents, state_tree):
+        ret = state.sls(
+            "state_max_parallel_2",
+            __pub_jid="1",  # Because these run in parallel we need a fake JID)
+        )
+        assert not ret.failed
+        assert all(single.result is True for single in ret)
+        start_a1 = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_a1_|-sleep 1.5_|-run"]["start_time"]
+            ),
+        )
+        start_c = datetime.datetime.combine(
+            datetime.date.today(),
+            datetime.time.fromisoformat(
+                ret["cmd_|-service_c_|-true_|-run"]["start_time"]
+            ),
+        )
+        start_diff = start_c - start_a1
+        # c needs to wait for b, b needs to wait for a1 or a2 to finish
+        assert start_diff > datetime.timedelta(seconds=3)


### PR DESCRIPTION
### What does this PR do?
Adds support for limiting the number of states executing in `parallel` via a new configuration called `state_max_parallel`.

This solution is a bit ugly, but alternative implementations proved hard to be implemented in a backwards-compatible way or came with performance concerns or fundamental architectural changes.

#### Note
This removes `salt.utils.process.Process` objects from the `running` dict (specifically the `proc` key of returns) and tracks them in an attribute of `salt.state.State` objects. The `running` dict needs to be picklable (on spawning platforms). Since this patch can delay the call to the `Process.start()` method (which would make the process object itself picklable, hence no issue until now) and this call needs to be wrapped in a retry logic for filtering unpicklable objects from the `__context__` dict, we need to preserve some context to regenerate the process object in the second case (solution: `ParallelState` object). If we wanted to leave the new `ParallellState` objects in `running`, the picklability filter could not be applied lazily (i.e.: only when necessary).

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/49301

### Previous Behavior
No limit on the number of states running in parallel.

### New Behavior
States running in parallel can be limited via configuration.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
