### PR TITLE
Fix test: tests\pytests\functional\modules\test_network.py::test_network_ping

### DIFF
--- a/tests/pytests/functional/modules/test_network.py
+++ b/tests/pytests/functional/modules/test_network.py
@@ -4,6 +4,8 @@ Validate network module
 
 import pytest
 
+import salt.utils.platform
+
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.requires_network,
@@ -26,12 +28,18 @@ def test_network_ping(network, url):
     network.ping
     """
     ret = network.ping(url)
-    if "100% packet loss" not in ret.lower():
+
+    # Github Runners are on Azure, which doesn't allow ping
+    packet_loss = "100% packet loss"
+    if salt.utils.platform.is_windows():
+        packet_loss = "100% loss"
+
+    if packet_loss not in ret.lower():
         exp_out = ["ping", url, "ms", "time"]
         for out in exp_out:
             assert out in ret.lower()
     else:
-        assert "100% packet loss" in ret.lower()
+        assert packet_loss in ret.lower()
 
 
 @pytest.mark.skip_on_darwin(reason="Not supported on macOS")


### PR DESCRIPTION
### What does this PR do?
Azure doesn't allow ping. This was fixed for Linux, this test adds the same fix for Windows. Check for failed ping on Windows

### What issues does this PR fix or reference?
Fixes failing test

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes