### PR TITLE
`re.split`: replace 3rd arg with `maxsplit=`

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1743,9 +1743,9 @@ ARGS = {arguments}\n'''.format(
                 saltwinshell.deploy_python(self)
                 stdout, stderr, retcode = self.shim_cmd(cmd_str)
                 while re.search(RSTR_RE, stdout):
-                    stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+                    stdout = re.split(RSTR_RE, stdout, maxsplit=1)[1].strip()
                 while re.search(RSTR_RE, stderr):
-                    stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+                    stderr = re.split(RSTR_RE, stderr, maxsplit=1)[1].strip()
             elif error == "Undefined SHIM state":
                 self.deploy()
                 stdout, stderr, retcode = self.shim_cmd(cmd_str)
@@ -1760,27 +1760,27 @@ ARGS = {arguments}\n'''.format(
                         retcode,
                     )
                 while re.search(RSTR_RE, stdout):
-                    stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+                    stdout = re.split(RSTR_RE, stdout, maxsplit=1)[1].strip()
                 while re.search(RSTR_RE, stderr):
-                    stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+                    stderr = re.split(RSTR_RE, stderr, maxsplit=1)[1].strip()
             else:
                 return f"ERROR: {error}", stderr, retcode
 
         # FIXME: this discards output from ssh_shim if the shim succeeds.  It should
         # always save the shim output regardless of shim success or failure.
         while re.search(RSTR_RE, stdout):
-            stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+            stdout = re.split(RSTR_RE, stdout, maxsplit=1)[1].strip()
 
         if re.search(RSTR_RE, stderr):
             # Found RSTR in stderr which means SHIM completed and only
             # and remaining output is only from salt.
             while re.search(RSTR_RE, stderr):
-                stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+                stderr = re.split(RSTR_RE, stderr, maxsplit=1)[1].strip()
 
         else:
             # RSTR was found in stdout but not stderr - which means there
             # is a SHIM command for the master.
-            shim_command = re.split(r"\r?\n", stdout, 1)[0].strip()
+            shim_command = re.split(r"\r?\n", stdout, maxsplit=1)[0].strip()
             log.debug("SHIM retcode(%s) and command: %s", retcode, shim_command)
             if (
                 "deploy" == shim_command
@@ -1811,12 +1811,12 @@ ARGS = {arguments}\n'''.format(
                             retcode,
                         )
                 while re.search(RSTR_RE, stdout):
-                    stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+                    stdout = re.split(RSTR_RE, stdout, maxsplit=1)[1].strip()
                 if self.tty:
                     stderr = ""
                 else:
                     while re.search(RSTR_RE, stderr):
-                        stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+                        stderr = re.split(RSTR_RE, stderr, maxsplit=1)[1].strip()
             elif "ext_mods" == shim_command:
                 self.deploy_ext()
                 stdout, stderr, retcode = self.shim_cmd(cmd_str)
@@ -1829,9 +1829,9 @@ ARGS = {arguments}\n'''.format(
                         retcode,
                     )
                 while re.search(RSTR_RE, stdout):
-                    stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+                    stdout = re.split(RSTR_RE, stdout, maxsplit=1)[1].strip()
                 while re.search(RSTR_RE, stderr):
-                    stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+                    stderr = re.split(RSTR_RE, stderr, maxsplit=1)[1].strip()
 
         return stdout, stderr, retcode
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -301,7 +301,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         try:
             # Some versions of pkgin check isatty unfortunately
             # this results in cases where a ' ' or ';' can be used
-            pkg, ver = re.split("[; ]", line, 1)[0].rsplit("-", 1)
+            pkg, ver = re.split("[; ]", line, maxsplit=1)[0].rsplit("-", 1)
         except ValueError:
             continue
         __salt__["pkg_resource.add_pkg"](ret, pkg, ver)

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -186,7 +186,7 @@ def render(input, saltenv="base", sls="", argline="", **kws):
         # backslash. A backslash preceded dot will be replaced with just dot.
         args = [
             arg.strip().replace("\\.", ".")
-            for arg in re.split(r"\s+(?<!\\)\.\s+", argline, 1)
+            for arg in re.split(r"\s+(?<!\\)\.\s+", argline, maxsplit=1)
         ]
         try:
             name, rd_argline = (args[0] + " ").split(" ", 1)


### PR DESCRIPTION
[`maxsplit` as positional argument is deprecated since Python 3.13.](https://docs.python.org/3/library/re.html)

### What does this PR do?

Replaces every instance of a 3rd positional argument to `re.split` with its respective keyword argument `maxsplit=`.

### What issues does this PR fix or reference?
Fixes DeprecationWarning.

### Previous Behavior

```console
/usr/lib/python3.13/site-packages/salt/client/ssh/__init__.py:1595: DeprecationWarning: 'maxsplit' is passed as positional argument
  stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
```

### New Behavior

Untested. Presume DeprecationWarning is gone.

### Merge requirements satisfied?

N/A. Very minor.

### Commits signed with GPG?
No