### PR TITLE
Fix test: tests\pytests\unit\modules\win_lgpo_test__policy_info.py

### DIFF
--- a/tests/pytests/unit/modules/win_lgpo/test__policy_info.py
+++ b/tests/pytests/unit/modules/win_lgpo/test__policy_info.py
@@ -226,15 +226,15 @@ def test_sidConversion_no_conversion(pol_info):
     assert pol_info._sidConversion([val]) == expected
 
 
-def test_sidConversion_everyone(pol_info):
+def test_sidConversion_sid(pol_info):
     val = ws.ConvertStringSidToSid("S-1-1-0")
     expected = ["Everyone"]
     assert pol_info._sidConversion([val]) == expected
 
 
-def test_sidConversion_administrator(pol_info):
-    val = ws.LookupAccountName("", "Administrator")[0]
-    expected = [f"{socket.gethostname()}\\Administrator"]
+def test_sidConversion_name(pol_info):
+    val = ws.LookupAccountName("", "DefaultAccount")[0]
+    expected = [f"{socket.gethostname()}\\DefaultAccount"]
     assert pol_info._sidConversion([val]) == expected
 
 
@@ -250,8 +250,8 @@ def test_usernamesToSidObjects_empty_value(pol_info, val, expected):
 
 
 def test_usernamesToSidObjects_string_list(pol_info):
-    val = "Administrator,Guest"
-    admin_sid = ws.LookupAccountName("", "Administrator")[0]
+    val = "DefaultAccount,Guest"
+    admin_sid = ws.LookupAccountName("", "DefaultAccount")[0]
     guest_sid = ws.LookupAccountName("", "Guest")[0]
     expected = [admin_sid, guest_sid]
     assert pol_info._usernamesToSidObjects(val) == expected


### PR DESCRIPTION
### What does this PR do?
Github runners rename the administrator account to runneradmin. This will use DefaultAccount instead of Administrator. I tried creating a temp_user instead, but this added quite a lot of time to what is supposed to be a quick unit test. I didn't figure they had renamed/removed the DefaultAccount.

### What issues does this PR fix or reference?
Fixes failing tests

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes