### PR TITLE
[3006.x] Fix find_json to not rely on newline after valid JSON

### DIFF
--- a/changelog/67023.added.md
+++ b/changelog/67023.added.md
@@ -1,0 +1,1 @@
+Enhance json.find_json to return json even when it contains text on the same line of the last closing parenthesis

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -971,7 +971,7 @@ def call(function, *args, **kwargs):
                 return local.get("return", local)
             else:
                 return local
-        except ValueError:
+        except (ValueError, AttributeError):
             return {"result": False, "retcode": 1, "comment": ret_stdout}
     finally:
         # Check if reboot is needed

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -27,10 +27,48 @@ def __split(raw):
 def find_json(raw):
     """
     Pass in a raw string and load the json when it starts. This allows for a
-    string to start with garbage and end with json but be cleanly loaded
+    string to start or end with garbage but the JSON be cleanly loaded
     """
     ret = {}
     lines = __split(raw)
+    lengths = list(map(len, lines))
+    starts = []
+    ends = []
+
+    # Search for possible starts and ends of the json fragments
+    for ind, _ in enumerate(lines):
+        line = lines[ind].lstrip()
+        line = line[0] if line else line
+        if line == "{" or line == "[":
+            starts.append((ind, line))
+        if line == "}" or line == "]":
+            ends.append((ind, line))
+
+    # List all the possible pairs of starts and ends,
+    # and fill the length of each block to sort by size after
+    starts_ends = []
+    for start, start_br in starts:
+        for end, end_br in reversed(ends):
+            if end > start and (
+                (start_br == "{" and end_br == "}")
+                or (start_br == "[" and end_br == "]")
+            ):
+                starts_ends.append((start, end, sum(lengths[start : end + 1])))
+
+    # Iterate through all the possible pairs starting from the largest
+    starts_ends.sort(key=lambda x: (x[2], x[1] - x[0], x[0]), reverse=True)
+    for start, end, _ in starts_ends:
+        # Try filtering non-JSON text right after the last closing curly brace
+        end_str = lines[end].lstrip()[0]
+        working = "\n".join(lines[start:end]) + end_str
+        try:
+            ret = json.loads(working)
+            return ret
+        except ValueError:
+            continue
+
+    # Fall back to old implementation for backward compatibility
+    # expecting json after the text
     for ind, _ in enumerate(lines):
         try:
             working = "\n".join(lines[ind:])

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -36,8 +36,8 @@ def find_json(raw):
     ends = []
 
     # Search for possible starts and ends of the json fragments
-    for ind, _ in enumerate(lines):
-        line = lines[ind].lstrip()
+    for ind, line in enumerate(lines):
+        line = line.lstrip()
         line = line[0] if line else line
         if line == "{" or line == "[":
             starts.append((ind, line))
@@ -47,18 +47,18 @@ def find_json(raw):
     # List all the possible pairs of starts and ends,
     # and fill the length of each block to sort by size after
     starts_ends = []
-    for start, start_br in starts:
+    for start, start_char in starts:
         for end, end_br in reversed(ends):
             if end > start and (
-                (start_br == "{" and end_br == "}")
-                or (start_br == "[" and end_br == "]")
+                (start_char == "{" and end_br == "}")
+                or (start_char == "[" and end_br == "]")
             ):
                 starts_ends.append((start, end, sum(lengths[start : end + 1])))
 
     # Iterate through all the possible pairs starting from the largest
     starts_ends.sort(key=lambda x: (x[2], x[1] - x[0], x[0]), reverse=True)
     for start, end, _ in starts_ends:
-        # Try filtering non-JSON text right after the last closing curly brace
+        # Try filtering non-JSON text right after the last closing character
         end_str = lines[end].lstrip()[0]
         working = "\n".join(lines[start:end]) + end_str
         try:

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -109,6 +109,11 @@ class JSONTestCase(TestCase):
         ret = salt.utils.json.find_json(garbage_prepend_json)
         self.assertDictEqual(ret, expected_ret)
 
+        # Append garbage right after closing bracket of the JSON
+        garbage_append_json = f"{test_sample_json.rstrip()}{LOREM_IPSUM}"
+        ret = salt.utils.json.find_json(garbage_append_json)
+        self.assertDictEqual(ret, expected_ret)
+
         # Test to see if a ValueError is raised if no JSON is passed in
         self.assertRaises(ValueError, salt.utils.json.find_json, LOREM_IPSUM)
 


### PR DESCRIPTION
### What does this PR do?

In this PR, we enhance the `find_json` function to work with valid JSONs that contain garbage right after the JSON end. This is a problem when the text contains JSON and, for example, deprecation messages, such as:

```
{
    "local": {
        "saltutil_|-sync_states_|-sync_states_|-sync_states": {
            "name": "sync_states",
            "changes": {},
            "result": true,
            "comment": "No updates to sync",
            "__sls__": "util.syncstates",
            "__run_num__": 0,
            "start_time": "14:35:37.150819",
            "duration": 1256.999,
            "__id__": "sync_states"
        },
...JSON continues...
}/usr/lib/python3.6/site-packages/salt/states/x509.py:214: DeprecationWarning: The x509 modules are deprecated. Please migrate to the replacement modules (x509_v2). They are the default from Salt 3008 (Argon) onwards.
  "The x509 modules are deprecated. Please migrate to the replacement "
```

### Previous Behavior
Previously, if the JSON contains text right after the closing parenthesis, we either get a ValueError, or we get a wrong return (in the example above, the return value is `"The x509 modules are deprecated. Please migrate to the replacement "`

### New Behavior
The `find_json` method is able to filter the text right after the closing parenthesis, and returns the valid JSON.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
