### PR TITLE
[3006.x] Fix nightly builds and psutil dependency handling with latest pytest-shell-utilities

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,3 +17,5 @@ croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 # We need contextvars for salt-ssh
 contextvars
 cryptography>=42.0.0
+
+# force rebuild

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
 distro>=1.0.1
-psutil>=5.0.0
+psutil>=6.0.0
 packaging>=21.3
 looseversion
 croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,12 +10,11 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
 distro>=1.0.1
-psutil>=5.0.0
+psutil<6.0.0; python_version <= '3.9'
+psutil>=5.0.0; python_version >= '3.10'
 packaging>=21.3
 looseversion
 croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 # We need contextvars for salt-ssh
 contextvars
 cryptography>=42.0.0
-
-# force rebuild

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
 distro>=1.0.1
-psutil>=6.0.0
+psutil>=5.0.0
 packaging>=21.3
 looseversion
 croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -15,3 +15,5 @@ pyfakefs
 trustme
 pytest-skip-markers >= 1.5.2 ; python_version >= '3.8'
 pytest-skip-markers <= 1.5.1 ; python_version < '3.8'
+pytest-shell-utilities <= 1.9.0; python_version <= '3.9'
+pytest-shell-utilities >= 1.9.7; python_version >= '3.10'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -395,7 +395,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -479,9 +479,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
@@ -689,7 +690,6 @@ trustme==1.1.0
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -395,7 +395,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -281,7 +281,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
@@ -336,8 +336,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -475,9 +477,7 @@ transitions==0.8.9
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.2.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -281,7 +281,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -274,7 +274,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -274,7 +274,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
@@ -329,8 +329,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -467,9 +469,7 @@ transitions==0.8.9
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -395,7 +395,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -395,7 +395,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -285,7 +285,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
@@ -346,8 +346,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -514,9 +516,7 @@ trustme==1.1.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 tzlocal==3.0
     # via apscheduler
 urllib3==1.26.18

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -285,7 +285,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -254,7 +254,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
@@ -307,8 +307,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -450,9 +452,7 @@ tomli==2.0.1
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.4.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -254,7 +254,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -367,7 +367,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -443,9 +443,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
@@ -636,7 +637,6 @@ trustme==1.1.0
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -367,7 +367,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -258,7 +258,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -258,7 +258,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt
@@ -307,8 +307,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -436,9 +438,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.2.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -255,7 +255,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
@@ -306,8 +306,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -433,9 +435,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -255,7 +255,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -370,7 +370,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -370,7 +370,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -266,7 +266,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt
@@ -323,8 +323,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -480,9 +482,7 @@ trustme==1.1.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 tzlocal==3.0
     # via apscheduler
 urllib3==1.26.18

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -266,7 +266,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -250,7 +250,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -250,7 +250,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt
@@ -303,8 +303,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -444,9 +446,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.4.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -367,7 +367,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -443,9 +443,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
@@ -636,7 +637,6 @@ trustme==1.1.0
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   pytest-shell-utilities
     #   pytest-system-statistics
 urllib3==1.26.18
     # via

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -367,7 +367,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -258,7 +258,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt
@@ -307,8 +307,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -436,9 +438,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.2.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -258,7 +258,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -255,7 +255,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
@@ -306,8 +306,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -433,9 +435,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -255,7 +255,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -370,7 +370,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -370,7 +370,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -266,7 +266,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -266,7 +266,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt
@@ -323,8 +323,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -480,9 +482,7 @@ trustme==1.1.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.8.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 tzlocal==3.0
     # via apscheduler
 urllib3==1.26.18

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -250,7 +250,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -250,7 +250,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt
@@ -303,8 +303,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt
@@ -444,9 +446,7 @@ toml==0.10.2
 trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.4.0
-    # via
-    #   pytest-shell-utilities
-    #   pytest-system-statistics
+    # via pytest-system-statistics
 urllib3==1.26.18
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -440,7 +440,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -440,7 +440,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -c requirements/static/ci/py3.7/linux.txt
@@ -527,9 +527,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.0 ; python_version < "3.8"
     # via

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -130,7 +130,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -130,7 +130,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -313,7 +313,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -313,7 +313,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
@@ -370,8 +370,10 @@ pytest-httpserver==1.0.6
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.0 ; python_version < "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -319,7 +319,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
@@ -382,8 +382,10 @@ pytest-httpserver==1.0.6
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.0 ; python_version < "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -319,7 +319,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -270,7 +270,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -270,7 +270,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
@@ -322,8 +322,10 @@ pytest-httpserver==1.0.6
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.0 ; python_version < "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -426,7 +426,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
@@ -513,9 +513,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -426,7 +426,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -126,7 +126,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -299,7 +299,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -299,7 +299,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
@@ -356,8 +356,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -419,7 +419,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -419,7 +419,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -305,7 +305,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
@@ -368,8 +368,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -305,7 +305,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -256,7 +256,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
@@ -308,8 +308,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -256,7 +256,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -426,7 +426,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -426,7 +426,7 @@ portend==2.4
     #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -515,9 +515,10 @@ pytest-salt-factories==1.0.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/pytest.txt
     #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -306,7 +306,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -306,7 +306,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
@@ -365,8 +365,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -130,7 +130,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -130,7 +130,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -299,7 +299,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
@@ -358,8 +358,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -299,7 +299,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -415,7 +415,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -415,7 +415,7 @@ portend==2.4
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -303,7 +303,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
@@ -368,8 +368,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -303,7 +303,7 @@ portend==2.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -256,7 +256,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
@@ -309,8 +309,10 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.1
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.8.0
-    # via pytest-salt-factories
+pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
+    # via
+    #   -r requirements/pytest.txt
+    #   pytest-salt-factories
 pytest-skip-markers==1.5.2 ; python_version >= "3.8"
     # via
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -256,7 +256,7 @@ portend==2.6
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version >= "3.10"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.17
     # via cffi

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -76,7 +76,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -68,7 +68,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -66,7 +66,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.4
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pycparser==2.21 ; python_version >= "3.9"
     # via

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==6.1.0
+psutil==5.8.0 ; python_version <= "3.9"
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -77,7 +77,7 @@ packaging==22.0
     # via -r requirements/base.txt
 portend==2.6
     # via cherrypy
-psutil==5.8.0
+psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -490,7 +490,7 @@ def fcontext_get_policy(
         "[[:alpha:] ]+" if filetype is None else filetype_id_to_string(filetype)
     )
     cmd = (
-        "semanage fcontext -l | egrep "
+        "semanage fcontext -l | grep -E "
         + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}{ospacer}$'".format(
             **cmd_kwargs
         )
@@ -616,7 +616,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | egrep '{filespec} '"
+        cmd = f"semanage fcontext -l | grep -E '{filespec}'"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"
@@ -762,7 +762,7 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
         "port": port,
     }
     cmd = (
-        "semanage port -l | egrep "
+        "semanage port -l | grep -E "
         + "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(
             **cmd_kwargs
         )

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -616,7 +616,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | grep -E '{filespec}'"
+        cmd = f"semanage fcontext -l | grep -E '{filespec} '"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -490,7 +490,7 @@ def fcontext_get_policy(
         "[[:alpha:] ]+" if filetype is None else filetype_id_to_string(filetype)
     )
     cmd = (
-        "semanage fcontext -l | grep -E "
+        "semanage fcontext -l | egrep "
         + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}{ospacer}$'".format(
             **cmd_kwargs
         )
@@ -616,7 +616,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | grep -E '{filespec} '"
+        cmd = f"semanage fcontext -l | egrep '{filespec} '"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"
@@ -762,7 +762,7 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
         "port": port,
     }
     cmd = (
-        "semanage port -l | grep -E "
+        "semanage port -l | egrep "
         + "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(
             **cmd_kwargs
         )

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -490,7 +490,7 @@ def fcontext_get_policy(
         "[[:alpha:] ]+" if filetype is None else filetype_id_to_string(filetype)
     )
     cmd = (
-        "semanage fcontext -l | egrep "
+        "semanage fcontext -l | grep -E "
         + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}{ospacer}$'".format(
             **cmd_kwargs
         )
@@ -616,7 +616,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | egrep '{filespec} '"
+        cmd = f"semanage fcontext -l | grep -E '{filespec} '"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"
@@ -762,7 +762,7 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
         "port": port,
     }
     cmd = (
-        "semanage port -l | egrep "
+        "semanage port -l | grep -E "
         + "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(
             **cmd_kwargs
         )

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -401,7 +401,7 @@ def test_selinux_add_policy_regex(name, sel_type):
     ):
         selinux.fcontext_add_policy(name, sel_type=sel_type)
         filespec = re.escape(name)
-        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec}'"
+        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec} '"
         mock_cmd_shell.assert_called_once_with(
             expected_cmd_shell,
             ignore_retcode=True,
@@ -433,7 +433,7 @@ def test_selinux_add_policy_shorter_path(name, sel_type):
     ):
         selinux.fcontext_add_policy(name, sel_type=sel_type)
         filespec = re.escape(name)
-        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec}'"
+        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec} '"
         mock_cmd_shell.assert_called_once_with(
             expected_cmd_shell,
             ignore_retcode=True,

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -401,7 +401,7 @@ def test_selinux_add_policy_regex(name, sel_type):
     ):
         selinux.fcontext_add_policy(name, sel_type=sel_type)
         filespec = re.escape(name)
-        expected_cmd_shell = f"semanage fcontext -l | egrep '{filespec}'"
+        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec}'"
         mock_cmd_shell.assert_called_once_with(
             expected_cmd_shell,
             ignore_retcode=True,
@@ -433,7 +433,7 @@ def test_selinux_add_policy_shorter_path(name, sel_type):
     ):
         selinux.fcontext_add_policy(name, sel_type=sel_type)
         filespec = re.escape(name)
-        expected_cmd_shell = f"semanage fcontext -l | egrep '{filespec}'"
+        expected_cmd_shell = f"semanage fcontext -l | grep -E '{filespec}'"
         mock_cmd_shell.assert_called_once_with(
             expected_cmd_shell,
             ignore_retcode=True,


### PR DESCRIPTION
### What does this PR do?
Updates dependency pytest-shell-utilities which handles pstuil >= 6.0.0 ,to allow for removal of connections and it's replacement with net_connections.  And fix nightly build for selinux usage, replacing ```egrep``` with ```grep -E```

### What issues does this PR fix or reference?
Fixes


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
