### PR TITLE
Use Current ioloop in SyncWrapper

### DIFF
--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -73,7 +73,8 @@ class SyncWrapper:
         self.cls = cls
         if loop_kwarg:
             kwargs[self.loop_kwarg] = self.io_loop
-        self.obj = cls(*args, **kwargs)
+        with current_ioloop(self.io_loop):
+            self.obj = cls(*args, **kwargs)
         self._async_methods = list(
             set(async_methods + getattr(self.obj, "async_methods", []))
         )


### PR DESCRIPTION
### What does this PR do?

A new ioloop is created for each SyncWrapper, but is not swapped in automatically (see make_current=False for Tornado) anymore - this means that the context manager (current_ioloop) is needed to access that ioloop for the purposes of the synchronus execution.

This also needs to be backported to 3007.x (3007.2)

### What issues does this PR fix or reference?
Fixes #66775

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
