### PR TITLE
Bump jinja2 to 3.1.5 due to GHSA-q2x7-8rv6-6q7h and GHSA-gmj6-6f8f-6699

### DIFF
--- a/changelog/67128.security.md
+++ b/changelog/67128.security.md
@@ -1,0 +1,1 @@
+Bump to ``jinja2==3.1.5`` due to https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h and https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699

--- a/requirements/static/ci/py3.10/changelog.txt
+++ b/requirements/static/ci/py3.10/changelog.txt
@@ -13,7 +13,7 @@ click==7.1.1
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -250,7 +250,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -183,7 +183,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -75,7 +75,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -175,7 +175,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -253,7 +253,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -184,7 +184,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/tools.txt
+++ b/requirements/static/ci/py3.10/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -174,7 +174,7 @@ jaraco.text==3.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/changelog.txt
+++ b/requirements/static/ci/py3.11/changelog.txt
@@ -13,7 +13,7 @@ click==7.1.1
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -242,7 +242,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -176,7 +176,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -75,7 +75,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -171,7 +171,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -249,7 +249,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -180,7 +180,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/tools.txt
+++ b/requirements/static/ci/py3.11/tools.txt
@@ -24,7 +24,7 @@ commonmark==0.9.1
     # via rich
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -170,7 +170,7 @@ jaraco.text==3.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/changelog.txt
+++ b/requirements/static/ci/py3.12/changelog.txt
@@ -13,7 +13,7 @@ click==7.1.1
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -242,7 +242,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -176,7 +176,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -75,7 +75,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -171,7 +171,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -249,7 +249,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -180,7 +180,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/tools.txt
+++ b/requirements/static/ci/py3.12/tools.txt
@@ -24,7 +24,7 @@ commonmark==0.9.1
     # via rich
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -170,7 +170,7 @@ jaraco.text==3.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/changelog.txt
+++ b/requirements/static/ci/py3.8/changelog.txt
@@ -13,7 +13,7 @@ click==7.1.1
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -261,7 +261,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -75,7 +75,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -183,7 +183,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -259,7 +259,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -c requirements/static/ci/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -189,7 +189,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -176,7 +176,7 @@ jaraco.text==3.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/changelog.txt
+++ b/requirements/static/ci/py3.9/changelog.txt
@@ -13,7 +13,7 @@ click==7.1.1
     #   towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   towncrier

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -261,7 +261,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -191,7 +191,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -79,7 +79,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -183,7 +183,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -255,7 +255,7 @@ jaraco.text==3.5.1
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -187,7 +187,7 @@ jaraco.text==3.5.1
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/tools.txt
+++ b/requirements/static/ci/py3.9/tools.txt
@@ -22,7 +22,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.7
     # via requests
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/static/ci/tools.in
 jmespath==1.0.1
     # via

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -176,7 +176,7 @@ jaraco.text==3.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -52,7 +52,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -46,7 +46,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -44,7 +44,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -53,7 +53,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -52,7 +52,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -46,7 +46,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -44,7 +44,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -53,7 +53,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -52,7 +52,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -46,7 +46,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -44,7 +44,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -53,7 +53,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -46,7 +46,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -44,7 +44,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -53,7 +53,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -52,7 +52,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -46,7 +46,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -44,7 +44,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.1
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -53,7 +53,7 @@ jaraco.functools==2.0
     #   tempora
 jaraco.text==3.5.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements/base.txt
 jmespath==1.0.1
     # via -r requirements/base.txt


### PR DESCRIPTION
### What does this PR do?
Bump jinja2 to 3.1.5 due to [GHSA-q2x7-8rv6-6q7h](https://github.com/pallets/jinja/security/advisories/GHSA-q2x7-8rv6-6q7h) and [GHSA-gmj6-6f8f-6699](https://github.com/pallets/jinja/security/advisories/GHSA-gmj6-6f8f-6699).

### What issues does this PR fix or reference?
Fixes #67128 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
