### PR TITLE
Implement multiple inventory for `ansible.targets`

### DIFF
--- a/changelog/67776.added.md
+++ b/changelog/67776.added.md
@@ -1,0 +1,1 @@
+Added possibility to load data from multiple inventories with `ansible.targets`.

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -420,7 +420,7 @@ def playbooks(
     return retdata
 
 
-def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
+def targets(inventory=None, inventories=None, yaml=False, export=False):
     """
     .. versionadded:: 3005
 
@@ -428,6 +428,10 @@ def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
 
     :param inventory:
         The inventory file to read the inventory from. Default: "/etc/ansible/hosts"
+
+    :param inventories:
+        The list of inventory files to read the inventory from.
+        Uses `inventory` in case if `inventories` is not specified.
 
     :param yaml:
         Return the inventory as yaml output. Default: False
@@ -443,7 +447,9 @@ def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
         salt 'ansiblehost' ansible.targets inventory=my_custom_inventory
 
     """
-    return salt.utils.ansible.targets(inventory=inventory, yaml=yaml, export=export)
+    return salt.utils.ansible.targets(
+        inventory=inventory, inventories=inventories, yaml=yaml, export=export
+    )
 
 
 def discover_playbooks(

--- a/salt/utils/ansible.py
+++ b/salt/utils/ansible.py
@@ -18,30 +18,57 @@ def __virtual__():
     return (False, "Install `ansible` to use inventory")
 
 
-def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
+def targets(inventory=None, inventories=None, yaml=False, export=False):
     """
     Return the targets from the ansible inventory_file
     Default: /etc/salt/roster
     """
-    if not os.path.isfile(inventory):
-        raise CommandExecutionError(f"Inventory file not found: {inventory}")
-    if not os.path.isabs(inventory):
-        raise CommandExecutionError("Path to inventory file must be an absolute path")
+
+    if inventory is None and inventories is None:
+        inventory = "/etc/ansible/hosts"
+    multi_inventory = True
+    if not isinstance(inventories, list):
+        multi_inventory = False
+        inventories = []
+    if inventory is not None and inventory not in inventories:
+        inventories.append(inventory)
 
     extra_cmd = []
     if export:
         extra_cmd.append("--export")
     if yaml:
         extra_cmd.append("--yaml")
-    inv = salt.modules.cmdmod.run(
-        "ansible-inventory -i {} --list {}".format(inventory, " ".join(extra_cmd)),
-        env={"ANSIBLE_DEPRECATION_WARNINGS": "0"},
-        reset_system_locale=False,
-    )
-    if yaml:
-        return salt.utils.stringutils.to_str(inv)
-    else:
-        try:
-            return salt.utils.json.loads(salt.utils.stringutils.to_str(inv))
-        except ValueError:
-            raise CommandExecutionError(f"Error processing the inventory: {inv}")
+
+    ret = {}
+
+    for inventory in inventories:
+        if not os.path.isfile(inventory):
+            raise CommandExecutionError(f"Inventory file not found: {inventory}")
+        if not os.path.isabs(inventory):
+            raise CommandExecutionError(
+                f"Path to inventory file must be an absolute path: {inventory}"
+            )
+
+        inv = salt.modules.cmdmod.run(
+            "ansible-inventory -i {} --list {}".format(inventory, " ".join(extra_cmd)),
+            env={"ANSIBLE_DEPRECATION_WARNINGS": "0"},
+            reset_system_locale=False,
+        )
+
+        if yaml:
+            inv = salt.utils.stringutils.to_str(inv)
+        else:
+            try:
+                inv = salt.utils.json.loads(salt.utils.stringutils.to_str(inv))
+            except ValueError:
+                raise CommandExecutionError(
+                    f"Error processing the inventory {inventory}: {inv}"
+                )
+
+        if not multi_inventory:
+            ret = inv
+            break
+
+        ret[inventory] = inv
+
+    return ret


### PR DESCRIPTION
### What does this PR do?

Adds `inventories` parameter for `ansible.targets` in case if the list passed to this parameter the function will return the dict with the inventory filenames as the keys and the content inside.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26439

### Previous Behavior
`ansible.targets` returns the content of only one single inventory

### New Behavior
`ansible.targets` can return the content of multiple inventory files

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
