### PR TITLE
Show error when user does not exist

### DIFF
--- a/changelog/56680.fixed.md
+++ b/changelog/56680.fixed.md
@@ -1,0 +1,2 @@
+Show a better error when running cmd.* commands using runas and the
+runas user does not exist

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2949,6 +2949,10 @@ def script(
             }
         shutil.copyfile(fn_, path)
     if not salt.utils.platform.is_windows():
+        # Let's make sure the user exists first
+        if not __salt__["user.info"](runas):
+            msg = f"Invalid user: {runas}"
+            raise CommandExecutionError(msg)
         os.chmod(path, 320)
         os.chown(path, __salt__["file.user_to_uid"](runas), -1)
 

--- a/tests/pytests/functional/modules/cmd/test_runas.py
+++ b/tests/pytests/functional/modules/cmd/test_runas.py
@@ -1,6 +1,9 @@
 import pytest
 
 import salt.modules.cmdmod as cmdmod
+from salt.exceptions import CommandExecutionError
+
+pytestmark = [pytest.mark.windows_whitelisted]
 
 
 @pytest.fixture(scope="module")
@@ -20,7 +23,12 @@ def configure_loader_modules():
 
 @pytest.mark.skip_on_windows
 @pytest.mark.skip_if_not_root
-def test_run_as(account):
+def test_runas(account):
     ret = cmdmod.run("id", runas=account.username)
     assert f"gid={account.info.gid}" in ret
     assert f"uid={account.info.uid}" in ret
+
+
+def test_runas_missing_user():
+    with pytest.raises(CommandExecutionError):
+        cmdmod.run("echo HOLO", runas="non-existent-user", password="junk")

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -822,14 +822,12 @@ def test_cmd_script_saltenv_from_config():
 def test_cmd_script_saltenv_from_config_windows():
     mock_cp_get_template = MagicMock()
     mock_cp_cache_file = MagicMock()
-    mock_run = MagicMock()
     with patch.dict(cmdmod.__opts__, {"saltenv": "base"}):
         with patch.dict(
             cmdmod.__salt__,
             {
                 "cp.cache_file": mock_cp_cache_file,
                 "cp.get_template": mock_cp_get_template,
-                "file.user_to_uid": MagicMock(),
                 "file.remove": MagicMock(),
             },
         ):


### PR DESCRIPTION
### What does this PR do?
Fixes the cmd._run function to show an error when the user specified in "runas" does not exist

### What issues does this PR fix or reference?
Fixes #56680 

### Previous Behavior
It would display the docs for the cmd.run function

### New Behavior
Raises a CommandExecutionError with a message that the user does not exist

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes