### PR TITLE
[3006.x] Fix builds

### DIFF
--- a/.github/workflows/build-deps-ci-action.yml
+++ b/.github/workflows/build-deps-ci-action.yml
@@ -56,7 +56,9 @@ jobs:
     env:
       PIP_INDEX_URL: https://pypi.org/simple
     steps:
-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: "Throttle Builds"
         shell: bash
         run: |

--- a/.github/workflows/build-deps-ci-action.yml
+++ b/.github/workflows/build-deps-ci-action.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
       - name: "Throttle Builds"
         shell: bash
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Download Release Patch
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -36,6 +36,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Download Release Patch
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/test-action-linux.yml
+++ b/.github/workflows/test-action-linux.yml
@@ -326,6 +326,10 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: "Throttle Builds"
         shell: bash
         run: |

--- a/.github/workflows/test-action-linux.yml
+++ b/.github/workflows/test-action-linux.yml
@@ -86,6 +86,9 @@ jobs:
       matrix-include: ${{ steps.generate-matrix.outputs.matrix }}
       build-reports: ${{ steps.generate-matrix.outputs.build-reports }}
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: "Throttle Builds"
         shell: bash

--- a/.github/workflows/test-action-macos.yml
+++ b/.github/workflows/test-action-macos.yml
@@ -356,6 +356,10 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: "Throttle Builds"
         shell: bash
         run: |

--- a/.github/workflows/test-action-macos.yml
+++ b/.github/workflows/test-action-macos.yml
@@ -83,6 +83,9 @@ jobs:
       matrix-include: ${{ steps.generate-matrix.outputs.matrix }}
       build-reports: ${{ steps.generate-matrix.outputs.build-reports }}
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: "Throttle Builds"
         shell: bash

--- a/.github/workflows/test-action-windows.yml
+++ b/.github/workflows/test-action-windows.yml
@@ -86,6 +86,9 @@ jobs:
       matrix-include: ${{ steps.generate-matrix.outputs.matrix }}
       build-reports: ${{ steps.generate-matrix.outputs.build-reports }}
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: "Throttle Builds"
         shell: bash

--- a/.github/workflows/test-action-windows.yml
+++ b/.github/workflows/test-action-windows.yml
@@ -327,6 +327,10 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: "Throttle Builds"
         shell: bash
         run: |


### PR DESCRIPTION
Github actions now uses python 3.12 for their default interpreter. Fix steps that do not work with 3.12.