### PR TITLE
[3006.x] Remove wmic usage from disk grains on Windows

### DIFF
--- a/changelog/66959.fixed.md
+++ b/changelog/66959.fixed.md
@@ -1,2 +1,2 @@
-Removed the usage of wmic to get the disk grains for Windows. The wmic binary is
-being deprecated.
+Removed the usage of wmic to get the disk and iscsi grains for Windows. The wmic
+binary is being deprecated.

--- a/changelog/66959.fixed.md
+++ b/changelog/66959.fixed.md
@@ -1,0 +1,2 @@
+Removed the usage of wmic to get the disk grains for Windows. The wmic binary is
+being deprecated.

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -19,8 +19,6 @@ __salt__ = {
     "cmd.powershell": salt.modules.cmdmod.powershell,
 }
 
-from salt.exceptions import CommandExecutionError
-
 log = logging.getLogger(__name__)
 
 

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -16,7 +16,10 @@ import salt.utils.platform
 __salt__ = {
     "cmd.run": salt.modules.cmdmod._run_quiet,
     "cmd.run_all": salt.modules.cmdmod._run_all_quiet,
+    "cmd.powershell": salt.modules.cmdmod.powershell,
 }
+
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -153,41 +156,28 @@ def _linux_disks():
 
 
 def _windows_disks():
-    wmic = salt.utils.path.which("wmic")
 
-    namespace = r"\\root\microsoft\windows\storage"
-    path = "MSFT_PhysicalDisk"
-    get = "DeviceID,MediaType"
-
+    cmd = "Get-PhysicalDisk | Select DeviceID, MediaType"
     ret = {"disks": [], "ssds": []}
 
-    cmdret = __salt__["cmd.run_all"](
-        "{} /namespace:{} path {} get {} /format:table".format(
-            wmic, namespace, path, get
-        )
-    )
+    drive_info = __salt__["cmd.powershell"](cmd)
 
-    if cmdret["retcode"] != 0:
-        log.trace("Disk grain does not support this version of Windows")
-    else:
-        for line in cmdret["stdout"].splitlines():
-            info = line.split()
-            if len(info) != 2 or not info[0].isdigit() or not info[1].isdigit():
-                continue
-            device = rf"\\.\PhysicalDrive{info[0]}"
-            mediatype = info[1]
-            if mediatype == "3":
-                log.trace("Device %s reports itself as an HDD", device)
-                ret["disks"].append(device)
-            elif mediatype == "4":
-                log.trace("Device %s reports itself as an SSD", device)
-                ret["ssds"].append(device)
-                ret["disks"].append(device)
-            elif mediatype == "5":
-                log.trace("Device %s reports itself as an SCM", device)
-                ret["disks"].append(device)
-            else:
-                log.trace("Device %s reports itself as Unspecified", device)
-                ret["disks"].append(device)
+    if not drive_info:
+        log.trace("No physical discs found")
+        return ret
+
+    # We need a list of dict
+    if isinstance(drive_info, dict):
+        drive_info = [drive_info]
+
+    for drive in drive_info:
+        # Make sure we have a valid drive type
+        if drive["MediaType"].lower() not in ["hdd", "ssd", "scm", "unspecified"]:
+            log.trace(f'Unknown media type: {drive["MediaType"]}')
+            continue
+        device = rf'\\.\PhysicalDrive{drive["DeviceID"]}'
+        ret["disks"].append(device)
+        if drive["MediaType"].lower() == "ssd":
+            ret["ssds"].append(device)
 
     return ret

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -266,7 +266,7 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
     win_shell = salt.utils.path.which(win_shell)
 
     if not win_shell:
-        raise CommandExecutionError("PowerShell binary not found")
+        raise CommandExecutionError(f"PowerShell binary not found: {win_shell}")
 
     new_cmd = [win_shell, "-NonInteractive", "-NoProfile", "-ExecutionPolicy", "Bypass"]
 

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -203,7 +203,7 @@ def which(exe=None):
 
     # now to search through our system_path
     for path in system_path:
-        p = join(path, exe)
+        p = join(os.path.expandvars(path), exe)
 
         # iterate through all extensions to see which one is executable
         for ext in pathext:

--- a/tests/pytests/unit/grains/test_iscsi.py
+++ b/tests/pytests/unit/grains/test_iscsi.py
@@ -9,16 +9,39 @@ import salt.grains.iscsi as iscsi
 from tests.support.mock import MagicMock, mock_open, patch
 
 
-def test_windows_iscsi_iqn_grains():
-    cmd_run_mock = MagicMock(
-        return_value={"stdout": "iSCSINodeName\niqn.1991-05.com.microsoft:simon-x1\n"}
-    )
-    _grains = {}
-    with patch("salt.utils.path.which", MagicMock(return_value=True)):
-        with patch("salt.modules.cmdmod.run_all", cmd_run_mock):
-            _grains["iscsi_iqn"] = iscsi._windows_iqn()
+def test_windows_iscsi_iqn_grains_empty():
+    nodes_dict = {}
+    cmd_powershell_mock = MagicMock(return_value=nodes_dict)
+    with patch("salt.modules.cmdmod.powershell", cmd_powershell_mock):
+        result = iscsi._windows_iqn()
+    expected = []
+    assert result == expected
 
-    assert _grains.get("iscsi_iqn") == ["iqn.1991-05.com.microsoft:simon-x1"]
+
+def test_windows_iscsi_iqn_grains_single():
+    nodes_dict = {"NodeAddress": "iqn.1991-05.com.microsoft:simon-x1"}
+    cmd_powershell_mock = MagicMock(return_value=nodes_dict)
+    with patch("salt.modules.cmdmod.powershell", cmd_powershell_mock):
+        result = iscsi._windows_iqn()
+    expected = ["iqn.1991-05.com.microsoft:simon-x1"]
+    assert result == expected
+
+
+def test_windows_iscsi_iqn_grains_multiple():
+    nodes_list = [
+        {"NodeAddress": "iqn.1991-05.com.microsoft:simon-x1"},
+        {"NodeAddress": "iqn.1991-05.com.microsoft:simon-x2"},
+        {"NodeAddress": "iqn.1991-05.com.microsoft:simon-x3"},
+    ]
+    cmd_powershell_mock = MagicMock(return_value=nodes_list)
+    with patch("salt.modules.cmdmod.powershell", cmd_powershell_mock):
+        result = iscsi._windows_iqn()
+    expected = [
+        "iqn.1991-05.com.microsoft:simon-x1",
+        "iqn.1991-05.com.microsoft:simon-x2",
+        "iqn.1991-05.com.microsoft:simon-x3",
+    ]
+    assert result == expected
 
 
 def test_aix_iscsi_iqn_grains():


### PR DESCRIPTION
### What does this PR do?
The `wmic` binary is being deprecated on Windows. Newer releases of Windows are starting to come with the binary disabled. This can be enabled, but we should probably migrate to something else.

This PR will migrate the "disk" grain from using `wmic` to using the PowerShell commandlet "Get-PhysicalDisk".

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66959

### Previous Behavior
A stack trace would occur and disk grains would be missing.

### New Behavior
No stack trace, disk grains are present

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes