### PR TITLE
add option to ignore duplicate includes

### DIFF
--- a/changelog/67081.added.md
+++ b/changelog/67081.added.md
@@ -1,0 +1,1 @@
+Add option to ignore duplicate includes

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -790,6 +790,8 @@ VALID_OPTS = immutabletypes.freeze(
         "jinja_trim_blocks": bool,
         # Cache minion ID to file
         "minion_id_caching": bool,
+        # Allow duplicate includes
+        "allow_duplicate_includes": bool,
         # Always generate minion id in lowercase.
         "minion_id_lowercase": bool,
         # Remove either a single domain (foo.org), or all (True) from a generated minion id.
@@ -1271,6 +1273,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "grains_refresh_every": 0,
         "minion_id_caching": True,
         "minion_id_lowercase": False,
+        "allow_duplicate_includes": False,
         "minion_id_remove_domain": False,
         "keysize": 2048,
         "transport": "zeromq",

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -34,7 +34,9 @@ def get_yaml_loader(argline):
             yamlloader = yamlloader_old
         else:
             yamlloader = yamlloader_new
-        return yamlloader.SaltYamlSafeLoader(*args, dictclass=OrderedDict)
+        return yamlloader.SaltYamlSafeLoader(
+            *args, dictclass=OrderedDict, opts=__opts__
+        )
 
     return yaml_loader
 

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -23,8 +23,9 @@ class SaltYamlSafeLoader(BaseLoader):
     to make things like sls file more intuitive.
     """
 
-    def __init__(self, stream, dictclass=dict):
+    def __init__(self, stream, dictclass=dict, opts=None):
         super().__init__(stream)
+        self.__opts__ = opts or {}
         if dictclass is not dict:
             # then assume ordered dict and use it for both !map and !omap
             self.add_constructor("tag:yaml.org,2002:map", type(self).construct_yaml_map)
@@ -76,6 +77,11 @@ class SaltYamlSafeLoader(BaseLoader):
                 )
             value = self.construct_object(value_node, deep=deep)
             if key in mapping:
+                if key == "include" and self.__opts__.get(
+                    "allow_duplicate_includes", False
+                ):
+                    continue
+
                 raise ConstructorError(
                     context,
                     node.start_mark,

--- a/salt/utils/yamlloader_old.py
+++ b/salt/utils/yamlloader_old.py
@@ -28,8 +28,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
     to make things like sls file more intuitive.
     """
 
-    def __init__(self, stream, dictclass=dict):
+    def __init__(self, stream, dictclass=dict, opts=None):
         super().__init__(stream)
+        self.__opts__ = opts or {}
         if dictclass is not dict:
             # then assume ordered dict and use it for both !map and !omap
             self.add_constructor("tag:yaml.org,2002:map", type(self).construct_yaml_map)
@@ -81,6 +82,11 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
                 )
             value = self.construct_object(value_node, deep=deep)
             if key in mapping:
+                if key == "include" and self.__opts__.get(
+                    "allow_duplicate_includes", False
+                ):
+                    continue
+
                 raise ConstructorError(
                     context,
                     node.start_mark,


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #67081 

### Previous Behavior
We would exit with a `ConstructorError` if a duplicate `include` is encountered

### New Behavior
With `allow_duplicate_includes=True` we continue applying states.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
