### PR TITLE
[aptpkg] Add deb822 repository format support

### DIFF
--- a/changelog/67748.added.md
+++ b/changelog/67748.added.md
@@ -1,0 +1,1 @@
+Enhance aptpkg to support the DEB822 repository format

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3004,11 +3004,11 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
         if HAS_DEB822:
             apt_source_file = kwargs.get("file")
             section = _deb822.Section("")
-            section["Types"] = repo_type
-            section["URIs"] = repo_uri
-            section["Suites"] = repo_dist
-            section["Components"] = " ".join(repo_comps)
-            if kwargs.get("trusted") == True or kwargs.get("Trusted") == True:
+            section["Types"] = repo_entry["type"]
+            section["URIs"] = repo_entry["uri"]
+            section["Suites"] = repo_entry["dist"]
+            section["Components"] = " ".join(repo_entry["comps"])
+            if kwargs.get("trusted") or kwargs.get("Trusted"):
                 section["Trusted"] = "yes"
             mod_source = Deb822SourceEntry(section, apt_source_file)
         else:
@@ -3019,7 +3019,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
     elif "comments" in kwargs:
         mod_source.comment = kwargs["comments"]
 
-    mod_source.line = repo_source_entry.line  # TODO: Check
+    mod_source.line = repo_source_entry.line
     if not mod_source.line.endswith("\n"):
         mod_source.line = mod_source.line + "\n"
 
@@ -3048,7 +3048,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
 
     repo_source_line = mod_source.line
     if "Types: " in repo_source_line and "\n" in repo_source_line:
-        repo_source_line = f"{mod_source.type} {mod_source.uri} {repo_dist} {' '.join(mod_source.comps)}"
+        repo_source_line = f"{mod_source.type} {mod_source.uri} {repo_entry['dist']} {' '.join(mod_source.comps)}"
 
     return {
         repo: {

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -359,7 +359,7 @@ def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
 
     result = aptpkg.get_repo(repo)
 
-    assert bool(result) == True
+    assert bool(result)
     assert result["uri"] == uri
 
 


### PR DESCRIPTION
### What does this PR do?

In this PR, we are:

- Adding aptpkg support for repositories in the deb 822 format.
- Improving the docs a little bit (I found the examples for aptpkg to be not very useful)

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66928, https://github.com/saltstack/salt/discussions/67334, #67760

Forward port from: https://github.com/openSUSE/salt/pull/692

### Previous Behavior
Deb822 repositories are not recognized.

### New Behavior
Users can use debian repositories in either the DEB822 or the old one-line format.  

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices, including the
[PR Guidelines](https://docs.saltproject.io/en/master/topics/development/pull_requests.html).

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
