### PR TITLE
Enable pkg.installed to detect packages by their origin name on FreeBSD

### DIFF
--- a/changelog/67126.fixed.md
+++ b/changelog/67126.fixed.md
@@ -1,0 +1,1 @@
+Fixed pkg.install in test mode would not detect FreeBSD packages installed by their origin name

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -927,7 +927,7 @@ def remove(
 
     .. note::
 
-        This function can accessed using ``pkg.delete`` in addition to
+        This function can be accessed using ``pkg.delete`` in addition to
         ``pkg.remove``, to more closely match the CLI usage of ``pkg(8)``.
 
     name
@@ -1904,7 +1904,7 @@ def hold(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     .. note::
         This function is provided primarily for compatibility with some
         parts of :py:mod:`states.pkg <salt.states.pkg>`.
-        Consider using Consider using :py:func:`pkg.lock <salt.modules.pkgng.lock>` instead. instead.
+        Consider using :py:func:`pkg.lock <salt.modules.pkgng.lock>` instead. instead.
 
     name
         The name of the package to be held.
@@ -2030,7 +2030,7 @@ def list_locked(**kwargs):
     Query the package database those packages which are
     locked against reinstallation, modification or deletion.
 
-    Returns returns a list of package names with version strings
+    Returns a list of package names with version strings
 
     CLI Example:
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -2369,15 +2369,15 @@ def _parse_upgrade(stdout):
     """
     # Match strings like 'python36: 3.6.3 -> 3.6.4 [FreeBSD]'
     upgrade_regex = re.compile(
-        r"^\s+([^:]+):\s([0-9a-z_,.]+)\s+->\s+([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?"
+        r"^\s+([^:]+):\s([0-9a-z_,.]+)\s+->\s+([0-9a-z_,.]+)\s*(\[([^]]+)])?\s*(\(([^)]+)\))?"
     )
     # Match strings like 'rubygem-bcrypt_pbkdf: 1.0.0 [FreeBSD]'
     install_regex = re.compile(
-        r"^\s+([^:]+):\s+([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?"
+        r"^\s+([^:]+):\s+([0-9a-z_,.]+)\s*(\[([^]]+)])?\s*(\(([^)]+)\))?"
     )
     # Match strings like 'py27-yaml-3.11_2 [FreeBSD] (direct dependency changed: py27-setuptools)'
     reinstall_regex = re.compile(
-        r"^\s+(\S+)-(?<=-)([0-9a-z_,.]+)\s*(\[([^]]+)\])?\s*(\(([^)]+)\))?"
+        r"^\s+(\S+)-(?<=-)([0-9a-z_,.]+)\s*(\[([^]]+)])?\s*(\(([^)]+)\))?"
     )
 
     result = {

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -745,10 +745,10 @@ def _find_install_targets(
     for package_name, version_string in desired.items():
 
         # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names
-        origin = bool(re.search('/', package_name))
+        origin = bool(re.search("/", package_name))
 
-        if __grains__['os'] == 'FreeBSD' and origin:
-            cver = [k for k, v in cur_pkgs.items() if v['origin'] == package_name]
+        if __grains__["os"] == "FreeBSD" and origin:
+            cver = [k for k, v in cur_pkgs.items() if v["origin"] == package_name]
         else:
             cver = cur_pkgs.get(package_name, [])
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -743,7 +743,15 @@ def _find_install_targets(
     warnings = []
     failed_verify = False
     for package_name, version_string in desired.items():
-        cver = cur_pkgs.get(package_name, [])
+
+        # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names
+        origin = bool(re.search('/', package_name))
+
+        if __grains__['os'] == 'FreeBSD' and origin:
+            cver = [k for k, v in cur_pkgs.items() if v['origin'] == package_name]
+        else:
+            cver = cur_pkgs.get(package_name, [])
+
         if resolve_capabilities and not cver and package_name in cur_prov:
             cver = cur_pkgs.get(cur_prov.get(package_name)[0], [])
 

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -7,8 +7,8 @@ import salt.modules.beacons as beaconmod
 import salt.modules.cp as cp
 import salt.modules.pacmanpkg as pacmanpkg
 import salt.modules.pkg_resource as pkg_resource
-import salt.modules.yumpkg as yumpkg
 import salt.modules.pkgng as pkgng
+import salt.modules.yumpkg as yumpkg
 import salt.states.beacon as beaconstate
 import salt.states.pkg as pkg
 import salt.utils.state as state_utils


### PR DESCRIPTION
### What does this PR do?
Enable pkg.installed to detect packages by their origin name on FreeBSD

### What issues does this PR fix or reference?
Fixes #67126

### Previous Behavior
`pkg.installed` would not detect packages installed by their origin name when run in *test mode*

### New Behavior
`pkg.installed` correctly detects packages installed by their origin name when run in *test mode* and reports no changes.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs - N/A
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

