### PR TITLE
[3006.x] Disable gatekeeper before running package tests

### DIFF
--- a/.github/workflows/test-packages-action-macos.yml
+++ b/.github/workflows/test-packages-action-macos.yml
@@ -175,6 +175,10 @@ jobs:
         run: |
           nox --force-color -e decompress-dependencies -- macos ${{ inputs.arch }}
 
+      - name: Disable Gatekeeper
+        run: |
+          sudo -E spctl --master-disable
+
       - name: Show System Info
         env:
           SKIP_REQUIREMENTS_INSTALL: "1"


### PR DESCRIPTION
### What does this PR do?
Disables gatekeeper for package tests, since we're not longer signing and notarizing them.
