### PR TITLE
[3006.x] Removed dependency on bsdmainutils package for Debian and Ubuntu

### DIFF
--- a/changelog/67184.removed.md
+++ b/changelog/67184.removed.md
@@ -1,0 +1,1 @@
+Removed dependency on bsdmainutils package for Debian and Ubuntu

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -79,8 +79,7 @@ Package: salt-minion
 Architecture: amd64 arm64
 Replaces: salt-common (<= 3006.4)
 Breaks: salt-common (<= 3006.4)
-Depends: bsdmainutils,
-         dctrl-tools,
+Depends: dctrl-tools,
          salt-common (= ${source:Version}),
          ${misc:Depends}
 Recommends: debconf-utils, dmidecode, net-tools


### PR DESCRIPTION
### What does this PR do?
Removes dependency on bsdmainutils package for Debian and Ubuntu, since this packages is basically only providing ncal and calendar at this point.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/67184


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
