### PR TITLE
[3006.x]Repair Git state comment formatting

### DIFF
--- a/changelog/67944.fixed.md
+++ b/changelog/67944.fixed.md
@@ -1,0 +1,1 @@
+Repair Git state comment formatting

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -949,9 +949,7 @@ def latest(
                         target,
                         force_reset,
                     )
-                    return _uptodate(
-                        ret, target, _format_comments(comments), local_changes
-                    )
+                    return _uptodate(ret, target, comments, local_changes)
 
             if (
                 remote_rev_type == "sha1"
@@ -1181,7 +1179,7 @@ def latest(
                             # user of the actions taken.
                             ret["comment"] = _format_comments(actions)
                             return ret
-                        return _uptodate(ret, target, _format_comments(actions))
+                        return _uptodate(ret, target, actions)
 
                 # The fetch_url for the desired remote does not match the
                 # specified URL (or the remote does not exist), so set the
@@ -1291,7 +1289,7 @@ def latest(
                         if not revs_match and not update_head and formatted_actions:
                             ret["comment"] = formatted_actions
                             return ret
-                        return _uptodate(ret, target, _format_comments(actions))
+                        return _uptodate(ret, target, actions)
 
                 if not upstream and desired_upstream:
                     upstream_action = "Tracking branch was set to {}".format(
@@ -1685,7 +1683,7 @@ def latest(
             ret["comment"] = _format_comments(comments)
             ret["changes"]["revision"] = {"old": local_rev, "new": new_rev}
         else:
-            return _uptodate(ret, target, _format_comments(comments))
+            return _uptodate(ret, target, comments)
     else:
         if os.path.isdir(target):
             target_contents = os.listdir(target)

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -295,6 +295,17 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             "git.latest", name=TEST_REPO, target=target, force_reset=True
         )
         self.assertSaltTrueReturn(ret)
+        ret = ret[next(iter(ret))]
+        # beginning of comment
+        self.assertEqual(
+            f"Repository {target} is up-to-date\n",
+            ret["comment"][0 : 26 + len(target)],
+        )
+        self.assertIn("Uncommitted changes were discarded.", ret["comment"])
+        # ending of comment
+        self.assertEqual(
+            "Repository was hard-reset to remote HEAD (bbefe81).", ret["comment"][-51:]
+        )
 
         # Make sure that we no longer have uncommitted changes
         self.assertFalse(self.run_function("git.diff", [target, "HEAD"]))


### PR DESCRIPTION
The _uptodate() function already invokes _format_comments() on the comments passed, avoid duplicate invocations of _format_comments() which caused the joined string result from being joined with dots a second time, effectively placing a dot after every character in the resulting comment output.

### What does this PR do?

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/67944

### Previous Behavior

```
          ID: salt_formula_clone
    Function: git.latest
        Name: https://gitlab.infra.opensuse.org/infra/salt-formulas-git.git
      Result: True
     Comment: Repository /srv/formulas is up-to-date

              Changes made: U. n. c. o. m. m. i. t. t. e. d.  . c. h. a. n. g. e. s.  . w. e. r. e.  . d. i. s. c. a. r. d. e. d. ..  . R. e. p. o. s. i. t. o. r. y.  . w. a.
 s.  . h. a. r. d. -. r. e. s. e. t.  . t. o.  . o. r. i. g. i. n. /. p. r. o. d. u. c. t. i. o. n.  . (. 4. e. d. 6. b. 6. 1. ). ..
     Started: 14:50:13.673535
    Duration: 3066.77 ms
     Changes:
              ----------
              forced update:
                  True
```

### New Behavior

```
          ID: salt_formula_clone
    Function: git.latest
        Name: https://gitlab.infra.opensuse.org/infra/salt-formulas-git.git
      Result: True
     Comment: Repository /srv/formulas is up-to-date

              Changes made: Uncommitted changes were discarded. Repository was hard-reset to origin/production (4ed6b61).
     Started: 15:27:59.400230
    Duration: 1799.01 ms
     Changes:
              ----------
              forced update:
                  True
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
