### PR TITLE
[3006.x] Updating version comparison for rpm and removed obsolete comparison methods for rpm

### DIFF
--- a/changelog/65443.fixed.md
+++ b/changelog/65443.fixed.md
@@ -1,0 +1,1 @@
+Updating version comparison for rpm and removed obsolete comparison methods for rpms

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -22,19 +22,21 @@ try:
 except ImportError:
     HAS_RPM = False
 
-try:
-    import rpmUtils.miscutils
-
-    HAS_RPMUTILS = True
-except ImportError:
-    HAS_RPMUTILS = False
-
-try:
-    import rpm_vercmp
-
-    HAS_PY_RPM = True
-except ImportError:
-    HAS_PY_RPM = False
+## DGM rpmUtils.miscutils was used in older versions and is now removed.
+## DGM try:
+## DGM     import rpmUtils.miscutils
+## DGM
+## DGM     HAS_RPMUTILS = True
+## DGM except ImportError:
+## DGM     HAS_RPMUTILS = False
+## DGM
+## DGM  rpm_vercmp has not been maintained since 2018, so removing it, since that is pretty pre-Py3
+## DGM try:
+## DGM     import rpm_vercmp
+## DGM
+## DGM     HAS_PY_RPM = True
+## DGM except ImportError:
+## DGM     HAS_PY_RPM = False
 
 
 log = logging.getLogger(__name__)
@@ -730,18 +732,18 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     "labelCompare function. Not using rpm.labelCompare for "
                     "version comparison."
                 )
-        elif HAS_PY_RPM:
-            cmp_func = rpm_vercmp.vercmp
+        ## DGM elif HAS_PY_RPM:
+        ## DGM     cmp_func = rpm_vercmp.vercmp
         else:
             log.warning(
                 "Please install a package that provides rpm.labelCompare for "
                 "more accurate version comparisons."
             )
-        if cmp_func is None and HAS_RPMUTILS:
-            try:
-                cmp_func = rpmUtils.miscutils.compareEVR
-            except AttributeError:
-                log.debug("rpmUtils.miscutils.compareEVR is not available")
+        ## DGM if cmp_func is None and HAS_RPMUTILS:
+        ## DGM     try:
+        ## DGM         cmp_func = rpmUtils.miscutils.compareEVR
+        ## DGM     except AttributeError:
+        ## DGM         log.debug("rpmUtils.miscutils.compareEVR is not available")
 
         # If one EVR is missing a release but not the other and they
         # otherwise would be equal, ignore the release. This can happen if
@@ -750,12 +752,22 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
         (ver1_e, ver1_v, ver1_r) = salt.utils.pkg.rpm.version_to_evr(ver1)
         (ver2_e, ver2_v, ver2_r) = salt.utils.pkg.rpm.version_to_evr(ver2)
 
+        print(
+            f"DGM version_cmp, ver1 evr '{ver1_e},{ver1_v},{ver1_r}', ver2 evr '{ver2_e},{ver2_v},{ver2_r}'",
+            flush=True,
+        )
         if not ver1_r or not ver2_r:
             ver1_r = ver2_r = ""
 
         if cmp_func is None:
             ver1 = f"{ver1_e}:{ver1_v}-{ver1_r}"
             ver2 = f"{ver2_e}:{ver2_v}-{ver2_r}"
+
+            print(
+                f"DGM version_cmp, cmp_func is None, ver1 '{ver1}', ver2 '{ver2}'",
+                flush=True,
+            )
+
             if salt.utils.path.which("rpmdev-vercmp"):
                 log.warning(
                     "Installing the rpmdevtools package may surface dev tools in"
@@ -776,6 +788,10 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
 
                 ver1 = _ensure_epoch(ver1)
                 ver2 = _ensure_epoch(ver2)
+                print(
+                    f"DGM version_cmp, using rpmdev-cmp ver1 '{ver1}', ver2 '{ver2}'",
+                    flush=True,
+                )
                 result = __salt__["cmd.run_all"](
                     ["rpmdev-vercmp", ver1, ver2],
                     python_shell=False,
@@ -784,6 +800,9 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                 )
                 # rpmdev-vercmp returns 0 on equal, 11 on greater-than, and
                 # 12 on less-than.
+                print(
+                    f"DGM version_cmp, using rpmdev-cmp result '{result}''", flush=True
+                )
                 if result["retcode"] == 0:
                     return 0
                 elif result["retcode"] == 11:
@@ -805,20 +824,26 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     " comparisons"
                 )
         else:
-            if HAS_PY_RPM:
-                ver1 = f"{ver1_v}-{ver1_r}"
-                ver2 = f"{ver2_v}-{ver2_r}"
+            ## DGM if HAS_PY_RPM:
+            ## DGM     ver1 = f"{ver1_v}-{ver1_r}"
+            ## DGM     ver2 = f"{ver2_v}-{ver2_r}"
 
-                # handle epoch version comparison first
-                # rpm_vercmp.vercmp does not handle epoch version comparison
-                ret = salt.utils.versions.version_cmp(ver1_e, ver2_e)
-                if ret in (1, -1):
-                    return ret
-                cmp_result = cmp_func(ver1, ver2)
-            else:
-                cmp_result = cmp_func(
-                    (ver1_e, ver1_v, ver1_r), (ver2_e, ver2_v, ver2_r)
-                )
+            ## DGM     # handle epoch version comparison first
+            ## DGM     # rpm_vercmp.vercmp does not handle epoch version comparison
+            ## DGM     ret = salt.utils.versions.version_cmp(ver1_e, ver2_e)
+            ## DGM     if ret in (1, -1):
+            ## DGM         return ret
+            ## DGM     cmp_result = cmp_func(ver1, ver2)
+            ## DGM else:
+            ## DGM     cmp_result = cmp_func(
+            ## DGM         (ver1_e, ver1_v, ver1_r), (ver2_e, ver2_v, ver2_r)
+            ## DGM     )
+
+            cmp_result = cmp_func((ver1_e, ver1_v, ver1_r), (ver2_e, ver2_v, ver2_r))
+            print(
+                f"DGM version_cmp cmp_func, cmp_result '{cmp_result}' for ver1 evr '{ver1_e},{ver1_v},{ver1_r}', ver2 evr '{ver2_e},{ver2_v},{ver2_r}'",
+                flush=True,
+            )
             if cmp_result not in (-1, 0, 1):
                 raise CommandExecutionError(
                     f"Comparison result '{cmp_result}' is invalid"

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -22,22 +22,6 @@ try:
 except ImportError:
     HAS_RPM = False
 
-## DGM rpmUtils.miscutils was used in older versions and is now removed.
-## DGM try:
-## DGM     import rpmUtils.miscutils
-## DGM
-## DGM     HAS_RPMUTILS = True
-## DGM except ImportError:
-## DGM     HAS_RPMUTILS = False
-## DGM
-## DGM  rpm_vercmp has not been maintained since 2018, so removing it, since that is pretty pre-Py3
-## DGM try:
-## DGM     import rpm_vercmp
-## DGM
-## DGM     HAS_PY_RPM = True
-## DGM except ImportError:
-## DGM     HAS_PY_RPM = False
-
 
 log = logging.getLogger(__name__)
 
@@ -732,18 +716,11 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     "labelCompare function. Not using rpm.labelCompare for "
                     "version comparison."
                 )
-        ## DGM elif HAS_PY_RPM:
-        ## DGM     cmp_func = rpm_vercmp.vercmp
         else:
             log.warning(
                 "Please install a package that provides rpm.labelCompare for "
                 "more accurate version comparisons."
             )
-        ## DGM if cmp_func is None and HAS_RPMUTILS:
-        ## DGM     try:
-        ## DGM         cmp_func = rpmUtils.miscutils.compareEVR
-        ## DGM     except AttributeError:
-        ## DGM         log.debug("rpmUtils.miscutils.compareEVR is not available")
 
         # If one EVR is missing a release but not the other and they
         # otherwise would be equal, ignore the release. This can happen if
@@ -752,21 +729,12 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
         (ver1_e, ver1_v, ver1_r) = salt.utils.pkg.rpm.version_to_evr(ver1)
         (ver2_e, ver2_v, ver2_r) = salt.utils.pkg.rpm.version_to_evr(ver2)
 
-        print(
-            f"DGM version_cmp, ver1 evr '{ver1_e},{ver1_v},{ver1_r}', ver2 evr '{ver2_e},{ver2_v},{ver2_r}'",
-            flush=True,
-        )
         if not ver1_r or not ver2_r:
             ver1_r = ver2_r = ""
 
         if cmp_func is None:
             ver1 = f"{ver1_e}:{ver1_v}-{ver1_r}"
             ver2 = f"{ver2_e}:{ver2_v}-{ver2_r}"
-
-            print(
-                f"DGM version_cmp, cmp_func is None, ver1 '{ver1}', ver2 '{ver2}'",
-                flush=True,
-            )
 
             if salt.utils.path.which("rpmdev-vercmp"):
                 log.warning(
@@ -788,10 +756,6 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
 
                 ver1 = _ensure_epoch(ver1)
                 ver2 = _ensure_epoch(ver2)
-                print(
-                    f"DGM version_cmp, using rpmdev-cmp ver1 '{ver1}', ver2 '{ver2}'",
-                    flush=True,
-                )
                 result = __salt__["cmd.run_all"](
                     ["rpmdev-vercmp", ver1, ver2],
                     python_shell=False,
@@ -800,9 +764,6 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                 )
                 # rpmdev-vercmp returns 0 on equal, 11 on greater-than, and
                 # 12 on less-than.
-                print(
-                    f"DGM version_cmp, using rpmdev-cmp result '{result}''", flush=True
-                )
                 if result["retcode"] == 0:
                     return 0
                 elif result["retcode"] == 11:
@@ -824,26 +785,7 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     " comparisons"
                 )
         else:
-            ## DGM if HAS_PY_RPM:
-            ## DGM     ver1 = f"{ver1_v}-{ver1_r}"
-            ## DGM     ver2 = f"{ver2_v}-{ver2_r}"
-
-            ## DGM     # handle epoch version comparison first
-            ## DGM     # rpm_vercmp.vercmp does not handle epoch version comparison
-            ## DGM     ret = salt.utils.versions.version_cmp(ver1_e, ver2_e)
-            ## DGM     if ret in (1, -1):
-            ## DGM         return ret
-            ## DGM     cmp_result = cmp_func(ver1, ver2)
-            ## DGM else:
-            ## DGM     cmp_result = cmp_func(
-            ## DGM         (ver1_e, ver1_v, ver1_r), (ver2_e, ver2_v, ver2_r)
-            ## DGM     )
-
             cmp_result = cmp_func((ver1_e, ver1_v, ver1_r), (ver2_e, ver2_v, ver2_r))
-            print(
-                f"DGM version_cmp cmp_func, cmp_result '{cmp_result}' for ver1 evr '{ver1_e},{ver1_v},{ver1_r}', ver2 evr '{ver2_e},{ver2_v},{ver2_r}'",
-                flush=True,
-            )
             if cmp_result not in (-1, 0, 1):
                 raise CommandExecutionError(
                     f"Comparison result '{cmp_result}' is invalid"

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -11,21 +11,13 @@ import salt.modules.rpm_lowpkg as rpm
 import salt.utils.path
 from tests.support.mock import MagicMock, patch
 
-# pylint: disable=unused-import
 try:
-    import rpm as rpm_lib
+    import rpm
 
     HAS_RPM = True
 except ImportError:
     HAS_RPM = False
-
-## DGM try:
-## DGM     import rpm_vercmp
-## DGM
-## DGM     HAS_PY_RPM = True
-## DGM except ImportError:
-## DGM     HAS_PY_RPM = False
-## DGM # pylint: enable=unused-import
+# pylint: enable=unused-import
 
 
 def _called_with_root(mock):
@@ -244,7 +236,6 @@ def test_checksum_root():
         assert _called_with_root(mock)
 
 
-## DGM @pytest.mark.parametrize("rpm_lib", ["HAS_RPM", "HAS_PY_RPM", "rpmdev-vercmp"])
 @pytest.mark.parametrize("rpm_lib", ["HAS_RPM", "rpmdev-vercmp"])
 def test_version_cmp_rpm_all_libraries(rpm_lib):
     """
@@ -255,25 +246,16 @@ def test_version_cmp_rpm_all_libraries(rpm_lib):
     if rpm_lib == "rpmdev-vercmp":
         if rpmdev:
             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-            ## DGM patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
         else:
             pytest.skip("The rpmdev-vercmp binary is not installed")
     elif rpm_lib == "HAS_RPM":
         if HAS_RPM:
             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", True)
-            ## DGM patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
         else:
             pytest.skip("The RPM lib is not installed, skipping")
-    ## DGM     elif rpm_lib == "HAS_PY_RPM":
-    ## DGM         if HAS_PY_RPM:
-    ## DGM             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    ## DGM             patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", True)
-    ## DGM         else:
-    ## DGM             pytest.skip("The Python RPM lib is not installed, skipping")
     else:
         pytest.skip("The Python RPM lib is not installed, skipping")
 
-    ## DGM with patch_rpm, patch_py_rpm, patch_cmd:
     with patch_rpm, patch_cmd:
         assert rpm.version_cmp("1", "2") == -1
         assert rpm.version_cmp("2.9.1-6.el7_2.3", "2.9.1-6.el7.4") == -1
@@ -307,28 +289,6 @@ def test_version_cmp_rpm():
         assert mock_label.called
 
 
-## DGM def test_version_cmp_rpmutils():
-## DGM     """
-## DGM     Test package version if rpmUtils.miscutils called
-## DGM
-## DGM     :return:
-## DGM     """
-## DGM     mock_log = MagicMock()
-## DGM     mock_rpmUtils = MagicMock()
-## DGM     mock_rpmUtils.miscutils = MagicMock()
-## DGM     mock_rpmUtils.miscutils.compareEVR = MagicMock(return_value=-1)
-## DGM     patch_utils = patch("salt.modules.rpm_lowpkg.rpmUtils", mock_rpmUtils, create=True)
-## DGM     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-## DGM     patch_utils_lib = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", True)
-## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
-## DGM     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
-## DGM
-## DGM     with patch_utils, patch_rpm, patch_py_rpm, patch_utils_lib, patch_log:
-## DGM         assert -1 == rpm.version_cmp("1", "2")
-## DGM         assert mock_log.warning.called
-## DGM         assert mock_rpmUtils.miscutils.compareEVR.called
-
-
 def test_version_cmp_rpmdev_vercmp():
     """
     Test package version if rpmdev-vercmp is installed
@@ -338,12 +298,9 @@ def test_version_cmp_rpmdev_vercmp():
     mock__salt__ = MagicMock(return_value={"retcode": 12})
     mock_log = MagicMock()
     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    ## DGM     patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
-    ## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
     patch_which = patch("salt.utils.path.which", return_value=True)
     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
 
-    ## DGM with patch_rpm, patch_rpmutils, patch_py_rpm, patch_which, patch_log:
     with patch_rpm, patch_which, patch_log:
         with patch.dict(rpm.__salt__, {"cmd.run_all": mock__salt__}):
             assert -1 == rpm.version_cmp("1", "2")
@@ -367,14 +324,11 @@ def test_version_cmp_python():
     """
     mock_log = MagicMock()
     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    ## DGM     patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
     mock_version_cmp = MagicMock(return_value=-1)
-    ## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
     patch_cmp = patch("salt.utils.versions.version_cmp", mock_version_cmp)
     patch_which = patch("salt.utils.path.which", return_value=False)
     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
 
-    ## DGM with patch_rpm, patch_rpmutils, patch_py_rpm, patch_cmp, patch_which, patch_log:
     with patch_rpm, patch_cmp, patch_which, patch_log:
         assert -1 == rpm.version_cmp("1", "2")
         assert mock_version_cmp.called

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -283,6 +283,7 @@ def test_version_cmp_rpm_all_libraries(rpm_lib):
         assert rpm.version_cmp("3:2.9.1-8.el7.4", "3:2.9.1-7.el7.4") == 1
         assert rpm.version_cmp("3.23-6.el9", "3.23") == 0
         assert rpm.version_cmp("3.23", "3.23-6.el9") == 0
+        assert rpm.version_cmp("release_web_294-6", "release_web_294_applepay-1") == -1
 
 
 def test_version_cmp_rpm():

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -19,13 +19,13 @@ try:
 except ImportError:
     HAS_RPM = False
 
-try:
-    import rpm_vercmp
-
-    HAS_PY_RPM = True
-except ImportError:
-    HAS_PY_RPM = False
-# pylint: enable=unused-import
+## DGM try:
+## DGM     import rpm_vercmp
+## DGM
+## DGM     HAS_PY_RPM = True
+## DGM except ImportError:
+## DGM     HAS_PY_RPM = False
+## DGM # pylint: enable=unused-import
 
 
 def _called_with_root(mock):
@@ -244,7 +244,8 @@ def test_checksum_root():
         assert _called_with_root(mock)
 
 
-@pytest.mark.parametrize("rpm_lib", ["HAS_RPM", "HAS_PY_RPM", "rpmdev-vercmp"])
+## DGM @pytest.mark.parametrize("rpm_lib", ["HAS_RPM", "HAS_PY_RPM", "rpmdev-vercmp"])
+@pytest.mark.parametrize("rpm_lib", ["HAS_RPM", "rpmdev-vercmp"])
 def test_version_cmp_rpm_all_libraries(rpm_lib):
     """
     Test package version when each library is installed
@@ -254,23 +255,26 @@ def test_version_cmp_rpm_all_libraries(rpm_lib):
     if rpm_lib == "rpmdev-vercmp":
         if rpmdev:
             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-            patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
+            ## DGM patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
         else:
             pytest.skip("The rpmdev-vercmp binary is not installed")
     elif rpm_lib == "HAS_RPM":
         if HAS_RPM:
             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", True)
-            patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
+            ## DGM patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
         else:
             pytest.skip("The RPM lib is not installed, skipping")
-    elif rpm_lib == "HAS_PY_RPM":
-        if HAS_PY_RPM:
-            patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-            patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", True)
-        else:
-            pytest.skip("The Python RPM lib is not installed, skipping")
+    ## DGM     elif rpm_lib == "HAS_PY_RPM":
+    ## DGM         if HAS_PY_RPM:
+    ## DGM             patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
+    ## DGM             patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", True)
+    ## DGM         else:
+    ## DGM             pytest.skip("The Python RPM lib is not installed, skipping")
+    else:
+        pytest.skip("The Python RPM lib is not installed, skipping")
 
-    with patch_rpm, patch_py_rpm, patch_cmd:
+    ## DGM with patch_rpm, patch_py_rpm, patch_cmd:
+    with patch_rpm, patch_cmd:
         assert rpm.version_cmp("1", "2") == -1
         assert rpm.version_cmp("2.9.1-6.el7_2.3", "2.9.1-6.el7.4") == -1
         assert rpm.version_cmp("3.2", "3.0") == 1
@@ -303,26 +307,26 @@ def test_version_cmp_rpm():
         assert mock_label.called
 
 
-def test_version_cmp_rpmutils():
-    """
-    Test package version if rpmUtils.miscutils called
-
-    :return:
-    """
-    mock_log = MagicMock()
-    mock_rpmUtils = MagicMock()
-    mock_rpmUtils.miscutils = MagicMock()
-    mock_rpmUtils.miscutils.compareEVR = MagicMock(return_value=-1)
-    patch_utils = patch("salt.modules.rpm_lowpkg.rpmUtils", mock_rpmUtils, create=True)
-    patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    patch_utils_lib = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", True)
-    patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
-    patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
-
-    with patch_utils, patch_rpm, patch_py_rpm, patch_utils_lib, patch_log:
-        assert -1 == rpm.version_cmp("1", "2")
-        assert mock_log.warning.called
-        assert mock_rpmUtils.miscutils.compareEVR.called
+## DGM def test_version_cmp_rpmutils():
+## DGM     """
+## DGM     Test package version if rpmUtils.miscutils called
+## DGM
+## DGM     :return:
+## DGM     """
+## DGM     mock_log = MagicMock()
+## DGM     mock_rpmUtils = MagicMock()
+## DGM     mock_rpmUtils.miscutils = MagicMock()
+## DGM     mock_rpmUtils.miscutils.compareEVR = MagicMock(return_value=-1)
+## DGM     patch_utils = patch("salt.modules.rpm_lowpkg.rpmUtils", mock_rpmUtils, create=True)
+## DGM     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
+## DGM     patch_utils_lib = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", True)
+## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
+## DGM     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
+## DGM
+## DGM     with patch_utils, patch_rpm, patch_py_rpm, patch_utils_lib, patch_log:
+## DGM         assert -1 == rpm.version_cmp("1", "2")
+## DGM         assert mock_log.warning.called
+## DGM         assert mock_rpmUtils.miscutils.compareEVR.called
 
 
 def test_version_cmp_rpmdev_vercmp():
@@ -334,12 +338,13 @@ def test_version_cmp_rpmdev_vercmp():
     mock__salt__ = MagicMock(return_value={"retcode": 12})
     mock_log = MagicMock()
     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
-    patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
+    ## DGM     patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
+    ## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
     patch_which = patch("salt.utils.path.which", return_value=True)
     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
 
-    with patch_rpm, patch_rpmutils, patch_py_rpm, patch_which, patch_log:
+    ## DGM with patch_rpm, patch_rpmutils, patch_py_rpm, patch_which, patch_log:
+    with patch_rpm, patch_which, patch_log:
         with patch.dict(rpm.__salt__, {"cmd.run_all": mock__salt__}):
             assert -1 == rpm.version_cmp("1", "2")
             assert mock__salt__.called
@@ -362,14 +367,15 @@ def test_version_cmp_python():
     """
     mock_log = MagicMock()
     patch_rpm = patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
-    patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
+    ## DGM     patch_rpmutils = patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
     mock_version_cmp = MagicMock(return_value=-1)
-    patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
+    ## DGM     patch_py_rpm = patch("salt.modules.rpm_lowpkg.HAS_PY_RPM", False)
     patch_cmp = patch("salt.utils.versions.version_cmp", mock_version_cmp)
     patch_which = patch("salt.utils.path.which", return_value=False)
     patch_log = patch("salt.modules.rpm_lowpkg.log", mock_log)
 
-    with patch_rpm, patch_rpmutils, patch_py_rpm, patch_cmp, patch_which, patch_log:
+    ## DGM with patch_rpm, patch_rpmutils, patch_py_rpm, patch_cmp, patch_which, patch_log:
+    with patch_rpm, patch_cmp, patch_which, patch_log:
         assert -1 == rpm.version_cmp("1", "2")
         assert mock_version_cmp.called
         assert mock_log.warning.called


### PR DESCRIPTION
### What does this PR do?
Updating version comparison for rpm and removed obsolete comparison methods for rpm

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/65443

### Previous Behavior
RPM version comparison failed on some rpm versions

### New Behavior
RPM version comparison is correct on all rpm versions


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
