### PR TITLE
Feature Alternatives to sudo for privilege escalation

### DIFF
--- a/changelog/67255.added.md
+++ b/changelog/67255.added.md
@@ -1,0 +1,2 @@
+Add ``sudo_cmd`` minion config option to allow alternative privilege
+escalation commands (e.g. ``doas``) in place of ``sudo``.

--- a/conf/minion
+++ b/conf/minion
@@ -95,6 +95,10 @@
 # directory will need to be changed to the ownership of the new user.
 #sudo_user: root
 
+# The command to use as an alternative to sudo when running remote execution
+# commands. This will default to sudo if the command below does not exist.
+#sudo_cmd: doas
+
 # Specify the location of the daemon process ID file.
 #pidfile: /var/run/salt-minion.pid
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -564,6 +564,20 @@ need to be changed to the ownership of the new user.
 
     sudo_user: root
 
+.. conf_minion:: sudo_cmd
+
+``sudo_cmd``
+-------------
+
+Default: ``''``
+
+The command to use as an alternative to sudo when running remote execution
+commands. This will default to sudo if the command below does not exist.
+
+.. code-block:: yaml
+
+    sudo_cmd: doas
+
 
 ``pidfile``
 -----------

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -933,6 +933,8 @@ VALID_OPTS = immutabletypes.freeze(
         "rest_timeout": int,
         # If set, all minion exec module actions will be rerouted through sudo as this user
         "sudo_user": str,
+        # If set, this command will be used instead of sudo
+        "sudo_cmd": str,
         # HTTP connection timeout in seconds. Applied for tornado http fetch functions like cp.get_url
         # should be greater than overall download time
         "http_connect_timeout": float,
@@ -1402,6 +1404,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "cache_sreqs": True,
         "cmd_safe": True,
         "sudo_user": "",
+        "sudo_cmd": "",
         "http_connect_timeout": 20.0,  # tornado default - 20 seconds
         "http_request_timeout": 1 * 60 * 60.0,  # 1 hour
         "http_max_body": 100 * 1024 * 1024 * 1024,  # 100GB

--- a/salt/executors/sudo.py
+++ b/salt/executors/sudo.py
@@ -12,7 +12,9 @@ __virtualname__ = "sudo"
 
 
 def __virtual__():
-    if salt.utils.path.which("sudo") and __opts__.get("sudo_user"):
+    if salt.utils.path.which(__opts__.get("sudo_cmd") or "sudo") and __opts__.get(
+        "sudo_user"
+    ):
         return __virtualname__
     return False
 
@@ -45,9 +47,18 @@ def execute(opts, data, func, args, kwargs):
         sudo -u saltdev salt-call cmd.run 'cat /etc/sudoers'
 
     being run on ``sudo_minion``.
+
+    .. code-block:: yaml
+
+        sudo_cmd: doas
+
+    Once this setting is made, any execution module call done by the minion will be
+    run using an alternative command to ``sudo``. For example, with the above
+    minion config, all commands will be run with ``doas ...`` instead of
+    ``sudo ...``.
     """
     cmd = [
-        "sudo",
+        opts.get("sudo_cmd") or "sudo",
         "-u",
         opts.get("sudo_user"),
         "salt-call",

--- a/tests/pytests/unit/executors/test_sudo.py
+++ b/tests/pytests/unit/executors/test_sudo.py
@@ -2,26 +2,25 @@ import salt.executors.sudo
 from tests.support.mock import MagicMock, patch
 
 
-def test_sudo_execute_adds_priv_arg():
-    # Setup inputs
-    opts = {"sudo_user": "saltdev", "config_dir": "/etc/salt"}
-    data = {"fun": "test.ping"}
-    func = MagicMock()
-    args = []
-    kwargs = {}
-
-    # Mock __salt__ and cmd.run_all
-    mock_run_all = MagicMock(
+def _make_run_all_mock():
+    return MagicMock(
         return_value={
             "retcode": 0,
             "stdout": '{"local": {"return": true, "retcode": 0}}',
         }
     )
 
-    # Mock __context__
+
+def _run_execute(opts, fun="test.ping", args=None, kwargs=None):
+    """Helper: run sudo.execute with mocked cmd.run_all and return call args."""
+    data = {"fun": fun}
+    func = MagicMock()
+    args = args or []
+    kwargs = kwargs or {}
+
+    mock_run_all = _make_run_all_mock()
     context_dict = {}
 
-    # Initialize dunder dictionaries if they don't exist
     if not hasattr(salt.executors.sudo, "__salt__"):
         salt.executors.sudo.__salt__ = {}
     if not hasattr(salt.executors.sudo, "__context__"):
@@ -30,23 +29,102 @@ def test_sudo_execute_adds_priv_arg():
     with patch.dict(
         salt.executors.sudo.__salt__, {"cmd.run_all": mock_run_all}
     ), patch.dict(salt.executors.sudo.__context__, context_dict):
-
         salt.executors.sudo.execute(opts, data, func, args, kwargs)
+        return mock_run_all.call_args[0][0]
 
-        # Verify the command called includes --priv saltdev
-        call_args = mock_run_all.call_args[0][0]
 
-        # Check expected parts of command
-        assert "sudo" in call_args
-        assert "-u" in call_args
-        assert "saltdev" in call_args
-        assert "salt-call" in call_args
-        assert "--priv" in call_args
+def test_sudo_execute_uses_sudo_by_default():
+    """When sudo_cmd is absent, execute() uses 'sudo'."""
+    opts = {"sudo_user": "saltdev", "config_dir": "/etc/salt"}
+    call_args = _run_execute(opts)
+    assert call_args[0] == "sudo"
+    assert "-u" in call_args
+    assert "saltdev" in call_args
+    assert "salt-call" in call_args
 
-        # Verify --priv follows salt-call and precedes saltdev
-        salt_call_idx = call_args.index("salt-call")
-        priv_idx = call_args.index("--priv")
-        user_idx = priv_idx + 1
 
-        assert priv_idx > salt_call_idx
-        assert call_args[user_idx] == "saltdev"
+def test_sudo_execute_adds_priv_arg():
+    """execute() passes --priv <sudo_user> to salt-call."""
+    opts = {"sudo_user": "saltdev", "config_dir": "/etc/salt"}
+    call_args = _run_execute(opts)
+
+    assert "--priv" in call_args
+    salt_call_idx = call_args.index("salt-call")
+    priv_idx = call_args.index("--priv")
+    assert priv_idx > salt_call_idx
+    assert call_args[priv_idx + 1] == "saltdev"
+
+
+def test_sudo_execute_uses_sudo_cmd_when_set():
+    """When sudo_cmd is set, execute() uses it instead of 'sudo'."""
+    opts = {"sudo_user": "saltdev", "config_dir": "/etc/salt", "sudo_cmd": "doas"}
+    call_args = _run_execute(opts)
+    assert call_args[0] == "doas"
+    assert "sudo" not in call_args
+
+
+def test_sudo_execute_uses_sudo_when_sudo_cmd_empty():
+    """When sudo_cmd is an empty string (default config value), execute() uses 'sudo'."""
+    opts = {"sudo_user": "saltdev", "config_dir": "/etc/salt", "sudo_cmd": ""}
+    call_args = _run_execute(opts)
+    assert call_args[0] == "sudo"
+
+
+def _with_opts(opts):
+    """Return a context manager that patches __opts__ on the sudo executor."""
+    if not hasattr(salt.executors.sudo, "__opts__"):
+        salt.executors.sudo.__opts__ = {}
+    return patch.dict(salt.executors.sudo.__opts__, opts)
+
+
+def test_sudo_virtual_loads_with_sudo_present(tmp_path):
+    """__virtual__ returns the virtualname when sudo is found and sudo_user is set."""
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.touch()
+    fake_sudo.chmod(0o755)
+
+    opts = {"sudo_user": "saltdev", "sudo_cmd": ""}
+    with _with_opts(opts), patch(
+        "salt.utils.path.which",
+        side_effect=lambda x: str(fake_sudo) if x == "sudo" else None,
+    ):
+        result = salt.executors.sudo.__virtual__()
+    assert result == "sudo"
+
+
+def test_sudo_virtual_loads_with_sudo_cmd(tmp_path):
+    """__virtual__ returns the virtualname when sudo_cmd binary is found."""
+    fake_doas = tmp_path / "doas"
+    fake_doas.touch()
+    fake_doas.chmod(0o755)
+
+    opts = {"sudo_user": "saltdev", "sudo_cmd": "doas"}
+    with _with_opts(opts), patch(
+        "salt.utils.path.which",
+        side_effect=lambda x: str(fake_doas) if x == "doas" else None,
+    ):
+        result = salt.executors.sudo.__virtual__()
+    assert result == "sudo"
+
+
+def test_sudo_virtual_false_without_sudo_user(tmp_path):
+    """__virtual__ returns False when sudo_user is not configured."""
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.touch()
+    fake_sudo.chmod(0o755)
+
+    opts = {"sudo_user": "", "sudo_cmd": ""}
+    with _with_opts(opts), patch(
+        "salt.utils.path.which",
+        side_effect=lambda x: str(fake_sudo) if x == "sudo" else None,
+    ):
+        result = salt.executors.sudo.__virtual__()
+    assert result is False
+
+
+def test_sudo_virtual_false_when_neither_sudo_nor_sudo_cmd_found():
+    """__virtual__ returns False when the escalation binary is not on PATH."""
+    opts = {"sudo_user": "saltdev", "sudo_cmd": "doas"}
+    with _with_opts(opts), patch("salt.utils.path.which", return_value=None):
+        result = salt.executors.sudo.__virtual__()
+    assert result is False


### PR DESCRIPTION
### What does this PR do?
This commit adds functionality for alternative privilege escalation
commands to be used via the `sudo_cmd` variable in the minion config
file. If the variable is absent the default of `sudo` is used.


### What issues does this PR fix or reference?
Fixes #67255 

### Previous Behavior
Only `sudo` was available for privilege escalation.

### New Behavior
`sudo` is the default privilege escalation. `sudo_cmd` has been added
and allows alternatives to be specified in the minion config file via this
variable.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes