### PR TITLE
Bump jinja2 to 3.1.5 due to GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699

### DIFF
--- a/changelog/67128.security.md
+++ b/changelog/67128.security.md
@@ -1,0 +1,1 @@
+Bump to ``jinja2==3.1.5`` due to https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h and https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699

--- a/requirements/static/ci/py3.10/changelog.txt
+++ b/requirements/static/ci/py3.10/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.3
     #   towncrier
 incremental==22.10.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -196,7 +196,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -62,7 +62,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/docs.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -195,7 +195,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -219,7 +219,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/tools.txt
+++ b/requirements/static/ci/py3.10/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -193,7 +193,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/changelog.txt
+++ b/requirements/static/ci/py3.11/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.3
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -189,7 +189,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -62,7 +62,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/docs.in

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -188,7 +188,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -210,7 +210,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/tools.txt
+++ b/requirements/static/ci/py3.11/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -186,7 +186,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/changelog.txt
+++ b/requirements/static/ci/py3.12/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.3
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -259,7 +259,7 @@ jaraco.text==3.11.1
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -189,7 +189,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -110,7 +110,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -188,7 +188,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -286,7 +286,7 @@ jaraco.text==3.11.1
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -210,7 +210,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/tools.txt
+++ b/requirements/static/ci/py3.12/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -186,7 +186,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/changelog.txt
+++ b/requirements/static/ci/py3.13/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.7
     #   towncrier
 incremental==24.7.2
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -246,7 +246,7 @@ jaraco.text==4.0.0
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -179,7 +179,7 @@ jaraco.text==4.0.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -106,7 +106,7 @@ jaraco.text==4.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -178,7 +178,7 @@ jaraco.text==4.0.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -272,7 +272,7 @@ jaraco.text==4.0.0
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -200,7 +200,7 @@ jaraco.text==4.0.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/tools.txt
+++ b/requirements/static/ci/py3.13/tools.txt
@@ -24,7 +24,7 @@ filelock==3.16.1
     # via python-tools-scripts
 idna==3.10
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -179,7 +179,7 @@ jaraco.text==4.0.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.13/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/changelog.txt
+++ b/requirements/static/ci/py3.8/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.3
     #   towncrier
 incremental==22.10.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -70,7 +70,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/static/ci/docs.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -199,7 +199,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -218,7 +218,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -197,7 +197,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/changelog.txt
+++ b/requirements/static/ci/py3.9/changelog.txt
@@ -13,7 +13,7 @@ click==8.1.3
     #   towncrier
 incremental==22.10.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -196,7 +196,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -66,7 +66,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/docs.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -195,7 +195,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -214,7 +214,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/tools.txt
+++ b/requirements/static/ci/py3.9/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -193,7 +193,7 @@ jaraco.text==3.11.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -67,7 +67,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -65,7 +65,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -59,7 +59,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -65,7 +65,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -57,7 +57,7 @@ jaraco.functools==4.1.0
     #   tempora
 jaraco.text==4.0.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -57,7 +57,7 @@ jaraco.functools==4.1.0
     #   tempora
 jaraco.text==4.0.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -57,7 +57,7 @@ jaraco.functools==4.1.0
     #   tempora
 jaraco.text==4.0.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -59,7 +59,7 @@ jaraco.functools==4.1.0
     #   tempora
 jaraco.text==4.0.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -63,7 +63,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -63,7 +63,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -69,7 +69,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -61,7 +61,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -67,7 +67,7 @@ jaraco.functools==3.7.0
     #   tempora
 jaraco.text==3.11.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt


### PR DESCRIPTION
### What does this PR do?
Bump jinja2 to 3.1.5 due to [GHSA-q2x7-8rv6-6q7h](https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h) and [GHSA-gmj6-6f8f-6699](https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699).

### What issues does this PR fix or reference?
Fixes #67128 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
