### PR TITLE
[3006.x] Fix parallel states on spawning platforms

### DIFF
--- a/changelog/66996.fixed.md
+++ b/changelog/66996.fixed.md
@@ -1,0 +1,1 @@
+Ensured global dunders like __env__ are defined in state module that are run in parallel on spawning platforms

--- a/changelog/66999.fixed.md
+++ b/changelog/66999.fixed.md
@@ -1,0 +1,1 @@
+Filtered unpicklable objects from the context dict when invoking states in parallel on spawning platforms to avoid a crash

--- a/salt/state.py
+++ b/salt/state.py
@@ -753,21 +753,21 @@ class State:
         loader="states",
         initial_pillar=None,
         file_client=None,
-        __invocation_id=None,
+        _invocation_id=None,
     ):
         """
         When instantiating an object of this class, do not pass
-        ``__invocation_id``. It is an internal field for tracking
+        ``_invocation_id``. It is an internal field for tracking
         parallel executions where no jid is available (Salt-SSH) and
         only exposed as an init argument to work on spawning platforms.
         """
         if jid is not None:
-            __invocation_id = jid
-        if __invocation_id is None:
+            _invocation_id = jid
+        if _invocation_id is None:
             # For salt-ssh parallel states, we need a unique identifier
             # for a single execution. self.jid should not be set there
             # since it's used for other purposes as well.
-            __invocation_id = salt.utils.jid.gen_jid(opts)
+            _invocation_id = salt.utils.jid.gen_jid(opts)
         self._init_kwargs = {
             "opts": opts,
             "pillar_override": pillar_override,
@@ -778,7 +778,7 @@ class State:
             "mocked": mocked,
             "loader": loader,
             "initial_pillar": initial_pillar,
-            "__invocation_id": __invocation_id,
+            "_invocation_id": _invocation_id,
         }
         self.states_loader = loader
         if "grains" not in opts:
@@ -825,7 +825,7 @@ class State:
         self.pre = {}
         self.__run_num = 0
         self.jid = jid
-        self.invocation_id = __invocation_id
+        self.invocation_id = _invocation_id
         self.instance_id = str(id(self))
         self.inject_globals = {}
         self.mocked = mocked

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -3,6 +3,7 @@ import os
 import textwrap
 import threading
 import time
+from textwrap import dedent
 
 import pytest
 
@@ -1081,3 +1082,47 @@ def test_state_sls_mock_ret(state_tree):
             ret["cmd_|-echo1_|-echo 'This is a test!'_|-run"]["comment"]
             == "Not called, mocked"
         )
+
+
+@pytest.fixture
+def _state_requires_env(loaders, state_tree):
+    mod_contents = dedent(
+        r"""
+        def test_it(name):
+            return {
+                "name": name,
+                "result": __env__ == "base",
+                "comment": "",
+                "changes": {},
+            }
+        """
+    )
+    sls = "test_spawning"
+    sls_contents = dedent(
+        """
+        This should not fail on spawning platforms:
+          requires_env.test_it:
+            - name: foo
+            - parallel: true
+        """
+    )
+    with pytest.helpers.temp_file(
+        f"{sls}.sls", sls_contents, state_tree
+    ), pytest.helpers.temp_file("_states/requires_env.py", mod_contents, state_tree):
+        res = loaders.modules.saltutil.sync_states()
+        assert "states.requires_env" in res
+        yield sls
+
+
+def test_state_apply_parallel_spawning_with_global_dunders(state, _state_requires_env):
+    """
+    Ensure state modules called via `parallel: true` have access to injected
+    global dunders like `__env__`.
+    """
+    ret = state.apply(_state_requires_env)
+    assert (
+        ret[
+            "requires_env_|-This should not fail on spawning platforms_|-foo_|-test_it"
+        ]["result"]
+        is True
+    )


### PR DESCRIPTION
### What does this PR do?
* Fixes a crash introduced in https://github.com/saltstack/salt/pull/66517 (Name mangling rewrites `__invocation_jid` to `_State__invocation_jid`, causing a TypeError when instantiating the class instance with `**init_kwargs`). This patch is not part of any release as of now.
* Fixes parallel runs of state modules which rely on global dunders like `__env__` to be defined
* Fixes parallel runs of state modules when the context dict contains unpicklable objects (e.g. when the `match` module has been invoked, which uses it to cache a LazyLoader instance)

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66996
Fixes: https://github.com/saltstack/salt/issues/66999

### Previous Behavior
* Crashes with a TypeError because of the first issue (this makes parallel states not work at all on spawning platforms).
* Fixing the previous, crashes with a NameError because `__env__` is not defined.
* Fixing the previous and having an unpicklable object in `__context__`, crashes with a TypeError, e.g. `cannot pickle '_thread.RLock' object`

### New Behavior
Works as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes