### PR TITLE
enhance firewalld modules and states with ipset, zone_absent, service_absent

### DIFF
--- a/changelog/67790.added.md
+++ b/changelog/67790.added.md
@@ -1,0 +1,1 @@
+Add ipset support to firewalld module and states, add zone_absent, service_absent, and target option to zone_present.

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -1042,6 +1042,7 @@ def remove_rich_rule(zone, rule, permanent=True):
 
     return __firewall_cmd(cmd)
 
+
 def get_target(zone):
     """
     Get zone's target
@@ -1101,7 +1102,9 @@ def __parse_ipset(cmd):
                         else:
                             _ipset[ipset_name].update({id_: val.strip().split(" ")})
                     elif id_ == "options":
-                        _ipset[ipset_name].update({id_: dict(item.split("=") for item in val.split())})
+                        _ipset[ipset_name].update(
+                            {id_: dict(item.split("=") for item in val.split())}
+                        )
                     else:
                         _ipset[ipset_name].update({id_: [val.strip()]})
                 else:
@@ -1142,7 +1145,7 @@ def info_ipset(ipset):
     return __parse_ipset(cmd)
 
 
-def new_ipset(ipset, ipset_type, family=None, options={}, restart=False):
+def new_ipset(ipset, ipset_type, family=None, options=None, restart=False):
     """
     Add a new ipset
 
@@ -1159,7 +1162,7 @@ def new_ipset(ipset, ipset_type, family=None, options={}, restart=False):
 
         salt '*' firewalld.new_ipset my_ipset False
     """
-    cmd = f'--permanent --new-ipset={ipset} --type={ipset_type}'
+    cmd = f"--permanent --new-ipset={ipset} --type={ipset_type}"
 
     if family:
         cmd += f" --family={family}"

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -425,7 +425,7 @@ def remove_service(service, zone=None, permanent=True):
     return __firewall_cmd(cmd)
 
 
-def add_service_port(service, port):
+def add_service_port(service, port, check_service=True):
     """
     Add a new port to the specified service.
 
@@ -437,14 +437,14 @@ def add_service_port(service, port):
 
         salt '*' firewalld.add_service_port zone 80
     """
-    if service not in get_services(permanent=True):
+    if check_service and service not in get_services(permanent=True):
         raise CommandExecutionError("The service does not exist.")
 
     cmd = f"--permanent --service={service} --add-port={port}"
     return __firewall_cmd(cmd)
 
 
-def remove_service_port(service, port):
+def remove_service_port(service, port, check_service=True):
     """
     Remove a port from the specified service.
 
@@ -456,7 +456,7 @@ def remove_service_port(service, port):
 
         salt '*' firewalld.remove_service_port zone 80
     """
-    if service not in get_services(permanent=True):
+    if check_service and service not in get_services(permanent=True):
         raise CommandExecutionError("The service does not exist.")
 
     cmd = f"--permanent --service={service} --remove-port={port}"
@@ -1040,4 +1040,192 @@ def remove_rich_rule(zone, rule, permanent=True):
     if permanent:
         cmd += " --permanent"
 
+    return __firewall_cmd(cmd)
+
+def get_target(zone):
+    """
+    Get zone's target
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.get_target zone
+    """
+    cmd = f"--zone={zone} --get-target --permanent"
+
+    return __firewall_cmd(cmd)
+
+
+def set_target(zone, target, permanent=True):
+    """
+    Set zone's target
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.set_target zone 'DROP'
+    """
+    cmd = f"--zone={zone} --set-target='{target}'"
+
+    if permanent:
+        cmd += " --permanent"
+
+    return __firewall_cmd(cmd)
+
+
+def __parse_ipset(cmd):
+    """
+    Return ipset information in a dictionary
+    """
+    _ipset = {}
+    id_ = ""
+
+    for i in __firewall_cmd(cmd).splitlines():
+        if i.strip():
+            if re.match("^[a-z0-9]", i, re.I):
+                ipset_name = i.rstrip()
+            else:
+                if i.startswith("\t"):
+                    _ipset[ipset_name][id_].append(i.strip())
+                    continue
+
+                (id_, val) = i.split(":", 1)
+
+                id_ = id_.strip()
+                if _ipset.get(ipset_name, None):
+                    if id_ == "entries":
+                        if val == "":
+                            _ipset[ipset_name].update({id_: []})
+                        else:
+                            _ipset[ipset_name].update({id_: val.strip().split(" ")})
+                    elif id_ == "options":
+                        _ipset[ipset_name].update({id_: dict(item.split("=") for item in val.split())})
+                    else:
+                        _ipset[ipset_name].update({id_: [val.strip()]})
+                else:
+                    _ipset[ipset_name] = {id_: [val.strip()]}
+    return _ipset
+
+
+def get_ipsets(permanent=True):
+    """
+    Print predefined ipsets
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.get_ipsets
+    """
+    cmd = "--get-ipsets"
+
+    if permanent:
+        cmd += " --permanent"
+
+    return __firewall_cmd(cmd).split()
+
+
+def info_ipset(ipset):
+    """
+    Print ipset info
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.get_ipsets
+    """
+    cmd = f"--info-ipset={ipset} --permanent"
+
+    return __parse_ipset(cmd)
+
+
+def new_ipset(ipset, ipset_type, family=None, options={}, restart=False):
+    """
+    Add a new ipset
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.new_ipset my_ipset
+
+    By default firewalld will be reloaded. However, to avoid reloading
+    you need to specify the restart as False
+
+    .. code-block:: bash
+
+        salt '*' firewalld.new_ipset my_ipset False
+    """
+    cmd = f'--permanent --new-ipset={ipset} --type={ipset_type}'
+
+    if family:
+        cmd += f" --family={family}"
+
+    if options:
+        for k, v in options.items():
+            cmd += f" --option={k}={v}"
+
+    out = __firewall_cmd(cmd)
+
+    if restart:
+        if out == "success":
+            return __firewall_cmd("--reload")
+
+    return out
+
+
+def delete_ipset(ipset, permanent=True, restart=True):
+    """
+    Delete an existing ipset
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.delete_ipset my_ipset
+
+    By default firewalld will be reloaded. However, to avoid reloading
+    you need to specify the restart as False
+
+    .. code-block:: bash
+
+        salt '*' firewalld.delete_ipset my_ipset False
+    """
+    out = __mgmt(ipset, "ipset", "delete")
+
+    if restart:
+        if out == "success":
+            return __firewall_cmd("--reload")
+
+    return out
+
+
+def add_ipset_entry(ipset, entry):
+    """
+    Add an new entry to the specified ipset.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.add_ipset_entry ipset1 10.0.0.1/32
+    """
+    cmd = f"--permanent --ipset={ipset} --add-entry={entry}"
+    return __firewall_cmd(cmd)
+
+
+def remove_ipset_entry(ipset, entry):
+    """
+    Remove an entry from the specified ipset.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewalld.remove_ipset_entry ipset1 10.0.0.1/32
+    """
+    cmd = f"--permanent --ipset={ipset} --remove-entry={entry}"
     return __firewall_cmd(cmd)

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -249,6 +249,7 @@ def service(name, ports=None, protocols=None):
     """
     return service_present(name, ports, protocols)
 
+
 def service_absent(name):
     """
     Ensure the service does not exists.
@@ -275,6 +276,7 @@ def service_absent(name):
         return ret
 
     return ret
+
 
 def service_present(name, ports=None, protocols=None):
     """
@@ -314,16 +316,16 @@ def service_present(name, ports=None, protocols=None):
 
     if ports:
         ports = ports or []
-    
+
         try:
             _current_ports = __salt__["firewalld.get_service_ports"](name)
         except CommandExecutionError as err:
             ret["comment"] = f"Error: {err}"
             return ret
-    
+
         new_ports = set(ports) - set(_current_ports)
         old_ports = set(_current_ports) - set(ports)
-    
+
         for port in new_ports:
             if not __opts__["test"]:
                 try:
@@ -331,7 +333,7 @@ def service_present(name, ports=None, protocols=None):
                 except CommandExecutionError as err:
                     ret["comment"] = f"Error: {err}"
                     return ret
-    
+
         for port in old_ports:
             if not __opts__["test"]:
                 try:
@@ -344,37 +346,37 @@ def service_present(name, ports=None, protocols=None):
             ret["changes"].update({"ports": {"old": _current_ports, "new": ports}})
 
     if protocols:
-       protocols = protocols or []
-   
-       try:
-           _current_protocols = __salt__["firewalld.get_service_protocols"](name)
-       except CommandExecutionError as err:
-           ret["comment"] = f"Error: {err}"
-           return ret
-   
-       new_protocols = set(protocols) - set(_current_protocols)
-       old_protocols = set(_current_protocols) - set(protocols)
-   
-       for protocol in new_protocols:
-           if not __opts__["test"]:
-               try:
-                   __salt__["firewalld.add_service_protocol"](name, protocol)
-               except CommandExecutionError as err:
-                   ret["comment"] = f"Error: {err}"
-                   return ret
-   
-       for protocol in old_protocols:
-           if not __opts__["test"]:
-               try:
-                   __salt__["firewalld.remove_service_protocol"](name, protocol)
-               except CommandExecutionError as err:
-                   ret["comment"] = f"Error: {err}"
-                   return ret
-   
-       if new_protocols or old_protocols:
-           ret["changes"].update(
-               {"protocols": {"old": _current_protocols, "new": protocols}}
-           )
+        protocols = protocols or []
+
+        try:
+            _current_protocols = __salt__["firewalld.get_service_protocols"](name)
+        except CommandExecutionError as err:
+            ret["comment"] = f"Error: {err}"
+            return ret
+
+        new_protocols = set(protocols) - set(_current_protocols)
+        old_protocols = set(_current_protocols) - set(protocols)
+
+        for protocol in new_protocols:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.add_service_protocol"](name, protocol)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+
+        for protocol in old_protocols:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.remove_service_protocol"](name, protocol)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+
+        if new_protocols or old_protocols:
+            ret["changes"].update(
+                {"protocols": {"old": _current_protocols, "new": protocols}}
+            )
 
     ret["result"] = True
     if ret["changes"] == {}:
@@ -428,7 +430,15 @@ def _normalize_rich_rules(rich_rules):
         normalized_rules.append(normalized_rule.lstrip())
     return normalized_rules
 
+
 def zone_absent(name):
+    """
+    Ensure the zone does not exists.
+
+    name
+        The zone to delete.
+
+    """
     ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
     if name in __salt__["firewalld.get_zones"](permanent=True):
@@ -447,6 +457,7 @@ def zone_absent(name):
         return ret
 
     return ret
+
 
 def zone_present(
     name,
@@ -565,12 +576,12 @@ def zone_present(
                     ret["comment"] = f"Error: {err}"
                     return ret
             ret["changes"].update(
-                    {
-                        "target": {
-                            "old": target_ret,
-                            "new": target,
-                        }
+                {
+                    "target": {
+                        "old": target_ret,
+                        "new": target,
                     }
+                }
             )
 
     if block_icmp or prune_block_icmp:
@@ -649,7 +660,6 @@ def zone_present(
                     ret["comment"] = f"Error: {err}"
                     return ret
             ret["changes"].update({"default": {"old": default_zone, "new": name}})
-
 
     if masquerade is not None:
         try:
@@ -1020,7 +1030,7 @@ def ipset_absent(name):
     return ret
 
 
-def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
+def ipset_present(name, ipset_type, family=None, options=None, entries=None):
     """
     Ensure the ipset exists and encompasses the specified entries.
 
@@ -1033,10 +1043,10 @@ def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
     family: None
         Address family, can be inet or inet6.
 
-    options: {}
+    options: None
         List of options to add to the ipset, can be timeout, maxelen or hashsize.
 
-    entries: []
+    entries: None
         List of entry to add to the ipset.
     """
 
@@ -1052,17 +1062,17 @@ def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
 
     if entries:
         entries = entries or []
-    
+
         try:
             info_ipset = __salt__["firewalld.info_ipset"](name)[name]
         except CommandExecutionError as err:
             ret["comment"] = f"Error: {err}"
             return ret
-    
-        _current_entries = info_ipset.get('entries', [])
+
+        _current_entries = info_ipset.get("entries", [])
         new_entries = set(entries) - set(_current_entries)
         old_entries = set(_current_entries) - set(entries)
-    
+
         for entry in new_entries:
             if not __opts__["test"]:
                 try:
@@ -1070,7 +1080,7 @@ def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
                 except CommandExecutionError as err:
                     ret["comment"] = f"Error: {err}"
                     return ret
-    
+
         for entry in old_entries:
             if not __opts__["test"]:
                 try:
@@ -1080,7 +1090,9 @@ def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
                     return ret
 
         if new_entries or old_entries:
-            ret["changes"].update({"entries": {"old": _current_entries, "new": entries}})
+            ret["changes"].update(
+                {"entries": {"old": _current_entries, "new": entries}}
+            )
 
     ret["result"] = True
     if ret["changes"] == {}:

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -100,6 +100,19 @@ with an example output of:
   rule protocol value="icmp" accept
   rule protocol value="ipv6-icmp" accept
   rule service name="snmp" accept
+
+Here, we define a new ipset that include 1.1.1.1/32 and 8.8.8.8/32:
+
+.. code-block:: yaml
+
+  saltmaster:
+    firewalld.ipset_present:
+      - name: ipset_salt
+      - ipset_type: hash:net
+      - entries:
+        - 1.1.1.1/32
+        - 8.8.8.8/32
+
 """
 
 import logging
@@ -186,6 +199,7 @@ def __virtual__():
 
 def present(
     name,
+    target=None,
     block_icmp=None,
     prune_block_icmp=False,
     default=None,
@@ -204,62 +218,11 @@ def present(
     prune_rich_rules=False,
 ):
     """
-    Ensure a zone has specific attributes.
-
-    name
-        The zone to modify.
-
-    default : None
-        Set this zone as the default zone if ``True``.
-
-    masquerade : None
-        Enable or disable masquerade for a zone. By default it will not change it.
-
-    block_icmp : None
-        List of ICMP types to block in the zone.
-
-    prune_block_icmp : False
-        If ``True``, remove all but the specified block_icmp from the zone.
-
-    ports : None
-        List of ports to add to the zone.
-
-    prune_ports : False
-        If ``True``, remove all but the specified ports from the zone.
-
-    port_fwd : None
-        List of port forwards to add to the zone.
-
-    prune_port_fwd : False
-        If ``True``, remove all but the specified port_fwd from the zone.
-
-    services : None
-        List of services to add to the zone.
-
-    prune_services : False
-        If ``True``, remove all but the specified services from the zone.
-        .. note:: Currently defaults to True for compatibility, but will be changed to False in a future release.
-
-    interfaces : None
-        List of interfaces to add to the zone.
-
-    prune_interfaces : False
-        If ``True``, remove all but the specified interfaces from the zone.
-
-    sources : None
-        List of sources to add to the zone.
-
-    prune_sources : False
-        If ``True``, remove all but the specified sources from the zone.
-
-    rich_rules : None
-        List of rich rules to add to the zone.
-
-    prune_rich_rules : False
-        If ``True``, remove all but the specified rich rules from the zone.
+    Ensure a zone has specific attributes. Alias to zone_present.
     """
-    ret = _present(
+    return zone_present(
         name,
+        target,
         block_icmp,
         prune_block_icmp,
         default,
@@ -278,89 +241,140 @@ def present(
         prune_rich_rules,
     )
 
-    # Reload firewalld service on changes
-    if ret["changes"] != {}:
-        __salt__["firewalld.reload_rules"]()
-
-    return ret
-
 
 def service(name, ports=None, protocols=None):
     """
     Ensure the service exists and encompasses the specified ports and
-    protocols.
+    protocols. Alias to service_present.
+    """
+    return service_present(name, ports, protocols)
 
-    .. versionadded:: 2016.11.0
+def service_absent(name):
+    """
+    Ensure the service does not exists.
+
+    name
+        The service to delete.
+
     """
     ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
-    if name not in __salt__["firewalld.get_services"]():
-        __salt__["firewalld.new_service"](name, restart=False)
+    if name in __salt__["firewalld.get_services"](permanent=True):
+        if not __opts__["test"]:
+            __salt__["firewalld.delete_service"](name, True)
+            ret["result"] = True
+            ret["comment"] = f"'{name}' has been deleted."
+            return ret
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' exists, it will be deleted."
+            return ret
+    else:
+        ret["result"] = True
+        ret["comment"] = f"'{name}' does not exist."
+        return ret
 
-    ports = ports or []
+    return ret
+
+def service_present(name, ports=None, protocols=None):
+    """
+    Ensure the service exists and encompasses the specified ports and
+    protocols.
+
+    name
+        The service to modify.
+
+    ports: None
+        List of ports to add to the service.
+
+    protocols: None
+        List of protocols to add to the service.
+    """
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
     try:
-        _current_ports = __salt__["firewalld.get_service_ports"](name)
+        services = __salt__["firewalld.get_services"]()
     except CommandExecutionError as err:
         ret["comment"] = f"Error: {err}"
         return ret
 
-    new_ports = set(ports) - set(_current_ports)
-    old_ports = set(_current_ports) - set(ports)
-
-    for port in new_ports:
+    if name not in services:
         if not __opts__["test"]:
             try:
-                __salt__["firewalld.add_service_port"](name, port)
+                __salt__["firewalld.new_service"](name, restart=False)
             except CommandExecutionError as err:
                 ret["comment"] = f"Error: {err}"
                 return ret
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' will be created."
+            return ret
 
-    for port in old_ports:
-        if not __opts__["test"]:
-            try:
-                __salt__["firewalld.remove_service_port"](name, port)
-            except CommandExecutionError as err:
-                ret["comment"] = f"Error: {err}"
-                return ret
+        ret["changes"].update({name: {"old": [], "new": name}})
 
-    if new_ports or old_ports:
-        ret["changes"].update({"ports": {"old": _current_ports, "new": ports}})
+    if ports:
+        ports = ports or []
+    
+        try:
+            _current_ports = __salt__["firewalld.get_service_ports"](name)
+        except CommandExecutionError as err:
+            ret["comment"] = f"Error: {err}"
+            return ret
+    
+        new_ports = set(ports) - set(_current_ports)
+        old_ports = set(_current_ports) - set(ports)
+    
+        for port in new_ports:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.add_service_port"](name, port, False)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+    
+        for port in old_ports:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.remove_service_port"](name, port, False)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
 
-    protocols = protocols or []
+        if new_ports or old_ports:
+            ret["changes"].update({"ports": {"old": _current_ports, "new": ports}})
 
-    try:
-        _current_protocols = __salt__["firewalld.get_service_protocols"](name)
-    except CommandExecutionError as err:
-        ret["comment"] = f"Error: {err}"
-        return ret
-
-    new_protocols = set(protocols) - set(_current_protocols)
-    old_protocols = set(_current_protocols) - set(protocols)
-
-    for protocol in new_protocols:
-        if not __opts__["test"]:
-            try:
-                __salt__["firewalld.add_service_protocol"](name, protocol)
-            except CommandExecutionError as err:
-                ret["comment"] = f"Error: {err}"
-                return ret
-
-    for protocol in old_protocols:
-        if not __opts__["test"]:
-            try:
-                __salt__["firewalld.remove_service_protocol"](name, protocol)
-            except CommandExecutionError as err:
-                ret["comment"] = f"Error: {err}"
-                return ret
-
-    if new_protocols or old_protocols:
-        ret["changes"].update(
-            {"protocols": {"old": _current_protocols, "new": protocols}}
-        )
-
-    if ret["changes"] != {}:
-        __salt__["firewalld.reload_rules"]()
+    if protocols:
+       protocols = protocols or []
+   
+       try:
+           _current_protocols = __salt__["firewalld.get_service_protocols"](name)
+       except CommandExecutionError as err:
+           ret["comment"] = f"Error: {err}"
+           return ret
+   
+       new_protocols = set(protocols) - set(_current_protocols)
+       old_protocols = set(_current_protocols) - set(protocols)
+   
+       for protocol in new_protocols:
+           if not __opts__["test"]:
+               try:
+                   __salt__["firewalld.add_service_protocol"](name, protocol)
+               except CommandExecutionError as err:
+                   ret["comment"] = f"Error: {err}"
+                   return ret
+   
+       for protocol in old_protocols:
+           if not __opts__["test"]:
+               try:
+                   __salt__["firewalld.remove_service_protocol"](name, protocol)
+               except CommandExecutionError as err:
+                   ret["comment"] = f"Error: {err}"
+                   return ret
+   
+       if new_protocols or old_protocols:
+           ret["changes"].update(
+               {"protocols": {"old": _current_protocols, "new": protocols}}
+           )
 
     ret["result"] = True
     if ret["changes"] == {}:
@@ -371,6 +385,9 @@ def service(name, ports=None, protocols=None):
         ret["result"] = None
         ret["comment"] = f"Configuration for '{name}' will change."
         return ret
+
+    if ret["changes"] != {}:
+        __salt__["firewalld.reload_rules"]()
 
     ret["comment"] = f"'{name}' was configured."
     return ret
@@ -411,9 +428,29 @@ def _normalize_rich_rules(rich_rules):
         normalized_rules.append(normalized_rule.lstrip())
     return normalized_rules
 
+def zone_absent(name):
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
-def _present(
+    if name in __salt__["firewalld.get_zones"](permanent=True):
+        if not __opts__["test"]:
+            __salt__["firewalld.delete_zone"](name, True)
+            ret["result"] = True
+            ret["comment"] = f"'{name}' has been deleted."
+            return ret
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' exists, it will be deleted."
+            return ret
+    else:
+        ret["result"] = True
+        ret["comment"] = f"'{name}' does not exist."
+        return ret
+
+    return ret
+
+def zone_present(
     name,
+    target=None,
     block_icmp=None,
     prune_block_icmp=False,
     default=None,
@@ -435,6 +472,61 @@ def _present(
 ):
     """
     Ensure a zone has specific attributes.
+
+    name
+        The zone to modify.
+
+    target: None
+        Set the target zone, zones target is one of: default, ACCEPT, DROP, REJECT.
+
+    default: None
+        Set this zone as the default zone if ``True``.
+
+    masquerade: None
+        Enable or disable masquerade for a zone. By default it will not change it.
+
+    block_icmp: None
+        List of ICMP types to block in the zone.
+
+    prune_block_icmp: False
+        If ``True``, remove all but the specified block_icmp from the zone.
+
+    ports: None
+        List of ports to add to the zone.
+
+    prune_ports: False
+        If ``True``, remove all but the specified ports from the zone.
+
+    port_fwd: None
+        List of port forwards to add to the zone.
+
+    prune_port_fwd: False
+        If ``True``, remove all but the specified port_fwd from the zone.
+
+    services: None
+        List of services to add to the zone.
+
+    prune_services: False
+        If ``True``, remove all but the specified services from the zone.
+        .. note:: Currently defaults to True for compatibility, but will be changed to False in a future release.
+
+    interfaces: None
+        List of interfaces to add to the zone.
+
+    prune_interfaces: False
+        If ``True``, remove all but the specified interfaces from the zone.
+
+    sources: None
+        List of sources to add to the zone.
+
+    prune_sources: False
+        If ``True``, remove all but the specified sources from the zone.
+
+    rich_rules: None
+        List of rich rules to add to the zone.
+
+    prune_rich_rules: False
+        If ``True``, remove all but the specified rich rules from the zone.
     """
     ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
@@ -451,8 +543,35 @@ def _present(
             except CommandExecutionError as err:
                 ret["comment"] = f"Error: {err}"
                 return ret
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' will be created."
+            return ret
 
-        ret["changes"].update({name: {"old": zones, "new": name}})
+        ret["changes"].update({name: {"old": [], "new": name}})
+
+    if target is not None:
+        try:
+            target_ret = __salt__["firewalld.get_target"](name)
+        except CommandExecutionError as err:
+            ret["comment"] = f"Error: {err}"
+            return ret
+
+        if target != target_ret:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.set_target"](name, target, permanent=True)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+            ret["changes"].update(
+                    {
+                        "target": {
+                            "old": target_ret,
+                            "new": target,
+                        }
+                    }
+            )
 
     if block_icmp or prune_block_icmp:
         block_icmp = block_icmp or []
@@ -531,12 +650,14 @@ def _present(
                     return ret
             ret["changes"].update({"default": {"old": default_zone, "new": name}})
 
-    try:
-        masquerade_ret = __salt__["firewalld.get_masquerade"](name, permanent=True)
-    except CommandExecutionError as err:
-        ret["comment"] = f"Error: {err}"
-        return ret
+
     if masquerade is not None:
+        try:
+            masquerade_ret = __salt__["firewalld.get_masquerade"](name, permanent=True)
+        except CommandExecutionError as err:
+            ret["comment"] = f"Error: {err}"
+            return ret
+
         if masquerade and not masquerade_ret:
             if not __opts__["test"]:
                 try:
@@ -686,7 +807,6 @@ def _present(
         except CommandExecutionError as err:
             ret["comment"] = f"Error: {err}"
             return ret
-
         new_services = set(services) - set(_current_services)
         old_services = []
 
@@ -864,5 +984,116 @@ def _present(
 
     # Changes were made successfully
     ret["result"] = True
+    ret["comment"] = f"'{name}' was configured."
+
+    # Reload firewalld service on changes
+    if ret["changes"] != {}:
+        __salt__["firewalld.reload_rules"]()
+
+    return ret
+
+
+def ipset_absent(name):
+    """
+    Ensure the ipset is absent.
+
+    name
+        The ipset to delete.
+    """
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+
+    if name in __salt__["firewalld.get_ipsets"](permanent=True):
+        if not __opts__["test"]:
+            __salt__["firewalld.delete_ipset"](name, permanent=True, restart=True)
+            ret["result"] = True
+            ret["comment"] = f"'{name}' has been deleted."
+            return ret
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' exists, it will be deleted."
+            return ret
+    else:
+        ret["result"] = True
+        ret["comment"] = f"'{name}' does not exist."
+        return ret
+
+    return ret
+
+
+def ipset_present(name, ipset_type, family=None, options={}, entries=[]):
+    """
+    Ensure the ipset exists and encompasses the specified entries.
+
+    name
+        The ipset to modify.
+
+    ipset_type
+        Ipset type, please see: firewall-cmd --get-ipset-types.
+
+    family: None
+        Address family, can be inet or inet6.
+
+    options: {}
+        List of options to add to the ipset, can be timeout, maxelen or hashsize.
+
+    entries: []
+        List of entry to add to the ipset.
+    """
+
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+
+    if name not in __salt__["firewalld.get_ipsets"](permanent=True):
+        if not __opts__["test"]:
+            __salt__["firewalld.new_ipset"](name, ipset_type, family, options, True)
+        else:
+            ret["result"] = None
+            ret["comment"] = f"'{name}' will be created."
+            return ret
+
+    if entries:
+        entries = entries or []
+    
+        try:
+            info_ipset = __salt__["firewalld.info_ipset"](name)[name]
+        except CommandExecutionError as err:
+            ret["comment"] = f"Error: {err}"
+            return ret
+    
+        _current_entries = info_ipset.get('entries', [])
+        new_entries = set(entries) - set(_current_entries)
+        old_entries = set(_current_entries) - set(entries)
+    
+        for entry in new_entries:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.add_ipset_entry"](name, entry)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+    
+        for entry in old_entries:
+            if not __opts__["test"]:
+                try:
+                    __salt__["firewalld.remove_ipset_entry"](name, entry)
+                except CommandExecutionError as err:
+                    ret["comment"] = f"Error: {err}"
+                    return ret
+
+        if new_entries or old_entries:
+            ret["changes"].update({"entries": {"old": _current_entries, "new": entries}})
+
+    ret["result"] = True
+    if ret["changes"] == {}:
+        ret["comment"] = f"'{name}' is already in the desired state."
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Configuration for '{name}' will change."
+        return ret
+
+    if ret["changes"] != {}:
+        __salt__["firewalld.reload_rules"]()
+
     ret["comment"] = f"'{name}' was configured."
     return ret

--- a/tests/pytests/unit/modules/test_firewalld.py
+++ b/tests/pytests/unit/modules/test_firewalld.py
@@ -432,3 +432,103 @@ def test_remove_rich_rule():
             )
             == "success"
         )
+
+
+def test_get_target():
+    """
+    Test getting a zone's target
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="default"):
+        assert firewalld.get_target("public") == "default"
+
+
+def test_set_target():
+    """
+    Test setting a zone's target
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+        assert firewalld.set_target("public", "DROP") == "success"
+
+
+def test_get_ipsets():
+    """
+    Test listing predefined ipsets
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="myipset1 myipset2"):
+        assert firewalld.get_ipsets() == ["myipset1", "myipset2"]
+
+
+def test_get_ipsets_empty():
+    """
+    Test listing ipsets when none exist
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value=""):
+        assert firewalld.get_ipsets() == []
+
+
+def test_new_ipset():
+    """
+    Test creating a new ipset
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+        assert firewalld.new_ipset("myipset", "hash:net") == "success"
+
+
+def test_new_ipset_with_reload():
+    """
+    Test creating a new ipset triggers a reload when restart=True
+    """
+    with patch.object(firewalld, "__firewall_cmd", side_effect=["success", "success"]):
+        result = firewalld.new_ipset("myipset", "hash:net", restart=True)
+        assert result == "success"
+
+
+def test_delete_ipset():
+    """
+    Test deleting an existing ipset without reload
+    """
+    with patch.object(firewalld, "__mgmt", return_value="success"):
+        with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+            assert firewalld.delete_ipset("myipset", restart=True) == "success"
+
+    with patch.object(firewalld, "__mgmt", return_value="A"):
+        assert firewalld.delete_ipset("myipset", restart=False) == "A"
+
+
+def test_add_ipset_entry():
+    """
+    Test adding an entry to an ipset
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+        assert firewalld.add_ipset_entry("myipset", "10.0.0.1/32") == "success"
+
+
+def test_remove_ipset_entry():
+    """
+    Test removing an entry from an ipset
+    """
+    with patch.object(firewalld, "__firewall_cmd", return_value="success"):
+        assert firewalld.remove_ipset_entry("myipset", "10.0.0.1/32") == "success"
+
+
+def test_info_ipset():
+    """
+    Test parsing ipset information
+    """
+    firewall_cmd_ret = dedent(
+        """\
+        myipset
+          type: hash:net
+          options: family=inet
+          entries: 1.1.1.1/32 8.8.8.8/32
+        """
+    )
+    expected = {
+        "myipset": {
+            "type": ["hash:net"],
+            "options": {"family": "inet"},
+            "entries": ["1.1.1.1/32", "8.8.8.8/32"],
+        }
+    }
+    with patch.object(firewalld, "__firewall_cmd", return_value=firewall_cmd_ret):
+        assert firewalld.info_ipset("myipset") == expected

--- a/tests/pytests/unit/states/test_firewalld.py
+++ b/tests/pytests/unit/states/test_firewalld.py
@@ -61,6 +61,265 @@ def test_masquerade():
         }
 
 
+def test_zone_absent_zone_exists():
+    """
+    zone_absent removes a zone that currently exists.
+    """
+    firewalld_get_zones = MagicMock(return_value=["public", "myzone"])
+    firewalld_delete_zone = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.get_zones": firewalld_get_zones,
+        "firewalld.delete_zone": firewalld_delete_zone,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.zone_absent("myzone")
+        assert ret == {
+            "name": "myzone",
+            "result": True,
+            "changes": {},
+            "comment": "'myzone' has been deleted.",
+        }
+        firewalld_delete_zone.assert_called_once_with("myzone", True)
+
+
+def test_zone_absent_zone_does_not_exist():
+    """
+    zone_absent is a no-op when the zone does not exist.
+    """
+    firewalld_get_zones = MagicMock(return_value=["public"])
+
+    __salt__ = {
+        "firewalld.get_zones": firewalld_get_zones,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.zone_absent("myzone")
+        assert ret == {
+            "name": "myzone",
+            "result": True,
+            "changes": {},
+            "comment": "'myzone' does not exist.",
+        }
+
+
+def test_zone_absent_test_mode():
+    """
+    zone_absent in test mode reports the zone would be deleted without acting.
+    """
+    firewalld_get_zones = MagicMock(return_value=["public", "myzone"])
+    firewalld_delete_zone = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.get_zones": firewalld_get_zones,
+        "firewalld.delete_zone": firewalld_delete_zone,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        with patch.dict(firewalld.__opts__, {"test": True}):
+            ret = firewalld.zone_absent("myzone")
+            assert ret == {
+                "name": "myzone",
+                "result": None,
+                "changes": {},
+                "comment": "'myzone' exists, it will be deleted.",
+            }
+            firewalld_delete_zone.assert_not_called()
+
+
+def test_service_absent_service_exists():
+    """
+    service_absent removes a service that currently exists.
+    """
+    firewalld_get_services = MagicMock(return_value=["http", "mysvc"])
+    firewalld_delete_service = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.get_services": firewalld_get_services,
+        "firewalld.delete_service": firewalld_delete_service,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.service_absent("mysvc")
+        assert ret == {
+            "name": "mysvc",
+            "result": True,
+            "changes": {},
+            "comment": "'mysvc' has been deleted.",
+        }
+        firewalld_delete_service.assert_called_once_with("mysvc", True)
+
+
+def test_service_absent_service_does_not_exist():
+    """
+    service_absent is a no-op when the service does not exist.
+    """
+    firewalld_get_services = MagicMock(return_value=["http"])
+
+    __salt__ = {
+        "firewalld.get_services": firewalld_get_services,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.service_absent("mysvc")
+        assert ret == {
+            "name": "mysvc",
+            "result": True,
+            "changes": {},
+            "comment": "'mysvc' does not exist.",
+        }
+
+
+def test_ipset_absent_ipset_exists():
+    """
+    ipset_absent deletes an ipset that currently exists.
+    """
+    firewalld_get_ipsets = MagicMock(return_value=["myipset", "other"])
+    firewalld_delete_ipset = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.get_ipsets": firewalld_get_ipsets,
+        "firewalld.delete_ipset": firewalld_delete_ipset,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.ipset_absent("myipset")
+        assert ret == {
+            "name": "myipset",
+            "result": True,
+            "changes": {},
+            "comment": "'myipset' has been deleted.",
+        }
+        firewalld_delete_ipset.assert_called_once_with(
+            "myipset", permanent=True, restart=True
+        )
+
+
+def test_ipset_absent_ipset_does_not_exist():
+    """
+    ipset_absent is a no-op when the ipset does not exist.
+    """
+    firewalld_get_ipsets = MagicMock(return_value=[])
+
+    __salt__ = {
+        "firewalld.get_ipsets": firewalld_get_ipsets,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.ipset_absent("myipset")
+        assert ret == {
+            "name": "myipset",
+            "result": True,
+            "changes": {},
+            "comment": "'myipset' does not exist.",
+        }
+
+
+def test_ipset_present_creates_and_adds_entries():
+    """
+    ipset_present creates a new ipset and adds entries when ipset is absent.
+    """
+    firewalld_get_ipsets = MagicMock(return_value=[])
+    firewalld_new_ipset = MagicMock(return_value="success")
+    firewalld_info_ipset = MagicMock(
+        return_value={"myipset": {"type": ["hash:net"], "entries": []}}
+    )
+    firewalld_add_ipset_entry = MagicMock(return_value="success")
+    firewalld_reload_rules = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.get_ipsets": firewalld_get_ipsets,
+        "firewalld.new_ipset": firewalld_new_ipset,
+        "firewalld.info_ipset": firewalld_info_ipset,
+        "firewalld.add_ipset_entry": firewalld_add_ipset_entry,
+        "firewalld.remove_ipset_entry": MagicMock(return_value="success"),
+        "firewalld.reload_rules": firewalld_reload_rules,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.ipset_present(
+            "myipset",
+            "hash:net",
+            entries=["1.1.1.1/32", "8.8.8.8/32"],
+        )
+        assert ret["result"] is True
+        assert ret["name"] == "myipset"
+        assert "entries" in ret["changes"]
+        assert set(ret["changes"]["entries"]["new"]) == {"1.1.1.1/32", "8.8.8.8/32"}
+        firewalld_new_ipset.assert_called_once()
+        firewalld_add_ipset_entry.assert_called()
+
+
+def test_ipset_present_idempotent():
+    """
+    ipset_present is a no-op when the ipset and entries already match.
+    """
+    firewalld_get_ipsets = MagicMock(return_value=["myipset"])
+    firewalld_info_ipset = MagicMock(
+        return_value={
+            "myipset": {"type": ["hash:net"], "entries": ["1.1.1.1/32", "8.8.8.8/32"]}
+        }
+    )
+
+    __salt__ = {
+        "firewalld.get_ipsets": firewalld_get_ipsets,
+        "firewalld.info_ipset": firewalld_info_ipset,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.ipset_present(
+            "myipset",
+            "hash:net",
+            entries=["1.1.1.1/32", "8.8.8.8/32"],
+        )
+        assert ret == {
+            "name": "myipset",
+            "result": True,
+            "changes": {},
+            "comment": "'myipset' is already in the desired state.",
+        }
+
+
+def test_zone_present_with_target():
+    """
+    zone_present sets zone target when it differs from current value.
+    """
+    firewalld_reload_rules = MagicMock(return_value="success")
+    firewalld_get_zones = MagicMock(return_value=["public"])
+    firewalld_get_target = MagicMock(return_value="default")
+    firewalld_set_target = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.reload_rules": firewalld_reload_rules,
+        "firewalld.get_zones": firewalld_get_zones,
+        "firewalld.get_target": firewalld_get_target,
+        "firewalld.set_target": firewalld_set_target,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.zone_present("public", target="DROP")
+        assert ret["result"] is True
+        assert ret["changes"] == {"target": {"old": "default", "new": "DROP"}}
+        firewalld_set_target.assert_called_once_with("public", "DROP", permanent=True)
+
+
+def test_zone_present_target_already_set():
+    """
+    zone_present does not change target when it already matches.
+    """
+    firewalld_reload_rules = MagicMock(return_value="success")
+    firewalld_get_zones = MagicMock(return_value=["public"])
+    firewalld_get_target = MagicMock(return_value="DROP")
+    firewalld_set_target = MagicMock(return_value="success")
+
+    __salt__ = {
+        "firewalld.reload_rules": firewalld_reload_rules,
+        "firewalld.get_zones": firewalld_get_zones,
+        "firewalld.get_target": firewalld_get_target,
+        "firewalld.set_target": firewalld_set_target,
+    }
+    with patch.dict(firewalld.__dict__, {"__salt__": __salt__}):
+        ret = firewalld.zone_present("public", target="DROP")
+        assert ret == {
+            "name": "public",
+            "result": True,
+            "changes": {},
+            "comment": "'public' is already in the desired state.",
+        }
+        firewalld_set_target.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "rich_rule",
     [


### PR DESCRIPTION
enhance firewalld modules and states with ipset, zone_absent, service_absent

### What does this PR do?

- Add service_absent and service_present, service become an alias to service_present
- Add zone_absent and zone_present, present become an alias to zone_present
- Add ipset_absent and ipset_present with necessary functions in firewalld module
- add option to some functions to skip check in order to speed up executions
- Add target option to zone_present

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
