### PR TITLE
[WIP]Send show_jid output to stderr

### DIFF
--- a/changelog/25154.fixed.md
+++ b/changelog/25154.fixed.md
@@ -1,0 +1,1 @@
+Send show_jid output to stderr

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1058,7 +1058,7 @@ class LocalClient:
             print(msg)
             print("-" * len(msg) + "\n")
         elif show_jid:
-            print(f"jid: {jid}")
+            print(f"jid: {jid}", file=sys.stderr)
         if timeout is None:
             timeout = self.opts["timeout"]
         fret = {}
@@ -1550,7 +1550,7 @@ class LocalClient:
             print(msg)
             print("-" * len(msg) + "\n")
         elif show_jid:
-            print(f"jid: {jid}")
+            print(f"jid: {jid}", file=sys.stderr)
 
         if timeout is None:
             timeout = self.opts["timeout"]
@@ -1644,7 +1644,7 @@ class LocalClient:
             print(msg)
             print("-" * len(msg) + "\n")
         elif show_jid:
-            print(f"jid: {jid}")
+            print(f"jid: {jid}", file=sys.stderr)
 
         # lazy load the connected minions
         connected_minions = None

--- a/tests/pytests/functional/cli/test_salt_run_show_jid.py
+++ b/tests/pytests/functional/cli/test_salt_run_show_jid.py
@@ -36,7 +36,8 @@ def salt_run_cli(salt_master):
 
 def test_salt_run_show_jid(salt_run_cli):
     """
-    Test that jid is output
+    Test that jid is printed to stderr (not stdout) so --out=json stdout remains valid JSON.
     """
     ret = salt_run_cli.run("test.stdout_print")
-    assert re.match(r"jid: \d+", ret.stdout)
+    assert re.match(r"jid: \d+", ret.stderr)
+    assert not re.match(r"jid: \d+", ret.stdout)

--- a/tests/pytests/unit/client/test_init.py
+++ b/tests/pytests/unit/client/test_init.py
@@ -2,6 +2,7 @@ import pytest
 
 import salt.client
 from salt.exceptions import SaltInvocationError
+from tests.support.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -273,3 +274,47 @@ def test_prep_pub_ext_job_cache_existing(master_opts):
         "user": local_client.salt_user,
     }
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "method,extra_kwargs",
+    [
+        ("get_cli_returns", {}),
+        ("get_cli_static_event_returns", {}),
+        ("get_cli_event_returns", {}),
+    ],
+)
+def test_show_jid_goes_to_stderr(local_client, capsys, method, extra_kwargs):
+    """
+    When show_jid=True, the jid line must be printed to stderr, not stdout,
+    so that --out=json output on stdout remains valid JSON.
+    """
+    jid = "20250101000000000001"
+
+    with patch.object(local_client, "get_cache_returns", return_value={}), patch.object(
+        local_client,
+        "get_event_iter_returns",
+        return_value=iter([]),
+    ), patch.object(
+        local_client,
+        "get_iter_returns",
+        return_value=iter([]),
+    ), patch.dict(
+        local_client.opts,
+        {"timeout": 1, "gather_job_timeout": 1, "master_job_cache": "local_cache"},
+    ), patch.object(
+        local_client,
+        "returners",
+        {
+            "local_cache.get_load": MagicMock(return_value={"tgt": "*"}),
+        },
+    ):
+        func = getattr(local_client, method)
+        result = func(jid, minions=[], show_jid=True, **extra_kwargs)
+        # exhaust generator if needed
+        if hasattr(result, "__iter__") and not isinstance(result, dict):
+            list(result)
+
+    captured = capsys.readouterr()
+    assert f"jid: {jid}" in captured.err
+    assert f"jid: {jid}" not in captured.out


### PR DESCRIPTION

### What does this PR do?

When using --out=json, all data sent to stdout should be valid JSON to allow for piping into processing tools such as `jq`. Make this the case with "show_jid" being enabled as well, by printing the JID line to stderr instead of stdout.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/25154 (the issue was closed with `--static` being suggested as a solution, however this to me is merely a workaround, as it makes for a different output strategy).

### Previous Behavior

With `show_jid` enabled, piping into JSON processing tools leads to parsing exceptions.

### New Behavior

stdout can be processed as JSON with `show_jid` enabled, the same way as with `show_jid` disabled.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
