### PR TITLE
[master] Fix the installation of pip modules with special characters in the module name

### DIFF
--- a/changelog/66988.fixed.md
+++ b/changelog/66988.fixed.md
@@ -1,0 +1,1 @@
+Fix the installation of pip modules with special characters in the module name

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1379,12 +1379,14 @@ def list_(prefix=None, bin_env=None, user=None, cwd=None, env_vars=None, **kwarg
     except ValueError:
         raise CommandExecutionError("Invalid JSON", info=result)
 
+    normal_prefix = normalize(prefix) if prefix else None
     for pkg in pkgs:
+        normal_pkg_name = normalize(pkg["name"])
         if prefix:
-            if pkg["name"].lower().startswith(prefix.lower()):
-                packages[pkg["name"]] = pkg["version"]
+            if normal_pkg_name.startswith(normal_prefix):
+                packages[normal_pkg_name] = pkg["version"]
         else:
-            packages[pkg["name"]] = pkg["version"]
+            packages[normal_pkg_name] = pkg["version"]
 
     return packages
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -414,6 +414,19 @@ def _format_env_vars(env_vars):
     return ret
 
 
+def normalize(name):
+    """Normalize a package name according to the recommendations in PEP 503.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pip.normalize requests_ntlm
+
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def install(
     pkgs=None,  # pylint: disable=R0912,R0913,R0914
     requirements=None,

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -19,7 +19,6 @@ requisite to a pkg.installed state for the package which provides pip
 """
 
 import logging
-import re
 import sys
 import types
 
@@ -222,11 +221,12 @@ def _check_pkg_version_format(pkg):
         ret["version_spec"] = []
     else:
         ret["result"] = True
+        normalize = __salt__["pip.normalize"]
         try:
-            ret["prefix"] = install_req.req.project_name
+            ret["prefix"] = normalize(install_req.req.project_name)
             ret["version_spec"] = install_req.req.specs
         except Exception:  # pylint: disable=broad-except
-            ret["prefix"] = re.sub("[^A-Za-z0-9.]+", "-", install_req.name)
+            ret["prefix"] = normalize(install_req.name)
             if hasattr(install_req, "specifier"):
                 specifier = install_req.specifier
             else:

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -1891,12 +1891,12 @@ def test_list(python_binary):
                 python_shell=False,
             )
             assert ret == {
-                "MarkupSafe": "2.1.1",
+                "markupsafe": "2.1.1",
                 "idemenv": "0.2.0",
                 "pip": "22.3.1",
                 "pop": "23.0.0",
                 "salt": "3006.0+0na.5b18e86",
-                "typing_extensions": "4.4.0",
+                "typing-extensions": "4.4.0",
                 "unattended-upgrades": "0.1",
                 "yarl": "1.8.2",
             }

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -1909,3 +1909,16 @@ def test_list(python_binary):
                 CommandExecutionError,
                 pip.list_,
             )
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("pytest", "pytest"),
+        ("utf8-locale", "utf8-locale"),
+        ("utf8_locale", "utf8-locale"),
+        ("Typing__-__ExtensionS", "typing-extensions"),
+    ],
+)
+def test_normalize(name, expected):
+    assert pip.normalize(name) == expected

--- a/tests/pytests/unit/states/test_pip.py
+++ b/tests/pytests/unit/states/test_pip.py
@@ -6,6 +6,7 @@ import logging
 
 import pytest
 
+import salt.modules.pip as pip_module
 import salt.states.pip_state as pip_state
 from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
@@ -38,6 +39,7 @@ def test_issue_64169(caplog):
             "pip.list": mock_pip_list,
             "pip.version": mock_pip_version,
             "pip.install": mock_pip_install,
+            "pip.normalize": pip_module.normalize,
         },
     ):
         with caplog.at_level(logging.WARNING):

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+import salt.modules.pip as pip_module
 import salt.states.pip_state as pip_state
 import salt.utils.path
 import salt.version
@@ -25,7 +26,10 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
             pip_state: {
                 "__env__": "base",
                 "__opts__": {"test": False},
-                "__salt__": {"cmd.which_bin": lambda _: "pip"},
+                "__salt__": {
+                    "cmd.which_bin": lambda _: "pip",
+                    "pip.normalize": pip_module.normalize,
+                },
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

This pull request implements the changes described in #66988 to
make the `pip.installed` state handle correctly Python modules that
differ in their "user-friendly" PyPI name and the name that is
actually listed in the package metadata (and reported as installed by
the `pip` tool).

There are three user-visible changes:
- add the `pip.normalize` function that implements the normalization
  algorithm descrined in
  [PEP 503](https://peps.python.org/pep-0503/)
- make the `pip.list` function normalize the returned package names and
  also normalize the supplied prefix before using it to filter the names
- make the `pip.installed` state normalize the user-supplied package names
  before checking whether they are already installed and, later, checking
  whether they have been successfully installed or upgraded

As noted in the issue, this will change the behavior of `pip.list`;
however, I believe that packages with e.g. dashes in their names are
already handled incorrectly, so this will be an improvement.

There was another pull request (https://github.com/saltstack/salt/pull/66880) that attempted to fix
the warning reported by the `pip.installed` state when handling
package names with dashes; I have since come to believe that the solution
there was incomplete and it would be better to use the PEP 503
normalization algorithm in several places instead.


### What issues does this PR fix or reference?
Fixes #66988 

### Previous Behavior
The pip.installed state is unable to verify the successful installation of some modules.

### New Behavior
The pip.installed state finds the modules.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

