### PR TITLE
[3007.x] Fix/add nftables icmpv6 support

### DIFF
--- a/changelog/67882.fixed.md
+++ b/changelog/67882.fixed.md
@@ -1,0 +1,1 @@
+* Added support for `icmpv6-type` to salt.modules.nftables

--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -156,6 +156,10 @@ def build_rule(
         rule += "icmp type {{ {0} }} ".format(kwargs["icmp-type"])
         del kwargs["icmp-type"]
 
+    if "icmpv6-type" in kwargs:
+        rule += "icmpv6 type {{ {0} }} ".format(kwargs["icmpv6-type"])
+        del kwargs["icmpv6-type"]
+
     if "pkttype" in kwargs:
         rule += "meta pkttype {{ {0} }} ".format(kwargs["pkttype"])
         del kwargs["pkttype"]

--- a/tests/pytests/unit/modules/test_nftables.py
+++ b/tests/pytests/unit/modules/test_nftables.py
@@ -123,15 +123,15 @@ def test_build_rule():
         "comment": "Successfully built rule",
     }
 
-    assert nftables.build_rule(
-        table="filter",
-        chain="input",
-        family="ip6",
-        command="add",
-        icmpv6type="echo-request,echo-reply",
-        jump="accept",
-        full="True",
-    ) == {
+    assert nftables.build_rule(**{
+        "table": "filter",
+        "chain": "input",
+        "family": "ip6",
+        "command": "add",
+        "icmpv6-type": "echo-request,echo-reply",
+        "jump": "accept",
+        "full": "True",
+    }) == {
         "result": True,
         "rule": (
             "nft add rule ip6 filter input icmpv6 type {"

--- a/tests/pytests/unit/modules/test_nftables.py
+++ b/tests/pytests/unit/modules/test_nftables.py
@@ -123,15 +123,17 @@ def test_build_rule():
         "comment": "Successfully built rule",
     }
 
-    assert nftables.build_rule(**{
-        "table": "filter",
-        "chain": "input",
-        "family": "ip6",
-        "command": "add",
-        "icmpv6-type": "echo-request,echo-reply",
-        "jump": "accept",
-        "full": "True",
-    }) == {
+    assert nftables.build_rule(
+        **{
+            "table": "filter",
+            "chain": "input",
+            "family": "ip6",
+            "command": "add",
+            "icmpv6-type": "echo-request,echo-reply",
+            "jump": "accept",
+            "full": "True",
+        }
+    ) == {
         "result": True,
         "rule": (
             "nft add rule ip6 filter input icmpv6 type {"

--- a/tests/pytests/unit/modules/test_nftables.py
+++ b/tests/pytests/unit/modules/test_nftables.py
@@ -123,6 +123,23 @@ def test_build_rule():
         "comment": "Successfully built rule",
     }
 
+    assert nftables.build_rule(
+        table="filter",
+        chain="input",
+        family="ip6",
+        command="add",
+        icmpv6type="echo-request,echo-reply",
+        jump="accept",
+        full=True,
+    ) == {
+        "result": True,
+        "rule": (
+            "nft add rule ip6 filter input icmpv6 type {"
+            " echo-request,echo-reply } accept"
+        ),
+        "comment": "Successfully built rule",
+    }
+
     assert nftables.build_rule() == {"result": True, "rule": "", "comment": ""}
 
 

--- a/tests/pytests/unit/modules/test_nftables.py
+++ b/tests/pytests/unit/modules/test_nftables.py
@@ -130,7 +130,7 @@ def test_build_rule():
         command="add",
         icmpv6type="echo-request,echo-reply",
         jump="accept",
-        full=True,
+        full="True",
     ) == {
         "result": True,
         "rule": (


### PR DESCRIPTION
### What does this PR do?
Fixes #67882

The nftables state just sends its kwargs to the nftables module. This in turn is currently missing support for ipv6 icmp packet types (icmpv6). This means that currently Salt cannot configure a firewall in such a way that it allows pings, for example. This small patch remedies that.

### Previous Behavior
The following was impossible:
```yaml
icmp-recv-ipv4:
    nftables.append:
        - table: filter
        - family: ip4
        - chain: input
        - jump: accept
        - proto: icmp
        - icmp-type: echo-reply,destination-unreachable,source-quench,redirect,echo-request,time-exceeded,parameter-problem,timestamp-request,timestamp-reply,info-request,info-reply,address-mask-request,address-mask-reply,router-advertisement,router-solicitation
        - order: 4
        - save: True
        - require:
            - pkg: nftables


icmp-recv-ipv6:
    nftables.append:
        - table: filter
        - family: ip6
        - chain: input
        - jump: accept
        - proto: icmp
        # This wasn't supported until now --v
        - icmpv6-type: echo-reply,echo-request,nd-router-advert,nd-neighbor-solicit,nd-neighbor-advert
        - order: 4
        - save: True
        - require:
              - pkg: nftables
```

### New Behavior
The above works now.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**

I have not added any test for the above.
1. The current icmp-type functionality is untested
2. The current tests don't really test anything. They test that the module returns a state comment which fits the expectation and mock `cmd.run`. So `nft` is never executed by the tests, so you'd never know if any of this code produced an invalid rule. I do not have the time to contribute to Salt to essentially rewrite the nftables module, so this will have to live without tests.
3. The current documentation isn't really explaining the list of available parameters from the module. Neither does the module. Both need improvement, as do the tests, *but this PR is about simply adding support for icmpv6*.

<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
