### PR TITLE
Clarify docs about passing version numbers

### DIFF
--- a/salt/modules/aixpkg.py
+++ b/salt/modules/aixpkg.py
@@ -280,6 +280,12 @@ def install(name=None, refresh=False, pkgs=None, version=None, test=False, **kwa
         Install a specific version of a fileset/rpm package.
         (Unused at present).
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
     test
         Verify that command functions correctly.
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -708,6 +708,12 @@ def install(
         Install a specific version of the package, e.g. 1.2.3~0ubuntu0. Ignored
         if "pkgs" or "sources" is passed.
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
         .. versionchanged:: 2018.3.0
             version can now contain comparison operators (e.g. ``>1.2.3``,
             ``<=2.0``, etc.)

--- a/salt/modules/mac_portspkg.py
+++ b/salt/modules/mac_portspkg.py
@@ -261,6 +261,12 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     version
         Specify a version to pkg to install. Ignored if pkgs is specified.
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
         CLI Example:
 
         .. code-block:: bash

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -436,6 +436,12 @@ def install(
         Install a specific version of the package, e.g. 1.2.3~0ubuntu0. Ignored
         if "pkgs" or "sources" is passed.
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
         .. versionadded:: 2017.7.0
 
     reinstall : False

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1426,6 +1426,13 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             If passed with a list of packages in the ``pkgs`` parameter, the
             version will be ignored.
 
+            .. note::
+                Remember that versions that contain a single `.` will be
+                interpreted as numbers and must be double-quoted. For example,
+                version ``3006.10`` will be rendered as ``3006.1``. To pass
+                ``3006.10`` you'll need to use double-quotes.
+                ``version="'3006.10'"``
+
             CLI Example:
 
              .. code-block:: bash

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1294,6 +1294,12 @@ def install(
         Install a specific version of the package, e.g. 1.2.3-4.el5. Ignored
         if "pkgs" or "sources" is passed.
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
         .. versionchanged:: 2018.3.0
             version can now contain comparison operators (e.g. ``>1.2.3``,
             ``<=2.0``, etc.)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1520,6 +1520,12 @@ def install(
         operator (<, >, <=, >=, =) and a version number (ex. '>1.2.3-4').
         This parameter is ignored if ``pkgs`` or ``sources`` is passed.
 
+        .. note::
+            Remember that versions that contain a single `.` will be interpreted
+            as numbers and must be double-quoted. For example, version
+            ``3006.10`` will be rendered as ``3006.1``. To pass ``3006.10``
+            you'll need to use double-quotes. ``version="'3006.10'"``
+
     resolve_capabilities
         If this option is set to True zypper will take capabilities into
         account. In this case names which are just provided by a package


### PR DESCRIPTION
### What does this PR do?
Adds clarifying docs about passing version numbers to ``pkg.install``. Versions can be interpreted as numbers and strip trailing zeros. They must be double-quoted. This was exposed by the 3006.10 release which was being rendered as ``3006.1`` by the pyyaml renderer.

### What issues does this PR fix or reference?
Fixes #67902

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes