### PR TITLE
[3006.x]Fix tech-debt for Git Pillar data with os.walk

### DIFF
--- a/changelog/67733.fixed.md
+++ b/changelog/67733.fixed.md
@@ -1,0 +1,1 @@
+Use os.walk to traverse git branches, and no longer replace slash '/' in git branch names

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -491,9 +491,6 @@ class GitProvider:
         self._cache_basename = "_"
         if self.id.startswith("__env__"):
             try:
-                ## DGM self._cache_basename = self.get_checkout_target().replace(
-                ## DGM     "/", "-"
-                ## DGM )  # replace '/' with '-' to not cause trouble with file-system
                 self._cache_basename = self.get_checkout_target()
 
             except AttributeError:
@@ -2799,63 +2796,21 @@ class GitBase:
             name = getattr(repo, "name", None)
             if not remotes or (repo.id, name) in remotes or name in remotes:
                 try:
-                    ## DGM # Find and place fetch_request file for all the other branches for this repo
-                    ## DGM repo_work_hash = os.path.split(repo.get_salt_working_dir())[0]
-                    ## DGM for branch in os.listdir(repo_work_hash):
-                    ## DGM     # Don't place fetch request in current branch being updated
-                    ## DGM     if branch == repo.get_cache_basename():
-                    ## DGM         continue
-                    ## DGM     branch_salt_dir = salt.utils.path.join(repo_work_hash, branch)
-                    ## DGM     fetch_path = salt.utils.path.join(
-                    ## DGM         branch_salt_dir, "fetch_request"
-                    ## DGM     )
-                    ## DGM     if os.path.isdir(branch_salt_dir):
-                    ## DGM         try:
-                    ## DGM             with salt.utils.files.fopen(fetch_path, "w"):
-                    ## DGM                 pass
-                    ## DGM         except OSError as exc:  # pylint: disable=broad-except
-                    ## DGM             log.error(
-                    ## DGM                 "Failed to make fetch request: %s %s",
-                    ## DGM                 fetch_path,
-                    ## DGM                 exc,
-                    ## DGM                 exc_info=True,
-                    ## DGM             )
-                    ## DGM     else:
-                    ## DGM         log.error("Failed to make fetch request: %s", fetch_path)
-
                     # Find and place fetch_request file for all the other branches for this repo
                     repo_work_hash = os.path.split(repo.get_salt_working_dir())[0]
-                    print(
-                        f"DGM class GitBase fetch_remotes, repo_work_hash '{repo_work_hash}', salt working dir '{repo.get_salt_working_dir()}'",
-                        flush=True,
-                    )
-
                     branches = [
                         os.path.relpath(path, repo_work_hash)
                         for (path, subdirs, files) in os.walk(repo_work_hash)
                         if not subdirs
                     ]
-                    print(
-                        f"DGM class GitBase fetch_remotes, branches '{branches}' from repo_work_hash '{repo_work_hash}'",
-                        flush=True,
-                    )
 
-                    ## DGM for branch in os.listdir(repo_work_hash):
-                    for branch in os.listdir(branches):
+                    for branch in branches:
                         # Don't place fetch request in current branch being updated
-                        print(
-                            f"DGM class GitBase fetch_remotes, for loop branch, branch '{branch}', repo get_cache_basename '{repo.get_cache_basename()}'",
-                            flush=True,
-                        )
                         if branch == repo.get_cache_basename():
                             continue
                         branch_salt_dir = salt.utils.path.join(repo_work_hash, branch)
                         fetch_path = salt.utils.path.join(
                             branch_salt_dir, "fetch_request"
-                        )
-                        print(
-                            f"DGM class GitBase fetch_remotes, for loop branch, branch_salt_dir '{branch_salt_dir}', fetch_path '{fetch_path}'",
-                            flush=True,
                         )
                         if os.path.isdir(branch_salt_dir):
                             try:

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2798,8 +2798,77 @@ class GitBase:
             name = getattr(repo, "name", None)
             if not remotes or (repo.id, name) in remotes or name in remotes:
                 try:
+                    ## DGM # Find and place fetch_request file for all the other branches for this repo
+                    ## DGM repo_work_hash = os.path.split(repo.get_salt_working_dir())[0]
+                    ## DGM for branch in os.listdir(repo_work_hash):
+                    ## DGM     # Don't place fetch request in current branch being updated
+                    ## DGM     if branch == repo.get_cache_basename():
+                    ## DGM         continue
+                    ## DGM     branch_salt_dir = salt.utils.path.join(repo_work_hash, branch)
+                    ## DGM     fetch_path = salt.utils.path.join(
+                    ## DGM         branch_salt_dir, "fetch_request"
+                    ## DGM     )
+                    ## DGM     if os.path.isdir(branch_salt_dir):
+                    ## DGM         try:
+                    ## DGM             with salt.utils.files.fopen(fetch_path, "w"):
+                    ## DGM                 pass
+                    ## DGM         except OSError as exc:  # pylint: disable=broad-except
+                    ## DGM             log.error(
+                    ## DGM                 "Failed to make fetch request: %s %s",
+                    ## DGM                 fetch_path,
+                    ## DGM                 exc,
+                    ## DGM                 exc_info=True,
+                    ## DGM             )
+                    ## DGM     else:
+                    ## DGM         log.error("Failed to make fetch request: %s", fetch_path)
+
                     # Find and place fetch_request file for all the other branches for this repo
                     repo_work_hash = os.path.split(repo.get_salt_working_dir())[0]
+                    print(
+                        f"DGM class GitBase fetch_remotes, repo_work_hash '{repo_work_hash}', salt working dir '{repo.get_salt_working_dir()}'",
+                        flush=True,
+                    )
+
+                    branches = [
+                        os.path.relpath(path, repo_work_hash)
+                        for (path, subdirs, files) in os.walk(repo_work_hash)
+                        if not subdirs
+                    ]
+                    print(
+                        f"DGM class GitBase fetch_remotes, branches '{branches}' from repo_work_hash '{repo_work_hash}'",
+                        flush=True,
+                    )
+
+                    ## DGM for branch in os.listdir(repo_work_hash):
+                    for branch in os.listdir(branches):
+                        # Don't place fetch request in current branch being updated
+                        print(
+                            f"DGM class GitBase fetch_remotes, for loop branch, branch '{branch}', repo get_cache_basename '{repo.get_cache_basename()}'",
+                            flush=True,
+                        )
+                        if branch == repo.get_cache_basename():
+                            continue
+                        branch_salt_dir = salt.utils.path.join(repo_work_hash, branch)
+                        fetch_path = salt.utils.path.join(
+                            branch_salt_dir, "fetch_request"
+                        )
+                        print(
+                            f"DGM class GitBase fetch_remotes, for loop branch, branch_salt_dir '{branch_salt_dir}', fetch_path '{fetch_path}'",
+                            flush=True,
+                        )
+                        if os.path.isdir(branch_salt_dir):
+                            try:
+                                with salt.utils.files.fopen(fetch_path, "w"):
+                                    pass
+                            except OSError as exc:  # pylint: disable=broad-except
+                                log.error(
+                                    "Failed to make fetch request: %s %s",
+                                    fetch_path,
+                                    exc,
+                                    exc_info=True,
+                                )
+                        else:
+                            log.error("Failed to make fetch request: %s", fetch_path)
                     for branch in os.listdir(repo_work_hash):
                         # Don't place fetch request in current branch being updated
                         if branch == repo.get_cache_basename():

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -491,9 +491,10 @@ class GitProvider:
         self._cache_basename = "_"
         if self.id.startswith("__env__"):
             try:
-                self._cache_basename = self.get_checkout_target().replace(
-                    "/", "-"
-                )  # replace '/' with '-' to not cause trouble with file-system
+                ## DGM self._cache_basename = self.get_checkout_target().replace(
+                ## DGM     "/", "-"
+                ## DGM )  # replace '/' with '-' to not cause trouble with file-system
+                self._cache_basename = self.get_checkout_target()
 
             except AttributeError:
                 log.critical(


### PR DESCRIPTION
### What does this PR do?
Need to implement os.walk for handling traversal of Git Pillar branch names with a '/' slash in the Git branch name,

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/67722

### Previous Behavior
Previous behavior was to replace a '/' in the middle of a git branch name with a '-'

### New Behavior
Leaves the git branch name unmodified and uses a os.walk to ensure the '/' in a git branch name is handled without modifying the git branch name behavior

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
