### PR TITLE
Allow setting http_params in source dictionary

### DIFF
--- a/changelog/61052.added.md
+++ b/changelog/61052.added.md
@@ -1,0 +1,1 @@
+Allow the ``source`` parameter of ``file.managed`` and ``cp.cache_file`` to be a dictionary carrying HTTP request parameters (``headers``, ``auth``, ``cert``, ``params``, etc.) through to the underlying HTTP client

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -1086,6 +1086,7 @@ class SSHCpClient(salt.fileclient.FSClient):
         source_hash=None,
         verify_ssl=True,
         use_etag=False,
+        http_params=None,
     ):
         url_data = urllib.parse.urlparse(url)
         if url_data.scheme in ("file", ""):
@@ -1110,6 +1111,7 @@ class SSHCpClient(salt.fileclient.FSClient):
             source_hash=source_hash,
             verify_ssl=verify_ssl,
             use_etag=use_etag,
+            http_params=http_params,
         )
         if not cached:
             return cached

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -179,6 +179,7 @@ class Client:
         source_hash=None,
         verify_ssl=True,
         use_etag=False,
+        http_params=None,
     ):
         """
         Pull a file down from the file server and store it in the minion
@@ -193,6 +194,7 @@ class Client:
             source_hash=source_hash,
             verify_ssl=verify_ssl,
             use_etag=use_etag,
+            http_params=http_params,
         )
 
     def cache_files(self, paths, saltenv="base", cachedir=None):
@@ -544,6 +546,7 @@ class Client:
         source_hash=None,
         verify_ssl=True,
         use_etag=False,
+        http_params=None,
     ):
         """
         Get a single file from a URL.
@@ -704,6 +707,9 @@ class Client:
                 raise MinionError(f"Could not fetch from {url}")
 
         get_kwargs = {}
+        if http_params is not None:
+            get_kwargs.update(http_params)
+
         if url_data.username is not None and url_data.scheme in ("http", "https"):
             netloc = url_data.netloc
             at_sign_pos = netloc.rfind("@")

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -470,7 +470,14 @@ def get_file_str(path, saltenv=None):
     return fn_
 
 
-def cache_file(path, saltenv=None, source_hash=None, verify_ssl=True, use_etag=False):
+def cache_file(
+    path,
+    saltenv=None,
+    source_hash=None,
+    verify_ssl=True,
+    use_etag=False,
+    http_params=None,
+):
     """
     .. versionchanged:: 3005
         ``saltenv`` will use value from config if not explicitly set
@@ -563,6 +570,7 @@ def cache_file(path, saltenv=None, source_hash=None, verify_ssl=True, use_etag=F
             source_hash=source_hash,
             verify_ssl=verify_ssl,
             use_etag=use_etag,
+            http_params=http_params,
         )
     if not result and not use_etag:
         log.error("Unable to cache file '%s' from saltenv '%s'.", path, saltenv)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -772,6 +772,7 @@ def get_source_sum(
     keyring=None,
     gnupghome=None,
     sig_backend="gpg",
+    http_params=None,
 ):
     """
     .. versionadded:: 2016.11.0
@@ -888,7 +889,7 @@ def get_source_sum(
             proto = urllib.parse.urlparse(source_hash).scheme
             if proto in salt.utils.files.VALID_PROTOS:
                 hash_fn = __salt__["cp.cache_file"](
-                    source_hash, saltenv, verify_ssl=verify_ssl
+                    source_hash, saltenv, verify_ssl=verify_ssl, http_params=http_params
                 )
                 if not hash_fn:
                     raise CommandExecutionError(
@@ -4711,7 +4712,7 @@ def set_selinux_context(
         return ret
 
 
-def source_list(source, source_hash, saltenv):
+def source_list(source, source_hash, saltenv, http_params=None):
     """
     Check the source list and return the source to use
 
@@ -4769,7 +4770,7 @@ def source_list(source, source_hash, saltenv):
                         break
                 elif proto.startswith("http") or proto == "ftp":
                     query_res = salt.utils.http.query(
-                        single_src, method="HEAD", decode_body=False
+                        single_src, method="HEAD", decode_body=False, **http_params
                     )
                     if "error" not in query_res:
                         ret = (single_src, single_hash)
@@ -4913,6 +4914,7 @@ def get_managed(
     ignore_whitespace=False,
     ignore_comment_characters=None,
     sig_backend="gpg",
+    http_params=None,
     **kwargs,
 ):
     """
@@ -5128,6 +5130,7 @@ def get_managed(
                             keyring=keyring,
                             gnupghome=gnupghome,
                             sig_backend=sig_backend,
+                            http_params=http_params,
                         )
                     except CommandExecutionError as exc:
                         return "", {}, exc.strerror
@@ -5169,6 +5172,7 @@ def get_managed(
                     source_hash=source_sum.get("hsum"),
                     verify_ssl=verify_ssl,
                     use_etag=use_etag,
+                    http_params=http_params,
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 # A 404 or other error code may raise an exception, catch it
@@ -5815,6 +5819,7 @@ def check_managed(
     setype=None,
     serange=None,
     follow_symlinks=False,
+    http_params=None,
     **kwargs,
 ):
     """
@@ -5856,6 +5861,7 @@ def check_managed(
             context,
             defaults,
             skip_verify,
+            http_params,
             **kwargs,
         )
         if comments:
@@ -5918,6 +5924,7 @@ def check_managed_changes(
     ignore_whitespace=False,
     ignore_comment_characters=None,
     new_file_diff=False,
+    http_params=None,
     **kwargs,
 ):
     """
@@ -5986,7 +5993,7 @@ def check_managed_changes(
     """
     # If the source is a list then find which file exists
     source, source_hash = source_list(
-        source, source_hash, saltenv  # pylint: disable=W0633
+        source, source_hash, saltenv, http_params  # pylint: disable=W0633
     )
 
     sfn = ""
@@ -6012,6 +6019,7 @@ def check_managed_changes(
             ignore_ordering=ignore_ordering,
             ignore_whitespace=ignore_whitespace,
             ignore_comment_characters=ignore_comment_characters,
+            http_params=http_params,
             **kwargs,
         )
 
@@ -6581,6 +6589,7 @@ def manage_file(
     ignore_comment_characters=None,
     new_file_diff=False,
     sig_backend="gpg",
+    http_params=None,
     **kwargs,
 ):
     """
@@ -6959,7 +6968,11 @@ def manage_file(
         ):
             if not sfn:
                 sfn = __salt__["cp.cache_file"](
-                    source, saltenv, verify_ssl=verify_ssl, use_etag=use_etag
+                    source,
+                    saltenv,
+                    verify_ssl=verify_ssl,
+                    use_etag=use_etag,
+                    http_params=http_params,
                 )
             if not sfn:
                 return _error(ret, f"Source file '{source}' not found")
@@ -7232,7 +7245,9 @@ def manage_file(
         if source:
             # Apply the new file
             if not sfn:
-                sfn = __salt__["cp.cache_file"](source, saltenv, verify_ssl=verify_ssl)
+                sfn = __salt__["cp.cache_file"](
+                    source, saltenv, verify_ssl=verify_ssl, http_params=http_params
+                )
             if not sfn:
                 return _error(ret, f"Source file '{source}' not found")
             # If the downloaded file came from a non salt server source verify

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -411,6 +411,43 @@ __func_alias__ = {
 }
 
 
+def _get_http_params_from_source(source):
+    """
+    Extract http params from source if source is a dictionary
+    """
+    if not source or not isinstance(source, dict):
+        return [source, {}]
+
+    valid_http_params = [
+        "cert",
+        "params",
+        "headers",
+        "backend",
+        "port",
+        "username",
+        "password",
+        "auth",
+        "agent",
+    ]
+    http_params = {}
+
+    for key, value_ in source.items():
+        if key in valid_http_params:
+            if key == "cert" and isinstance(value_, dict):
+                if not "key" in value_:
+                    value_ = value_["cert"]
+                else:
+                    value_ = [value_["cert"], value_["key"]]
+            http_params[key] = value_
+
+    url = source.pop("url")
+
+    if not url:
+        raise CommandExecutionError("URL is required in source parameter")
+
+    return [url, http_params]
+
+
 def _http_ftp_check(source):
     """
     Check if source or sources is http, https or ftp.
@@ -2642,6 +2679,16 @@ def managed(
                   - salt://file_that_does_not_exist
                   - salt://file_that_exists
 
+        Sources can also be defined as dictionary:
+
+        .. code-block:: yaml
+
+            file_override_example:
+              file.managed:
+                - source:
+                  - url: https://host/file_that_exists
+                    cert: [mycrt.pem, mykey.pem]
+
     source_hash
         This can be one of the following:
             1. a source hash string
@@ -3366,6 +3413,8 @@ def managed(
         [x for x in (contents, contents_pillar, contents_grains) if x is not None]
     )
 
+    source, http_params = _get_http_params_from_source(source)
+
     if source and contents_count > 0:
         return _error(
             ret,
@@ -3569,7 +3618,7 @@ def managed(
             # We're doing this after basic checks to not slow down
             # runs where it does not matter.
             source, source_hash = __salt__["file.source_list"](
-                source, source_hash, __env__
+                source, source_hash, __env__, http_params
             )
             source_sum = None
             if (
@@ -3595,6 +3644,7 @@ def managed(
                     keyring=keyring,
                     gnupghome=gnupghome,
                     sig_backend=sig_backend,
+                    http_params=http_params,
                 )
                 hsum = __salt__["file.get_hash"](name, source_sum["hash_type"])
         except (CommandExecutionError, OSError) as err:
@@ -3695,6 +3745,7 @@ def managed(
                     ignore_whitespace=ignore_whitespace,
                     ignore_comment_characters=ignore_comment_characters,
                     new_file_diff=new_file_diff,
+                    http_params=http_params,
                     **kwargs,
                 )
                 if any([ignore_ordering, ignore_whitespace, ignore_comment_characters]):
@@ -3777,6 +3828,7 @@ def managed(
             keyring=keyring,
             gnupghome=gnupghome,
             sig_backend=sig_backend,
+            http_params=http_params,
             **kwargs,
         )
     except Exception as exc:  # pylint: disable=broad-except
@@ -3842,6 +3894,7 @@ def managed(
                 ignore_whitespace=ignore_whitespace,
                 ignore_comment_characters=ignore_comment_characters,
                 new_file_diff=new_file_diff,
+                http_params=http_params,
                 **kwargs,
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -3936,6 +3989,7 @@ def managed(
                 ignore_whitespace=ignore_whitespace,
                 ignore_comment_characters=ignore_comment_characters,
                 new_file_diff=new_file_diff,
+                http_params=http_params,
                 **kwargs,
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -9570,6 +9624,7 @@ def cached(
     keyring=None,
     gnupghome=None,
     sig_backend="gpg",
+    http_params=None,
 ):
     """
     .. versionadded:: 2017.7.3
@@ -9747,6 +9802,7 @@ def cached(
                 keyring=keyring,
                 gnupghome=gnupghome,
                 sig_backend=sig_backend,
+                http_params=http_params,
             )
         except CommandExecutionError as exc:
             ret["comment"] = exc.strerror

--- a/tests/pytests/unit/states/test_file.py
+++ b/tests/pytests/unit/states/test_file.py
@@ -72,6 +72,103 @@ def test_file_copy_should_use_provided_force_mode_for_file_remove(fake_remove):
     fake_remove.assert_called_with("/tmp/foo", force=True)
 
 
+class TestGetHttpParamsFromSource:
+    """Unit tests for salt.states.file._get_http_params_from_source (PR #67153)."""
+
+    def test_none_source_returns_none_and_empty_params(self):
+        url, http_params = file._get_http_params_from_source(None)
+        assert url is None
+        assert http_params == {}
+
+    def test_string_source_passes_through_unchanged(self):
+        src = "https://example.com/file.tar.gz"
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == src
+        assert http_params == {}
+
+    def test_list_source_passes_through_unchanged(self):
+        src = [
+            "https://example.com/file.tar.gz",
+            "https://mirror.example.com/file.tar.gz",
+        ]
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == src
+        assert http_params == {}
+
+    def test_dict_source_extracts_url_and_headers(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "headers": {"Authorization": "Bearer token"},
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert http_params == {"headers": {"Authorization": "Bearer token"}}
+
+    def test_dict_source_extracts_url_and_all_valid_params(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "headers": {"X-Custom": "value"},
+            "params": {"key": "val"},
+            "username": "user",
+            "password": "pass",
+            "auth": ("user", "pass"),
+            "backend": "requests",
+            "port": 8443,
+            "agent": "curl",
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert http_params["headers"] == {"X-Custom": "value"}
+        assert http_params["params"] == {"key": "val"}
+        assert http_params["username"] == "user"
+        assert http_params["password"] == "pass"
+        assert http_params["auth"] == ("user", "pass")
+        assert http_params["backend"] == "requests"
+        assert http_params["port"] == 8443
+        assert http_params["agent"] == "curl"
+
+    def test_dict_source_ignores_unknown_keys(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "unknown_key": "should_be_ignored",
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert "unknown_key" not in http_params
+
+    def test_dict_source_cert_as_string(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "cert": "/path/to/cert.pem",
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert http_params["cert"] == "/path/to/cert.pem"
+
+    def test_dict_source_cert_as_dict_with_key(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "cert": {"cert": "/path/to/cert.pem", "key": "/path/to/key.pem"},
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert http_params["cert"] == ["/path/to/cert.pem", "/path/to/key.pem"]
+
+    def test_dict_source_cert_as_dict_without_key(self):
+        src = {
+            "url": "https://example.com/file.tar.gz",
+            "cert": {"cert": "/path/to/cert.pem"},
+        }
+        url, http_params = file._get_http_params_from_source(src)
+        assert url == "https://example.com/file.tar.gz"
+        assert http_params["cert"] == "/path/to/cert.pem"
+
+    def test_dict_source_without_url_raises(self):
+        src = {"headers": {"X-Custom": "value"}}
+        with pytest.raises(KeyError):
+            file._get_http_params_from_source(src)
+
+
 def test_file_recurse_directory_test():
     salt_dunder = {
         "cp.list_master_dirs": MagicMock(return_value=[]),


### PR DESCRIPTION
### What does this PR do?
Allow the source parameter of `file.managed` and `cp.cache_file` to be a dictionary which allows it to set various http params.

### What issues does this PR fix or reference?
Fixes #61052

### Previous Behavior
Not able to set http params via source parameter

### New Behavior
With this change it's possible to set http params via the source parameter in `file.managed` and `cp.cache_file`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
