### PR TITLE
[BUGFIX 60515] - Fix bug when specifying template_source using net.load_template

### DIFF
--- a/changelog/60515.fixed.md
+++ b/changelog/60515.fixed.md
@@ -1,0 +1,1 @@
+Fix bug when specifying template_source using net.load_template

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1940,21 +1940,10 @@ def load_template(
         )
         return _loaded  # exit
 
-    # to check if will be rendered by salt or NAPALM
-    salt_render_prefixes = ("salt://", "http://", "https://", "ftp://")
-    salt_render = False
-    file_exists = False
-    if not isinstance(template_name, (tuple, list)):
-        for salt_render_prefix in salt_render_prefixes:
-            if not salt_render:
-                salt_render = salt_render or template_name.startswith(
-                    salt_render_prefix
-                )
-        file_exists = __salt__["file.file_exists"](template_name)
-
     if context is None:
         context = {}
     context.update(template_vars)
+
     # if needed to render the template send as inline arg
     if template_source:
         # render the content

--- a/tests/pytests/unit/modules/napalm/test_network.py
+++ b/tests/pytests/unit/modules/napalm/test_network.py
@@ -1,5 +1,5 @@
 """
-    :codeauthor: Anthony Shaw <anthonyshaw@apache.org>
+:codeauthor: Anthony Shaw <anthonyshaw@apache.org>
 """
 
 import pytest
@@ -20,7 +20,7 @@ def configure_loader_modules():
             "file.join": napalm_test_support.join,
             "file.get_managed": napalm_test_support.get_managed_file,
             "random.hash": napalm_test_support.random_hash,
-            "file.apply_template_on_contents": MagicMock()
+            "file.apply_template_on_contents": MagicMock(),
         }
     }
 
@@ -189,6 +189,7 @@ def test_load_template():
         # template_source
         ret = napalm_network.load_template(template_source="ntp server 192.168.0.1")
         assert ret["out"] is None
+
 
 def test_commit():
     with patch(

--- a/tests/pytests/unit/modules/napalm/test_network.py
+++ b/tests/pytests/unit/modules/napalm/test_network.py
@@ -20,6 +20,7 @@ def configure_loader_modules():
             "file.join": napalm_test_support.join,
             "file.get_managed": napalm_test_support.get_managed_file,
             "random.hash": napalm_test_support.random_hash,
+            "file.apply_template_on_contents": MagicMock()
         }
     }
 
@@ -181,9 +182,13 @@ def test_load_template():
         "salt.utils.napalm.get_device",
         MagicMock(return_value=napalm_test_support.MockNapalmDevice()),
     ):
+        # template_name
         ret = napalm_network.load_template("set_ntp_peers", peers=["192.168.0.1"])
         assert ret["out"] is None
 
+        # template_source
+        ret = napalm_network.load_template(template_source="ntp server 192.168.0.1")
+        assert ret["out"] is None
 
 def test_commit():
     with patch(


### PR DESCRIPTION
### What does this PR do?

Remove unsued code block that causes the script to fail. It sets the local variables `salt_render` and `file_exists`, neither of them is used later in the code.

The code block uses `template_name` which is not mandatory if the user specifies `template_source`. If `template_name` is not set, the code crashes.

### What issues does this PR fix or reference?
Fixes #60515 

### Previous Behavior
```
$ sudo salt XXXX net.load_template template_source='ntp server 192.168.1.100' test=true
XXXX:
    The minion function caused an exception: Traceback (most recent call last):
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/metaproxy/proxy.py", line 479, in thread_return
        return_data = minion_instance.executors[fname](
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1232, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1247, in _run_as
        return _func_or_method(*args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/executors/direct_call.py", line 10, in execute
        return func(*args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1232, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1247, in _run_as
        return _func_or_method(*args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/napalm.py", line 502, in func_wrapper
        ret = func(*args, **kwargs)
      File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/modules/napalm_network.py", line 1959, in load_template
        salt_render = False
    AttributeError: 'NoneType' object has no attribute 'startswith'
```

### New Behavior
```
$ sudo salt XXXX net.load_template template_source='ntp server 192.168.1.100' test=true
XXXX:
    ----------
    already_configured:
        False
    comment:
        Configuration discarded.
    diff:
        +ntp server 192.168.1.100
    loaded_config:
    result:
        True
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
