### PR TITLE
[master] Update onedir package url

### DIFF
--- a/salt/utils/relenv.py
+++ b/salt/utils/relenv.py
@@ -11,12 +11,15 @@ import salt.utils.thin
 
 log = logging.getLogger(__name__)
 
+BASE_URL = "https://packages.broadcom.com/artifactory/saltproject-generic/onedir/"
+
 
 def gen_relenv(
     cachedir,
     kernel,
     os_arch,
     overwrite=False,
+    base_url=BASE_URL,
 ):
     """
     Deploy salt-relenv.
@@ -26,30 +29,33 @@ def gen_relenv(
     :param overwrite: Whether to overwrite the existing cached tarball.
     :return: The path to the recompressed .tgz file.
     """
+    version = get_latest_version(base_url)
+
     # Set up directories
-    relenv_dir = os.path.join(cachedir, "relenv", kernel, os_arch)
+    relenv_dir = os.path.join(cachedir, "relenv", version, kernel, os_arch)
     if not os.path.isdir(relenv_dir):
         os.makedirs(relenv_dir)
 
-    relenv_url = get_tarball(kernel, os_arch)
+    relenv_url = get_tarball(f"{base_url}/{version}/", kernel, os_arch)
     tarball_path = os.path.join(relenv_dir, "salt-relenv.tar.xz")
 
     # Download the tarball if it doesn't exist or overwrite is True
     if overwrite or not os.path.exists(tarball_path):
-        if not download(cachedir, relenv_url, tarball_path):
+        if not download(relenv_url, tarball_path):
             return False
 
     return tarball_path
 
 
-def get_tarball(kernel, arch):
+def get_tarball(base_url, kernel, arch):
     """
     Get the latest Salt onedir tarball URL for the specified kernel and architecture.
+    :param base_url: The artifactory location
     :param kernel: The detected OS (e.g., 'linux', 'darwin', 'windows').
     :param arch: The detected architecture (e.g., 'amd64', 'x86_64', 'arm64').
     :return: The URL of the latest tarball.
     """
-    base_url = "https://packages.broadcom.com/artifactory/saltproject-generic/onedir"
+
     try:
         # Request the page listing
         response = requests.get(base_url, timeout=60)
@@ -81,9 +87,38 @@ def get_tarball(kernel, arch):
     return f"{base_url}/{latest}/{latest_tarball}"
 
 
-def download(cachedir, url, destination):
+def get_latest_version(base_url):
+    """
+    Retrieve the latest version from the base artifactory directory
+    :param base_url: The artifactory location
+    :return: The version number of the latest artifact
+    """
+    try:
+        response = requests.get(base_url, timeout=60)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        log.error(f"Failed to retrieve directory listing: {e}")
+        raise ValueError("Unable to fetch directory list from repository")
+
+    # Extract version numbers from hrefs
+    pattern = re.compile(r'href="(\d+\.\d+)/"')
+    versions = pattern.findall(response.text)
+
+    if not versions:
+        log.error("No versions found in directory listing")
+        raise ValueError("No versions found in directory listing")
+
+    # Sort versions numerically and return the latest one
+    versions.sort(key=lambda s: list(map(int, s.split("."))), reverse=True)
+    return versions[0]
+
+
+def download(url, destination):
     """
     Download the salt artifact from the given destination to the cache.
+    :param url: The artifact location
+    :param destination: Path to the downloaded file
+    :return: True if the download was successful, else False
     """
     if not os.path.exists(destination):
         log.info(f"Downloading from {url} to {destination}")


### PR DESCRIPTION
**What does this PR do?**

This PR updates the `salt-ssh --relenv` functionality to change the source from which the Salt Onedir package is downloaded. Instead of using `salt.utils.http` to fetch packages from `repo.saltproject.com`, the logic is updated to leverage `relenv.fetch` to pull the package from the new Artifactory location. This transition ensures that the retrieval process remains consistent and up-to-date with the newly hosted package locations.

**What issues does this PR fix or reference?**

Fixes #67010

**Previous Behavior**

- Utilized `salt.utils.http` to download the Salt Onedir package from `repo.saltproject.com`.

**New Behavior**

- Uses `relenv.fetch` to download the Salt Onedir package from the new Artifactory location. This abstracts URL handling and ensures download paths align with updated infrastructure.

**Merge requirements satisfied?**

- [x] **Documentation:** Updates have been made to reflect changes in the URL source.
- [x] **Changelog:** Please see the changelog for more information on this update: [Changelog](https://docs.saltproject.io/en/master/topics/development/changelog.html).
- [x] **Tests written/updated:** Tests have been adjusted to confirm the new download functionality works as expected.

**Commits signed with GPG?** 

Yes

Please review Salt's [Contributing Guide](https://docs.saltproject.io/en/latest/topics/development/contributing.html) for best practices, including the PR Guidelines.

For more information about signing commits with GPG, see GitHub's [page on GPG signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).