### PR TITLE
Remove extra space in process title

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -59,7 +59,7 @@ def appendproctitle(name):
         current = setproctitle.getproctitle()
         if current.strip().endswith("MainProcess"):
             current, _ = current.rsplit("MainProcess", 1)
-        setproctitle.setproctitle(f"{current.rstrip()} {name}")
+        setproctitle.setproctitle(f"{current.rstrip()}{name}")
 
 
 def daemonize(redirect_out=True):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -59,7 +59,10 @@ def appendproctitle(name):
         current = setproctitle.getproctitle()
         if current.strip().endswith("MainProcess"):
             current, _ = current.rsplit("MainProcess", 1)
-        setproctitle.setproctitle(f"{current.rstrip()}{name}")
+        if len(current) > 0:
+            setproctitle.setproctitle(f"{current.rstrip()} {name}")
+        else:
+            setproctitle.setproctitle(name)
 
 
 def daemonize(redirect_out=True):


### PR DESCRIPTION
Remove an extra space in daemons' process title.
before:
```
python3.11:  MultiMinionProcessManager MinionProcessManager (python3.11)
```
after:
```
python3.11: MultiMinionProcessManager MinionProcessManager (python3.11)
```
The extra space confuses FreeBSD's RC script.  See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285053

### What does this PR do?

Changes a double space in the minion's process title into a single space

### What issues does this PR fix or reference?
Partially fixes `service salt_minion status` and related commands on FreeBSD.  Some additional changes are necessary to completely fix the issue.
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285053

### Previous Behavior
The process title had two spaces between "python3.11:" and "MultiMinionProcessManager"

### New Behavior
The process title only has one space.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes