### PR TITLE
Add flatpak module and state

### DIFF
--- a/changelog/67937.added.md
+++ b/changelog/67937.added.md
@@ -1,0 +1,1 @@
+Added execution module and state module for managing flatpak packages and remotes.

--- a/salt/modules/flatpak.py
+++ b/salt/modules/flatpak.py
@@ -1,0 +1,295 @@
+"""
+Manage flatpak packages via Salt
+
+.. versionadded:: Sodium
+
+:depends: flatpak for distribution
+"""
+
+import logging
+import re
+
+import salt.utils.path
+
+__virtualname__ = "flatpak"
+
+FLATPAK_BINARY_NAME = "flatpak"
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def __virtual__():
+    if salt.utils.path.which("flatpak"):
+        return __virtualname__
+
+    return (
+        False,
+        'The flatpak execution module cannot be loaded: the "flatpak" binary is not in the path.',
+    )
+
+
+def _cmd_run_all(command):
+    """
+    Run the `command` via `cmd.run_all` and return a result dict that is
+    suitable for being returned from one of this execution module's functions.
+    """
+    # `cmd_output` is a dict looking like this:
+    # `{"pid": 123, "retcode": 0, "stdout": "abc", "stderr": "abc"}`
+    cmd_output = __salt__["cmd.run_all"](command)
+
+    if cmd_output["retcode"] != 0 and cmd_output["stderr"]:
+        # The command failed with a non-zero return code and some text on stderr.
+        return {
+            "result": False,
+            "stderr": cmd_output["stderr"].strip(),
+        }
+
+    # Either the command has a return code of 0, or stderr is empty.
+    return {
+        "result": True,
+        "stdout": cmd_output["stdout"].strip(),
+    }
+
+
+def install(name, location):
+    """
+    Install the specified flatpak package or runtime from the specified location.
+
+    Args:
+        name (str): The name of the package or runtime.
+        location (str): The location or remote to install from.
+
+    Returns:
+        dict: The ``result`` and ``stderr``/``stdout``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.install org.gimp.GIMP flathub
+    """
+    cmd = f"{FLATPAK_BINARY_NAME} install --noninteractive {location} {name}"
+    return _cmd_run_all(cmd)
+
+
+def is_installed(name):
+    """
+    Determine if a package or runtime is installed.
+
+    Args:
+        name (str): The name of the package or the runtime.
+
+    Returns:
+        bool: True if the specified package or runtime is installed, False otherwise.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.is_installed org.gimp.GIMP
+    """
+    cmd = f"{FLATPAK_BINARY_NAME} info {name}"
+    # `ignore_retcode` is needed to suppress Salt's error log in case of a
+    # non-zero return code. Here the return code is just a status info, and a
+    # non-zero return code doesn't mean "error".
+    returncode = __salt__["cmd.retcode"](cmd, ignore_retcode=True)
+    return returncode == 0
+
+
+def uninstall(pkg):
+    """
+    Uninstall the specified package.
+
+    Args:
+        pkg (str): The package name.
+
+    Returns:
+        dict: The ``result`` and ``stderr``/``stdout``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.uninstall org.gimp.GIMP
+    """
+    cmd = f"{FLATPAK_BINARY_NAME} uninstall --noninteractive {pkg}"
+    return _cmd_run_all(cmd)
+
+
+def add_remote(name, location):
+    """
+    Add a new location to install flatpak packages from.
+
+    Args:
+        name (str): The repository's name.
+        location (str): The location of the repository.
+
+    Returns:
+        dict: The ``result`` and ``stderr``/``stdout``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.add_remote flathub https://flathub.org/repo/flathub.flatpakrepo
+    """
+    cmd = f"{FLATPAK_BINARY_NAME} remote-add {name} {location}"
+    return _cmd_run_all(cmd)
+
+
+def modify_remote(name, **kwargs):
+    """
+    Modify options for an existing remote repository in the flatpak repository
+    configuration.
+
+    Args:
+        name (str): The repository's name.
+        kwargs: Options and their values; see flatpak-remote-modify(1) man page.
+
+    Returns:
+        dict: The ``result`` and ``stderr``/``stdout``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.modify_remote flathub title="The Hub" url=https://flathub.org/repo/flathub.flatpakrepo
+    """
+    # Format each option as '--key="value"'; separate multiple options with spaces.
+    # Apparently Salt adds some dict items to `kwargs` on its own, e.g.
+    # "__pub_fun"="flatpak.modify_remote" or "__pub_pid"=5170. We must skip those.
+    # We can skip all items in `kwargs` that have a leading underscore because
+    # there are no CLI options valid for "flatpak remote-modify" that have a
+    # leading underscore.
+    options = " ".join(
+        f'--{k}="{v}"' for k, v in kwargs.items() if not k.startswith("_")
+    )
+    cmd = f"{FLATPAK_BINARY_NAME} remote-modify {name} {options}"
+    log.debug(cmd)
+    return _cmd_run_all(cmd)
+
+
+def delete_remote(name):
+    """
+    Remove a remote repository from the flatpak repository configuration.
+
+    The remote is forcibly removed, even if it is still in use by installed apps
+    or runtimes.
+
+    Args:
+        name (str): The repository's name.
+
+    Returns:
+        dict: The ``result`` and ``stderr``/``stdout``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.delete_remote flathub
+    """
+    cmd = f"{FLATPAK_BINARY_NAME} remote-delete --force {name}"
+    return _cmd_run_all(cmd)
+
+
+def remotes_info():
+    """
+    Fetch information about all remote repositories.
+
+    Returns:
+        list: Attributes (``title``, ``url``, etc.) of all remotes; one dict for each remote.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.remotes_info
+    """
+    columns = [
+        "name",
+        "title",
+        "url",
+        "filter",
+        "collection",
+        "priority",
+        "options",
+        "comment",
+        "description",
+        "homepage",
+        "icon",
+    ]
+
+    # The command looks like this: "flatpak remotes --columns=name:f,title:f,...",
+    # so we must add ':f' to each column name.
+    # See: flatpak-remotes(1) man page.
+    columns_option = ",".join(c + ":f" for c in columns)
+
+    # List all remotes and their attributes. `cmd_output` is a dict looking like this:
+    # `{"pid": 123, "retcode": 0, "stdout": "abc", "stderr": "abc"}`
+    cmd = f"{FLATPAK_BINARY_NAME} remotes --columns={columns_option}"
+    log.debug(cmd)
+    cmd_output = __salt__["cmd.run_all"](cmd)
+
+    log.debug(cmd_output)
+    if cmd_output["retcode"] != 0 or cmd_output["stderr"]:
+        return []
+
+    lines = cmd_output["stdout"].splitlines()
+    # `lines` is a list of strings, with each attribute separated by a tab, e.g.:
+    # "foobar-flatpak-mirror\tFoobar Flatpak Mirror\t1"
+
+    remotes = []
+    # Iterate over each line (i.e. each remote) and add a dict with its attributes
+    # to the list `remotes`. The keys of this dict are always the same: always
+    # the `columns`.
+    for line in lines:
+        log.debug(line)
+        # And the line contains all the values, separated by tabs.
+        values = line.split("\t")
+        remotes.append(dict(zip(columns, values)))
+
+    return remotes
+
+
+def remote_info(remote):
+    """
+    Fetch information about one remote repository.
+
+    Args:
+        remote (str): The remote's name.
+
+    Returns:
+        dict: Attributes (``title``, ``url``, etc.) of the remote.
+        The dict is empty if the remote doesn't exist.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.remote_info flathub
+    """
+    for r in remotes_info():
+        if r["name"] == remote:
+            return r
+    return {}
+
+
+def is_remote_added(remote):
+    """
+    Determine if a remote repository exists.
+
+    Args:
+        remote (str): The remote's name.
+
+    Returns:
+        bool: True if the remote has already been added.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' flatpak.is_remote_added flathub
+    """
+    return any(remote == r["name"] for r in remotes_info())

--- a/salt/states/flatpak.py
+++ b/salt/states/flatpak.py
@@ -1,0 +1,182 @@
+"""
+Management of flatpak packages
+==============================
+Allows the installation and uninstallation of flatpak packages.
+
+.. versionadded:: Sodium
+"""
+
+import salt.utils.data
+import salt.utils.path
+
+__virtualname__ = "flatpak"
+
+
+def __virtual__():
+    if salt.utils.path.which("flatpak"):
+        return __virtualname__
+
+    return (
+        False,
+        'The flatpak state module cannot be loaded: the "flatpak" binary is not in the path.',
+    )
+
+
+def installed(name, location=""):
+    """
+    Ensure that the named package is installed.
+
+    Args:
+        name (str): The name of the package or runtime.
+        location (str): The location or remote to install the flatpak from.
+
+    Returns:
+        dict: The ``result``, ``comment``, and ``changes``.
+
+    Example:
+
+    .. code-block:: yaml
+
+        install_package:
+          flatpack.installed:
+            - name: gimp
+            - location: flathub
+    """
+    ret = {"name": name, "changes": {}, "result": None, "comment": ""}
+
+    old = __salt__["flatpak.is_installed"](name)
+    if old:
+        ret["comment"] = f'Flatpak package "{name}" is already installed'
+        if not __opts__["test"]:
+            ret["result"] = True
+        return ret
+
+    # The flatpak package is not installed yet.
+    if __opts__["test"]:
+        ret["comment"] = f'Flatpak package "{name}" would have been installed'
+        ret["changes"]["new"] = name
+        ret["changes"]["old"] = ""
+        return ret
+
+    # Install the flatpak package.
+    install_ret = __salt__["flatpak.install"](name, location)
+    # Verify that the flatpak package was installed.
+    if __salt__["flatpak.is_installed"](name):
+        ret["comment"] = f'Flatpak package "{name}" was installed'
+        ret["changes"]["new"] = name
+        ret["changes"]["old"] = ""
+        ret["result"] = True
+    else:
+        # Installing the flatpak package failed.
+        ret["comment"] = f'Flatpak package "{name}" failed to install'
+        ret["comment"] += "\noutput:\n" + install_ret["stderr"]
+        ret["result"] = False
+
+    return ret
+
+
+def uninstalled(name):
+    """
+    Ensure that the named package is not installed.
+
+    Args:
+        name (str): The flatpak package.
+
+    Returns:
+        dict: The ``result``, ``comment``, and ``changes``.
+
+    Example:
+
+    .. code-block:: yaml
+
+        uninstall_package:
+          flatpack.uninstalled:
+            - name: gimp
+    """
+    ret = {"name": name, "changes": {}, "result": None, "comment": ""}
+
+    old = __salt__["flatpak.is_installed"](name)
+    if not old:
+        ret["comment"] = f'Flatpak package "{name}" is not installed'
+        if not __opts__["test"]:
+            ret["result"] = True
+        return ret
+
+    # The flatpak package is still installed.
+    if __opts__["test"]:
+        ret["comment"] = f'Flatpak package "{name}" would have been uninstalled'
+        return ret
+
+    # Uninstall the flatpak package.
+    uninstall_ret = __salt__["flatpak.uninstall"](name)
+    # Verify that the flatpak package was uninstalled.
+    if not __salt__["flatpak.is_installed"](name):
+        ret["comment"] = f'Flatpak package "{name}" uninstalled'
+        ret["result"] = True
+    else:
+        # Uninstalling the flatpak package failed.
+        ret["comment"] = f'Flatpak package "{name}" failed to uninstall'
+        ret["comment"] += "\noutput:\n" + uninstall_ret["stderr"]
+        ret["result"] = False
+
+    return ret
+
+
+def add_remote(name, location, expected_homepage):
+    """
+    Adds a new location to install flatpak packages from.
+
+    This state only checks whether the remote repository is configured in
+    flatpak and adds it if necessary. It does not manage the remote's attributes
+    like description, comment, etc.
+    You may want to check these yourself using `flatpak.remote_info` and then
+    delete and re-add the remote if necessary.
+
+    Args:
+        name (str): The repository's name.
+        location (str): The location of the repository (URL of either a flatpak
+            repository or a .flatpakrepo file which describes a repository).
+
+    Returns:
+        dict: The ``result``, ``comment``, and ``changes``.
+
+    Example:
+
+    .. code-block:: yaml
+
+        add_flathub:
+          flatpack.add_remote:
+            - name: flathub
+            - location: https://flathub.org/repo/flathub.flatpakrepo
+    """
+    ret = {"name": name, "changes": {}, "result": None, "comment": ""}
+
+    current_remote = __salt__["flatpak.remote_info"](name)
+    if current_remote:
+        ret["comment"] = f'Remote "{name}" already exists'
+        if not __opts__["test"]:
+            ret["result"] = True
+        return ret
+
+    # The remote doesn't exist yet.
+    if __opts__["test"]:
+        ret["comment"] = f'Remote "{name}" would have been added'
+        ret["changes"]["new"] = name
+        ret["changes"]["old"] = ""
+        return ret
+
+    # Add the remote.
+    add_ret = __salt__["flatpak.add_remote"](name, location)
+    # Verify that the remote was added.
+    if __salt__["flatpak.is_remote_added"](name):
+        ret["comment"] = f'Remote "{name}" was added'
+        ret["changes"]["new"] = name
+        ret["changes"]["old"] = ""
+        ret["result"] = True
+    else:
+        # Adding the remote failed.
+        ret["comment"] = f'Failed to add remote "{name}"'
+        ret["comment"] += "\noutput:\n" + add_ret["stderr"]
+        ret["result"] = False
+
+    return ret

--- a/tests/integration/modules/test_flatpak.py
+++ b/tests/integration/modules/test_flatpak.py
@@ -1,0 +1,105 @@
+import pytest
+
+from tests.support.case import ModuleCase
+
+@pytest.mark.destructive_test
+class FlatpakModuleTest(ModuleCase):
+    """
+    Validate the flatpak module
+    """
+
+    def setUp(self):
+        """
+        Prepare variables
+        """
+        super().setUp()
+        self._package = "org.gimp.GIMP"
+        self._remote = "flathub"
+        self._repo = "https://flathub.org/repo/flathub.flatpakrepo"
+
+    def tearDown(self):
+        """
+        Ensure that no packages/remotes that were installed/added for testing remain on the system
+        """
+        self.run_function("flatpak.uninstall", [self._package])
+        self.run_function("flatpak.delete_remote", [self._remote])
+
+    @pytest.mark.destructive_test
+    def test_install(self):
+        """
+        Test the function to install a flatpak package
+        """
+        # install a flatpak package
+        ret = self.run_function("flatpak.install", [self._package, self._remote])
+        self.assertTrue(ret["result"])
+        # validate the installation
+        self.assertTrue(self.run_function("flatpak.is_installed", [self._package]))
+
+    @pytest.mark.destructive_test
+    def test_uninstall(self):
+        """
+        Test the function to uninstall a flatpak package
+        """
+        # install a flatpak package to have something to uninstall
+        self.run_function("flatpak.install", [self._package, self._remote])
+        # uninstall the flatpak package
+        ret = self.run_function("flatpak.uninstall", [self._package])
+        self.assertTrue(ret["result"])
+        # validate the uninstallation
+        self.assertFalse(self.run_function("flatpak.is_installed", [self._package]))
+
+    @pytest.mark.destructive_test
+    def test_add_remote(self):
+        """
+        Test the function to add a flatpak remote
+        """
+        # add a flatpak remote
+        ret = self.run_function("flatpak.add_remote", [self._remote, self._repo])
+        self.assertTrue(ret["result"])
+        # validate the addition
+        self.assertTrue(self.run_function("flatpak.is_remote_added", [self._remote]))
+
+    @pytest.mark.destructive_test
+    def test_delete_remote(self):
+        """
+        Test the function to delete a flatpak remote
+        """
+        # add a flatpak remote to have something to delete
+        self.run_function("flatpak.add_remote", [self._remote, self._repo])
+        # delete the flatpak remote
+        ret = self.run_function("flatpak.delete_remote", [self._remote])
+        self.assertTrue(ret["result"])
+        # validate the deletion
+        self.assertFalse(self.run_function("flatpak.is_remote_added", [self._remote]))
+
+    @pytest.mark.destructive_test
+    def test_remotes_info(self):
+        """
+        Test the function to get info about all remotes
+        """
+        # add a flatpak remote to have something to get info about
+        self.run_function("flatpak.add_remote", [self._remote, self._repo])
+        ret = self.run_function("flatpak.remotes_info")
+        self.assertTrue(len(ret) > 0)
+        remoteInfo = ret[0]
+        # check if the dict has all the expected keys and if any of them are None
+        attrs = ["name", "title", "url", "filter", "collection", "priority", "options", "comment", "description", "homepage", "icon"]
+        for attr in attrs:
+            self.assertIn(attr, remoteInfo)
+            self.assertIsNotNone(remoteInfo[attr])
+
+    @pytest.mark.destructive_test
+    def test_modify_remote(self):
+        """
+        Test the function to modify the attributes of a flatpak remote
+        """
+        # add a flatpak remote
+        self.run_function("flatpak.add_remote", [self._remote])
+        # we will change the "title" attribute of the remote to this value
+        newTitle = "Foobar remote"
+        self.assertNotEqual(self.run_function("flatpak.remote_info", [self._remote])["title"], newTitle)
+        # modify the remote to set a new "title" attribute
+        ret = self.run_function("flatpak.modify_remote", [self._remote], title=newTitle)
+        self.assertTrue(ret["result"])
+        # validate the change
+        self.assertEqual(self.run_function("flatpak.remote_info", [self._remote])["title"], newTitle)


### PR DESCRIPTION
### What does this PR do?

Adds a new execution module and a new state module for managing flatpak packages and flatpak remotes.

Note that there was a previous PR for flatpak support: #51993. It was never merged into `master`, though. There was also #56907 but it had no outcome either. The code in this PR is based on #51993 with substantial changes and modernization.

### What issues does this PR fix or reference?
None

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
