### PR TITLE
[3006.x] fix yumpkg for Python <3.8

### DIFF
--- a/changelog/67091.fixed.md
+++ b/changelog/67091.fixed.md
@@ -1,0 +1,1 @@
+Fix yumpkg module for Python<3.8

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1425,8 +1425,8 @@ def install(
                 'version': '<new-version>',
                 'arch': '<new-arch>'}}}
     """
-    if (version := kwargs.get("version")) is not None:
-        kwargs["version"] = str(version)
+    if kwargs.get("version") is not None:
+        kwargs["version"] = str(kwargs["version"])
     options = _get_options(**kwargs)
 
     if salt.utils.data.is_true(refresh):


### PR DESCRIPTION
### What does this PR do?
The yumpkg module doesn't not work anymore with Ptyhon versions older than 3.8 because of the usage of the assignment/named expression.
This is a trivial change to fix it.

### What issues does this PR fix or reference?
Fixes #67091