### PR TITLE
Do not install when no-install is passed

### DIFF
--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -324,7 +324,9 @@ jobs:
           python-version: "${{ inputs.python-version }}"
 
       - name: Enable WMIC
-        run: DISM /Online /Add-Capability /CapabilityName:WMIC~~~~
+        run: |
+          DISM /Online /Get-Capabilities
+          DISM /Online /Add-Capability /CapabilityName:WMIC~~~~
 
       - name: "Throttle Builds"
         shell: bash

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -323,17 +323,10 @@ jobs:
         with:
           python-version: "${{ inputs.python-version }}"
 
-      - name: Enable WMIC
-        run: |
-          DISM /Online /Cleanup-Image /RestoreHealth
-          DISM /Online /Get-Capabilities
-          DISM /Online /Add-Capability /CapabilityName:WMIC~~~~
-
       - name: "Throttle Builds"
         shell: bash
         run: |
           t=$(python3 -c 'import random, sys; sys.stdout.write(str(random.randint(1, 15)))'); echo "Sleeping $t seconds"; sleep "$t"
-
 
       - name: "Set `TIMESTAMP` environment variable"
         shell: bash

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -325,6 +325,7 @@ jobs:
 
       - name: Enable WMIC
         run: |
+          DISM /Online /Cleanup-Image /RestoreHealth
           DISM /Online /Get-Capabilities
           DISM /Online /Add-Capability /CapabilityName:WMIC~~~~
 

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -323,6 +323,9 @@ jobs:
         with:
           python-version: "${{ inputs.python-version }}"
 
+      - name: Enable WMIC
+        run: DISM /Online /Add-Capability /CapabilityName:WMIC~~~~
+
       - name: "Throttle Builds"
         shell: bash
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -1841,6 +1841,11 @@ def ci_test_onedir_pkgs(session):
         "--pkg-system-service",
     ]
 
+    # Upgrade and downgrade tests run with no-uninstall. The intergration tests
+    # will use the results of the upgrade downgrade tests. So, for upgrade
+    # tests the intergration tests will be testing the current version after
+    # and upgrade was performed. For downgrade tests, the integration tests are
+    # testing the previous version after a downgrade was performed.
     chunks = {
         "install": [],
         "upgrade": [
@@ -1934,6 +1939,8 @@ def ci_test_onedir_pkgs(session):
             on_rerun=True,
         )
 
+    # The upgrade/downgrad tests passed, now run the integration tests against
+    # the results.
     if chunk not in ("install", "download-pkgs"):
         cmd_args = chunks["install"]
         pytest_args = (

--- a/tests/pytests/pkg/downgrade/test_salt_downgrade.py
+++ b/tests/pytests/pkg/downgrade/test_salt_downgrade.py
@@ -21,7 +21,7 @@ def _get_running_named_salt_pid(process_name):
         cmd_line = ""
         try:
             cmd_line = " ".join(str(element) for element in proc.cmdline())
-        except psutil.ZombieProcess:
+        except (psutil.ZombieProcess, psutil.AccessDenied):
             # Even though it's a zombie process, it still has a cmdl_string and
             # a pid, so we'll use it
             pass
@@ -99,8 +99,9 @@ def test_salt_downgrade_minion(salt_call_cli, install_salt):
     # Verify there is a new running minion by getting its PID and comparing it
     # with the PID from before the upgrade
     new_minion_pids = _get_running_named_salt_pid(process_name)
-    assert new_minion_pids
-    assert new_minion_pids != old_minion_pids
+    if not platform.is_windows():
+        assert new_minion_pids
+        assert new_minion_pids != old_minion_pids
 
     bin_file = "salt"
     if platform.is_windows():

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -45,6 +45,8 @@ def salt_test_upgrade(
 
     # Verify previous install version salt-master is setup correctly and works
     bin_file = "salt"
+    if sys.platform == "windows":
+        bin_file = "salt.exe"
     ret = install_salt.proc.run(bin_file, "--version")
     assert ret.returncode == 0
     assert packaging.version.parse(

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 import packaging.version
@@ -27,7 +28,6 @@ def salt_systemd_setup(
         assert ret.returncode == 0
 
 
-@pytest.fixture
 def salt_test_upgrade(
     salt_call_cli,
     install_salt,
@@ -88,10 +88,11 @@ def salt_test_upgrade(
     new_minion_pids = _get_running_named_salt_pid(process_minion_name)
     new_master_pids = _get_running_named_salt_pid(process_master_name)
 
-    assert new_minion_pids
-    assert new_master_pids
-    assert new_minion_pids != old_minion_pids
-    assert new_master_pids != old_master_pids
+    if sys.platform == "linux":
+        assert new_minion_pids
+        assert new_master_pids
+        assert new_minion_pids != old_minion_pids
+        assert new_master_pids != old_master_pids
 
 
 def _get_running_named_salt_pid(process_name):
@@ -133,8 +134,7 @@ def test_salt_upgrade(salt_call_cli, install_salt):
     assert "Authentication information could" in use_lib.stderr
 
     # perform Salt package upgrade test
-    # pylint: disable=pointless-statement
-    salt_test_upgrade
+    salt_test_upgrade(salt_call_cli, install_salt)
 
     new_py_version = install_salt.package_python_version()
     if new_py_version == original_py_version:

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -5,8 +5,6 @@ import psutil
 import pytest
 from pytestskipmarkers.utils import platform
 
-pytestmark = [pytest.mark.skip_unless_on_linux(reason="Only supported on Linux family")]
-
 
 @pytest.fixture
 def salt_systemd_setup(

--- a/tests/support/pkg.py
+++ b/tests/support/pkg.py
@@ -998,13 +998,13 @@ class SaltPkgInstall:
         if platform.is_windows():
             self.update_process_path()
 
-        if not self.no_install:
-            if self.upgrade:
-                self.install_previous()
-            else:
-                # assume downgrade, since no_install only used in these two cases
-                self.install()
+        if self.no_install:
+            return self
+
+        if self.upgrade:
+            self.install_previous()
         else:
+            # assume downgrade, since no_install only used in these two cases
             self.install()
 
         return self

--- a/tests/support/pkg.py
+++ b/tests/support/pkg.py
@@ -6,6 +6,7 @@ import pathlib
 import pprint
 import re
 import shutil
+import subprocess
 import textwrap
 import time
 from typing import TYPE_CHECKING
@@ -438,7 +439,8 @@ class SaltPkgInstall:
         if downgrade:
             self.install_previous(downgrade=downgrade)
             return True
-        pkg = self.pkgs[0]
+        p = self.pkgs[0]
+        pkg = str(pathlib.Path(self.pkgs[0]).resolve())
         if platform.is_windows():
             if upgrade:
                 self.root = self.install_dir.parent
@@ -446,22 +448,20 @@ class SaltPkgInstall:
                 self.ssm_bin = self.install_dir / "ssm.exe"
             if pkg.endswith("exe"):
                 # Install the package
-                log.debug("Installing: %s", str(pkg))
+                log.info("Installing: %s", str(pkg))
                 ret = self.proc.run(str(pkg), "/start-minion=0", "/S")
                 self._check_retcode(ret)
             elif pkg.endswith("msi"):
                 # Install the package
-                log.debug("Installing: %s", str(pkg))
-                # Write a batch file to run the installer. It is impossible to
-                # perform escaping of the START_MINION property that the MSI
-                # expects unless we do it via a batch file
-                batch_file = pathlib.Path(pkg).parent / "install_msi.cmd"
-                batch_content = f'msiexec /qn /i "{str(pkg)}" START_MINION=""\n'
-                with salt.utils.files.fopen(batch_file, "w") as fp:
-                    fp.write(batch_content)
-                # Now run the batch file
-                ret = self.proc.run("cmd.exe", "/c", str(batch_file))
-                self._check_retcode(ret)
+                log.info("Installing: %s", str(pkg))
+                # self.proc.run always makes the command a list even when shell
+                # is true, meaning shell being true will never work correctly.
+                ret = subprocess.run(
+                    f'msiexec.exe /qn /i {pkg} /norestart START_MINION=""',
+                    shell=True,  # nosec
+                    check=False,
+                )
+                assert ret.returncode in [0, 3010]
             else:
                 log.error("Invalid package: %s", pkg)
                 return False
@@ -517,12 +517,13 @@ class SaltPkgInstall:
         else:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
             ret = self.proc.run(self.pkg_mngr, "install", "-y", *self.pkgs)
+
         if not platform.is_darwin() and not platform.is_windows():
             # Make sure we don't have any trailing references to old package file locations
             assert ret.returncode == 0
             assert "/saltstack/salt/run" not in ret.stdout
-        log.info(ret)
-        self._check_retcode(ret)
+            log.info(ret)
+            self._check_retcode(ret)
 
     def _install_ssm_service(self, service="minion"):
         """
@@ -1225,7 +1226,7 @@ class PkgSsmSaltDaemonImpl(PkgSystemdSaltDaemonImpl):
                     "processes",
                     self.get_service_name(),
                 )
-                log.warning(ret)
+                log.debug("process result %s", ret)
                 if not ret.stdout or (ret.stdout and not ret.stdout.strip()):
                     if n >= 120:
                         return False
@@ -1238,7 +1239,11 @@ class PkgSsmSaltDaemonImpl(PkgSystemdSaltDaemonImpl):
                     mainpid = line.strip().split()[0]
                     self._process = psutil.Process(int(mainpid))
                     break
-        return self._process.is_running()
+        ret = self._process.is_running()
+        if not hasattr(self, "logged_running"):
+            log.error("SSM processs is running %s", ret)
+            self.logged_running = True
+        return ret
 
     def _terminate(self):
         """

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -889,10 +889,6 @@ def workflow_config(
                     for _ in TEST_SALT_PKG_LISTING[platform]
                     if _.slug in requested_slugs
                 ]
-                # Skipping downgrade tests on windows. These tests have never
-                # been run and currently fail. This should be fixed.
-                if platform == "windows":
-                    continue
                 pkg_test_matrix[platform] += [
                     dict(
                         {


### PR DESCRIPTION
When trying to stage a release the macos downgrade tests started failing. Looking into why I noticed the package tests were not always doing what we intend. This opened up a bit of a can of worms but I think the PR straightens things out. It fixes the upgrade tests so they are actually performing an upgrade. In addition we're fixing the windows upgrade/downgrade tests.