### PR TITLE
Fix for module.run show result as True when module returned False as result

### DIFF
--- a/changelog/65842.fixed.md
+++ b/changelog/65842.fixed.md
@@ -1,0 +1,1 @@
+If module executed from state module.run contains a dict with result is not True it is passed to the module.run state.

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -665,9 +665,15 @@ def _legacy_run(name, **kwargs):
 
 def _get_result(func_ret, changes):
     res = True
-    # if mret is a dict and there is retcode and its non-zero
-    if isinstance(func_ret, dict) and func_ret.get("retcode", 0) != 0:
-        res = False
+    # if func_ret is a dict and there is retcode and its non-zero or func_ret contains result with False value
+    if isinstance(func_ret, dict):
+        retcode = func_ret.get("retcode", 0)
+        result = func_ret.get("result", True)
+
+        if (isinstance(retcode, int) and retcode != 0) or (
+            isinstance(result, bool) and result is False
+        ):
+            res = False
         # if its a boolean, return that as the result
     elif isinstance(func_ret, bool):
         res = func_ret

--- a/tests/pytests/functional/states/test_module.py
+++ b/tests/pytests/functional/states/test_module.py
@@ -135,3 +135,99 @@ def test_issue_62988_b(tmp_path, modules, state_tree, caplog):
             for k in ret.raw:
                 assert ret.raw[k]["result"] is True
             assert "Using new style module.run syntax: run_new" in caplog.messages
+
+
+@pytest.mark.core_test
+def test_issue_65842_result_false(tmp_path, modules, state_tree):
+
+    sls_contents = dedent(
+        """
+    failed_state_new_syntax_False_result:
+      module.run:
+        - test.kwarg:
+          - result: False
+          - comment: "My Failure"
+          - retcode: 0
+    """
+    )
+    with pytest.helpers.temp_file("issue-65842.sls", sls_contents, state_tree):
+        ret = modules.state.sls(
+            mods="issue-65842",
+        )
+        assert len(ret.raw) == 1
+        for k in ret.raw:
+            assert isinstance(ret.raw[k]["result"], bool)
+            assert ret.raw[k]["result"] is False
+            assert ret.raw[k]["comment"] == "'test.kwarg' failed: My Failure"
+
+
+@pytest.mark.core_test
+def test_issue_65842_should_ok(tmp_path, modules, state_tree):
+
+    sls_contents = dedent(
+        """
+    success_state_new_syntax:
+      module.run:
+        - test.kwarg:
+          - result: True
+          - comment: "This should be success"
+          - retcode: 0
+    """
+    )
+    with pytest.helpers.temp_file("issue-65842.sls", sls_contents, state_tree):
+        ret = modules.state.sls(
+            mods="issue-65842",
+        )
+        assert len(ret.raw) == 1
+        for k in ret.raw:
+            assert isinstance(ret.raw[k]["result"], bool)
+            assert ret.raw[k]["result"] is True
+            assert ret.raw[k]["comment"] == "test.kwarg: This should be success"
+
+
+@pytest.mark.core_test
+def test_issue_65842_retcode_1(tmp_path, modules, state_tree):
+
+    sls_contents = dedent(
+        """
+    failed_state_new_syntax_1_retcode:
+      module.run:
+        - test.kwarg:
+          - result: True
+          - comment: "My Failure"
+          - retcode: 1
+    """
+    )
+    with pytest.helpers.temp_file("issue-65842.sls", sls_contents, state_tree):
+        ret = modules.state.sls(
+            mods="issue-65842",
+        )
+        assert len(ret.raw) == 1
+        for k in ret.raw:
+            assert isinstance(ret.raw[k]["result"], bool)
+            assert ret.raw[k]["result"] is False
+            assert ret.raw[k]["comment"] == "'test.kwarg' failed: My Failure"
+
+
+@pytest.mark.core_test
+def test_issue_65842_test_result_non_boolean_ok(tmp_path, modules, state_tree):
+
+    sls_contents = dedent(
+        """
+    success_state_new_syntax_wrong_result_type:
+      module.run:
+        - test.kwarg:
+          - result: "OK"
+          - comment: "This should be success"
+          - retcode: 0
+    """
+    )
+    with pytest.helpers.temp_file("issue-65842.sls", sls_contents, state_tree):
+        ret = modules.state.sls(
+            mods="issue-65842",
+        )
+        assert len(ret.raw) == 1
+        for k in ret.raw:
+            assert isinstance(ret.raw[k]["result"], bool)
+            assert ret.raw[k]["result"] is True
+            assert ret.raw[k]["comment"] == "test.kwarg: This should be success"


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #65842

### Previous Behavior
If `module.run` was running a module which returned `False` in it's `result`, the `module.run` state would return it as successful with it's `result` set to `True`.

### New Behavior
With this change the state will have `result` set to `False` if the module contains a `result` where the value not is equal to `True`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
