### PR TITLE
Adding feature to postgres returner to save minion which are expected to return for a job

### DIFF
--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -128,6 +128,9 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
 
 import logging
 import sys
+import ast
+import subprocess
+import json
 from contextlib import contextmanager
 
 import salt.exceptions
@@ -269,12 +272,24 @@ def event_return(events):
             cur.execute(sql, (tag, salt.utils.json.dumps(data), __opts__["id"]))
 
 
-def all_minions():
+def all_minions(tgt,tgt_type):
     """
-    Retrive all the minions which are expected to return for job.
+    Retrive all the minions which are expected to return for a job based of the target or target type passed.
     """
-    
-    return ret
+    if tgt_type == 'glob':
+        salt_command = ['salt',tgt,'--preview-target','--out=text']
+    elif tgt_type == 'compound' or tgt_type == 'list' or tgt_type == 'grain':
+        if tgt_type == "compound":
+            tgt_type = '-C'
+        elif tgt_type == "list":
+            return tgt
+        elif tgt_type == "grain":
+            tgt_type = '-G'
+        salt_command=['salt',tgt_type,tgt,'--preview-target','--out=text']
+    result = subprocess.run(salt_command, capture_output=True, text=True, check=True)
+    minions= ast.literal_eval(result.stdout)
+    return minions
+
 
 def save_load(jid, load, minions=None):  # pylint: disable=unused-argument
     """
@@ -287,6 +302,10 @@ def save_load(jid, load, minions=None):  # pylint: disable=unused-argument
                 VALUES (%s, %s)"""
 
         json_data = salt.utils.json.dumps(salt.utils.data.decode(load))
+        load_dict = json.loads(json_data)
+        if load_dict.get('tgt') and load_dict.get('tgt_type') is not None:
+            load_dict['Minions'] = all_minions(load_dict['tgt'], load_dict['tgt_type'])  #add a key 'Minions' containing list of minions which are expected to return
+        json_data = json.dumps(load_dict)
         try:
             cur.execute(sql, (jid, json_data))
         except psycopg2.IntegrityError:

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -269,6 +269,13 @@ def event_return(events):
             cur.execute(sql, (tag, salt.utils.json.dumps(data), __opts__["id"]))
 
 
+def all_minions():
+    """
+    Retrive all the minions which are expected to return for job.
+    """
+    
+    return ret
+
 def save_load(jid, load, minions=None):  # pylint: disable=unused-argument
     """
     Save the load to the specified jid id


### PR DESCRIPTION
### What does this PR do?
This PR enables the PostgreSQL returner to store expected minion IDs for a job within the returner, ensuring that the returner correctly reports missing minions when missing=True is used.

### What issues does this PR fix or reference?
While using the PostgreSQL returner to store job caches, `salt_returns`, and `salt_events` in a PostgreSQL database, the following issue arises:  

When executing a command in `--async` mode, we receive a Job ID (JID). To track the progress of this JID, we run:  

```bash
salt-run jobs.lookup_jid <JID> missing=True
```

We expect this command to return **"minion did not return"** for any minions that have not yet responded. However, this is not happening—no output is provided for minions that haven't returned.  

This functionality works correctly when we remove the PostgreSQL returner configuration and use the local job cache instead.

Salt-user group discussion link: https://groups.google.com/g/salt-users/c/eN6mvymi1qA

### New Behavior
With the raised enhancement, the PostgreSQL returner is now able to save minion IDs correctly and accurately detect which minions have returned and which have not.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
