### PR TITLE
Make x509 module compatible with M2Crypto 0.44.0

### DIFF
--- a/changelog/67782.fixed.md
+++ b/changelog/67782.fixed.md
@@ -1,0 +1,1 @@
+Make x509 module compatible with M2Crypto 0.44.0.

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -43,6 +43,10 @@ from salt.utils.odict import OrderedDict
 try:
     import M2Crypto
 
+    # These imports intended to be used from M2Crypto,
+    # but not loaded by-default with recent M2Crypto version.
+    from M2Crypto import ASN1, BIO, EVP, RSA, X509, m2  # pylint: disable=unused-import
+
     HAS_M2 = True
 except ImportError:
     HAS_M2 = False


### PR DESCRIPTION
### What does this PR do?

Even if the module is specified as deprecated, we need to keep it working until it gets removed with `3009`.
With the most recent M2Crypto version there are differences in the exported objects, so it's better to align import to make it compatible.

### Previous Behavior
Exceptions on loading the module with new M2Crypto version due to the differences in exports

### New Behavior
Now is compatible with new and the previous versions

### Merge requirements satisfied?
No need to adjust the tests as they were failing with the recent M2Crypto version.

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
