### PR TITLE
[3006.x] Add cryptography back as a dependency for Salt 3006 to base.txt requirements

### DIFF
--- a/changelog/66883.fixed.md
+++ b/changelog/66883.fixed.md
@@ -1,0 +1,1 @@
+Added cryptogrpahy back to base.txt requirements as a dependency

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,3 +16,4 @@ looseversion
 croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 # We need contextvars for salt-ssh
 contextvars
+cryptography>=42.0.0

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -127,6 +127,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -93,6 +93,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -13,6 +13,10 @@ certifi==2024.7.4 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
@@ -122,6 +130,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
+pycparser==2.21 ; python_version >= "3.9"
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -90,6 +90,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -139,6 +139,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -99,6 +99,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -82,6 +82,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -123,6 +123,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -89,6 +89,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -13,6 +13,10 @@ certifi==2024.7.4 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
@@ -122,6 +130,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
+pycparser==2.21 ; python_version >= "3.9"
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -88,6 +88,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -135,6 +135,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -97,6 +97,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -80,6 +80,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -123,6 +123,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -89,6 +89,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -13,6 +13,10 @@ certifi==2024.7.4 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
@@ -122,6 +130,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
+pycparser==2.21 ; python_version >= "3.9"
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -88,6 +88,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -135,6 +135,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -97,6 +97,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   ansible-core
     #   etcd3-py

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -80,6 +80,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -141,6 +141,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -13,6 +13,10 @@ certifi==2023.07.22 ; python_version < "3.10"
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.7/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.7/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
@@ -126,6 +134,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/py3.7/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -100,6 +100,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -107,6 +107,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -89,6 +89,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -136,6 +136,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -13,6 +13,10 @@ certifi==2023.07.22 ; python_version < "3.10"
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.8/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.8/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt
@@ -122,6 +130,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/py3.8/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -95,6 +95,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -144,6 +144,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -102,6 +102,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -84,6 +84,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -136,6 +136,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -98,6 +98,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -13,6 +13,10 @@ certifi==2023.07.22 ; python_version < "3.10"
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
     #   requests
+cffi==1.14.6
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   cryptography
 charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -30,6 +34,10 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
 croniter==2.0.5 ; sys_platform != "win32"
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
+cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
@@ -126,6 +134,10 @@ psutil==5.8.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
+pycparser==2.21 ; python_version >= "3.9"
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   cffi
 pycryptodomex==3.19.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -95,6 +95,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -140,6 +140,7 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -100,6 +100,7 @@ croniter==2.0.5 ; sys_platform != "win32"
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
     #   moto

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -84,6 +84,7 @@ contextvars==2.4
 cryptography==42.0.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -24,6 +24,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -24,6 +24,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -24,6 +24,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -24,6 +24,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -22,6 +22,7 @@ croniter==2.0.5 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
 distro==1.5.0

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -25,6 +25,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 cryptography==42.0.5
     # via
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   pyopenssl
 distro==1.5.0


### PR DESCRIPTION
### What does this PR do?
Adds cryptography as a dependency to base.txt requirements. This will ensure that cryptography is installed as a dependency when pip installing salt, currently even though it is present in static ci and pkg, it is not installed as a dependency, unlike Salt 3007.x where it is. Salt 3007.x has cryptography as a dependency in base.txt and it was added to 3007 by PR https://github.com/saltstack/salt/commit/4de6b1011fd5be21c52ecde3a779f94ee8c75dec, a Merge 3006.x to 3007.x (circa 7th Feb 2024), but it must have been between tagged versions of 3006 since it does not exist in any tagged version of 3006.x

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66883

### Previous Behavior
cryptography failed to install as a dependency of Salt 3006 when pip installed.

### New Behavior
cryptography now installs as a dependency of Salt 3006 when pip installed.


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
