### PR TITLE
Fix osrelease_info grain on Windows

### DIFF
--- a/changelog/66936.fixed.md
+++ b/changelog/66936.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue with the osrelease_info grain that was displaying empty strings

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2685,6 +2685,7 @@ def os_data():
             osrelease_info[1] = osrelease_info[1].lstrip("R")
         else:
             osrelease_info = grains["osrelease"].split(".")
+        osrelease_info = [s for s in osrelease_info if s]
 
         for idx, value in enumerate(osrelease_info):
             if not value.isdigit():

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1552,7 +1552,7 @@ def test_windows_platform_data():
         "2016Server",
         "2019Server",
         "2022Server",
-        "2025Server"
+        "2025Server",
     ]
     assert returned_grains["osrelease"] in valid_releases
 
@@ -3058,19 +3058,17 @@ def test_osdata_virtual_key_win():
 @pytest.mark.parametrize(
     "osrelease, expected",
     [
-        ("2025Server", (2025, )),
+        ("2025Server", (2025,)),
         ("2012ServerR2", (2012, 2)),
-        ("11", (11, )),
-        ("8.1", (8, 1))
-    ]
+        ("11", (11,)),
+        ("8.1", (8, 1)),
+    ],
 )
 def test_windows_osdata_osrelease_info(osrelease, expected):
     platform_data = core._windows_platform_data()
     platform_data["osrelease"] = osrelease
     mock_platform_data = MagicMock(return_value=platform_data)
-    with patch.object(
-        core, "_windows_platform_data", mock_platform_data
-    ):
+    with patch.object(core, "_windows_platform_data", mock_platform_data):
         os_data = core.os_data()
         assert os_data["osrelease_info"] == expected
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1552,12 +1552,17 @@ def test_windows_platform_data():
         "2016Server",
         "2019Server",
         "2022Server",
+        "2025Server"
     ]
     assert returned_grains["osrelease"] in valid_releases
 
 
 def test__windows_os_release_grain(subtests):
     versions = {
+        "Windows 11 Enterprise": "11",
+        "Windows 11 Pro": "11",
+        "Windows 11 Home": "11",
+        "Windows 11 Education": "11",
         "Windows 10 Home": "10",
         "Windows 10 Pro": "10",
         "Windows 10 Pro for Workstations": "10",
@@ -2933,6 +2938,7 @@ def test_virtual_has_virtual_grain():
 
 
 def test__windows_platform_data():
+
     pass
 
 
@@ -3046,6 +3052,27 @@ def test_windows_virtual_has_virtual_grain():
 def test_osdata_virtual_key_win():
     osdata_grains = core.os_data()
     assert "virtual" in osdata_grains
+
+
+@pytest.mark.skip_unless_on_windows
+@pytest.mark.parametrize(
+    "osrelease, expected",
+    [
+        ("2025Server", (2025, )),
+        ("2012ServerR2", (2012, 2)),
+        ("11", (11, )),
+        ("8.1", (8, 1))
+    ]
+)
+def test_windows_osdata_osrelease_info(osrelease, expected):
+    platform_data = core._windows_platform_data()
+    platform_data["osrelease"] = osrelease
+    mock_platform_data = MagicMock(return_value=platform_data)
+    with patch.object(
+        core, "_windows_platform_data", mock_platform_data
+    ):
+        os_data = core.os_data()
+        assert os_data["osrelease_info"] == expected
 
 
 @pytest.mark.skip_unless_on_linux


### PR DESCRIPTION
### What does this PR do?
Removes empty data from the osrelease_info grain on Windows

### What issues does this PR fix or reference?
Fixes #66936 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes