### PR TITLE
Prepend cmd when using built-in commands on Windows

### DIFF
--- a/changelog/54821.fixed.md
+++ b/changelog/54821.fixed.md
@@ -1,0 +1,2 @@
+Fixes an issue with cmd.run where the command is a built-in command and must be
+run with cmd.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -287,9 +287,9 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
         # We need to append $LASTEXITCODE here to return the actual exit code
         # from the script. Otherwise, it will always return 1 on any non-zero
         # exit code failure. Issue: #60884
-        new_cmd.append(f"& {cmd.strip()}; exit $LASTEXITCODE")
+        new_cmd.append(f'"& {cmd.strip()}; exit $LASTEXITCODE"')
     elif encoded_cmd:
-        new_cmd.extend(["-EncodedCommand", f"{cmd}"])
+        new_cmd.extend(["-EncodedCommand", f'"{cmd}"'])
     else:
         # Strip whitespace
         if isinstance(cmd, list):
@@ -301,10 +301,10 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
 
         for keyword in keywords:
             if cmd.lower().startswith(keyword.lower()):
-                new_cmd.extend(["-Command", f"{cmd.strip()}"])
+                new_cmd.extend(["-Command", f'"{cmd.strip()}"'])
                 break
         else:
-            new_cmd.extend(["-Command", f"& {cmd.strip()}"])
+            new_cmd.extend(["-Command", f'"& {cmd.strip()}"'])
 
     log.debug(new_cmd)
     return new_cmd

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -20,6 +20,7 @@ import time
 import traceback
 
 import salt.grains.extra
+import salt.platform.win
 import salt.utils.args
 import salt.utils.data
 import salt.utils.files
@@ -450,13 +451,16 @@ def _run(
         )
         log.info(log_callback(msg))
 
-    if runas and salt.utils.platform.is_windows():
-        if not HAS_WIN_RUNAS:
-            msg = "missing salt/utils/win_runas.py"
-            raise CommandExecutionError(msg)
+    if salt.utils.platform.is_windows():
+        if runas:
+            if not HAS_WIN_RUNAS:
+                msg = "missing salt/utils/win_runas.py"
+                raise CommandExecutionError(msg)
 
         if isinstance(cmd, (list, tuple)):
             cmd = " ".join(cmd)
+
+        cmd = salt.platform.win.prepend_cmd(cmd)
 
     if runas and salt.utils.platform.is_darwin():
         # We need to insert the user simulation into the command itself and not

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -20,7 +20,6 @@ import time
 import traceback
 
 import salt.grains.extra
-import salt.platform.win
 import salt.utils.args
 import salt.utils.data
 import salt.utils.files
@@ -54,6 +53,7 @@ except ImportError:
     pass
 
 if salt.utils.platform.is_windows():
+    import salt.platform.win
     from salt.utils.win_functions import escape_argument as _cmd_quote
     from salt.utils.win_runas import runas as win_runas
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -269,7 +269,13 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
     if not win_shell:
         raise CommandExecutionError(f"PowerShell binary not found: {win_shell}")
 
-    new_cmd = [win_shell, "-NonInteractive", "-NoProfile", "-ExecutionPolicy", "Bypass"]
+    new_cmd = [
+        f'"{win_shell}"',
+        "-NonInteractive",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+    ]
 
     # extract_stack() returns a list of tuples.
     # The last item in the list [-1] is the current method.
@@ -456,9 +462,6 @@ def _run(
             if not HAS_WIN_RUNAS:
                 msg = "missing salt/utils/win_runas.py"
                 raise CommandExecutionError(msg)
-
-        if isinstance(cmd, (list, tuple)):
-            cmd = " ".join(cmd)
 
         cmd = salt.platform.win.prepend_cmd(cmd)
 

--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -75,7 +75,16 @@ def rm_dns(ip, interface="Local Area Connection"):
 
         salt '*' win_dns_client.rm_dns <ip> <interface>
     """
-    cmd = ["netsh", "interface", "ip", "delete", "dns", interface, ip, "validate=no"]
+    cmd = [
+        "netsh",
+        "interface",
+        "ip",
+        "delete",
+        "dns",
+        f'"{interface}"',
+        f'"{ip}"',
+        "validate=no",
+    ]
     return __salt__["cmd.retcode"](cmd, python_shell=False) == 0
 
 
@@ -116,8 +125,8 @@ def add_dns(ip, interface="Local Area Connection", index=1):
         "ip",
         "add",
         "dns",
-        interface,
-        ip,
+        f'"{interface}"',
+        f'"{ip}"',
         f"index={index}",
         "validate=no",
     ]
@@ -135,7 +144,7 @@ def dns_dhcp(interface="Local Area Connection"):
 
         salt '*' win_dns_client.dns_dhcp <interface>
     """
-    cmd = ["netsh", "interface", "ip", "set", "dns", interface, "source=dhcp"]
+    cmd = ["netsh", "interface", "ip", "set", "dns", f'"{interface}"', "source=dhcp"]
     return __salt__["cmd.retcode"](cmd, python_shell=False) == 0
 
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -59,7 +59,7 @@ def _pshell(cmd, cwd=None, json_depth=2, ignore_retcode=False):
     in json format and load that into python. Either return a dict or raise a
     CommandExecutionError.
     """
-    if "convertto-json" not in cmd.lower():
+    if "ConvertTo-Json" not in cmd.lower():
         cmd = f"{cmd} | ConvertTo-Json -Depth {json_depth}"
     log.debug("DSC: %s", cmd)
     results = __salt__["cmd.run_all"](
@@ -300,7 +300,7 @@ def compile_config(
     cmd.append(
         r"| Where-Object FullName -match '(?<!\.meta)\.mof$' "
         "| Select-Object -Property FullName, Extension, Exists, "
-        '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
+        "@{Name='LastWriteTime';Expression={Get-Date ($_.LastWriteTime) "
         "-Format g}}"
     )
 
@@ -325,7 +325,7 @@ def compile_config(
     cmd.append(
         r"| Where-Object FullName -match '(?<!\.meta)\.mof$' "
         "| Select-Object -Property FullName, Extension, Exists, "
-        '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
+        "@{Name='LastWriteTime';Expression={Get-Date ($_.LastWriteTime) "
         "-Format g}}"
     )
 
@@ -414,7 +414,7 @@ def apply_config(path, source=None, salt_env="base"):
 
     # Run the DSC Configuration
     # Putting quotes around the parameter protects against command injection
-    cmd = f'Start-DscConfiguration -Path "{config}" -Wait -Force'
+    cmd = f"Start-DscConfiguration -Path '{config}' -Wait -Force"
     _pshell(cmd)
 
     cmd = "$status = Get-DscConfigurationStatus; $status.Status"
@@ -635,7 +635,7 @@ def get_config_status():
     cmd = (
         "Get-DscConfigurationStatus | "
         "Select-Object -Property HostName, Status, MetaData, "
-        '@{Name="StartDate";Expression={Get-Date ($_.StartDate) -Format g}}, '
+        "@{Name='StartDate';Expression={Get-Date ($_.StartDate) -Format g}}, "
         "Type, Mode, RebootRequested, NumberofResources"
     )
     try:
@@ -761,7 +761,7 @@ def set_lcm_config(
                 "or ApplyAndAutoCorrect. Passed {}".format(config_mode)
             )
             raise SaltInvocationError(error)
-        cmd += f'            ConfigurationMode = "{config_mode}";'
+        cmd += f"            ConfigurationMode = '{config_mode}';"
     if config_mode_freq:
         if not isinstance(config_mode_freq, int):
             error = "config_mode_freq must be an integer. Passed {}".format(
@@ -776,7 +776,7 @@ def set_lcm_config(
             raise SaltInvocationError(
                 "refresh_mode must be one of Disabled, Push, or Pull"
             )
-        cmd += f'            RefreshMode = "{refresh_mode}";'
+        cmd += f"            RefreshMode = '{refresh_mode}';"
     if refresh_freq:
         if not isinstance(refresh_freq, int):
             raise SaltInvocationError("refresh_freq must be an integer")

--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -151,7 +151,7 @@ def get_rule(name="all"):
 
         salt '*' firewall.get_rule 'MyAppPort'
     """
-    cmd = ["netsh", "advfirewall", "firewall", "show", "rule", f"name={name}"]
+    cmd = ["netsh", "advfirewall", "firewall", "show", "rule", f'name="{name}"']
     ret = __salt__["cmd.run_all"](cmd, python_shell=False, ignore_retcode=True)
     if ret["retcode"] != 0:
         raise CommandExecutionError(ret["stdout"])
@@ -228,15 +228,15 @@ def add_rule(name, localport, protocol="tcp", action="allow", dir="in", remoteip
         "firewall",
         "add",
         "rule",
-        f"name={name}",
-        f"protocol={protocol}",
-        f"dir={dir}",
-        f"action={action}",
-        f"remoteip={remoteip}",
+        f'name="{name}"',
+        f'protocol="{protocol}"',
+        f'dir="{dir}"',
+        f'action="{action}"',
+        f'remoteip="{remoteip}"',
     ]
 
     if protocol is None or ("icmpv4" not in protocol and "icmpv6" not in protocol):
-        cmd.append(f"localport={localport}")
+        cmd.append(f'localport="{localport}"')
 
     ret = __salt__["cmd.run_all"](cmd, python_shell=False, ignore_retcode=True)
     if ret["retcode"] != 0:
@@ -292,19 +292,19 @@ def delete_rule(name=None, localport=None, protocol=None, dir=None, remoteip=Non
     """
     cmd = ["netsh", "advfirewall", "firewall", "delete", "rule"]
     if name:
-        cmd.append(f"name={name}")
+        cmd.append(f'name="{name}"')
     if protocol:
-        cmd.append(f"protocol={protocol}")
+        cmd.append(f'protocol="{protocol}"')
     if dir:
-        cmd.append(f"dir={dir}")
+        cmd.append(f'dir="{dir}"')
     if remoteip:
-        cmd.append(f"remoteip={remoteip}")
+        cmd.append(f'remoteip="{remoteip}"')
 
     if protocol is None or ("icmpv4" not in protocol and "icmpv6" not in protocol):
         if localport:
             if not protocol:
                 cmd.append("protocol=tcp")
-            cmd.append(f"localport={localport}")
+            cmd.append(f'localport="{localport}"')
 
     ret = __salt__["cmd.run_all"](cmd, python_shell=False, ignore_retcode=True)
     if ret["retcode"] != 0:

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1345,7 +1345,17 @@ def prepend_cmd(cmd):
     # built-in commands such as echo. So, let's check for the binary in the
     # path. If it does not exist, let's assume it's a built-in and requires us
     # to run it in a cmd prompt.
-    first_cmd = cmd.split(" ", 1)[0]
+    if not isinstance(cmd, (list, tuple)):
+        cmd = cmd.split()
+
+    # Let's try to figure out what the fist command is so we can check for
+    # builtin commands such as echo
+    first_cmd = cmd[0].split("\\")[-1].strip("\"'")
+
+    cmd = " ".join(cmd)
+
+    # If the first command can't be found, we'll assume it's a builtin command
+    # We'll need to prepend cmd /c
     if salt.utils.path.which(first_cmd) is None:
         cmd = f'cmd /c "{cmd}"'
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1354,6 +1354,15 @@ def prepend_cmd(cmd):
 
     cmd = " ".join(cmd)
 
+    # TODO: SDL: This is for testing. Remove this once we've figured out why
+    # TODO: SDL: the unit.platform.test_win test is failing to detect echo
+    # TODO: SDL: as a builtin command
+    print("")
+    print("*" * 80)
+    print("first_cmd: ", first_cmd)
+    print("which_cmd: ", salt.utils.path.which(first_cmd))
+    print("*" * 80)
+
     # If the first command can't be found, we'll assume it's a builtin command
     # We'll need to prepend cmd /c
     if salt.utils.path.which(first_cmd) is None:

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1354,18 +1354,55 @@ def prepend_cmd(cmd):
 
     cmd = " ".join(cmd)
 
-    # TODO: SDL: This is for testing. Remove this once we've figured out why
-    # TODO: SDL: the unit.platform.test_win test is failing to detect echo
-    # TODO: SDL: as a builtin command
-    print("")
-    print("*" * 80)
-    print("first_cmd: ", first_cmd)
-    print("which_cmd: ", salt.utils.path.which(first_cmd))
-    print("*" * 80)
+    # Known builtin cmd commands
+    known_builtins = [
+        "assoc",
+        "break",
+        "call",
+        "cd",
+        "chdir",
+        "cls",
+        "color",
+        "copy",
+        "date",
+        "del",
+        "dir",
+        "echo",
+        "endlocal",
+        "erase",
+        "exit",
+        "for",
+        "ftype",
+        "goto",
+        "if",
+        "md",
+        "mklink",
+        "move",
+        "path",
+        "pause",
+        "popd",
+        "prompt",
+        "pushd",
+        "rd",
+        "rem",
+        "ren",
+        "rmdir",
+        "set",
+        "setlocal",
+        "shift",
+        "start",
+        "time",
+        "title",
+        "type",
+        "ver",
+        "verify",
+        "vol",
+        "::",
+    ]
 
-    # If the first command can't be found, we'll assume it's a builtin command
-    # We'll need to prepend cmd /c
-    if salt.utils.path.which(first_cmd) is None:
+    # If the first command is one of the known builtin commands or if it is a
+    # binary that can't be found, we'll prepend cmd /c
+    if first_cmd in known_builtins or salt.utils.path.which(first_cmd) is None:
         cmd = f'cmd /c "{cmd}"'
 
     # There are a few other things we need to check for that require cmd. If the

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -8,6 +8,7 @@ import threading
 
 import salt.exceptions
 import salt.utils.data
+import salt.utils.platform
 import salt.utils.stringutils
 
 
@@ -52,11 +53,12 @@ class TimedProc:
             self.process = subprocess.Popen(args, **kwargs)
         except (AttributeError, TypeError):
             if not kwargs.get("shell", False):
+                use_posix = not salt.utils.platform.is_windows()
                 if not isinstance(args, (list, tuple)):
                     try:
-                        args = shlex.split(args)
+                        args = shlex.split(args, posix=use_posix)
                     except AttributeError:
-                        args = shlex.split(str(args))
+                        args = shlex.split(str(args), posix=use_posix)
                 str_args = []
                 for arg in args:
                     if not isinstance(arg, str):

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -8,7 +8,6 @@ import logging
 import os
 import time
 
-import salt.utils.path
 from salt.exceptions import CommandExecutionError
 
 try:
@@ -204,18 +203,6 @@ def runas(cmd, username, password=None, cwd=None):
     # Create the environment for the user
     env = create_env(user_token, False)
 
-    # Because we're launching runas commands using the Windows API they are run in a
-    # process instead of a cmd or powershell prompt. Built-in commands, such as echo,
-    # are not available. So, let's check for the binary in the path. If it does not
-    # exist, let's assume it's a built-in and requires us to run it in a cmd prompt.
-    first_cmd = cmd.split(" ", 1)[0]
-    if salt.utils.path.which(first_cmd) is None:
-        cmd = f'cmd /c "{cmd}"'
-
-    # The "&&" is a function of CMD.
-    if "&&" in cmd and not cmd.startswith("cmd"):
-        cmd = f'cmd /c "{cmd}"'
-
     hProcess = None
     try:
         # Start the process in a suspended state.
@@ -317,18 +304,6 @@ def runas_unpriv(cmd, username, password, cwd=None):
         hStdOutput=c2pwrite,
         hStdError=errwrite,
     )
-
-    # Because we're launching runas commands using the Windows API they are run in a
-    # process instead of a cmd or powershell prompt. Built-in commands, such as echo,
-    # are not available. So, let's check for the binary in the path. If it does not
-    # exist, let's assume it's a built-in and requires us to run it in a cmd prompt.
-    first_cmd = cmd.split(" ", 1)[0]
-    if salt.utils.path.which(first_cmd) is None:
-        cmd = f'cmd /c "{cmd}"'
-
-    # The "&&" is a function of CMD.
-    if "&&" in cmd and not cmd.startswith("cmd"):
-        cmd = f'cmd /c "{cmd}"'
 
     try:
         # Run command and return process info structure

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -50,6 +50,9 @@ salt/modules/*apache.py:
 salt/modules/augeas_cfg.py:
   - pytests.unit.states.test_augeas
 
+salt/platform/win.py:
+  - pytests.unit.platform.test_win
+
 salt/modules/cp.py:
   - pytests.functional.modules.file.test_replace
   - pytests.unit.modules.file.test_file_basics

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -329,17 +329,17 @@ class GitModuleTest(ModuleCase):
         # Stage the file
         self.run_function("git.add", [self.repo, filename])
         # Commit the staged file
-        commit_msg = "Add a line to " + filename
-        ret = self.run_function("git.commit", [self.repo, f'"{commit_msg}"'])
+        commit_msg = f'"Add a line to {filename}"'
+        ret = self.run_function("git.commit", [self.repo, commit_msg])
         # Make sure the expected line is in the output
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
         # Add another line
         with salt.utils.files.fopen(os.path.join(self.repo, filename), "a") as fp_:
             fp_.write("Added another line\n")
         # Commit the second file without staging
-        commit_msg = "Add another line to " + filename
+        commit_msg = f'"Add another line to {filename}"'
         ret = self.run_function(
-            "git.commit", [self.repo, f'"{commit_msg}"'], filename=filename
+            "git.commit", [self.repo, commit_msg], filename=filename
         )
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
 

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -329,19 +329,21 @@ class GitModuleTest(ModuleCase):
         # Stage the file
         self.run_function("git.add", [self.repo, filename])
         # Commit the staged file
-        commit_msg = f'"Add a line to {filename}"'
-        ret = self.run_function("git.commit", [self.repo, commit_msg])
+        commit_msg = f"Add a line to {filename}"
+        ret = self.run_function("git.commit", [self.repo, f'"{commit_msg}"'])
         # Make sure the expected line is in the output
-        self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
+        self.assertTrue(bool(re.search(commit_re_prefix, ret)))
+        self.assertTrue(bool(commit_msg in ret))
         # Add another line
         with salt.utils.files.fopen(os.path.join(self.repo, filename), "a") as fp_:
             fp_.write("Added another line\n")
         # Commit the second file without staging
-        commit_msg = f'"Add another line to {filename}"'
+        commit_msg = f"Add another line to {filename}"
         ret = self.run_function(
-            "git.commit", [self.repo, commit_msg], filename=filename
+            "git.commit", [self.repo, f'"{commit_msg}"'], filename=filename
         )
-        self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
+        self.assertTrue(bool(re.search(commit_re_prefix, ret)))
+        self.assertTrue(bool(commit_msg in ret))
 
     @pytest.mark.slow_test
     def test_config(self):

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -330,7 +330,7 @@ class GitModuleTest(ModuleCase):
         self.run_function("git.add", [self.repo, filename])
         # Commit the staged file
         commit_msg = "Add a line to " + filename
-        ret = self.run_function("git.commit", [self.repo, commit_msg])
+        ret = self.run_function("git.commit", [self.repo, f'"{commit_msg}"'])
         # Make sure the expected line is in the output
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
         # Add another line
@@ -339,7 +339,7 @@ class GitModuleTest(ModuleCase):
         # Commit the second file without staging
         commit_msg = "Add another line to " + filename
         ret = self.run_function(
-            "git.commit", [self.repo, commit_msg], filename=filename
+            "git.commit", [self.repo, f'"{commit_msg}"'], filename=filename
         )
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
 
@@ -674,7 +674,7 @@ class GitModuleTest(ModuleCase):
             "ERROR",
             self.run_function(
                 "git.commit",
-                [self.repo, "Added a line to " + self.files[1]],
+                [self.repo, f'"Added a line to {self.files[1]}"'],
                 filename=self.files[1],
             ),
         )

--- a/tests/pytests/functional/modules/cmd/test_run_win.py
+++ b/tests/pytests/functional/modules/cmd/test_run_win.py
@@ -3,6 +3,7 @@ import pytest
 pytestmark = [
     pytest.mark.core_test,
     pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
 ]
 
 
@@ -12,7 +13,6 @@ def account():
         yield _account
 
 
-@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
 @pytest.mark.parametrize(
     "exit_code, return_code, result",
     [
@@ -28,7 +28,6 @@ def test_script_exitcode(modules, state_tree, exit_code, return_code, result):
     assert ret.filtered["changes"]["retcode"] == return_code
 
 
-@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
 @pytest.mark.parametrize(
     "exit_code, return_code, result",
     [

--- a/tests/pytests/functional/modules/cmd/test_run_win.py
+++ b/tests/pytests/functional/modules/cmd/test_run_win.py
@@ -20,7 +20,7 @@ def account():
         (299, 299, False),
     ],
 )
-def test_windows_script_exitcode(modules, state_tree, exit_code, return_code, result):
+def test_script_exitcode(modules, state_tree, exit_code, return_code, result):
     ret = modules.state.single(
         "cmd.run", name=f"cmd.exe /c exit {exit_code}", success_retcodes=[2, 44, 300]
     )
@@ -36,7 +36,7 @@ def test_windows_script_exitcode(modules, state_tree, exit_code, return_code, re
         (299, 299, False),
     ],
 )
-def test_windows_script_exitcode_runas(
+def test_script_exitcode_runas(
     modules, state_tree, exit_code, return_code, result, account
 ):
     ret = modules.state.single(
@@ -48,3 +48,33 @@ def test_windows_script_exitcode_runas(
     )
     assert ret.result is result
     assert ret.filtered["changes"]["retcode"] == return_code
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        ("echo foo", "foo"),
+        ("cmd /c echo foo", "foo"),
+        ("whoami && echo foo", "foo"),
+        ("cmd /c whoami && echo foo", "foo"),
+    ],
+)
+def test_run_builtins(modules, command, expected):
+    result = modules.cmd.run(command)
+    assert expected in result
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        ("echo foo", "foo"),
+        ("cmd /c echo foo", "foo"),
+        ("whoami && echo foo", "foo"),
+        ("cmd /c whoami && echo foo", "foo"),
+    ],
+)
+def test_run_builtins_runas(modules, account, command, expected):
+    result = modules.cmd.run(
+        cmd=command, runas=account.username, password=account.password
+    )
+    assert expected in result

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -5,6 +5,7 @@ import salt.utils.path
 pytestmark = [
     pytest.mark.core_test,
     pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
 ]
 
 
@@ -55,7 +56,6 @@ def issue_56195(state_tree):
         yield
 
 
-@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
 def test_windows_script_args_powershell(cmd, shell, issue_56195):
     """
     Ensure that powershell processes an inline script with args where the args
@@ -73,7 +73,6 @@ def test_windows_script_args_powershell(cmd, shell, issue_56195):
     assert ret["stdout"] == password
 
 
-@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
 def test_windows_script_args_powershell_runas(cmd, shell, account, issue_56195):
     """
     Ensure that powershell processes an inline script with args where the args
@@ -98,7 +97,6 @@ def test_windows_script_args_powershell_runas(cmd, shell, account, issue_56195):
     assert ret["stdout"] == password
 
 
-@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
 def test_windows_script_exitcode(cmd, shell, exitcode_script):
     ret = cmd.script("salt://exit_code.ps1", shell=shell, saltenv="base")
     assert ret["retcode"] == exitcode_script

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -7,6 +7,7 @@ from random import randint
 import pytest
 
 import salt.modules.win_useradd as win_useradd
+import salt.platform.win
 import salt.utils.win_runas as win_runas
 
 pytestmark = [
@@ -42,7 +43,7 @@ def test_compound_runas(user, cmd, expected):
     if expected == "username":
         expected = user.username
     result = win_runas.runas(
-        cmd=cmd,
+        cmd=salt.platform.win.prepend_cmd(cmd),
         username=user.username,
         password=user.password,
     )
@@ -61,7 +62,7 @@ def test_compound_runas_unpriv(user, cmd, expected):
     if expected == "username":
         expected = user.username
     result = win_runas.runas_unpriv(
-        cmd=cmd,
+        cmd=salt.platform.win.prepend_cmd(cmd),
         username=user.username,
         password=user.password,
     )

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -42,7 +42,7 @@ def test_compound_runas(user, cmd, expected):
     if expected == "username":
         expected = user.username
     result = win_runas.runas(
-        cmdLine=cmd,
+        cmd=cmd,
         username=user.username,
         password=user.password,
     )
@@ -70,14 +70,14 @@ def test_compound_runas_unpriv(user, cmd, expected):
 
 def test_runas_str_user(user):
     result = win_runas.runas(
-        cmdLine="whoami", username=user.username, password=user.password
+        cmd="whoami", username=user.username, password=user.password
     )
     assert user.username in result["stdout"]
 
 
 def test_runas_int_user(int_user):
     result = win_runas.runas(
-        cmdLine="whoami", username=int(int_user.username), password=int_user.password
+        cmd="whoami", username=int(int_user.username), password=int_user.password
     )
     assert str(int_user.username) in result["stdout"]
 

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -7,12 +7,19 @@ from random import randint
 import pytest
 
 import salt.modules.win_useradd as win_useradd
-import salt.platform.win
 import salt.utils.win_runas as win_runas
+
+try:
+    import salt.platform.win
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_unless_on_windows,
+    pytest.mark.skipif(HAS_WIN32 is False, reason="Win32 Libraries not available"),
 ]
 
 

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -1125,12 +1125,16 @@ def test_issue_62117(
 
     jinja_contents = '{%- import_yaml "./issue-62117.yaml" as grains %}'
 
-    sls_contents = """
-    {%- from "./issue-62117.jinja" import grains with context %}
+    if salt.utils.platform.is_windows():
+        cmd = "cd"
+    else:
+        cmd = "pwd"
+    sls_contents = f"""
+    {{%- from "./issue-62117.jinja" import grains with context %}}
 
     test_jinja/issue-62117/cmd.run:
       cmd.run:
-        - name: pwd
+        - name: {cmd}
     """
 
     yaml_tempfile = salt_master.state_tree.base.temp_file(f"{name}.yaml", yaml_contents)

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1084,7 +1084,7 @@ def test_prep_powershell_cmd(cmd, parsed):
             win_shell="powershell", cmd=cmd, encoded_cmd=False
         )
         expected = [
-            "C:\\powershell.exe",
+            '"C:\\powershell.exe"',
             "-NonInteractive",
             "-NoProfile",
             "-ExecutionPolicy",
@@ -1110,7 +1110,7 @@ def test_prep_powershell_cmd_encoded():
             win_shell="powershell", cmd=e_cmd, encoded_cmd=True
         )
         expected = [
-            "C:\\powershell.exe",
+            '"C:\\powershell.exe"',
             "-NonInteractive",
             "-NoProfile",
             "-ExecutionPolicy",
@@ -1135,7 +1135,7 @@ def test_prep_powershell_cmd_script():
             win_shell="powershell", cmd=script, encoded_cmd=False
         )
         expected = [
-            "C:\\powershell.exe",
+            '"C:\\powershell.exe"',
             "-NonInteractive",
             "-NoProfile",
             "-ExecutionPolicy",

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1090,7 +1090,7 @@ def test_prep_powershell_cmd(cmd, parsed):
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            parsed,
+            f'"{parsed}"',
         ]
         assert ret == expected
 
@@ -1116,7 +1116,7 @@ def test_prep_powershell_cmd_encoded():
             "-ExecutionPolicy",
             "Bypass",
             "-EncodedCommand",
-            f"{e_cmd}",
+            f'"{e_cmd}"'
         ]
         assert ret == expected
 
@@ -1141,7 +1141,7 @@ def test_prep_powershell_cmd_script():
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            f"& {script}; exit $LASTEXITCODE",
+            f'"& {script}; exit $LASTEXITCODE"',
         ]
         assert ret == expected
 

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1116,7 +1116,7 @@ def test_prep_powershell_cmd_encoded():
             "-ExecutionPolicy",
             "Bypass",
             "-EncodedCommand",
-            f'"{e_cmd}"'
+            f'"{e_cmd}"',
         ]
         assert ret == expected
 

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,0 +1,27 @@
+import pytest
+
+from salt.platform import win
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        ("whoami", "whoami"),
+        ("hostname", "hostname"),
+        ("cmd /c hostname", "cmd /c hostname"),
+        ("echo foo", 'cmd /c "echo foo"'),
+        ('cmd /c "echo foo"', 'cmd /c "echo foo"'),
+        ("whoami && echo foo", 'cmd /c "whoami && echo foo"'),
+        ("whoami || echo foo", 'cmd /c "whoami || echo foo"'),
+    ],
+)
+def test_prepend_cmd(command, expected):
+    """
+    Test that the command is prepended with "cmd /c" where appropriate
+    """
+    result = win.prepend_cmd(command)
+    assert result == expected

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -4,6 +4,7 @@ from salt.platform import win
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
 ]
 
 

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,6 +1,9 @@
 import pytest
 
-from salt.platform import win
+import salt.utils.platform
+
+if salt.utils.platform.is_windows():
+    from salt.platform import win
 
 pytestmark = [
     pytest.mark.windows_whitelisted,

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1611,7 +1611,7 @@ class VirtualEnv:
     venv_bin_dir = attr.ib(init=False, repr=False)
 
     @pip_requirement.default
-    def _default_pip_requiremnt(self):
+    def _default_pip_requirement(self):
         if os.environ.get("ONEDIR_TESTRUN", "0") == "1":
             return "pip>=22.3.1,<23.0"
         return "pip>=20.2.4,<21.2"


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with running commands on Windows using `cmd.run`. Some commands are built-in commands only available when run from a cmd prompt. This checks for a binary for the command. If the binary does not exist, it is assumed that this is a built-in command and prepends `cmd /c` to the command. There are also some operators built-in to cmd such as `&&` and `||`. If those are present and the command does not start with `cmd`, it will be prepended.

### What issues does this PR fix or reference?
Fixes #54821 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes