### PR TITLE
Fix refresh of osrelease and related grains on Python 3.10+

### DIFF
--- a/changelog/67932.fixed.md
+++ b/changelog/67932.fixed.md
@@ -1,0 +1,1 @@
+Fix refresh of osrelease and related grains on Python 3.10+

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2243,6 +2243,11 @@ def _linux_distribution_data():
 
     log.trace("Getting OS name, release, and codename from freedesktop_os_release")
     try:
+        # If using platform.freedesktop_os_release we must invalidate
+        # the internal platform os_release cache to allow grains to be
+        # actually recalculated during grains_refresh
+        if hasattr(platform, "_os_release_cache"):
+            platform._os_release_cache = None
         os_release = _freedesktop_os_release()
         grains.update(_os_release_to_grains(os_release))
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue introduced by https://github.com/saltstack/salt/commit/dab8ea5b45323a8f0f814db60ea6d6fcc6daa406 , as the `platform` library contains an internal os release cache.

This internal cache causes that the `osrelease` and other related grains are not getting refreshed when running `saltutil.refresh_grains`.

This PR fixes this issue, by invalidating the internal cache, if existing, at the time of calculating  the os related grains.

### What issues does this PR fix or reference?
Fixes #67932

### Previous Behavior
On Python 3.10+ grains are not refreshed while they get refreshed on Python < 3.10

### New Behavior
Consistent behavior across Python versions. Grains get refreshed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
