### PR TITLE
Handle AllowInboundRules when configuring Windows Firewall

### DIFF
--- a/changelog/67122.fixed.md
+++ b/changelog/67122.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue with making changes to the Windows Firewall when the
+AllowInboundRules setting is set to True

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5762,8 +5762,9 @@ def _set_netsh_value(profile, section, option, value):
         salt.utils.win_lgpo_netsh.set_logging_settings(
             profile=profile, setting=option, value=value, store="lgpo"
         )
-    log.trace("LGPO: Clearing netsh data for %s profile", profile)
-    __context__["lgpo.netsh_data"].pop(profile)
+    if profile in __context__["lgpo.netsh_data"]:
+        log.trace("LGPO: Clearing netsh data for %s profile", profile)
+        __context__["lgpo.netsh_data"].pop(profile, {})
     return True
 
 

--- a/salt/utils/win_lgpo_netsh.py
+++ b/salt/utils/win_lgpo_netsh.py
@@ -74,8 +74,6 @@ Usage:
                                                     store='lgpo')
 """
 
-from lib2to3.fixer_util import Comma
-
 import salt.utils.platform
 import salt.utils.win_pwsh
 from salt.exceptions import CommandExecutionError
@@ -546,7 +544,7 @@ def set_logging_settings(profile, setting, value, store="local"):
     if str(value).lower() == "notconfigured" and store.lower() == "local":
         if setting in ["allowedconnections", "droppedconnections", "maxfilesize"]:
             raise CommandExecutionError(
-                f"NotConfigured only valid when setting Group Policy"
+                "NotConfigured only valid when setting Group Policy"
             )
     if setting == "maxfilesize" and str(value).lower() == "notconfigured":
         raise CommandExecutionError(f"NotConfigured not a valid option for {setting}")

--- a/salt/utils/win_lgpo_netsh.py
+++ b/salt/utils/win_lgpo_netsh.py
@@ -74,6 +74,8 @@ Usage:
                                                     store='lgpo')
 """
 
+from lib2to3.fixer_util import Comma
+
 import salt.utils.platform
 import salt.utils.win_pwsh
 from salt.exceptions import CommandExecutionError
@@ -110,19 +112,37 @@ def _get_inbound_text(rule, action):
     The "Inbound connections" setting is a combination of 2 parameters:
 
     - AllowInboundRules
+      0 = False
+      1 = True
+      2 = NotConfigured
+      I don't see a way to set "AllowInboundRules" outside of PowerShell
+
     - DefaultInboundAction
+      0 = Not Configured
+      2 = Allow Inbound
+      4 = Block Inbound
 
     The settings are as follows:
 
     Rules Action
+    0     4       BlockInboundAlways
+    1     0       NotConfigured
+    1     2       AllowInbound
+    1     4       BlockInbound
+    2     0       NotConfigured
     2     2       AllowInbound
     2     4       BlockInbound
-    0     4       BlockInboundAlways
-    2     0       NotConfigured
     """
     settings = {
         0: {
+            0: "NotConfigured",
+            2: "AllowInbound",
             4: "BlockInboundAlways",
+        },
+        1: {
+            0: "NotConfigured",
+            2: "AllowInbound",
+            4: "BlockInbound",
         },
         2: {
             0: "NotConfigured",
@@ -141,6 +161,30 @@ def _get_inbound_settings(text):
         "notconfigured": (2, 0),
     }
     return settings[text.lower()]
+
+
+def _get_all_settings(profile, store="local"):
+    # Get current settings using PowerShell
+    # if "lgpo.firewall_profile_settings" not in __context__:
+    cmd = ["Get-NetFirewallProfile"]
+    if profile:
+        cmd.append(profile)
+    if store.lower() == "lgpo":
+        cmd.extend(["-PolicyStore", "localhost"])
+
+    # Run the command and get dict
+    settings = salt.utils.win_pwsh.run_dict(cmd)
+
+    # A successful run should return a dictionary
+    if not settings:
+        raise CommandExecutionError("LGPO NETSH: An unknown error occurred")
+
+    # Remove the junk
+    for setting in list(settings.keys()):
+        if setting.startswith("Cim"):
+            settings.pop(setting)
+
+    return settings
 
 
 def get_settings(profile, section, store="local"):
@@ -190,24 +234,7 @@ def get_settings(profile, section, store="local"):
     if store.lower() not in ("local", "lgpo"):
         raise ValueError(f"Incorrect store: {store}")
 
-    # Build the powershell command
-    cmd = ["Get-NetFirewallProfile"]
-    if profile:
-        cmd.append(profile)
-    if store and store.lower() == "lgpo":
-        cmd.extend(["-PolicyStore", "localhost"])
-
-    # Run the command
-    settings = salt.utils.win_pwsh.run_dict(cmd)
-
-    # A successful run should return a dictionary
-    if not settings:
-        raise CommandExecutionError("LGPO NETSH: An unknown error occurred")
-
-    # Remove the junk
-    for setting in list(settings.keys()):
-        if setting.startswith("Cim"):
-            settings.pop(setting)
+    settings = _get_all_settings(profile=profile, store=store)
 
     # Make it look like netsh output
     ret_settings = {
@@ -299,24 +326,7 @@ def get_all_settings(profile, store="local"):
     if store.lower() not in ("local", "lgpo"):
         raise ValueError(f"Incorrect store: {store}")
 
-    # Build the powershell command
-    cmd = ["Get-NetFirewallProfile"]
-    if profile:
-        cmd.append(profile)
-    if store and store.lower() == "lgpo":
-        cmd.extend(["-PolicyStore", "localhost"])
-
-    # Run the command
-    settings = salt.utils.win_pwsh.run_dict(cmd)
-
-    # A successful run should return a dictionary
-    if not settings:
-        raise CommandExecutionError("LGPO NETSH: An unknown error occurred")
-
-    # Remove the junk
-    for setting in list(settings.keys()):
-        if setting.startswith("Cim"):
-            settings.pop(setting)
+    settings = _get_all_settings(profile=profile, store=store)
 
     # Make it look like netsh output
     ret_settings = {
@@ -409,6 +419,9 @@ def set_firewall_settings(profile, inbound=None, outbound=None, store="local"):
         raise ValueError(f"Incorrect outbound value: {outbound}")
     if not inbound and not outbound:
         raise ValueError("Must set inbound or outbound")
+
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-allowinboundrules
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-defaultoutboundaction
     if store == "local":
         if inbound and inbound.lower() == "notconfigured":
             msg = "Cannot set local inbound policies as NotConfigured"
@@ -417,16 +430,26 @@ def set_firewall_settings(profile, inbound=None, outbound=None, store="local"):
             msg = "Cannot set local outbound policies as NotConfigured"
             raise CommandExecutionError(msg)
 
+    # Get current settings
+    settings = _get_all_settings(profile=profile, store=store)
+
     # Build the powershell command
     cmd = ["Set-NetFirewallProfile"]
     if profile:
         cmd.append(profile)
-    if store and store.lower() == "lgpo":
+    if store.lower() == "lgpo":
         cmd.extend(["-PolicyStore", "localhost"])
 
     # Get inbound settings
     if inbound:
         in_rule, in_action = _get_inbound_settings(inbound.lower())
+        # If current AllowInboundRules is set (1 or 2) and new AllowInboundRules is 2
+        # We want to just keep the current setting.
+        # We don't have a way in LGPO to set the AllowInboundRules. I can't find it in
+        # gpedit.msc either. Not sure how to set it outside of PowerShell
+        current_in_rule = settings["AllowInboundRules"]
+        if current_in_rule > 0 and in_rule == 2:
+            in_rule = current_in_rule
         cmd.extend(["-AllowInboundRules", in_rule, "-DefaultInboundAction", in_action])
 
     if outbound:
@@ -509,10 +532,6 @@ def set_logging_settings(profile, setting, value, store="local"):
     # Input validation
     if profile.lower() not in ("domain", "public", "private"):
         raise ValueError(f"Incorrect profile: {profile}")
-    if store == "local":
-        if str(value).lower() == "notconfigured":
-            msg = "Cannot set local policies as NotConfigured"
-            raise CommandExecutionError(msg)
     if setting.lower() not in (
         "allowedconnections",
         "droppedconnections",
@@ -520,6 +539,18 @@ def set_logging_settings(profile, setting, value, store="local"):
         "maxfilesize",
     ):
         raise ValueError(f"Incorrect setting: {setting}")
+
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-logallowed
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-logblocked
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-logmaxsizekilobytes
+    if str(value).lower() == "notconfigured" and store.lower() == "local":
+        if setting in ["allowedconnections", "droppedconnections", "maxfilesize"]:
+            raise CommandExecutionError(
+                f"NotConfigured only valid when setting Group Policy"
+            )
+    if setting == "maxfilesize" and str(value).lower() == "notconfigured":
+        raise CommandExecutionError(f"NotConfigured not a valid option for {setting}")
+
     settings = {"filename": ["-LogFileName", value]}
     if setting.lower() in ("allowedconnections", "droppedconnections"):
         if value.lower() not in ("enable", "disable", "notconfigured"):
@@ -588,7 +619,7 @@ def set_settings(profile, setting, value, store="local"):
 
             - enable
             - disable
-            - notconfigured
+            - notconfigured  <== lgpo only
 
         store (str):
             The store to use. This is either the local firewall policy or the
@@ -618,20 +649,19 @@ def set_settings(profile, setting, value, store="local"):
         raise ValueError(f"Incorrect setting: {setting}")
     if value.lower() not in ("enable", "disable", "notconfigured"):
         raise ValueError(f"Incorrect value: {value}")
-    if setting.lower() in ["localfirewallrules", "localconsecrules"]:
-        if store.lower() != "lgpo":
-            msg = f"{setting} can only be set using Group Policy"
-            raise CommandExecutionError(msg)
-    if setting.lower() == "inboundusernotification" and store.lower() != "lgpo":
-        if value.lower() == "notconfigured":
-            msg = "NotConfigured is only valid when setting group policy"
-            raise CommandExecutionError(msg)
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-allowlocalfirewallrules
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-allowlocalipsecrules
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-allowunicastresponsetomulticast
+    # https://learn.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2025-ps#-notifyonlisten
+    if value.lower() == "notconfigured" and store.lower() == "local":
+        msg = "NotConfigured is only valid when setting group policy"
+        raise CommandExecutionError(msg)
 
     # Build the powershell command
     cmd = ["Set-NetFirewallProfile"]
     if profile:
         cmd.append(profile)
-    if store and store.lower() == "lgpo":
+    if store.lower() == "lgpo":
         cmd.extend(["-PolicyStore", "localhost"])
 
     settings = {
@@ -706,7 +736,7 @@ def set_state(profile, state, store="local"):
     cmd = ["Set-NetFirewallProfile"]
     if profile:
         cmd.append(profile)
-    if store and store.lower() == "lgpo":
+    if store.lower() == "lgpo":
         cmd.extend(["-PolicyStore", "localhost"])
 
     cmd.extend(["-Enabled", ON_OFF[state.lower()]])

--- a/tests/pytests/unit/utils/win_lgpo/test_netsh.py
+++ b/tests/pytests/unit/utils/win_lgpo/test_netsh.py
@@ -1,9 +1,7 @@
 import pytest
 
 import salt.utils.win_lgpo_netsh as win_lgpo_netsh
-import salt.utils.win_pwsh as win_pwsh
 from salt.exceptions import CommandExecutionError
-from salt.modules.win_useradd import current
 
 pytestmark = [
     pytest.mark.windows_whitelisted,

--- a/tests/pytests/unit/utils/win_lgpo/test_netsh.py
+++ b/tests/pytests/unit/utils/win_lgpo/test_netsh.py
@@ -1,7 +1,9 @@
 import pytest
 
 import salt.utils.win_lgpo_netsh as win_lgpo_netsh
+import salt.utils.win_pwsh as win_pwsh
 from salt.exceptions import CommandExecutionError
+from salt.modules.win_useradd import current
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
@@ -9,72 +11,42 @@ pytestmark = [
 ]
 
 
-def test_get_settings_firewallpolicy_local():
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_settings_firewallpolicy(store):
     ret = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="local"
+        profile="domain", section="firewallpolicy", store=store
     )
     assert "Inbound" in ret
     assert "Outbound" in ret
 
 
-def test_get_settings_firewallpolicy_lgpo():
-    ret = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="lgpo"
-    )
-    assert "Inbound" in ret
-    assert "Outbound" in ret
-
-
-def test_get_settings_logging_local():
-    ret = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
-    )
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_settings_logging(store):
+    ret = win_lgpo_netsh.get_settings(profile="domain", section="logging", store=store)
     assert "FileName" in ret
     assert "LogAllowedConnections" in ret
     assert "LogDroppedConnections" in ret
     assert "MaxFileSize" in ret
 
 
-def test_get_settings_logging_lgpo():
-    ret = win_lgpo_netsh.get_settings(profile="domain", section="logging", store="lgpo")
-    assert "FileName" in ret
-    assert "LogAllowedConnections" in ret
-    assert "LogDroppedConnections" in ret
-    assert "MaxFileSize" in ret
-
-
-def test_get_settings_settings_local():
-    ret = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="local"
-    )
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_settings_settings(store):
+    ret = win_lgpo_netsh.get_settings(profile="domain", section="settings", store=store)
     assert "InboundUserNotification" in ret
     assert "LocalConSecRules" in ret
     assert "LocalFirewallRules" in ret
     assert "UnicastResponseToMulticast" in ret
 
 
-def test_get_settings_settings_lgpo():
-    ret = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="lgpo"
-    )
-    assert "InboundUserNotification" in ret
-    assert "LocalConSecRules" in ret
-    assert "LocalFirewallRules" in ret
-    assert "UnicastResponseToMulticast" in ret
-
-
-def test_get_settings_state_local():
-    ret = win_lgpo_netsh.get_settings(profile="domain", section="state", store="local")
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_settings_state(store):
+    ret = win_lgpo_netsh.get_settings(profile="domain", section="state", store=store)
     assert "State" in ret
 
 
-def test_get_settings_state_lgpo():
-    ret = win_lgpo_netsh.get_settings(profile="domain", section="state", store="lgpo")
-    assert "State" in ret
-
-
-def test_get_all_settings_local():
-    ret = win_lgpo_netsh.get_all_settings(profile="domain", store="local")
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_all_settings(store):
+    ret = win_lgpo_netsh.get_all_settings(profile="domain", store=store)
     assert "Inbound" in ret
     assert "Outbound" in ret
     assert "FileName" in ret
@@ -88,470 +60,268 @@ def test_get_all_settings_local():
     assert "State" in ret
 
 
-def test_get_all_settings_lgpo():
-    ret = win_lgpo_netsh.get_all_settings(profile="domain", store="local")
-    assert "Inbound" in ret
-    assert "Outbound" in ret
-    assert "FileName" in ret
-    assert "LogAllowedConnections" in ret
-    assert "LogDroppedConnections" in ret
-    assert "MaxFileSize" in ret
-    assert "InboundUserNotification" in ret
-    assert "LocalConSecRules" in ret
-    assert "LocalFirewallRules" in ret
-    assert "UnicastResponseToMulticast" in ret
-    assert "State" in ret
-
-
-def test_get_all_profiles_local():
-    ret = win_lgpo_netsh.get_all_profiles(store="local")
-    assert "Domain Profile" in ret
-    assert "Private Profile" in ret
-    assert "Public Profile" in ret
-
-
-def test_get_all_profiles_lgpo():
-    ret = win_lgpo_netsh.get_all_profiles(store="lgpo")
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+def test_get_all_profiles(store):
+    ret = win_lgpo_netsh.get_all_profiles(store=store)
     assert "Domain Profile" in ret
     assert "Private Profile" in ret
     assert "Public Profile" in ret
 
 
 @pytest.mark.destructive_test
-def test_set_firewall_settings_inbound_local():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="local"
-    )["Inbound"]
-    try:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", inbound="allowinbound", store="local"
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="firewallpolicy", store="local"
-        )["Inbound"]
-        assert new == "AllowInbound"
-    finally:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", inbound=current, store="local"
-        )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_settings_inbound_local_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="local"
-    )["Inbound"]
-    try:
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize(
+    "inbound", ["allowinbound", "blockinbound", "blockinboundalways", "notconfigured"]
+)
+def test_set_firewall_settings_inbound(store, inbound):
+    if inbound == "notconfigured" and store == "local":
         pytest.raises(
             CommandExecutionError,
             win_lgpo_netsh.set_firewall_settings,
             profile="domain",
-            inbound="notconfigured",
-            store="local",
+            inbound=inbound,
+            store=store,
         )
-    finally:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", inbound=current, store="local"
-        )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_settings_inbound_lgpo_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="lgpo"
-    )["Inbound"]
-    try:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", inbound="notconfigured", store="lgpo"
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="firewallpolicy", store="lgpo"
+    else:
+        current = win_lgpo_netsh.get_settings(
+            profile="domain", section="firewallpolicy", store=store
         )["Inbound"]
-        assert new == "NotConfigured"
-    finally:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", inbound=current, store="lgpo"
-        )
-        assert ret is True
+        try:
+            ret = win_lgpo_netsh.set_firewall_settings(
+                profile="domain", inbound=inbound, store=store
+            )
+            assert ret is True
+            new = win_lgpo_netsh.get_settings(
+                profile="domain", section="firewallpolicy", store=store
+            )["Inbound"]
+            assert new.lower() == inbound
+        finally:
+            ret = win_lgpo_netsh.set_firewall_settings(
+                profile="domain", inbound=current, store=store
+            )
+            assert ret is True
 
 
 @pytest.mark.destructive_test
-def test_set_firewall_settings_outbound_local():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="firewallpolicy", store="local"
-    )["Outbound"]
-    try:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", outbound="allowoutbound", store="local"
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize(
+    "outbound", ["allowoutbound", "blockoutbound", "notconfigured"]
+)
+def test_set_firewall_settings_outbound(store, outbound):
+    if outbound == "notconfigured" and store == "local":
+        pytest.raises(
+            CommandExecutionError,
+            win_lgpo_netsh.set_firewall_settings,
+            profile="domain",
+            inbound=outbound,
+            store=store,
         )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="firewallpolicy", store="local"
+    else:
+        current = win_lgpo_netsh.get_settings(
+            profile="domain", section="firewallpolicy", store=store
         )["Outbound"]
-        assert new == "AllowOutbound"
-    finally:
-        ret = win_lgpo_netsh.set_firewall_settings(
-            profile="domain", outbound=current, store="local"
-        )
-        assert ret is True
+        try:
+            ret = win_lgpo_netsh.set_firewall_settings(
+                profile="domain", outbound=outbound, store=store
+            )
+            assert ret is True
+            new = win_lgpo_netsh.get_settings(
+                profile="domain", section="firewallpolicy", store=store
+            )["Outbound"]
+            assert new.lower() == outbound
+        finally:
+            ret = win_lgpo_netsh.set_firewall_settings(
+                profile="domain", outbound=current, store=store
+            )
+            assert ret is True
 
 
 @pytest.mark.destructive_test
-def test_set_firewall_logging_allowed_local_enable():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
-    )["LogAllowedConnections"]
-    try:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="allowedconnections",
-            value="enable",
-            store="local",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="logging", store="local"
-        )["LogAllowedConnections"]
-        assert new == "Enable"
-    finally:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="allowedconnections",
-            value=current,
-            store="local",
-        )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_logging_allowed_local_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
-    )["LogAllowedConnections"]
-    try:
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize("setting", ["allowedconnections", "droppedconnections"])
+@pytest.mark.parametrize("value", ["enable", "disable", "notconfigured"])
+def test_set_firewall_logging_connections(store, setting, value):
+    if value == "notconfigured" and store == "local":
         pytest.raises(
             CommandExecutionError,
             win_lgpo_netsh.set_logging_settings,
             profile="domain",
-            setting="allowedconnections",
-            value="notconfigured",
-            store="local",
+            setting=setting,
+            value=value,
+            store=store,
         )
-    finally:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="allowedconnections",
-            value=current,
-            store="local",
-        )
-        assert ret is True
+    else:
+        setting_map = {
+            "allowedconnections": "LogAllowedConnections",
+            "droppedconnections": "LogDroppedConnections",
+        }
+        current = win_lgpo_netsh.get_settings(
+            profile="domain", section="logging", store=store
+        )[setting_map[setting]]
+        try:
+            ret = win_lgpo_netsh.set_logging_settings(
+                profile="domain",
+                setting=setting,
+                value=value,
+                store=store,
+            )
+            assert ret is True
+            new = win_lgpo_netsh.get_settings(
+                profile="domain", section="logging", store=store
+            )[setting_map[setting]]
+            assert new.lower() == value
+        finally:
+            ret = win_lgpo_netsh.set_logging_settings(
+                profile="domain",
+                setting=setting,
+                value=current,
+                store=store,
+            )
+            assert ret is True
 
 
 @pytest.mark.destructive_test
-def test_set_firewall_logging_allowed_lgpo_notconfigured():
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize("value", ["C:\\Temp\\test.log", "notconfigured"])
+def test_set_firewall_logging_filename(store, value):
     current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="lgpo"
-    )["LogAllowedConnections"]
-    try:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="allowedconnections",
-            value="notconfigured",
-            store="lgpo",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="logging", store="lgpo"
-        )["LogAllowedConnections"]
-        assert new == "NotConfigured"
-    finally:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="allowedconnections",
-            value=current,
-            store="lgpo",
-        )
-        assert ret is True
-
-
-def test_set_firewall_logging_dropped_local_enable():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
-    )["LogDroppedConnections"]
-    try:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="droppedconnections",
-            value="enable",
-            store="local",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="logging", store="local"
-        )["LogDroppedConnections"]
-        assert new == "Enable"
-    finally:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain",
-            setting="droppedconnections",
-            value=current,
-            store="local",
-        )
-        assert ret is True
-
-
-def test_set_firewall_logging_filename_local():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
+        profile="domain", section="logging", store=store
     )["FileName"]
     try:
         ret = win_lgpo_netsh.set_logging_settings(
             profile="domain",
             setting="filename",
-            value="C:\\Temp\\test.log",
-            store="local",
+            value=value,
+            store=store,
         )
         assert ret is True
         new = win_lgpo_netsh.get_settings(
-            profile="domain", section="logging", store="local"
+            profile="domain", section="logging", store=store
         )["FileName"]
-        assert new == "C:\\Temp\\test.log"
+        assert new.lower() == value.lower()
     finally:
         ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain", setting="filename", value=current, store="local"
+            profile="domain", setting="filename", value=current, store=store
         )
         assert ret is True
 
 
-def test_set_firewall_logging_maxfilesize_local():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="logging", store="local"
-    )["MaxFileSize"]
-    try:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain", setting="maxfilesize", value="16384", store="local"
+@pytest.mark.destructive_test
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize("value", ["16384", "notconfigured"])
+def test_set_firewall_logging_maxfilesize(store, value):
+    if value == "notconfigured":
+        pytest.raises(
+            CommandExecutionError,
+            win_lgpo_netsh.set_logging_settings,
+            profile="domain",
+            setting="maxfilesize",
+            value=value,
+            store=store,
         )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="logging", store="local"
+    else:
+        current = win_lgpo_netsh.get_settings(
+            profile="domain", section="logging", store=store
         )["MaxFileSize"]
-        assert new == 16384
-    finally:
-        ret = win_lgpo_netsh.set_logging_settings(
-            profile="domain", setting="maxfilesize", value=current, store="local"
+        try:
+            ret = win_lgpo_netsh.set_logging_settings(
+                profile="domain", setting="maxfilesize", value=value, store=store
+            )
+            assert ret is True
+            new = win_lgpo_netsh.get_settings(
+                profile="domain", section="logging", store=store
+            )["MaxFileSize"]
+            assert new == int(value)
+        finally:
+            ret = win_lgpo_netsh.set_logging_settings(
+                profile="domain", setting="maxfilesize", value=current, store=store
+            )
+            assert ret is True
+
+
+@pytest.mark.destructive_test
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize(
+    "setting",
+    ["localconsecrules", "inboundusernotification", "unicastresponsetomulticast"],
+)
+@pytest.mark.parametrize("value", ["enable", "disable", "notconfigured"])
+def test_set_firewall_settings(store, setting, value):
+    setting_map = {
+        "localconsecrules": "LocalConSecRules",
+        "inboundusernotification": "InboundUserNotification",
+        "unicastresponsetomulticast": "UnicastResponseToMulticast",
+    }
+    if value == "notconfigured" and store == "local":
+        pytest.raises(
+            CommandExecutionError,
+            win_lgpo_netsh.set_settings,
+            profile="domain",
+            setting=setting,
+            value=value,
+            store=store,
         )
-        assert ret is True
+    else:
+        current = win_lgpo_netsh.get_settings(
+            profile="domain", section="settings", store=store
+        )[setting_map[setting]]
+        try:
+            ret = win_lgpo_netsh.set_settings(
+                profile="domain",
+                setting=setting,
+                value=value,
+                store=store,
+            )
+            assert ret is True
+            new = win_lgpo_netsh.get_settings(
+                profile="domain", section="settings", store=store
+            )[setting_map[setting]]
+            assert new.lower() == value
+        finally:
+            if current != "notconfigured":
+                ret = win_lgpo_netsh.set_settings(
+                    profile="domain",
+                    setting=setting,
+                    value=current,
+                    store=store,
+                )
+            assert ret is True
 
 
 @pytest.mark.destructive_test
-def test_set_firewall_settings_fwrules_local_enable():
-    pytest.raises(
-        CommandExecutionError,
-        win_lgpo_netsh.set_settings,
-        profile="domain",
-        setting="localfirewallrules",
-        value="enable",
-        store="local",
-    )
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_settings_fwrules_lgpo_notconfigured():
-    current = win_lgpo_netsh.get_settings(
+@pytest.mark.parametrize("store", ["local", "lgpo"])
+@pytest.mark.parametrize("allow_inbound", ["enable", "disable"])
+@pytest.mark.parametrize("state", ["on", "off", "notconfigured"])
+def test_set_firewall_state(store, allow_inbound, state):
+    current_state = win_lgpo_netsh.get_settings(
+        profile="domain", section="state", store=store
+    )["State"]
+    current_local_fw_rules = win_lgpo_netsh.get_settings(
         profile="domain", section="settings", store="lgpo"
     )["LocalFirewallRules"]
     try:
         ret = win_lgpo_netsh.set_settings(
             profile="domain",
             setting="localfirewallrules",
-            value="notconfigured",
-            store="lgpo",
+            value=allow_inbound,
+            store=store,
         )
         assert ret is True
         new = win_lgpo_netsh.get_settings(
-            profile="domain", section="settings", store="lgpo"
+            profile="domain", section="settings", store=store
         )["LocalFirewallRules"]
-        assert new == "NotConfigured"
+        assert new.lower() == allow_inbound.lower()
+        ret = win_lgpo_netsh.set_state(profile="domain", state=state, store=store)
+        assert ret is True
+        new = win_lgpo_netsh.get_settings(
+            profile="domain", section="state", store=store
+        )["State"]
+        assert new.lower() == state.lower()
     finally:
-        ret = win_lgpo_netsh.set_settings(
+        win_lgpo_netsh.set_settings(
             profile="domain",
             setting="localfirewallrules",
-            value=current,
-            store="lgpo",
+            value=current_local_fw_rules,
+            store=store,
         )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_settings_consecrules_local_enable():
-    pytest.raises(
-        CommandExecutionError,
-        win_lgpo_netsh.set_settings,
-        profile="domain",
-        setting="localconsecrules",
-        value="enable",
-        store="local",
-    )
-
-
-def test_set_firewall_settings_notification_local_enable():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="local"
-    )["InboundUserNotification"]
-    try:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="inboundusernotification",
-            value="enable",
-            store="local",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="settings", store="local"
-        )["InboundUserNotification"]
-        assert new == "Enable"
-    finally:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="inboundusernotification",
-            value=current,
-            store="local",
-        )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_settings_notification_local_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="local"
-    )["InboundUserNotification"]
-    try:
-        pytest.raises(
-            CommandExecutionError,
-            win_lgpo_netsh.set_settings,
-            profile="domain",
-            setting="inboundusernotification",
-            value="notconfigured",
-            store="local",
-        )
-    finally:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="inboundusernotification",
-            value=current,
-            store="local",
-        )
-        assert ret is True
-
-
-def test_set_firewall_settings_notification_lgpo_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="lgpo"
-    )["InboundUserNotification"]
-    try:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="inboundusernotification",
-            value="notconfigured",
-            store="lgpo",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="settings", store="lgpo"
-        )["InboundUserNotification"]
-        assert new == "NotConfigured"
-    finally:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="inboundusernotification",
-            value=current,
-            store="lgpo",
-        )
-        assert ret is True
-
-
-def test_set_firewall_settings_unicast_local_disable():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="settings", store="local"
-    )["UnicastResponseToMulticast"]
-    try:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="unicastresponsetomulticast",
-            value="disable",
-            store="local",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="settings", store="local"
-        )["UnicastResponseToMulticast"]
-        assert new == "Disable"
-    finally:
-        ret = win_lgpo_netsh.set_settings(
-            profile="domain",
-            setting="unicastresponsetomulticast",
-            value=current,
-            store="local",
-        )
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_state_local_on():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="state", store="local"
-    )["State"]
-    try:
-        ret = win_lgpo_netsh.set_state(profile="domain", state="off", store="local")
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="state", store="local"
-        )["State"]
-        assert new == "OFF"
-    finally:
-        ret = win_lgpo_netsh.set_state(profile="domain", state=current, store="local")
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_state_local_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="state", store="local"
-    )["State"]
-    try:
-        ret = win_lgpo_netsh.set_state(
-            profile="domain",
-            state="notconfigured",
-            store="local",
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="state", store="local"
-        )["State"]
-        assert new == "NotConfigured"
-    finally:
-        ret = win_lgpo_netsh.set_state(profile="domain", state=current, store="local")
-        assert ret is True
-
-
-@pytest.mark.destructive_test
-def test_set_firewall_state_lgpo_notconfigured():
-    current = win_lgpo_netsh.get_settings(
-        profile="domain", section="state", store="local"
-    )["State"]
-    try:
-        ret = win_lgpo_netsh.set_state(
-            profile="domain", state="notconfigured", store="lgpo"
-        )
-        assert ret is True
-        new = win_lgpo_netsh.get_settings(
-            profile="domain", section="state", store="lgpo"
-        )["State"]
-        assert new == "NotConfigured"
-    finally:
-        ret = win_lgpo_netsh.set_state(profile="domain", state=current, store="lgpo")
-        assert ret is True
+        win_lgpo_netsh.set_state(profile="domain", state=current_state, store=store)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the win_lgpo_netsh.py salt util. It was stacktracing when the `AllowInboundRules` setting was set to `True`.

### What issues does this PR fix or reference?
Fixes # 67122

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes