### PR TITLE
[3007.x] Updated psutil dependency handling with latest pytest-shell-utilities

### DIFF
--- a/changelog/66985.fixed.md
+++ b/changelog/66985.fixed.md
@@ -1,0 +1,1 @@
+Updated psutil dependency to version 6.0.0 or greater

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
 distro>=1.0.1
-psutil>=5.0.0
+psutil>=6.0.0
 packaging>=21.3
 looseversion
 tornado>=6.3.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,8 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
 distro>=1.0.1
-psutil>=6.0.0
+psutil<6.0.0; python_version <= '3.9'
+psutil>=5.0.0; python_version >= '3.10'
 packaging>=21.3
 looseversion
 tornado>=6.3.3

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -15,3 +15,5 @@ pyfakefs
 trustme
 pytest-skip-markers >= 1.5.2 ; python_version >= '3.8'
 pytest-skip-markers <= 1.5.1 ; python_version < '3.8'
+pytest-shell-utilities <= 1.9.0; python_version <= '3.9'
+pytest-shell-utilities >= 1.9.7; python_version >= '3.10'

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -310,7 +310,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -310,7 +310,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
@@ -373,8 +373,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -534,7 +536,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -314,7 +314,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
@@ -377,8 +377,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -539,7 +541,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -314,7 +314,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -340,7 +340,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -340,7 +340,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
@@ -411,8 +411,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -603,7 +605,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -272,7 +272,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
@@ -335,8 +335,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -486,7 +488,6 @@ typing-extensions==4.8.0
     #   inflect
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -272,7 +272,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -303,7 +303,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -303,7 +303,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt
@@ -366,8 +366,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -525,7 +527,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -307,7 +307,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
@@ -370,8 +370,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -531,7 +533,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -307,7 +307,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -331,7 +331,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -331,7 +331,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt
@@ -402,8 +402,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -593,7 +595,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -265,7 +265,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt
@@ -328,8 +328,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -477,7 +479,6 @@ typing-extensions==4.8.0
     #   inflect
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -265,7 +265,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -427,7 +427,7 @@ portend==3.1.0
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -525,9 +525,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
@@ -758,7 +759,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -427,7 +427,7 @@ portend==3.1.0
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -303,7 +303,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt
@@ -366,8 +366,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -525,7 +527,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -303,7 +303,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -168,7 +168,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -168,7 +168,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -307,7 +307,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -307,7 +307,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
@@ -370,8 +370,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -531,7 +533,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -453,7 +453,7 @@ portend==3.1.0
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -453,7 +453,7 @@ portend==3.1.0
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -331,7 +331,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt
@@ -402,8 +402,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -593,7 +595,6 @@ typing-extensions==4.8.0
     #   napalm
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -331,7 +331,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -265,7 +265,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -265,7 +265,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt
@@ -328,8 +328,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -477,7 +479,6 @@ typing-extensions==4.8.0
     #   inflect
     #   pydantic
     #   pydantic-core
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -318,7 +318,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
@@ -381,8 +381,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -318,7 +318,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -337,7 +337,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -337,7 +337,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
@@ -408,8 +408,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -276,7 +276,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
@@ -339,8 +339,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -276,7 +276,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -310,7 +310,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
@@ -373,8 +373,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -310,7 +310,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -314,7 +314,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
@@ -377,8 +377,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -314,7 +314,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -333,7 +333,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
@@ -404,8 +404,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -333,7 +333,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -272,7 +272,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -272,7 +272,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
@@ -335,8 +335,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -97,7 +97,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -97,7 +97,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -95,7 +95,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -95,7 +95,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -87,7 +87,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -95,7 +95,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -95,7 +95,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -91,7 +91,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -91,7 +91,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -91,7 +91,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -91,7 +91,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -99,7 +99,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -99,7 +99,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -89,7 +89,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -97,7 +97,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==6.1.0
+psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -97,7 +97,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.6
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21
     # via cffi


### PR DESCRIPTION
### What does this PR do?
Updates dependency pytest-shell-utilities which handles pstuil >= 6.0.0 ,to allow for removal of connections and it's replacement with net_connections.

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
