### PR TITLE
Distribute virtualenv_mod in the windows packages

### DIFF
--- a/pkg/windows/msi/build_pkg.ps1
+++ b/pkg/windows/msi/build_pkg.ps1
@@ -359,7 +359,7 @@ $modules = "acme",
            "uswgi",
            "varnish",
            "vbox",
-           "virt",
+           "virt.py",  # We don't want to remove virtualenv_mod.py
            "xapi",
            "xbpspkg",
            "xfs",

--- a/pkg/windows/nsis/build_pkg.ps1
+++ b/pkg/windows/nsis/build_pkg.ps1
@@ -261,7 +261,7 @@ $modules = "acme",
            "uswgi",
            "varnish",
            "vbox",
-           "virt",
+           "virt.py",  # We don't want to remove virtualenv_mod.py
            "xapi",
            "xbpspkg",
            "xfs",


### PR DESCRIPTION
Due to an oversight the virtualenv_mod module was not distributes with the Windows package anymore.

### What does this PR do?
Add the virtualenv_mod module back in the windows packages

### What issues does this PR fix or reference?
Fixes #65672 

### Commits signed with GPG?
Yes