### PR TITLE
Fix test: tests/pytests/functional/modules/cmd/test_script.py::test_windows_script_args_powershell

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2942,6 +2942,23 @@ def script(
     else:
         cmd_path = _cmd_quote(path)
 
+        if not env:
+            env = {}
+
+        paths = [
+            fr'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules',
+            fr'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules',
+            fr'{os.getenv("ProgramFiles(x86)", "")}\WindowsPowerShell\Modules',
+        ]
+
+        ps_module_path = os.getenv("PSModulePath", "").split(";")
+
+        for path in paths:
+            if os.path.exists(path):
+                ps_module_path.append(path)
+
+        env.update({"PSModulePath": ";".join(ps_module_path)})
+
     ret = _run(
         cmd_path + " " + str(args) if args else cmd_path,
         cwd=cwd,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2946,9 +2946,9 @@ def script(
             env = {}
 
         paths = [
-            fr'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules',
-            fr'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules',
-            fr'{os.getenv("ProgramFiles(x86)", "")}\WindowsPowerShell\Modules',
+            rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules',
+            rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules',
+            rf'{os.getenv("ProgramFiles(x86)", "")}\WindowsPowerShell\Modules',
         ]
 
         ps_module_path = os.getenv("PSModulePath", "").split(";")

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -62,7 +62,7 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
         args=args,
         shell="powershell",
         saltenv="base",
-        env={"PSModulePath": ""}
+        env={"PSModulePath": ""},
     )
 
     assert ret["stdout"] == password

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -57,7 +57,13 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     )
     script = "salt://issue-56195/test.ps1"
 
-    ret = cmd.script(source=script, args=args, shell="powershell", saltenv="base")
+    ret = cmd.script(
+        source=script,
+        args=args,
+        shell="powershell",
+        saltenv="base",
+        env={"PSModulePath": ""}
+    )
 
     assert ret["stdout"] == password
 

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -57,13 +57,7 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     )
     script = "salt://issue-56195/test.ps1"
 
-    ret = cmd.script(
-        source=script,
-        args=args,
-        shell="powershell",
-        saltenv="base",
-        env={"PSModulePath": ""},
-    )
+    ret = cmd.script(source=script, args=args, shell="powershell", saltenv="base")
 
     assert ret["stdout"] == password
 


### PR DESCRIPTION
### What does this PR do?
The test is failing with the following powershell error:

```
ConvertTo-SecureString : The 'ConvertTo-SecureString' command was found in the module 'Microsoft.PowerShell.Security', but the module could not be loaded. For more information, run 'Import-Module Microsoft.PowerShell.Security'.
```

According to [StackOverflow](https://stackoverflow.com/questions/74862849/powershell-convertto-securestring-not-recognised-if-run-script-inline-from-cmd) the workaround is to clear the `PSModulePath` environment variable. That's what this tries to do

### What issues does this PR fix or reference?
Fixes failing test

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes