### PR TITLE
[3006.x] Added support and tests for Sys V service files for RedHat family

### DIFF
--- a/changelog/67888.fixed.md
+++ b/changelog/67888.fixed.md
@@ -1,0 +1,1 @@
+Added service files for specific rpm packages to /etc/init.d

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -330,6 +330,13 @@ install -p -m 0644 %{_salt_src}/doc/man/salt-api.1 %{buildroot}%{_mandir}/man1/s
 install -p -m 0644 %{_salt_src}/doc/man/salt-cloud.1 %{buildroot}%{_mandir}/man1/salt-cloud.1
 install -p -m 0644 %{_salt_src}/doc/man/salt-ssh.1 %{buildroot}%{_mandir}/man1/salt-ssh.1
 
+# Sys V service files
+mkdir -p %{buildroot}%{_sysconfdir}/init.d
+install -p -m 0755 %{_salt_src}/pkg/rpm/salt-minion %{buildroot}%{_sysconfdir}/init.d/salt-minion
+install -p -m 0755 %{_salt_src}/pkg/rpm/salt-master %{buildroot}%{_sysconfdir}/init.d/salt-master
+install -p -m 0755 %{_salt_src}/pkg/rpm/salt-syndic %{buildroot}%{_sysconfdir}/init.d/salt-syndic
+install -p -m 0755 %{_salt_src}/pkg/rpm/salt-api %{buildroot}%{_sysconfdir}/init.d/salt-api
+
 
 %clean
 rm -rf %{buildroot}
@@ -381,6 +388,7 @@ rm -rf %{buildroot}
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/roots/
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/syndics/
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/tokens/
+%{_sysconfdir}/init.d/salt-master
 
 
 %files minion
@@ -398,12 +406,14 @@ rm -rf %{buildroot}
 %config(noreplace) %{_sysconfdir}/salt/pki/minion
 %dir %{_sysconfdir}/salt/minion.d
 %dir %attr(0750, root, root) %{_var}/cache/salt/minion/
+%{_sysconfdir}/init.d/salt-minion
 
 
 %files syndic
 %doc %{_mandir}/man1/salt-syndic.1*
 %{_bindir}/salt-syndic
 %{_unitdir}/salt-syndic.service
+%{_sysconfdir}/init.d/salt-syndic
 
 
 %files api
@@ -411,6 +421,7 @@ rm -rf %{buildroot}
 %doc %{_mandir}/man1/salt-api.1*
 %{_bindir}/salt-api
 %{_unitdir}/salt-api.service
+%{_sysconfdir}/init.d/salt-api
 
 
 %files cloud

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import pathlib
+import subprocess
 import sys
 import time
 
@@ -8,6 +10,7 @@ import psutil
 import pytest
 from pytestskipmarkers.utils import platform
 
+import salt.utils.path
 from tests.support.pkg import pep440_public_equal
 
 log = logging.getLogger(__name__)
@@ -252,6 +255,62 @@ def _get_installed_salt_packages():
             packages.append((name.strip(), version.strip()))
 
     return packages
+
+
+def test_salt_sysv_service_files(install_salt):
+    """
+    Test an upgrade of Salt, Minion and Master
+    """
+    if not install_salt.upgrade:
+        pytest.skip("Not testing an upgrade, do not run")
+
+    if sys.platform != "linux":
+        pytest.skip("Not testing on a Linux platform, do not run")
+
+    if not (salt.utils.path.which("dpkg") or salt.utils.path.which("rpm")):
+        pytest.skip("Not testing on a Debian or RedHat family platform, do not run")
+
+    test_pkgs = install_salt.pkgs
+    for test_pkg_name in test_pkgs:
+        test_pkg_basename = os.path.basename(test_pkg_name)
+        # Debian/Ubuntu name typically salt-minion_300xxxxxx
+        # Redhat name typically salt-minion-300xxxxxx
+        test_pkg_basename_dash_underscore = test_pkg_basename.split("300")[0]
+        test_pkg_basename_adj = test_pkg_basename_dash_underscore[:-1]
+        if test_pkg_basename_adj in (
+            "salt-minion",
+            "salt-master",
+            "salt-syndic",
+            "salt-api",
+        ):
+            test_initd_name = f"/etc/init.d/{test_pkg_basename_adj}"
+            if salt.utils.path.which("dpkg"):
+                if os.path.exists("/etc/debian_version"):
+                    proc = subprocess.run(
+                        ["dpkg", "-c", f"{test_pkg_name}"],
+                        capture_output=True,
+                        check=True,
+                    )
+                else:
+                    proc = subprocess.run(
+                        ["dpkg", "-q", "-c", f"{test_pkg_name}"],
+                        capture_output=True,
+                        check=True,
+                    )
+            elif salt.utils.path.which("rpm"):
+                proc = subprocess.run(
+                    ["rpm", "-q", "-l", "-p", f"{test_pkg_name}"],
+                    capture_output=True,
+                    check=True,
+                )
+            found_line = False
+            for line in proc.stdout.decode().splitlines():
+                # If test_initd_name not present we should fail.
+                if line == test_initd_name:
+                    found_line = True
+                    break
+
+            assert found_line
 
 
 def test_salt_upgrade(


### PR DESCRIPTION
### What does this PR do?
Adds service files for salt-minion, salt-master, salt-syndic and salt-api to /etc/init.d

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/67888

### Previous Behavior
Sys V Service files were missing since 3006.0 release

### New Behavior
Sys V Service files are now present after installation

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
