### PR TITLE
salt/state.py: support retry: True as per docs

### DIFF
--- a/changelog/67049.fixed.md
+++ b/changelog/67049.fixed.md
@@ -1,0 +1,1 @@
+support retry: True as per docs

--- a/salt/state.py
+++ b/salt/state.py
@@ -2746,7 +2746,7 @@ class State:
                     "interval": 30,
                 }
         else:
-            log.debug(
+            log.warning(
                 "State is set to retry, but retry: True or a valid dict for "
                 "retry configuration was not found.  Using retry defaults"
             )

--- a/salt/state.py
+++ b/salt/state.py
@@ -2736,7 +2736,9 @@ class State:
             if retry_data:
                 validated_retry_data = retry_defaults
             else:
-                log.debug("State is set with explicit retry: False so using default retry configuration with 0 attempts")
+                log.debug(
+                    "State is set with explicit retry: False so using default retry configuration with 0 attempts"
+                )
                 validated_retry_data = {
                     "until": True,
                     "attempts": 0,

--- a/salt/state.py
+++ b/salt/state.py
@@ -2731,10 +2731,22 @@ class State:
                         ]
                 else:
                     validated_retry_data[expected_key] = retry_defaults[expected_key]
+
+        elif isinstance(retry_data, bool):
+            if retry_data:
+                validated_retry_data = retry_defaults
+            else:
+                log.debug("State is set with explicit retry: False so using default retry configuration with 0 attempts")
+                validated_retry_data = {
+                    "until": True,
+                    "attempts": 0,
+                    "splay": 0,
+                    "interval": 30,
+                }
         else:
-            log.warning(
-                "State is set to retry, but a valid dict for retry "
-                "configuration was not found.  Using retry defaults"
+            log.debug(
+                "State is set to retry, but retry: True or a valid dict for "
+                "retry configuration was not found.  Using retry defaults"
             )
             validated_retry_data = retry_defaults
         return validated_retry_data

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -711,6 +711,30 @@ def test_retry_option(state, state_tree):
             assert state_return.full_return["duration"] >= 3
 
 
+def test_retry_option_is_true(state, state_tree):
+    """
+    test the retry: True on a simple state with defaults
+    ensure comment is as expected
+    ensure state duration is greater than configured the passed (interval * attempts)
+    """
+    sls_contents = """
+    file_test:
+      file.exists:
+        - name: /path/to/a/non-existent/file.txt
+        - retry: True
+    """
+    expected_comment = (
+        'Attempt 1: Returned a result of "False", with the following '
+        'comment: "Specified path /path/to/a/non-existent/file.txt does not exist"'
+    )
+    with pytest.helpers.temp_file("retry.sls", sls_contents, state_tree):
+        ret = state.sls("retry")
+        for state_return in ret:
+            assert state_return.result is False
+            assert expected_comment in state_return.comment
+            assert state_return.full_return["duration"] >= 3
+
+
 @pytest.mark.skip_initial_gh_actions_failure(skip=_check_skip)
 def test_retry_option_success(state, state_tree, tmp_path):
     """


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #67048 

### Previous Behavior
Below warning displayed when [valid option](https://docs.saltproject.io/en/latest/ref/states/requisites.html#retrying-states) `retry: True` used
```
[WARNING ] State is set to retry, but a valid dict for retry configuration was not found.  Using retry defaults
```

### New Behavior
No warning shown. Defaults used as documented 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
