### PR TITLE
Fix 67120 - Fix order list and order first clash

### DIFF
--- a/changelog/67120.fixed.md
+++ b/changelog/67120.fixed.md
@@ -1,0 +1,1 @@
+Fixed order chunks not handling a state with both require and order first or last

--- a/salt/utils/requisite.py
+++ b/salt/utils/requisite.py
@@ -202,6 +202,16 @@ class DependencyGraph:
                                 .get("chunk", {})
                                 .get("order", float("inf"))
                             )
+                            if child_order is None or not isinstance(
+                                child_order, (int, float)
+                            ):
+                                if child_order == "last":
+                                    child_order = cap + 1000000
+                                elif child_order == "first":
+                                    child_order = 0
+                                else:
+                                    child_order = cap
+                                dag.nodes[child]["chunk"]["order"] = child_order
                             child_min = min(child_min, child_order)
                     node_data["child_min"] = child_min
                     if order > child_min:

--- a/tests/pytests/unit/utils/requisite/test_dependency_graph.py
+++ b/tests/pytests/unit/utils/requisite/test_dependency_graph.py
@@ -20,10 +20,54 @@ def test_ordering():
     env = "base"
     chunks = [
         {
+            "__id__": "success-last-1",
+            "name": "success-last-1",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "order": "last",
+        },
+        {
+            "__id__": "success-last-3",
+            "name": "success-last-3",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "require": [{"test": "success-last-2"}],
+            "order": "last",
+        },
+        {
+            "__id__": "success-last-2",
+            "name": "success-last-2",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "order": "last",
+        },
+        {
             "__id__": "success-6",
             "name": "success-6",
             "state": "test",
             "fun": "succeed_with_changes",
+        },
+        {
+            "__id__": "success-first-1",
+            "name": "success-first-1",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "order": "first",
+        },
+        {
+            "__id__": "success-first-3",
+            "name": "success-first-3",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "require": [{"test": "success-first-2"}],
+            "order": "first",
+        },
+        {
+            "__id__": "success-first-2",
+            "name": "success-first-2",
+            "state": "test",
+            "fun": "succeed_with_changes",
+            "order": "first",
         },
         {
             "__id__": "fail-0",
@@ -123,6 +167,9 @@ def test_ordering():
         chunk["__id__"] for chunk in depend_graph.aggregate_and_order_chunks(100)
     ]
     expected_order = [
+        "success-first-1",
+        "success-first-2",
+        "success-first-3",
         "success-1",
         "success-2",
         "success-a",
@@ -136,6 +183,9 @@ def test_ordering():
         "success-5",
         "success-6",
         "success-d",
+        "success-last-1",
+        "success-last-2",
+        "success-last-3",
     ]
     assert expected_order == ordered_chunk_ids
 


### PR DESCRIPTION
### What does this PR do?

Fixes ordering states when state has both require and `order: "last"` or `order: "first"`

### What issues does this PR fix or reference?
Fixes #67120

### Previous Behavior
Runtime type error trying to compare int to str

### New Behavior
States correctly ordered and no runtime type error exception

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
