### PR TITLE
Increase timeout on windows tests to allow functional tests to complete

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -986,8 +986,8 @@ jobs:
     if: ${{ toJSON(fromJSON(inputs.matrix)['windows']) != '[]' }}
     runs-on: ${{ matrix.slug }}
     # Full test runs. Each chunk should never take more than 2 hours.
-    # Partial test runs(no chunk parallelization), 6 Hours
-    timeout-minutes: ${{ fromJSON(inputs.testrun)['type'] == 'full' && inputs.default-timeout || 360 }}
+    # Partial test runs(no chunk parallelization), 7 Hours
+    timeout-minutes: ${{ fromJSON(inputs.testrun)['type'] == 'full' && inputs.default-timeout || 420 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What does this PR do?
Increases the timeout from 6 hours to 7 hours for windows as we are seeing one lot of functional tests hit 6 hours and get killed. Whilst it would be good to try to get that test run down or perhaps change how those tests are split up, for the moment I'd just like to see a full clean test run on the 3006.x overnight.

![Screenshot from 2025-01-25 11-50-19](https://github.com/user-attachments/assets/27693b32-4a40-4437-b453-978b70c95ca6)

Not entirely sure upping to 7 hours will be sufficient, but no easy way to test.

