### PR TITLE
Ensure the right HOME environment value is set during Pygit2 remote initialization

### DIFF
--- a/changelog/64121.fixed.md
+++ b/changelog/64121.fixed.md
@@ -1,0 +1,1 @@
+Ensure the right HOME environment value is set during Pygit2 remote initialization.

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2012,7 +2012,12 @@ class Pygit2(GitProvider):
         """
         # https://github.com/libgit2/pygit2/issues/339
         # https://github.com/libgit2/libgit2/issues/2122
+        # https://github.com/saltstack/salt/issues/64121
         home = os.path.expanduser("~")
+        if "HOME" not in os.environ:
+            # Make sure $HOME env variable is set to prevent
+            # _pygit2.GitError: error loading known_hosts in some libgit2 versions.
+            os.environ["HOME"] = home
         pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
         new = False
         if not os.listdir(self._cachedir):

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -8,6 +8,7 @@ import salt.exceptions
 import salt.fileserver.gitfs
 import salt.utils.gitfs
 from salt.exceptions import FileserverConfigError
+from tests.support.helpers import patched_environ
 from tests.support.mock import MagicMock, patch
 
 try:
@@ -251,6 +252,20 @@ def test_checkout_pygit2(_prepare_provider):
     assert provider.get_cachedir() in provider.checkout()
     provider.branch = "does_not_exist"
     assert provider.checkout() is None
+
+
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
+@pytest.mark.skip_on_windows(
+    reason="Skip Pygit2 on windows, due to pygit2 access error on windows"
+)
+def test_checkout_pygit2_with_home_env_unset(_prepare_provider):
+    provider = _prepare_provider
+    provider.remotecallbacks = None
+    provider.credentials = None
+    with patched_environ(__cleanup__=["HOME"]):
+        assert "HOME" not in os.environ
+        provider.init_remote()
+        assert "HOME" in os.environ
 
 
 @pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")


### PR DESCRIPTION
### What does this PR do?

This PR ensures the right value for `HOME` environment is properly set during Pygit2 remote initialization for the running process, according to the right `user` defined in the Salt Master configuration, preventing possible errors when the `HOME` env is missing, i.a.:

```
_pygit2.GitError: error loading known_hosts:
```

### What issues does this PR fix or reference?
Fixes #64121

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
