### PR TITLE
Workaround for Pillar payload signature error

### DIFF
--- a/changelog/62318.fixed.md
+++ b/changelog/62318.fixed.md
@@ -1,0 +1,1 @@
+Fixed `Pillar payload signature failed to validate` error on master failover

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -218,9 +218,12 @@ class AsyncReqChannel:
 
         # Validate the master's signature.
         if not self.verify_signature(signed_msg["data"], signed_msg["sig"]):
-            raise salt.crypt.AuthenticationError(
-                "Pillar payload signature failed to validate."
-            )
+            # Try to reauth on error
+            yield self.auth.authenticate()
+            if not self.verify_signature(signed_msg["data"], signed_msg["sig"]):
+                raise salt.crypt.AuthenticationError(
+                    "Pillar payload signature failed to validate."
+                )
 
         # Make sure the signed key matches the key we used to decrypt the data.
         data = salt.payload.loads(signed_msg["data"])

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -958,6 +958,13 @@ async def test_req_chan_decode_data_dict_entry_v2_bad_signature(
 
     client.transport.send = mocksend
 
+    # Minion should try to authenticate on bad signature
+    @salt.ext.tornado.gen.coroutine
+    def mockauthenticate():
+        pass
+
+    client.auth.authenticate = MagicMock(wraps=mockauthenticate)
+
     # Note the 'ver' value in 'load' does not represent the the 'version' sent
     # in the top level of the transport's message.
     load = {
@@ -977,6 +984,7 @@ async def test_req_chan_decode_data_dict_entry_v2_bad_signature(
             dictkey="pillar",
         )
     assert "Pillar payload signature failed to validate." == excinfo.value.message
+    client.auth.authenticate.assert_called_once()
 
 
 async def test_req_chan_decode_data_dict_entry_v2_bad_key(


### PR DESCRIPTION
### What does this PR do?
Adds re-authentication before throwing error `Pillar payload signature failed to validate`.

### What issues does this PR fix or reference?
Fixes #62318, [my steps to reproduce](https://github.com/saltstack/salt/issues/62318#issuecomment-2808760968)

### Previous Behavior
Minion is constantly logging error `Pillar payload signature failed to validate` after master failover.

### New Behavior
Minion tries to re-authenticate before throwing error. If auth did not help, minion still raises error.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
