### PR TITLE
[3006.x] Remove broken salt-common bash-completion links in root filesystem

### DIFF
--- a/changelog/67915.fixed.md
+++ b/changelog/67915.fixed.md
@@ -1,0 +1,1 @@
+Remove broken salt-common bash-completion links in root filesystem

--- a/pkg/debian/salt-common.links
+++ b/pkg/debian/salt-common.links
@@ -1,9 +1,3 @@
-# permissions on /var/log/salt to permit adm group ownership
-salt-common: non-standard-dir-perm
-
-# minor formatting error in table in man page
-salt-common: manpage-has-errors-from-man
-
 opt/saltstack/salt/salt-pip /usr/bin/salt-pip
 opt/saltstack/salt/salt-call /usr/bin/salt-call
 usr/share/bash-completion/completions/salt-common usr/share/bash-completion/completions/salt-call


### PR DESCRIPTION
### What does this PR do?
Remove Debian broken salt-common bash-completion links in root filesystem

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/67915

### Previous Behavior
Created salt-common file in root directory '/' and broken symbolic links **_manpage-has-errors-from-man_** and **_non-standard-dir-perm_**

### New Behavior
No longer create broken symbolic links and salt-common in root directory '/'

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
