### PR TITLE
throw a TypeError when trying to merge a list with a mapping when `me…

### DIFF
--- a/changelog/67092.fixed.md
+++ b/changelog/67092.fixed.md
@@ -1,0 +1,1 @@
+dictupdate.update: throw a TypeError when trying to merge a list with a mapping when ``merge_lists=True``.

--- a/tests/unit/utils/test_dictupdate.py
+++ b/tests/unit/utils/test_dictupdate.py
@@ -353,5 +353,8 @@ class UtilDeepDictUpdateTestCase(TestCase):
         mdict["A"] = [1, 2]
         with self.assertRaises(TypeError):
             dictupdate.update(
-                copy.deepcopy(mdict), {"A": {"key": "value"}}, merge_lists=True, strict=True
+                copy.deepcopy(mdict),
+                {"A": {"key": "value"}},
+                merge_lists=True,
+                strict=True,
             )

--- a/tests/unit/utils/test_dictupdate.py
+++ b/tests/unit/utils/test_dictupdate.py
@@ -343,3 +343,15 @@ class UtilDeepDictUpdateTestCase(TestCase):
                 dictupdate.update_dict_key_value(
                     {}, "foo", update_with, ordered_dict=True
                 )
+
+    def test_update_with_merge_lists_and_mapping(self):
+        """
+        Test that updating a list with a mapping raises a TypeError
+        when merge_lists=True.
+        """
+        mdict = copy.deepcopy(self.dict1)
+        mdict["A"] = [1, 2]
+        with self.assertRaises(TypeError):
+            dictupdate.update(
+                copy.deepcopy(mdict), {"A": {"key": "value"}}, merge_lists=True, strict=True
+            )


### PR DESCRIPTION
throw a TypeError when trying to merge a list with a mapping when `merge_lists=True`

### What does this PR do?

### What issues does this PR fix or reference?
Fixes #67092 

### Previous Behavior
Silently drops values

### New Behavior
Throws TypeError

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
