### PR TITLE
[3007.x] Add MAINTAIN (m) privilege to postgres module lookup tables

### DIFF
--- a/changelog/66962.fixed.md
+++ b/changelog/66962.fixed.md
@@ -1,0 +1,1 @@
+Added support for MAINTAIN (m) privilege to salt.modules.postgres

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -96,6 +96,7 @@ _PRIVILEGES_MAP = {
     "X": "EXECUTE",
     "x": "REFERENCES",
     "d": "DELETE",
+    "m": "MAINTAIN",
     "*": "GRANT",
 }
 _PRIVILEGES_OBJECTS = frozenset(
@@ -111,7 +112,7 @@ _PRIVILEGES_OBJECTS = frozenset(
     )
 )
 _PRIVILEGE_TYPE_MAP = {
-    "table": "arwdDxt",
+    "table": "arwdDxtm",
     "tablespace": "C",
     "language": "U",
     "sequence": "rwU",

--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -130,6 +130,7 @@ def present(
        - EXECUTE
        - REFERENCES
        - DELETE
+       - MAINTAIN
        - ALL
 
        :note: privileges should not be set when granting group membership
@@ -260,6 +261,7 @@ def absent(
        - EXECUTE
        - REFERENCES
        - DELETE
+       - MAINTAIN
        - ALL
 
        :note: privileges should not be set when revoking group membership

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -57,7 +57,7 @@ def get_test_list_language_csv():
 @pytest.fixture
 def get_test_privileges_list_table_csv():
     return """name
-"{baruwatest=arwdDxt/baruwatest,bayestest=arwd/baruwatest,baruwa=a*r*w*d*D*x*t*/baruwatest}"
+"{baruwatest=arwdDxtm/baruwatest,bayestest=arwd/baruwatest,baruwa=a*r*w*d*D*x*t*m*/baruwatest}"
 """
 
 
@@ -1624,6 +1624,7 @@ def test_privileges_list_table(get_test_privileges_list_table_csv):
                 "REFERENCES": True,
                 "SELECT": True,
                 "DELETE": True,
+                "MAINTAIN": True,
             },
             "baruwatest": {
                 "INSERT": False,
@@ -1633,6 +1634,7 @@ def test_privileges_list_table(get_test_privileges_list_table_csv):
                 "REFERENCES": False,
                 "SELECT": False,
                 "DELETE": False,
+                "MAINTAIN": False,
             },
         }
         assert ret == expected


### PR DESCRIPTION
### What does this PR do?
Adds `MAINTAIN` (m) to the supported privileges in salt.modules.postgres.

### What issues does this PR fix or reference?
Fixes #66962

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
