### PR TITLE
Fix systemd.enabled on Rocky 8

### DIFF
--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -172,7 +172,10 @@ def _pid_to_service_systemctl(pid):
     systemd_cmd = ["systemctl", "--output", "json", "status", str(pid)]
     try:
         systemd_output = subprocess.run(
-            systemd_cmd, check=True, text=True, capture_output=True
+            systemd_cmd,
+            check=True,
+            text=True,
+            capture_output=True,
         )
         status_json = salt.utils.json.find_json(systemd_output.stdout)
     except (ValueError, subprocess.CalledProcessError):


### PR DESCRIPTION
Test fix for rocky 8 
`tests/pytests/integration/ssh/test_master.py::test_service`