### PR TITLE
Fix test: tests/pytests/integration/states/test_file.py on windows

### DIFF
--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -400,7 +400,7 @@ def _check_min_patch_version(shell):
     min_patch_ver = "2.6"
     ret = shell.run("patch", "--version")
     assert ret.returncode == 0
-    version = ret.stdout.strip().split()[2]
+    version = ret.stdout.splitlines()[0].split()[-1]
     if Version(version) < Version(min_patch_ver):
         pytest.xfail(
             "Minimum version of patch not found, expecting {}, found {}".format(


### PR DESCRIPTION
### What does this PR do?
Fixes the version check for patch in test_file.py. It was expecting the version string to be the 2nd string in the output, but it can be the 3rd. Updated the parsing to just get the last string on the first line.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/67140

### Previous Behavior
Test failed due to the version check fixture throwing an exception when trying to parse the version

### New Behavior
Now parses the version correctly. Unfortunately, the version installed is 2.5.9 and the version check is for >= 2.6, so it will now skip the tests. Will open an issue to work out getting a newer version of patch installed.

