### PR TITLE
[3006.x] Handle zombie processes when getting pids

### DIFF
--- a/tests/pytests/pkg/downgrade/test_salt_downgrade.py
+++ b/tests/pytests/pkg/downgrade/test_salt_downgrade.py
@@ -18,16 +18,26 @@ def _get_running_named_salt_pid(process_name):
 
     pids = []
     for proc in psutil.process_iter():
-        cmdl_strg = " ".join(str(element) for element in proc.cmdline())
-        if process_name in cmdl_strg:
-            pids.append(proc.pid)
+        cmd_line = ""
+        try:
+            cmd_line = " ".join(str(element) for element in proc.cmdline())
+        except psutil.ZombieProcess:
+            # Even though it's a zombie process, it still has a cmdl_string and
+            # a pid, so we'll use it
+            pass
+        if process_name in cmd_line:
+            try:
+                pids.append(proc.pid)
+            except psutil.NoSuchProcess:
+                # Process is now closed
+                continue
 
     return pids
 
 
 def test_salt_downgrade_minion(salt_call_cli, install_salt):
     """
-    Test an downgrade of Salt Minion.
+    Test a downgrade of Salt Minion.
     """
     is_restart_fixed = packaging.version.parse(
         install_salt.prev_version


### PR DESCRIPTION
### What does this PR do?
Process Zombie Processes when getting current pids before pkg downgrade tests
