### PR TITLE
set virtual grain for docker using systemd and virt-what

### DIFF
--- a/changelog/67905.fixed.md
+++ b/changelog/67905.fixed.md
@@ -1,0 +1,1 @@
+Set virtual grain for docker using systemd and virt-what

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -933,6 +933,10 @@ def _virtual(osdata):
                 grains["virtual"] = "container"
                 grains["virtual_subtype"] = "Podman"
                 break
+            elif "docker" in output:
+                grains["virtual"] = "container"
+                grains["virtual_subtype"] = "Docker"
+                break
             elif "amazon" in output:
                 grains["virtual"] = "Nitro"
                 grains["virtual_subtype"] = "Amazon EC2"
@@ -945,6 +949,10 @@ def _virtual(osdata):
                 elif "lxc" in line:
                     grains["virtual"] = "container"
                     grains["virtual_subtype"] = "LXC"
+                    break
+                elif "docker" in line:
+                    grains["virtual"] = "container"
+                    grains["virtual_subtype"] = "Docker"
                     break
                 elif "vmware" in line:
                     grains["virtual"] = "VMware"


### PR DESCRIPTION
### What does this PR do?

Correctly handle the systemd-detect-virt and virt-what output to identify a
Docker container running systemd as what it is instead of as a physical machine.

### What issues does this PR fix or reference?
Fixes #67905

### Previous Behavior
```
# systemd-detect-virt
docker

# virt-what
docker

# salt-call --local grains.get virtual
local:
    physical
```

### New Behavior
```
# systemd-detect-virt
docker

# virt-what
docker

# salt-call --local grains.get virtual
local:
    container
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
