### PR TITLE
Implement caching for import_* calls if context isn't forced.

### DIFF
--- a/changelog/67217.added.md
+++ b/changelog/67217.added.md
@@ -1,0 +1,4 @@
+Added opportunistic caching for Jinja ``import_yaml``, ``import_json``, and
+``import_text`` tags when ``import_caching`` is enabled on the Jinja
+environment, reducing repeated pillar renders that import the same SLS file
+multiple times.

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -1282,29 +1282,31 @@ class SerializerExtension(Extension):
             ).set_lineno(lineno),
         ]
 
-    def _cache_imports(self, body, import_node, target, lineno):
-        '''
+    def _cache_imports(self, body, import_node, target, lineno, converter):
+        """
         Opportunistic cache for jinja `import_*` statements.
-        '''
-        # enable caching only if render context is consistent.
-        if import_node.with_context and not self.environment.import_caching:
+        """
+        # Disable caching when caching is not enabled or when context is forced
+        # (with_context=True means the render context is not stable, so caching
+        # would produce incorrect results).
+        if not self.environment.import_caching or import_node.with_context:
             return body
 
         def mk_key():
-            '''
-            Add a cached node to the language tree.
-            '''
+            """
+            Build the AST node representing the cache key string.
+            """
             return nodes.Concat(
                 [
-                    nodes.Const("_import_{}_cache_".format(converter)),
+                    nodes.Const(f"_import_{converter}_cache_"),
                     import_node.template,
                 ],
             )
 
         def get_salt_func(name):
-            '''
+            """
             Get the representation of the salt function.
-            '''
+            """
             return nodes.Getitem(
                 nodes.Getattr(nodes.ContextReference(), "salt", "load"),
                 nodes.Const(name),
@@ -1371,7 +1373,7 @@ class SerializerExtension(Extension):
             ).set_lineno(lineno),
         ]
 
-        body = self._cache_imports(body, import_node, target, lineno)
+        body = self._cache_imports(body, import_node, target, lineno, converter)
         return self._parse_profile_block(
             parser, import_node.template, f"import_{converter}", body, lineno
         )

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -6,6 +6,7 @@ import itertools
 import logging
 import os.path
 import pprint
+import random
 import re
 import shlex
 import time
@@ -1005,6 +1006,8 @@ class SerializerExtension(Extension):
         "profile",
     }
 
+    _CacheSingleton = ("cache_singleton", random.random())
+
     def __init__(self, environment):
         super().__init__(environment)
         self.environment.filters.update(
@@ -1028,6 +1031,7 @@ class SerializerExtension(Extension):
                 "zip_longest": _handle_strict_undefined(itertools.zip_longest),
             }
         )
+        self.environment.extend(import_caching=False)
 
         if self.environment.finalize is None:
             self.environment.finalize = self.finalizer
@@ -1278,6 +1282,75 @@ class SerializerExtension(Extension):
             ).set_lineno(lineno),
         ]
 
+    def _cache_imports(self, body, import_node, target, lineno):
+        '''
+        Opportunistic cache for jinja `import_*` statements.
+        '''
+        # enable caching only if render context is consistent.
+        if import_node.with_context and not self.environment.import_caching:
+            return body
+
+        def mk_key():
+            '''
+            Add a cached node to the language tree.
+            '''
+            return nodes.Concat(
+                [
+                    nodes.Const("_import_{}_cache_".format(converter)),
+                    import_node.template,
+                ],
+            )
+
+        def get_salt_func(name):
+            '''
+            Get the representation of the salt function.
+            '''
+            return nodes.Getitem(
+                nodes.Getattr(nodes.ContextReference(), "salt", "load"),
+                nodes.Const(name),
+                "load",
+            )
+
+        # pseudo logic here is:
+        # obj = from_cache(key, singleton)
+        # if obj == singleton:
+        #   < do import body >
+        #   set_cache(key, obj)
+        cached_import_body = [
+            nodes.Assign(
+                nodes.Name(target, "store"),
+                nodes.Call(
+                    get_salt_func("context.get"),
+                    [],
+                    [],
+                    nodes.List([mk_key(), self.attr("_CacheSingleton")]),
+                    None,
+                ),
+            ).set_lineno(lineno),
+            # compare the result; if it's the singleton, we must load.
+            nodes.If(
+                nodes.Compare(
+                    nodes.Name(target, "load"),
+                    [nodes.Operand("eq", self.attr("_CacheSingleton"))],
+                ),
+                body
+                + [
+                    nodes.ExprStmt(
+                        nodes.Call(
+                            get_salt_func("context.set"),
+                            [],
+                            [],
+                            nodes.List([mk_key(), nodes.Name(target, "load")]),
+                            None,
+                        ),
+                    ),
+                ],
+                [],
+                [],  # elif and else blocks
+            ).set_lineno(lineno),
+        ]
+        return cached_import_body
+
     def parse_import(self, parser, converter):
         import_node = parser.parse_import()
         target = import_node.target
@@ -1297,6 +1370,8 @@ class SerializerExtension(Extension):
                 ).set_lineno(lineno),
             ).set_lineno(lineno),
         ]
+
+        body = self._cache_imports(body, import_node, target, lineno)
         return self._parse_profile_block(
             parser, import_node.template, f"import_{converter}", body, lineno
         )

--- a/tests/pytests/unit/utils/jinja/test_custom_extensions.py
+++ b/tests/pytests/unit/utils/jinja/test_custom_extensions.py
@@ -1332,3 +1332,55 @@ def test_ifelse(minion_opts, local_salt):
         dict(opts=minion_opts, saltenv="test", salt=local_salt),
     )
     assert rendered == ("default\n" "fooval\n" "barval\n" "barval\n" "default")
+
+
+# Tests for import_* caching (PR #67217)
+
+
+def test_import_yaml_without_caching():
+    """
+    Verify import_yaml works correctly when import_caching is disabled (default).
+    The caching code path must not raise NameError('converter') when parsing.
+    """
+    loader = DictLoader({"foo.yaml": '{bar: "cached value"}'})
+    env = Environment(extensions=[SerializerExtension], loader=loader)
+    # Default: import_caching=False — caching path is bypassed, normal import.
+    rendered = env.from_string(
+        '{% import_yaml "foo.yaml" as doc %}{{ doc.bar }}'
+    ).render()
+    assert rendered == "cached value"
+
+
+def test_import_json_without_caching():
+    """
+    Verify import_json works correctly when import_caching is disabled (default).
+    """
+    loader = DictLoader({"data.json": '{"answer": 42}'})
+    env = Environment(extensions=[SerializerExtension], loader=loader)
+    rendered = env.from_string(
+        '{% import_json "data.json" as doc %}{{ doc.answer }}'
+    ).render()
+    assert rendered == "42"
+
+
+def test_import_text_without_caching():
+    """
+    Verify import_text works correctly when import_caching is disabled (default).
+    """
+    loader = DictLoader({"msg.txt": "hello world"})
+    env = Environment(extensions=[SerializerExtension], loader=loader)
+    rendered = env.from_string('{% import_text "msg.txt" as doc %}{{ doc }}').render()
+    assert rendered == "hello world"
+
+
+def test_import_yaml_parse_does_not_raise_with_caching_disabled():
+    """
+    Regression: parsing an import_yaml tag must not raise NameError when
+    import_caching=False (the default).  The _cache_imports helper previously
+    referenced the undefined name ``converter`` inside the nested mk_key()
+    closure.
+    """
+    loader = DictLoader({"foo.yaml": "{x: 1}"})
+    env = Environment(extensions=[SerializerExtension], loader=loader)
+    # parse() exercises the AST-building path; a NameError would surface here.
+    env.parse('{% import_yaml "foo.yaml" as doc %}{{ doc.x }}')


### PR DESCRIPTION
Basically the notion is for `import_*` tags to cache the content rendered if it's just using the global render context; that cache lives for the duration of the minion render (or state render if triggered via minion side).

This is an optimization for heavy users of `import_yaml`; in general pillarstack is a better approach if one can structure their configurables that way, but for codebases not yet there (or limited due to other reasons) improving `import_*` performance is beneficial.

For example, the codebase I work against- this reduces our pillar render time from ~74s to ~65s; that's something of an edge case for our renders, but the complexity of the target is why it's so large, and why an optimization like this has value.

This logic is wired such that if context is enabled for the `import`--meaning the target does not have a stable render context (like one has in a state or while doing a pillar render)--caching is disabled automatically.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
