### PR TITLE
Minion has the option to skip pillars

### DIFF
--- a/changelog/67216.added.md
+++ b/changelog/67216.added.md
@@ -1,0 +1,1 @@
+Added ``skip_init_pillar`` minion config option and ``--skip-pillars`` / ``--no-skip-init-pillar`` salt-call CLI flags to skip the initial pillar compilation on minion startup, reducing overhead for commands that do not require pillar data.

--- a/conf/minion
+++ b/conf/minion
@@ -388,6 +388,12 @@
 # protected accordingly.
 #minion_pillar_cache: False
 
+# When set to True the minion will not request a pillar from the master upon
+# startup.  Pillar can still be fetched later via a manual operation like
+# `saltutil.refresh_pillar` or similar.  Enabling this option might break pillar
+# related functionality (e.g. pillar targeter).
+#skip_init_pillar: False
+
 # Grains cache expiration, in seconds. If the cache file is older than this
 # number of seconds then the grains cache will be dumped and fully re-populated
 # with fresh data. Defaults to 5 minutes. Will have no effect if 'grains_cache'

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -54,6 +54,11 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
             self.config["extension_modules"] = os.path.join(cache_dir, "extmods")
             prepend_root_dir(self.config, ["cachedir", "extension_modules"])
 
+        if self.config["fun"].split(".")[0] == "pillar":
+            if self.options.skip_init_pillar:
+                self.options.skip_init_pillar = False
+                self.config["skip_init_pillar"] = False
+
         if self.config["verify_env"]:
             # When --priv is used, MergeConfigMixIn has already overwritten
             # config["user"] with the --priv value during parse_args().  We need

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -686,6 +686,11 @@ VALID_OPTS = immutabletypes.freeze(
         "pillar_cache_ttl": int,
         # Pillar cache backend. Defaults to `disk` which stores caches in the master cache
         "pillar_cache_backend": str,
+        # When set to True the minion will not request a pillar from the master upon startup.
+        # Pillar can still be fetched later via a manual operation like `saltutil.refresh_pillar` or
+        # similar.  Enabling this option might break pillar related functionality (e.g. pillar
+        # targeter).
+        "skip_init_pillar": bool,
         # Cache the GPG data to avoid having to pass through the gpg renderer
         "gpg_cache": bool,
         # GPG data cache TTL, in seconds. Has no effect unless `gpg_cache` is True
@@ -1174,6 +1179,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "pillar_cache_backend": "disk",
         "request_channel_timeout": 60,
         "request_channel_tries": 3,
+        "skip_init_pillar": False,
         "gpg_cache": False,
         "gpg_cache_ttl": 86400,
         "gpg_cache_backend": "disk",

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -499,13 +499,16 @@ class MinionBase:
         if context is None:
             context = {}
         if initial_load:
-            self.opts["pillar"] = salt.pillar.get_pillar(
-                self.opts,
-                self.opts["grains"],
-                self.opts["id"],
-                self.opts["saltenv"],
-                pillarenv=self.opts.get("pillarenv"),
-            ).compile_pillar()
+            if self.opts.get("skip_init_pillar", False):
+                self.opts["pillar"] = {}
+            else:
+                self.opts["pillar"] = salt.pillar.get_pillar(
+                    self.opts,
+                    self.opts["grains"],
+                    self.opts["id"],
+                    self.opts["saltenv"],
+                    pillarenv=self.opts.get("pillarenv"),
+                ).compile_pillar()
 
         # Populate opts["resources"] from pillar now that pillar is available.
         # Must happen before the resource loader loop below so that per-type
@@ -1712,16 +1715,19 @@ class Minion(MinionBase):
         if self.connected:
             self.opts["master"] = master
 
-            # Initialize pillar before loader to make pillar accessible in modules
-            async_pillar = salt.pillar.get_async_pillar(
-                self.opts,
-                self.opts["grains"],
-                self.opts["id"],
-                self.opts["saltenv"],
-                pillarenv=self.opts.get("pillarenv"),
-            )
-            self.opts["pillar"] = await async_pillar.compile_pillar()
-            async_pillar.destroy()
+            if self.opts.get("skip_init_pillar", False):
+                self.opts["pillar"] = {}
+            else:
+                # Initialize pillar before loader to make pillar accessible in modules
+                async_pillar = salt.pillar.get_async_pillar(
+                    self.opts,
+                    self.opts["grains"],
+                    self.opts["id"],
+                    self.opts["saltenv"],
+                    pillarenv=self.opts.get("pillarenv"),
+                )
+                self.opts["pillar"] = await async_pillar.compile_pillar()
+                async_pillar.destroy()
             # _setup_core uses _load_modules only — unlike gen_modules it does not
             # run _discover_resources().  tune_in schedules _register_resources_with_master
             # right after connect; without this, the master registry gets {} until an

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2944,6 +2944,21 @@ class SaltCallOptionParser(
             help="Do not load grains.",
         )
         self.add_option(
+            "--no-skip-init-pillar",
+            default=True,
+            action="store_false",
+            dest="skip_init_pillar",
+            help=(
+                "Explicitly load pillar on minion startup (overrides any skip_init_pillar in /etc/salt/minion)"
+            ),
+        )
+        self.add_option(
+            "--skip-pillars",
+            default=False,
+            action="store_true",
+            help=("Do not load pillars."),
+        )
+        self.add_option(
             "--refresh-grains-cache",
             default=False,
             action="store_true",

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1367,6 +1367,68 @@ def test_gen_modules_executors(minion_opts):
         minion.destroy()
 
 
+def test_gen_modules_skip_init_pillar_false(minion_opts):
+    """
+    When skip_init_pillar is False, get_pillar is called during gen_modules
+    initial_load so that pillar data is available to modules.
+    """
+    minion_opts["skip_init_pillar"] = False
+    io_loop = tornado.ioloop.IOLoop()
+    minion = salt.minion.Minion(minion_opts, io_loop=io_loop)
+
+    class MockPillarCompiler:
+        def compile_pillar(self):
+            return {"test_key": "test_value"}
+
+    try:
+        with patch(
+            "salt.pillar.get_pillar", return_value=MockPillarCompiler()
+        ) as get_pillar_mock:
+            minion.gen_modules(initial_load=True)
+        get_pillar_mock.assert_called_once()
+        assert minion.opts["pillar"] == {"test_key": "test_value"}
+    finally:
+        minion.destroy()
+
+
+def test_gen_modules_skip_init_pillar_true(minion_opts):
+    """
+    When skip_init_pillar is True, get_pillar is NOT called during gen_modules
+    initial_load and pillar is set to an empty dict.
+    """
+    minion_opts["skip_init_pillar"] = True
+    io_loop = tornado.ioloop.IOLoop()
+    minion = salt.minion.Minion(minion_opts, io_loop=io_loop)
+
+    try:
+        with patch("salt.pillar.get_pillar") as get_pillar_mock:
+            minion.gen_modules(initial_load=True)
+        get_pillar_mock.assert_not_called()
+        assert minion.opts["pillar"] == {}
+    finally:
+        minion.destroy()
+
+
+def test_gen_modules_skip_init_pillar_not_initial_load(minion_opts):
+    """
+    When skip_init_pillar is True but initial_load is False (a reload),
+    get_pillar is still not called from gen_modules (skip_init_pillar only
+    applies to the initial_load path).
+    """
+    minion_opts["skip_init_pillar"] = True
+    io_loop = tornado.ioloop.IOLoop()
+    minion = salt.minion.Minion(minion_opts, io_loop=io_loop)
+    # Pre-populate pillar so the non-initial-load path does not clobber it.
+    minion.opts["pillar"] = {"pre": "existing"}
+
+    try:
+        with patch("salt.pillar.get_pillar") as get_pillar_mock:
+            minion.gen_modules(initial_load=False)
+        get_pillar_mock.assert_not_called()
+    finally:
+        minion.destroy()
+
+
 def test_minion_manage_schedule(minion_opts):
     """
     Tests that the manage_schedule will call the add function, adding


### PR DESCRIPTION
This adds a new boolean flag `--skip-init-pillar` to salt-call and a boolean option `skip_init_pillar: true`  (default `false`) to minion config. Judicious skipping of the initial pillar, or the copy of pillar rendered upon minion startup, can greatly speed up things like `salt-call test.ping` and eliminate redundant pillar rendering. Warning: Enabling this in minion config is likely to break some pillar related functionality.

`salt-call --no-skip-init-pillar` can be used to interactively override any `skip_init_pillar: true` config in `/etc/salt/minion` in the event that you do want the initial pillar (e.g. when using `salt-call pillar.get`). This flag is automatically supplied when `salt-call` detects that the function is from the pillar family.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
