### PR TITLE
[master] feat: Add OS grain mappings for AlmaLinux Kitten

### DIFF
--- a/changelog/66991.added.md
+++ b/changelog/66991.added.md
@@ -1,0 +1,1 @@
+Add detection for OS grains when running in [AlmaLinux Kitten](https://wiki.almalinux.org/release-notes/kitten-10.html)

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2494,7 +2494,15 @@ def _osrelease_data(os, osfullname, osrelease):
             grains["osrelease_info"],
         )
 
-    if os in ("Debian", "FreeBSD", "OpenBSD", "NetBSD", "Mac", "Raspbian", "AlmaLinux",):
+    if os in (
+        "Debian",
+        "FreeBSD",
+        "OpenBSD",
+        "NetBSD",
+        "Mac",
+        "Raspbian",
+        "AlmaLinux",
+    ):
         os_name = os
     else:
         os_name = osfullname

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1775,6 +1775,7 @@ _OS_NAME_MAP = {
     "cloudlinux": "CloudLinux",
     "virtuozzo": "Virtuozzo",
     "almalinux": "AlmaLinux",
+    "almalinuxk": "AlmaLinux",
     "pidora": "Fedora",
     "scientific": "ScientificLinux",
     "synology": "Synology",
@@ -1846,6 +1847,7 @@ _OS_FAMILY_MAP = {
     "CloudLinux": "RedHat",
     "Virtuozzo": "RedHat",
     "AlmaLinux": "RedHat",
+    "AlmaLinux Kitten": "RedHat",
     "OVS": "RedHat",
     "OEL": "RedHat",
     "XCP": "RedHat",
@@ -2492,7 +2494,7 @@ def _osrelease_data(os, osfullname, osrelease):
             grains["osrelease_info"],
         )
 
-    if os in ("Debian", "FreeBSD", "OpenBSD", "NetBSD", "Mac", "Raspbian"):
+    if os in ("Debian", "FreeBSD", "OpenBSD", "NetBSD", "Mac", "Raspbian", "AlmaLinux",):
         os_name = os
     else:
         os_name = osfullname

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1156,6 +1156,48 @@ def test_almalinux_8_os_grains():
 
 
 @pytest.mark.skip_unless_on_linux
+def test_almalinux_kitten_os_grains():
+    """
+    Test that 'os' grain will properly detect AlmaLinux Kitten
+    """
+    # /etc/os-release data taken from an AlmaLinux Kitten VM, install ISO
+    # AlmaLinux-Kitten-10-20241018.0-x86_64_v2-minimal.iso. At the time of
+    # writting, there was no docker image for Kitten
+    _os_release_data = {
+        "NAME": "AlmaLinux Kitten",
+        "VERSION": "10 (Lion Cub)",
+        "ID": "almalinux",
+        "ID_LIKE": "rhel centos fedora",
+        "VERSION_ID": "10",
+        "PLATFORM_ID": "platform:el10",
+        "PRETTY_NAME": "AlmaLinux Kitten 10 (Lion Cub)",
+        "ANSI_COLOR": "0;34",
+        "LOGO": "fedora-logo-icon",
+        "CPE_NAME": "cpe:/o:almalinux:almalinux:10::baseos",
+        "HOME_URL": "https://almalinux.org/",
+        "DOCUMENTATION_URL": "https://wiki.almalinux.org/",
+        "VENDOR_NAME": "AlmaLinux",
+        "VENDOR_URL": "https://almalinux.org/",
+        "BUG_REPORT_URL": "https://bugs.almalinux.org/",
+        "ALMALINUX_MANTISBT_PROJECT": "AlmaLinux-10",
+        "ALMALINUX_MANTISBT_PROJECT_VERSION": "10",
+        "REDHAT_SUPPORT_PRODUCT": "AlmaLinux",
+        "REDHAT_SUPPORT_PRODUCT_VERSION": "10",
+    }
+    expectation = {
+        "os": "AlmaLinux",
+        "os_family": "RedHat",
+        "oscodename": "Lion Cub",
+        "osfullname": "AlmaLinux Kitten",
+        "osrelease": "10",
+        "osrelease_info": (10,),
+        "osmajorrelease": 10,
+        "osfinger": "AlmaLinux-10",
+    }
+    _run_os_grains_tests(_os_release_data, {}, expectation)
+
+
+@pytest.mark.skip_unless_on_linux
 def test_virtuozzo_7_os_grains():
     """
     Test if OS grains are parsed correctly in Virtuozzo 7

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -449,10 +449,10 @@ def test_gnu_slash_linux_in_os_name():
     orig_import = __import__
     built_in = "builtins"
 
-    def _import_mock(name, *args):
+    def _import_mock(name, *args, **kwargs):
         if name == "lsb_release":
             raise ImportError("No module named lsb_release")
-        return orig_import(name, *args)
+        return orig_import(name, *args, **kwargs)
 
     # - Skip the first if statement
     # - Skip the selinux/systemd stuff (not pertinent)
@@ -526,10 +526,10 @@ def test_suse_os_from_cpe_data():
     orig_import = __import__
     built_in = "builtins"
 
-    def _import_mock(name, *args):
+    def _import_mock(name, *args, **kwargs):
         if name == "lsb_release":
             raise ImportError("No module named lsb_release")
-        return orig_import(name, *args)
+        return orig_import(name, *args, **kwargs)
 
     distro_mock = MagicMock(
         return_value=("SUSE Linux Enterprise Server ", "12", "x86_64")
@@ -595,10 +595,10 @@ def _run_os_grains_tests(os_release_data, os_release_map, expectation):
     orig_import = __import__
     built_in = "builtins"
 
-    def _import_mock(name, *args):
+    def _import_mock(name, *args, **kwargs):
         if name == "lsb_release":
             raise ImportError("No module named lsb_release")
-        return orig_import(name, *args)
+        return orig_import(name, *args, **kwargs)
 
     suse_release_file = os_release_map.get("suse_release_file")
 


### PR DESCRIPTION
### What does this PR do?

Add OS grain mappings to appropriately detect AlmaLinux Kitten (beta release of AlmaLinux 10) and treat it as a RHEL distribution.

AlmaLinux Kitten Release Notes: https://almalinux.org/blog/2024-10-22-introducing-almalinux-os-kitten/

### What issues does this PR fix or reference?
No existing bug/issue

### New Behavior
`AlmaLinux Kitten` is detected and sets `os_family="RHEL"` in grains; additionally the `os` grain is mapped to `AlmaLinux` instead of `AlmaLinux Kitten`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
