### PR TITLE
Fix redis cache

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -541,7 +541,7 @@ def list_(bank):
     Lists entries stored in the specified bank.
     """
     redis_server = _get_redis_server()
-    bank_redis_key = _get_bank_keys_redis_key(bank)
+    bank_redis_key = _get_bank_redis_key(bank)
     try:
         banks = redis_server.smembers(bank_redis_key)
     except (RedisConnectionError, RedisResponseError) as rerr:

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -300,7 +300,7 @@ def _get_bank_redis_key(bank):
 def _get_timestamp_key(bank, key):
     opts = _get_redis_keys_opts()
     return "{}{}{}/{}".format(
-        opts["timestamp_prefix"], opts["separator"], {bank}, {key}
+        opts["timestamp_prefix"], opts["separator"], bank, key
     )
     # Use this line when we can use modern python
     # return f"{opts['timestamp_prefix']}{opts['separator']}{bank}/{key}"


### PR DESCRIPTION
Since commit deeeaa3cd30 the `redis_cache` module seems to have been broken in multiple places:

#### The format of timestamp keys is malformed
This is because of an apparent attempt to refactor code to be compatible with older versions of python: the refactored code contains a silly copy-paste error that results in curly braces appearing in the keys, which breaks timestamp handling.

This PR fixes this mistake.

#### Listing child banks is broken, which results in commands like `salt-run cache.list minions` returning nothing every time
Child banks should be listed with `_get_bank_redis_key` instead of `_get_bank_keys_redis_key`

This PR fixes this mistake.

#### New objects get inserted in the wrong paths
The function `_build_bank_hier` seems to have been refactored from using a for-loop and several accumulating variables into a more functional style with `itertools.accumulate`. However, instead of adding the names of child banks as set-members into the parent bank, the refactored code only adds a `"."` member into each newly-created bank. This is a bug and causes all queries for nested banks to fail.

This PR rewrites the function in a way that:
- Retains the functional style established by commit 9233e1cc3
- Reimplements the old behaviour of inserting the names of child banks into parent banks
- Retains the logic that adds a `"."` member into newly-created banks