### PR TITLE
Allow `file.recurse` to merge all existing `source` dirs

### DIFF
--- a/changelog/67072.added.md
+++ b/changelog/67072.added.md
@@ -1,0 +1,1 @@
+Added a `merge` option to `file.recurse`, which merges subpaths from all existing `source`s before managing the directory. Handy when using different saltenvs or the TOFS pattern.

--- a/changelog/67766.fixed.md
+++ b/changelog/67766.fixed.md
@@ -1,0 +1,1 @@
+Fixed creating relative directory symlinks on Windows, ensured listing targets of symlinks in file_roots always produces POSIX-style paths

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -413,6 +413,12 @@ def _file_lists(load, form):
                             abs_path,
                         )
                         link_dest = abs_path
+                    # Not sure what the purpose of this is since symlinks that point outside
+                    # the file roots are allowed (when following symlinks). Either way, this does not do what
+                    # it's intended to do since a symlink that starts with ../ is not resolved
+                    # relative to its full path, but to the containing directory as well.
+                    # This allows symlinks to point to the parent and sibling directories of the file root
+                    # and still be listed here.
                     if link_dest.startswith(".."):
                         joined = os.path.join(abs_path, link_dest)
                     else:
@@ -428,10 +434,10 @@ def _file_lists(load, form):
                         # Only count the link if it does not point
                         # outside of the root dir of the fileserver
                         # (i.e. the "path" variable)
-                        ret["links"][rel_path] = link_dest
+                        ret["links"][rel_path] = _translate_sep(link_dest)
                     else:
                         if not __opts__["fileserver_followsymlinks"]:
-                            ret["links"][rel_path] = link_dest
+                            ret["links"][rel_path] = _translate_sep(link_dest)
 
         for path in __opts__["file_roots"][saltenv]:
             if saltenv == "__env__":

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1462,7 +1462,7 @@ def symlink(src, link, force=False, atomic=False, follow_symlinks=True):
     src = os.path.normpath(src)
     link = os.path.normpath(link)
 
-    is_dir = os.path.isdir(src)
+    is_dir = os.path.isdir(os.path.join(os.path.dirname(link), src))
 
     # Elevate the token from the current process
     desired_access = win32security.TOKEN_QUERY | win32security.TOKEN_ADJUST_PRIVILEGES

--- a/tests/pytests/functional/fileserver/test_roots.py
+++ b/tests/pytests/functional/fileserver/test_roots.py
@@ -1,3 +1,6 @@
+import os.path
+import posixpath
+
 import pytest
 
 import salt.fileserver.roots as roots
@@ -20,7 +23,7 @@ def test_symlink_list(state_tree):
         link = state_tree / "link"
         link.symlink_to(str(target))
         ret = roots.symlink_list({"saltenv": "base"})
-        assert ret == {"link": str(target)}
+        assert ret == {"link": str(target).replace(os.path.sep, posixpath.sep)}
 
 
 @pytest.mark.parametrize(

--- a/tests/pytests/unit/states/file/test_filestate.py
+++ b/tests/pytests/unit/states/file/test_filestate.py
@@ -258,22 +258,17 @@ def test_recurse():
             assert filestate.recurse(name, source) == ret
 
         with patch.object(os.path, "isabs", mock_t):
-            comt = "Invalid source '1' (must be a salt:// URI)"
+            comt = "Recurse failed: Invalid source '1' (must be a salt:// URI)"
             ret.update({"comment": comt})
             assert filestate.recurse(name, 1) == ret
 
-            comt = "Invalid source '//code/flask' (must be a salt:// URI)"
+            comt = (
+                "Recurse failed: Invalid source '//code/flask' (must be a salt:// URI)"
+            )
             ret.update({"comment": comt})
             assert filestate.recurse(name, "//code/flask") == ret
 
-            comt = "Recurse failed: "
-            ret.update({"comment": comt})
-            assert filestate.recurse(name, source) == ret
-
-            comt = (
-                "The directory 'code/flask' does not exist"
-                " on the salt fileserver in saltenv 'base'"
-            )
+            comt = "Recurse failed: none of the specified sources were found"
             ret.update({"comment": comt})
             assert filestate.recurse(name, source) == ret
 

--- a/tests/pytests/unit/states/file/test_recurse.py
+++ b/tests/pytests/unit/states/file/test_recurse.py
@@ -17,7 +17,8 @@ def configure_loader_modules():
 
 def test__gen_recurse_managed_files():
     """
-    Test _gen_recurse_managed_files to make sure it puts symlinks at the end of the list of files.
+    Test _gen_recurse_managed_files to make sure it does not include
+    symlinks in the list of files that is passed to file.managed.
     """
     target_dir = pathlib.Path(f"{os.sep}some{os.sep}path{os.sep}target")
     cp_list_master = MagicMock(
@@ -28,6 +29,12 @@ def test__gen_recurse_managed_files():
             "target/notasymlink",
         ],
     )
+    cp_list_master_dirs = MagicMock(
+        return_value=[
+            "target",
+            "target/not_a_symlink",
+        ],
+    )
     cp_list_master_symlinks = MagicMock(
         return_value={
             "target/symlink": f"{target_dir}{os.sep}not_a_symlink{os.sep}symlink"
@@ -35,14 +42,22 @@ def test__gen_recurse_managed_files():
     )
     patch_salt = {
         "cp.list_master": cp_list_master,
+        "cp.list_master_dirs": cp_list_master_dirs,
         "cp.list_master_symlinks": cp_list_master_symlinks,
     }
     with patch.dict(filestate.__salt__, patch_salt):
         files, dirs, links, keep = filestate._gen_recurse_managed_files(
-            name=str(target_dir), source=f"salt://{target_dir.name}", keep_symlinks=True
+            name=str(target_dir),
+            sources=[f"salt://{target_dir.name}"],
+            keep_symlinks=True,
         )
-    expected = (
+    unexpected = (
         f"{os.sep}some{os.sep}path{os.sep}target{os.sep}symlink",
         "salt://target/symlink?saltenv=base",
     )
-    assert files[-1] == expected
+    assert unexpected not in files
+    expected = (
+        f"{os.sep}some{os.sep}path{os.sep}target{os.sep}symlink",
+        f"{os.sep}some{os.sep}path{os.sep}target{os.sep}not_a_symlink{os.sep}symlink",
+    )
+    assert expected in links

--- a/tests/pytests/unit/states/file/test_recurse.py
+++ b/tests/pytests/unit/states/file/test_recurse.py
@@ -56,8 +56,10 @@ def test__gen_recurse_managed_files():
         "salt://target/symlink?saltenv=base",
     )
     assert unexpected not in files
+    expected_dest = f"{os.sep}some{os.sep}path{os.sep}target{os.sep}symlink"
     expected = (
-        f"{os.sep}some{os.sep}path{os.sep}target{os.sep}symlink",
+        f"{os.sep}some{os.sep}path{os.sep}target{os.sep}not_a_symlink{os.sep}symlink",
         f"{os.sep}some{os.sep}path{os.sep}target{os.sep}not_a_symlink{os.sep}symlink",
     )
-    assert expected in links
+    assert expected_dest in links
+    assert links[expected_dest] == expected

--- a/tests/pytests/unit/states/test_file.py
+++ b/tests/pytests/unit/states/test_file.py
@@ -81,11 +81,10 @@ def test_file_recurse_directory_test():
         ret = file.recurse("/tmp/test", "salt://does_not_exist", saltenv="base")
         assert ret == {
             "changes": {},
-            "comment": "The directory 'does_not_exist' does not exist on the salt fileserver in saltenv 'base'",
+            "comment": "Recurse failed: none of the specified sources were found",
             "name": "/tmp/test",
             "result": False,
         }
         salt_dunder["cp.list_master_dirs"].assert_called_once_with(
             saltenv="base",
-            prefix="does_not_exist/",
         )


### PR DESCRIPTION
### What does this PR do?
Adds a `merge` parameter to `file.recurse`. When enabled, instead of selecting the first existing source, merges source directories recursively.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/67072
Fixes: https://github.com/saltstack/salt/issues/67766

### Previous Behavior
Selects the first source only.

### New Behavior
Can merge multiple sources.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes