### PR TITLE
[3007.x] Add started event to PublishServer

### DIFF
--- a/changelog/66931.fixed.md
+++ b/changelog/66931.fixed.md
@@ -1,0 +1,4 @@
+transports.tcp: ensure pull path is being used before attempting chmod.
+The fix prevents an unnecessary traceback when the TCP transport is
+not using unix sockets. No functionaly has changed as the traceback
+occurs when an async task was about to exit anyway.

--- a/changelog/66993.fixed.md
+++ b/changelog/66993.fixed.md
@@ -1,0 +1,1 @@
+Salt master waits for publish servers while starting up.

--- a/salt/master.py
+++ b/salt/master.py
@@ -813,9 +813,9 @@ class Master(SMaster):
             for _, opts in iter_transport_opts(self.opts):
                 chan = salt.channel.server.PubServerChannel.factory(opts)
                 chan.pre_fork(self.process_manager, kwargs={"secrets": SMaster.secrets})
-                if not chan.transport.started.wait(30):
+                if not chan.transport.started.wait(60):
                     raise salt.exceptions.SaltMasterError(
-                        "Publish server did not start within 30 seconds. Something went wrong."
+                        "Publish server did not start within 60 seconds. Something went wrong.",
                     )
                 pub_channels.append(chan)
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1331,6 +1331,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         pull_path_perms=0o600,
         pub_path_perms=0o600,
         ssl=None,
+        started=None,
     ):
         self.opts = opts
         self.pub_sock = None
@@ -1343,6 +1344,10 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         self.pull_path_perms = pull_path_perms
         self.pub_path_perms = pub_path_perms
         self.ssl = ssl
+        if started is None:
+            self.started = multiprocessing.Event()
+        else:
+            self.started = started
 
     @property
     def topic_support(self):
@@ -1362,6 +1367,8 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             "pull_path": self.pull_path,
             "pub_path_perms": self.pub_path_perms,
             "pull_path_perms": self.pull_path_perms,
+            "ssl": self.ssl,
+            "started": self.started,
         }
 
     def publish_daemon(
@@ -1456,6 +1463,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         with salt.utils.files.set_umask(0o177):
             self.pull_sock.start()
             os.chmod(self.pull_path, self.pull_path_perms)
+        self.started.set()
 
     def pre_fork(self, process_manager):
         """

--- a/salt/transport/ws.py
+++ b/salt/transport/ws.py
@@ -312,7 +312,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         publish_payload,
         presence_callback=None,
         remove_presence_callback=None,
-        event=None,
     ):
         """
         Bind to the interface specified in the configuration file

--- a/tests/pytests/functional/channel/test_server.py
+++ b/tests/pytests/functional/channel/test_server.py
@@ -59,6 +59,8 @@ def transport_ids(value):
 @pytest.fixture(
     params=[
         "ws",
+        "tcp",
+        "zeromq",
     ],
     ids=transport_ids,
 )
@@ -173,6 +175,8 @@ def test_pub_server_channel(
         master_config,
     )
     server_channel.pre_fork(process_manager)
+    if not server_channel.transport.started.wait(30):
+        pytest.fail("Server channel did not start within 30 seconds.")
     req_server_channel = salt.channel.server.ReqServerChannel.factory(master_config)
     req_server_channel.pre_fork(process_manager)
 

--- a/tests/pytests/unit/transport/test_tcp.py
+++ b/tests/pytests/unit/transport/test_tcp.py
@@ -705,6 +705,7 @@ async def test_pub_server_paths_no_perms(master_opts, io_loop):
         assert p.call_count == 0
 
 
+@pytest.mark.skip_on_windows()
 async def test_pub_server_publisher_pull_path_perms(master_opts, io_loop, tmp_path):
     def publish_payload(payload):
         return payload
@@ -730,6 +731,7 @@ async def test_pub_server_publisher_pull_path_perms(master_opts, io_loop, tmp_pa
         assert p.call_args.args == (pubserv.pull_path, pubserv.pull_path_perms)
 
 
+@pytest.mark.skip_on_windows()
 async def test_pub_server_publisher_pub_path_perms(master_opts, io_loop, tmp_path):
     def publish_payload(payload):
         return payload


### PR DESCRIPTION
- Add a started event that gets set after the server transport is ready for clients to connect.
- Wait on publish servers start while the master process is starting up.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes #66993

### Previous Behavior

Publish clients in the master process could encounter exceptions while trying to connect.

### New Behavior

Publish clients within the master processes connect without error.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

