### PR TITLE
Remove warning when rendering non-SLS files

### DIFF
--- a/changelog/67067.changed.md
+++ b/changelog/67067.changed.md
@@ -1,0 +1,1 @@
+Remove warning when running `slsutil.renderer` on non-SLS files

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -121,8 +121,16 @@ def generate_sls_context(tmplpath, sls):
         elif template.endswith(f"{slspath}/init.sls"):
             template = template[-(9 + len(slspath)) :]
         else:
-            # Something went wrong
-            log.warning("Failed to determine proper template path")
+            # It is not an SLS file being processed
+            template = sls
+            sls_context.update(
+                dict(
+                    tplpath=tmplpath,
+                    tplfile=template,
+                    tpldir=str(pathlib.Path(sls).parents[0].as_posix()),
+                )
+            )
+            return sls_context
 
         slspath = template.rsplit("/", 1)[0] if "/" in template else ""
 

--- a/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
+++ b/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
@@ -231,3 +231,45 @@ def test_generate_sls_context__backslash_in_path():
         sls_path="foo",
         slspath="foo",
     )
+
+
+def test_generate_sls_context__non_sls_root():
+    """generate_sls_context - Non-SLS template in the root directory
+
+    (Issue #56410)
+    """
+    _test_generated_sls_context(
+        "jinja.yaml",
+        "jinja.yaml",
+        tplpath="jinja.yaml",
+        tplfile="jinja.yaml",
+        tpldir=".",
+    )
+
+
+def test_generate_sls_context__non_sls_one_level():
+    """generate_sls_context - Non-SLS template with one-level directory
+
+    (Issue #56410)
+    """
+    _test_generated_sls_context(
+        "one/jinja.yaml",
+        "one/jinja.yaml",
+        tplpath="one/jinja.yaml",
+        tplfile="one/jinja.yaml",
+        tpldir="one",
+    )
+
+
+def test_generate_sls_context__non_sls_two_level():
+    """generate_sls_context - Non-SLS template with two-level directory
+
+    (Issue #56410)
+    """
+    _test_generated_sls_context(
+        "one/two/jinja.yaml",
+        "one/two/jinja.yaml",
+        tplpath="one/two/jinja.yaml",
+        tplfile="one/two/jinja.yaml",
+        tpldir="one/two",
+    )


### PR DESCRIPTION
### What does this PR do?
My Salt states contain code to render Jinja in YAML files using the `slsutil.renderer` function, such as:
```
{% set defaults = salt["slsutil.renderer"]("salt://defaults.yaml", sls="defaults.yaml") %}
```
This works fine, but it always produces the error message: "Failed to determine proper template path"

### What issues does this PR fix or reference?
None

### Previous Behavior
Running `slsutil.renderer` on any file other than an SLS file would work, but produce a superfluous warning.

### New Behavior
Running `slsutil.renderer` on non-SLS files succeeds without a warning, and populates the following context variables:
- `tplpath`
- `tplfile`
- `tpldir`

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
