### PR TITLE
Escape spaces found while parsing GPO XMLNS tags

### DIFF
--- a/changelog/66992.fixed.md
+++ b/changelog/66992.fixed.md
@@ -1,0 +1,2 @@
+Fixes an issue with the LGPO module when trying to parse ADMX/ADML files
+that have a space in the XMLNS url in the policyDefinitionsResources header.

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5060,6 +5060,16 @@ def _remove_invalid_xmlns(xml_file):
     xml_tree = lxml.etree.parse(io.StringIO(modified_xml))
     return xml_tree
 
+def _encode_xmlns_url(match):
+    """
+    Escape spaces in xmlns urls
+    """
+    before_xmlns = match.group(1)
+    xmlns = match.group(2)
+    url = match.group(3)
+    after_url = match.group(4)
+    encoded_url = re.sub(r'\s+', '%20', url)
+    return f'{before_xmlns}{xmlns}="{encoded_url}"{after_url}'
 
 def _parse_xml(adm_file):
     """
@@ -5107,6 +5117,8 @@ def _parse_xml(adm_file):
                 encoding = "utf-16"
                 raw = raw.decode(encoding)
             for line in raw.split("\r\n"):
+                if 'xmlns="' in line:
+                    line = re.sub(r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)', _encode_xmlns_url, line)
                 if 'key="' in line:
                     start = line.index('key="')
                     q1 = line[start:].index('"') + start

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5060,6 +5060,7 @@ def _remove_invalid_xmlns(xml_file):
     xml_tree = lxml.etree.parse(io.StringIO(modified_xml))
     return xml_tree
 
+
 def _encode_xmlns_url(match):
     """
     Escape spaces in xmlns urls
@@ -5068,8 +5069,9 @@ def _encode_xmlns_url(match):
     xmlns = match.group(2)
     url = match.group(3)
     after_url = match.group(4)
-    encoded_url = re.sub(r'\s+', '%20', url)
+    encoded_url = re.sub(r"\s+", "%20", url)
     return f'{before_xmlns}{xmlns}="{encoded_url}"{after_url}'
+
 
 def _parse_xml(adm_file):
     """
@@ -5118,7 +5120,11 @@ def _parse_xml(adm_file):
                 raw = raw.decode(encoding)
             for line in raw.split("\r\n"):
                 if 'xmlns="' in line:
-                    line = re.sub(r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)', _encode_xmlns_url, line)
+                    line = re.sub(
+                        r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)',
+                        _encode_xmlns_url,
+                        line,
+                    )
                 if 'key="' in line:
                     start = line.index('key="')
                     q1 = line[start:].index('"') + start

--- a/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
+++ b/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
@@ -772,6 +772,8 @@ def test__encode_xmlns_url():
     Spaces in the xmlns url should be converted to %20
     """
     line = '<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/Policysecurity intelligence">'
-    result = re.sub(r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)', win_lgpo._encode_xmlns_url, line)
+    result = re.sub(
+        r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)', win_lgpo._encode_xmlns_url, line
+    )
     expected = '<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/Policysecurity%20intelligence">'
     assert result == expected

--- a/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
+++ b/tests/pytests/unit/modules/win_lgpo/test_admx_policies.py
@@ -349,6 +349,9 @@ def _test_set_user_policy(lgpo_bin, shell, name, setting, exp_regexes):
             ],
         ),
         (
+            # This will need to be fixed for Windows Server 2025
+            # The bottom two options have been removed in 2025
+            # Though not set here, we're verifying there were set
             "Specify settings for optional component installation and component repair",
             "Disabled",
             [
@@ -358,6 +361,8 @@ def _test_set_user_policy(lgpo_bin, shell, name, setting, exp_regexes):
             ],
         ),
         (
+            # This will need to be fixed for Windows Server 2025
+            # The bottom two options have been removed in 2025
             "Specify settings for optional component installation and component repair",
             {
                 "Alternate source file path": "",
@@ -371,6 +376,8 @@ def _test_set_user_policy(lgpo_bin, shell, name, setting, exp_regexes):
             ],
         ),
         (
+            # This will need to be fixed for Windows Server 2025
+            # The bottom two options have been removed in 2025
             "Specify settings for optional component installation and component repair",
             {
                 "Alternate source file path": r"\\some\fake\server",
@@ -757,3 +764,14 @@ def test_set_computer_policy_multiple_policies(clean_comp, lgpo_bin, shell):
             r"\\AU[\s]*AllowMUUpdateService[\s]*DELETE",
         ],
     )
+
+
+def test__encode_xmlns_url():
+    """
+    Tests the _encode_xmlns_url function.
+    Spaces in the xmlns url should be converted to %20
+    """
+    line = '<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/Policysecurity intelligence">'
+    result = re.sub(r'(.*)(\bxmlns(?::\w+)?)\s*=\s*"([^"]+)"(.*)', win_lgpo._encode_xmlns_url, line)
+    expected = '<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/Policysecurity%20intelligence">'
+    assert result == expected


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Escapes spaces found in XMLNS urls in Windows GPO documents with `%20`
Closes #66992

### Previous Behavior
Spaces would not be escaped, breaking lgpo state application.

### New Behavior
Spaces are properly escaped allow lgpo state application to operate correctly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
