### PR TITLE
Fix `gpg.verify` with python-gnupg >= 0.5.1

### DIFF
--- a/changelog/66685.fixed.md
+++ b/changelog/66685.fixed.md
@@ -1,0 +1,1 @@
+Fixed gpp module trust level reporting/crash with python-gnupg>=0.5.1

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -29,9 +29,17 @@ from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
-# Define the module's virtual name
+try:
+    import gnupg
+
+    HAS_GPG_BINDINGS = True
+except ImportError:
+    HAS_GPG_BINDINGS = False
+
+
 __virtualname__ = "gpg"
 
+# Map of letters indicating key validity to pretty string (for display)
 LETTER_TRUST_DICT = immutabletypes.freeze(
     {
         "e": "Expired",
@@ -45,6 +53,22 @@ LETTER_TRUST_DICT = immutabletypes.freeze(
     }
 )
 
+
+# Map of allowed `trust_level` param values in `trust_key`
+# to trust parameter for python-gnupg trust_keys (to manage owner trust)
+TRUST_KEYS_TRUST_LEVELS = immutabletypes.freeze(
+    {
+        "expired": "TRUST_EXPIRED",
+        "unknown": "TRUST_UNDEFINED",
+        "not_trusted": "TRUST_NEVER",
+        "marginally": "TRUST_MARGINAL",
+        "fully": "TRUST_FULLY",
+        "ultimately": "TRUST_ULTIMATE",
+    }
+)
+
+# Map of allowed `trust_level` param values in `trust_key`
+# to owner trust numeric values
 NUM_TRUST_DICT = immutabletypes.freeze(
     {
         "expired": "1",
@@ -56,6 +80,7 @@ NUM_TRUST_DICT = immutabletypes.freeze(
     }
 )
 
+# Map of owner trust numeric values to pretty string (for display)
 INV_NUM_TRUST_DICT = immutabletypes.freeze(
     {
         "1": "Expired",
@@ -67,35 +92,32 @@ INV_NUM_TRUST_DICT = immutabletypes.freeze(
     }
 )
 
-VERIFY_TRUST_LEVELS = immutabletypes.freeze(
-    {
-        "0": "Undefined",
-        "1": "Never",
-        "2": "Marginal",
-        "3": "Fully",
-        "4": "Ultimate",
-    }
-)
-
-TRUST_KEYS_TRUST_LEVELS = immutabletypes.freeze(
-    {
-        "expired": "TRUST_EXPIRED",
-        "unknown": "TRUST_UNDEFINED",
-        "never": "TRUST_NEVER",
-        "marginally": "TRUST_MARGINAL",
-        "fully": "TRUST_FULLY",
-        "ultimately": "TRUST_ULTIMATE",
-    }
-)
+# Map of signature validity numeric values to pretty string (for display)
+if not HAS_GPG_BINDINGS:
+    VERIFY_TRUST_LEVELS = {}
+elif salt.utils.versions.version_cmp(gnupg.__version__, "0.5.1") >= 0:
+    VERIFY_TRUST_LEVELS = immutabletypes.freeze(
+        {
+            "0": "Expired",
+            "1": "Undefined",
+            "2": "Never",
+            "3": "Marginal",
+            "4": "Fully",
+            "5": "Ultimate",
+        }
+    )
+else:
+    VERIFY_TRUST_LEVELS = immutabletypes.freeze(
+        {
+            "0": "Undefined",
+            "1": "Never",
+            "2": "Marginal",
+            "3": "Fully",
+            "4": "Ultimate",
+        }
+    )
 
 _DEFAULT_KEY_SERVER = "keys.openpgp.org"
-
-try:
-    import gnupg
-
-    HAS_GPG_BINDINGS = True
-except ImportError:
-    HAS_GPG_BINDINGS = False
 
 
 def _gpg():

--- a/tests/pytests/functional/modules/test_gpg.py
+++ b/tests/pytests/functional/modules/test_gpg.py
@@ -797,7 +797,7 @@ def test_verify_with_keyring(gpghome, gnupg, gpg, keyring, sig, signed_data, key
 @pytest.mark.usefixtures("_pubkeys_present")
 # Can't easily test the other signature validity levels since
 # we would need to sign the pubkey ourselves, which is not
-# exposed by python-gpg as of release 0.5.2.
+# exposed by python-gnupg as of release 0.5.2.
 @pytest.mark.parametrize(
     "ownertrust,text", (("TRUST_NEVER", "Undefined"), ("TRUST_ULTIMATE", "Ultimate"))
 )

--- a/tests/pytests/functional/modules/test_gpg.py
+++ b/tests/pytests/functional/modules/test_gpg.py
@@ -795,6 +795,29 @@ def test_verify_with_keyring(gpghome, gnupg, gpg, keyring, sig, signed_data, key
 
 
 @pytest.mark.usefixtures("_pubkeys_present")
+# Can't easily test the other signature validity levels since
+# we would need to sign the pubkey ourselves, which is not
+# exposed by python-gpg as of release 0.5.2.
+@pytest.mark.parametrize(
+    "ownertrust,text", (("TRUST_NEVER", "Undefined"), ("TRUST_ULTIMATE", "Ultimate"))
+)
+def test_verify_trust_levels(
+    gpghome, gpg, gnupg, key_a_fp, sig, signed_data, ownertrust, text
+):
+    gnupg.trust_keys(key_a_fp, ownertrust)
+    res = gpg.verify(
+        filename=str(signed_data),
+        signature=sig,
+        gnupghome=str(gpghome),
+    )
+    assert res["res"] is True
+    assert "is verified" in res["message"]
+    assert "key_id" in res
+    assert res["key_id"] == key_a_fp[-16:]
+    assert res["trust_level"] == text
+
+
+@pytest.mark.usefixtures("_pubkeys_present")
 @pytest.mark.requires_random_entropy
 def test_encrypt(gpghome, gpg, gnupg, key_b_fp):
     assert gnupg.list_keys(keys=key_b_fp)


### PR DESCRIPTION
### What does this PR do?
Fixes signature validity reporting with `python-gnupg >=0.5.1`, where the reported levels are off by -1 (changed in https://github.com/vsajip/python-gnupg/pull/205). Thus also fixes a crash with the highest level, which would throw a `KeyError`.

Note: This issue is found in 3006.9 as well, but not as relevant since the pinned version there is `0.4.8`. The code has changed a lot between both versions, which is why I opted to submit this for 3007+ only.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66685

### Previous Behavior
* Crashes when an ultimately trusted key made a signature
* Otherwise reports one level too low

### New Behavior
Works as expected/reports correct levels

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes