### PR TITLE
Fix test: salt\tests\functional\modules\cmd\test_script.py

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1092,6 +1092,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+          AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL: "1"
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --core-tests --slow-tests --suppress-no-test-exit-code

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1068,6 +1068,7 @@ jobs:
           PRINT_SYSTEM_INFO_ONLY: "1"
         run: |
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }}
+          cmd /c set
 
       - name: Run Changed Tests
         id: run-fast-changed-tests

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1092,7 +1092,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
-          AZP_AGENT_CLEANUP_PSMODULES_IN_POWERSHELL: "1"
+          PSModulePath: ""
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --core-tests --slow-tests --suppress-no-test-exit-code

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1119,6 +1119,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --suppress-no-test-exit-code
@@ -1145,6 +1146,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --suppress-no-test-exit-code --no-fast-tests --slow-tests
@@ -1171,6 +1173,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --suppress-no-test-exit-code --no-fast-tests --core-tests
@@ -1197,6 +1200,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --suppress-no-test-exit-code --no-fast-tests --flaky-jail
@@ -1223,6 +1227,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           --slow-tests --core-tests -k "win" --test-group-count=${{ matrix.test-group-count || 1 }} --test-group=${{ matrix.test-group || 1 }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1068,7 +1068,6 @@ jobs:
           PRINT_SYSTEM_INFO_ONLY: "1"
         run: |
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }}
-          cmd /c set
 
       - name: Run Changed Tests
         id: run-fast-changed-tests
@@ -1092,7 +1091,7 @@ jobs:
           RAISE_DEPRECATIONS_RUNTIME_ERRORS: "1"
           SALT_TRANSPORT: ${{ matrix.transport }}
           TMPDIR: ${{ runner.temp }}
-          PSModulePath: ""
+        shell: powershell
         run: >
           nox --force-color -e ${{ inputs.nox-session }} -- ${{ matrix.tests-chunk }} --
           -k "win" --core-tests --slow-tests --suppress-no-test-exit-code

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2973,7 +2973,8 @@ def script(
             for mod_path in ps_module_path:
                 if mod_path:
                     mod_paths += f"{str(path)};"
-            env.update({"PSModulePath": mod_paths})
+            # env.update({"PSModulePath": mod_paths})
+            env.update({"PSModulePath": ""})
     else:
         cmd_path = _cmd_quote(path)
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -11,7 +11,6 @@ import functools
 import glob
 import logging
 import os
-import pathlib
 import re
 import shutil
 import subprocess
@@ -2943,6 +2942,7 @@ def script(
             cmd_path = _cmd_quote(path, escape=False)
         else:
             cmd_path = path
+            # import pathlib
             # if not env:
             #     env = {}
             # if shell.lower() == "powershell":

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2943,38 +2943,34 @@ def script(
             cmd_path = _cmd_quote(path, escape=False)
         else:
             cmd_path = path
-            if not env:
-                env = {}
-            if shell.lower() == "powershell":
-                mod_paths = [
-                    pathlib.Path(
-                        rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules'
-                    ),
-                    pathlib.Path(
-                        rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules'
-                    ),
-                ]
-            else:
-                mod_paths = [
-                    pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\Modules'),
-                    pathlib.Path(
-                        rf'{os.getenv("ProgramFiles")}\PowerShell\6.0.0\Modules'
-                    ),
-                    pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\7\Modules'),
-                ]
-            ps_module_path = [
-                pathlib.Path(x) for x in os.getenv("PSModulePath", "").split(";")
-            ]
-            for mod_path in mod_paths:
-                if mod_path.exists():
-                    if mod_path not in ps_module_path:
-                        ps_module_path.append(mod_path)
-            mod_paths = ""
-            for mod_path in ps_module_path:
-                if mod_path:
-                    mod_paths += f"{str(path)};"
+            # if not env:
+            #     env = {}
+            # if shell.lower() == "powershell":
+            #     mod_paths = [
+            #         pathlib.Path(
+            #             rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules'
+            #         ),
+            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules'),
+            #     ]
+            # else:
+            #     mod_paths = [
+            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\Modules'),
+            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\6.0.0\Modules'),
+            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\7\Modules'),
+            #     ]
+            # ps_module_path = [
+            #     pathlib.Path(x) for x in os.getenv("PSModulePath", "").split(";")
+            # ]
+            # for mod_path in mod_paths:
+            #     if mod_path.exists():
+            #         if mod_path not in ps_module_path:
+            #             ps_module_path.append(mod_path)
+            # mod_paths = ""
+            # for mod_path in ps_module_path:
+            #     if mod_path:
+            #         mod_paths += f"{str(path)};"
             # env.update({"PSModulePath": mod_paths})
-            env.update({"PSModulePath": ""})
+            # env.update({"PSModulePath": ""})
     else:
         cmd_path = _cmd_quote(path)
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2939,21 +2939,29 @@ def script(
         os.chown(path, __salt__["file.user_to_uid"](runas), -1)
 
     if salt.utils.platform.is_windows():
-        if shell.lower() != "powershell":
+        if shell.lower() not in ["powershell", "pwsh"]:
             cmd_path = _cmd_quote(path, escape=False)
         else:
             cmd_path = path
             if not env:
                 env = {}
-            mod_paths = [
-                pathlib.Path(
-                    rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules'
-                ),
-                pathlib.Path(rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules'),
-                pathlib.Path(
-                    rf'{os.getenv("ProgramFiles(x86)", "")}\WindowsPowerShell\Modules'
-                ),
-            ]
+            if shell.lower() == "powershell":
+                mod_paths = [
+                    pathlib.Path(
+                        rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules'
+                    ),
+                    pathlib.Path(
+                        rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules'
+                    ),
+                ]
+            else:
+                mod_paths = [
+                    pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\Modules'),
+                    pathlib.Path(
+                        rf'{os.getenv("ProgramFiles")}\PowerShell\6.0.0\Modules'
+                    ),
+                    pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\7\Modules'),
+                ]
             ps_module_path = [
                 pathlib.Path(x) for x in os.getenv("PSModulePath", "").split(";")
             ]

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2942,35 +2942,6 @@ def script(
             cmd_path = _cmd_quote(path, escape=False)
         else:
             cmd_path = path
-            # import pathlib
-            # if not env:
-            #     env = {}
-            # if shell.lower() == "powershell":
-            #     mod_paths = [
-            #         pathlib.Path(
-            #             rf'{os.getenv("SystemRoot")}\System32\WindowsPowerShell\v1.0\Modules'
-            #         ),
-            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\WindowsPowerShell\Modules'),
-            #     ]
-            # else:
-            #     mod_paths = [
-            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\Modules'),
-            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\6.0.0\Modules'),
-            #         pathlib.Path(rf'{os.getenv("ProgramFiles")}\PowerShell\7\Modules'),
-            #     ]
-            # ps_module_path = [
-            #     pathlib.Path(x) for x in os.getenv("PSModulePath", "").split(";")
-            # ]
-            # for mod_path in mod_paths:
-            #     if mod_path.exists():
-            #         if mod_path not in ps_module_path:
-            #             ps_module_path.append(mod_path)
-            # mod_paths = ""
-            # for mod_path in ps_module_path:
-            #     if mod_path:
-            #         mod_paths += f"{str(path)};"
-            # env.update({"PSModulePath": mod_paths})
-            # env.update({"PSModulePath": ""})
     else:
         cmd_path = _cmd_quote(path)
 

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -60,6 +60,7 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     ret = cmd.script(source=script, args=args, shell=shell, saltenv="base")
 
     import_result = cmd.run("Import-Module Microsoft.PowerShell.Security", shell=shell)
+    powershell_version = cmd.run("$PSVersionTable", shell=shell)
 
     assert ret["stdout"] == password
 

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -57,12 +57,7 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     )
     script = "salt://issue-56195/test.ps1"
 
-    ps_path = {"PSModulePath": ""}
-    ret = cmd.script(source=script, args=args, shell=shell, saltenv="base", env=ps_path)
-
-    import_result = cmd.run("Import-Module Microsoft.PowerShell.Security", shell=shell)
-    powershell_version = cmd.run("$PSVersionTable", shell=shell)
-    ps_module_path = cmd.run("$env:PSModulePath", shell=shell)
+    ret = cmd.script(source=script, args=args, shell=shell, saltenv="base")
 
     assert ret["stdout"] == password
 

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -57,7 +57,8 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     )
     script = "salt://issue-56195/test.ps1"
 
-    ret = cmd.script(source=script, args=args, shell=shell, saltenv="base")
+    ps_path = {"PSModulePath": ""}
+    ret = cmd.script(source=script, args=args, shell=shell, saltenv="base", env=ps_path)
 
     import_result = cmd.run("Import-Module Microsoft.PowerShell.Security", shell=shell)
     powershell_version = cmd.run("$PSVersionTable", shell=shell)

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -57,7 +57,9 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     )
     script = "salt://issue-56195/test.ps1"
 
-    ret = cmd.script(source=script, args=args, shell="powershell", saltenv="base")
+    ret = cmd.script(source=script, args=args, shell=shell, saltenv="base")
+
+    import_result = cmd.run("Import-Module Microsoft.PowerShell.Security", shell=shell)
 
     assert ret["stdout"] == password
 
@@ -78,7 +80,7 @@ def test_windows_script_args_powershell_runas(cmd, shell, account, issue_56195):
     ret = cmd.script(
         source=script,
         args=args,
-        shell="powershell",
+        shell=shell,
         saltenv="base",
         runas=account.username,
         password=account.password,

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -61,6 +61,7 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
 
     import_result = cmd.run("Import-Module Microsoft.PowerShell.Security", shell=shell)
     powershell_version = cmd.run("$PSVersionTable", shell=shell)
+    ps_module_path = cmd.run("$env:PSModulePath", shell=shell)
 
     assert ret["stdout"] == password
 


### PR DESCRIPTION
### What does this PR do?

Runs the tests from `powershell` instead of `pwsh`

The github runners use either PowerShell 6+ (`pwsh`) or PowerShell Core (also `pwsh`) as the default shell. This causes problems when trying to run tests on `powershell`. The PSModulePath from `pwsh` is used for `powershell` and the modules it tries to load are the `pwsh` versions. This only happens when going from `pwsh` to `powershell`. The older `powershell` can't handle the `pwsh` `psmodulepath`. It isn't an issue in the other direction however. `pwsh` seems to handle `powershell` `psmodulepath` just fine.

### What issues does this PR fix or reference?
Fixes failing tests

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes