### PR TITLE
Fixes 67185: Makes the correct pki_dir available for key_cache

### DIFF
--- a/changelog/67185.fixed.md
+++ b/changelog/67185.fixed.md
@@ -1,0 +1,1 @@
+Made the correct PKI directory available for key_cache use

--- a/salt/master.py
+++ b/salt/master.py
@@ -226,6 +226,11 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
         self.loop_interval = int(self.opts["loop_interval"])
         # A serializer for general maint operations
         self.restart_interval = int(self.opts["maintenance_interval"])
+        # Initializes pki_dir with the correct option for clustered environments
+        if "cluster_id" in self.opts and self.opts["cluster_id"]:
+            self.pki_dir = self.opts["cluster_pki_dir"]
+        else:
+            self.pki_dir = self.opts.get("pki_dir", "")
 
     def _post_fork_init(self):
         """

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -78,6 +78,31 @@ def encrypted_requests(tmp_path):
     )
 
 
+def test_maintenance_pki_dir_initialized():
+    """
+    Verify Maintenance pki_dir property initalization
+    """
+    not_clustered_path = "not_clustered"
+    clustered_path = "clustered"
+    opts = {
+        "loop_interval": 10,
+        "maintenance_interval": 1,
+        "pki_dir": not_clustered_path,
+        "cluster_pki_dir": clustered_path,
+    }
+
+    # If it's not a cluster, pki_dir is opts['pki_dir']
+    mp = salt.master.Maintenance(opts)
+    assert mp.pki_dir == not_clustered_path
+    assert mp.pki_dir != clustered_path
+
+    # If it's a cluster, pki_dir is opts['cluster_pki_dir']
+    opts.update(cluster_id="test-cluster")
+    mp = salt.master.Maintenance(opts)
+    assert mp.pki_dir == clustered_path
+    assert mp.pki_dir != not_clustered_path
+
+
 def test_maintenance_duration():
     """
     Validate Maintenance process duration.


### PR DESCRIPTION
### What does this PR do?
Makes the correct PKI directory available for handle_key_cache function.

### What issues does this PR fix or reference?
Fixes #67185 

### Previous Behavior
```
2025-01-22 08:19:16,192 [salt.utils.process:1000][ERROR   ][40178] An un-handled exception from the multiprocessing process 'Maintenance' was caught:
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/process.py", line 995, in wrapped_run_func
    return run_func()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/master.py", line 312, in run
    self.handle_key_cache()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/master.py", line 339, in handle_key_cache
    os.path.join(self.pki_dir, acc, ".key_cache"), mode="wb"
AttributeError: 'Maintenance' object has no attribute 'pki_dir'
```

### New Behavior
No error

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs - I don't know which Docs are expected for this kind of bug fix, but I hope the code itself is well commented.
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
