### PR TITLE
paste error in disable_job

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -713,7 +713,7 @@ def disable_job(name, **kwargs):
                         return ret
         except KeyError:
             # Effectively a no-op, since we can't really return without an event system
-            ret['comment'] = 'Event module not available. Schedule enable job failed.'
+            ret['comment'] = 'Event module not available. Schedule disable job failed.'
     return ret
 
 


### PR DESCRIPTION
error states "enable job failed" in disable_job

### What does this PR do?
Corrects a copy-pasta error in disable_job

### Previous Behavior
Outputs "Event module not available. Schedule enable job failed." on failure.

### New Behavior
Outputs "Event module not available. Schedule disable job failed." on failure.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Unknown 
