### PR TITLE
Better support for dnf5 in Fedora 41/42

### DIFF
--- a/changelog/67975.fixed.md
+++ b/changelog/67975.fixed.md
@@ -1,0 +1,1 @@
+Improve support for installing via groups with dnf5 on Fedora 41/42

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2643,7 +2643,8 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
     for pkgtype in pkgtypes:
         target_found = False
         for line in salt.utils.itertools.split(out, "\n"):
-            line = line.strip().lstrip(string.punctuation)
+            line = line.strip().lstrip(string.punctuation).lstrip()
+            # dnf
             match = re.match(
                 pkgtypes_capturegroup + r" (?:groups|packages):\s*$", line.lower()
             )
@@ -2656,6 +2657,24 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
                         # We've reached the targeted section
                         target_found = True
                     continue
+            # dnf5
+            match_dnf5 = re.match(
+                pkgtypes_capturegroup + r" (?:groups|packages)\s*:\s*(.*?)$", line.lower()
+            )
+            if match_dnf5:
+                if target_found:
+                    # We've reached a new section, break from loop
+                    break
+                else:
+                    if match_dnf5.group(1) == pkgtype:
+                        # We've reached the targeted section
+                        target_found = True
+                        # The difference here from dnf (above) is that this line
+                        # also contains the first package of this section.
+                        # Let line be the match we found, and then simply
+                        # continue on, where we'll add this to the appropriate group
+                        line = match_dnf5.group(2)
+
             if target_found:
                 if expand and ret["type"] == "environment group":
                     if not line or line in completed_groups:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2514,7 +2514,9 @@ def group_list():
 
     if _yum() in ("dnf5"):
         out = __salt__["cmd.run_stdout"](
-            [_yum(), "group", "list", "--hidden"], output_loglevel="trace", python_shell=False
+            [_yum(), "group", "list", "--hidden"],
+            output_loglevel="trace",
+            python_shell=False,
         )
 
         for line in salt.utils.itertools.split(out, "\n"):
@@ -2654,8 +2656,12 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
     elif "group" in g_info:
         ret["type"] = "package group"
 
-    ret["group"] = g_info.get("environment group") or g_info.get("group") or g_info.get("name")
-    ret["id"] = g_info.get("environment-id") or g_info.get("group-id") or g_info.get("id")
+    ret["group"] = (
+        g_info.get("environment group") or g_info.get("group") or g_info.get("name")
+    )
+    ret["id"] = (
+        g_info.get("environment-id") or g_info.get("group-id") or g_info.get("id")
+    )
     if not ret["group"] and not ret["id"]:
         raise CommandExecutionError(f"Group '{name}' not found")
 
@@ -2682,7 +2688,8 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
                     continue
             # dnf5
             match_dnf5 = re.match(
-                pkgtypes_capturegroup + r" (?:groups|packages)\s*:\s*(.*?)$", line.lower()
+                pkgtypes_capturegroup + r" (?:groups|packages)\s*:\s*(.*?)$",
+                line.lower(),
             )
             if match_dnf5:
                 if target_found:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2513,7 +2513,7 @@ def group_list():
     }
 
     out = __salt__["cmd.run_stdout"](
-        [_yum(), "grouplist", "hidden"], output_loglevel="trace", python_shell=False
+        [_yum(), "group", "list", "hidden"], output_loglevel="trace", python_shell=False
     )
     key = None
     for line in salt.utils.itertools.split(out, "\n"):
@@ -2615,7 +2615,7 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
         }
     )
 
-    cmd = [_yum(), "--quiet"] + options + ["groupinfo", name]
+    cmd = [_yum(), "--quiet"] + options + ["group", "info", name]
     out = __salt__["cmd.run_stdout"](cmd, output_loglevel="trace", python_shell=False)
 
     g_info = {}
@@ -2631,8 +2631,8 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
     elif "group" in g_info:
         ret["type"] = "package group"
 
-    ret["group"] = g_info.get("environment group") or g_info.get("group")
-    ret["id"] = g_info.get("environment-id") or g_info.get("group-id")
+    ret["group"] = g_info.get("environment group") or g_info.get("group") or g_info.get("name")
+    ret["id"] = g_info.get("environment-id") or g_info.get("group-id") or g_info.get("id")
     if not ret["group"] and not ret["id"]:
         raise CommandExecutionError(f"Group '{name}' not found")
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2514,14 +2514,14 @@ def group_list():
 
     if _yum() in ("dnf5"):
         out = __salt__["cmd.run_stdout"](
-            [_yum(), "group","list", "--hidden"], output_loglevel="trace", python_shell=False
+            [_yum(), "group", "list", "--hidden"], output_loglevel="trace", python_shell=False
         )
 
         for line in salt.utils.itertools.split(out, "\n"):
             line_lc = line.lower()
             # split line into 3 parts: ID (no spaces), Name (contains spaces), and
             # Installed (one of 'yes' or 'no')
-            match = re.match(r"^(\S+?)\s+(.+?)\s*(yes|no)$" ,line_lc)
+            match = re.match(r"^(\S+?)\s+(.+?)\s*(yes|no)$", line_lc)
             if match:
                 pkg_id, pkg_name, pkg_installed = match.groups()
                 if pkg_id not in ("id"):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2655,6 +2655,8 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
         ret["type"] = "environment group"
     elif "group" in g_info:
         ret["type"] = "package group"
+    elif "name" in g_info:
+        ret["type"] = "package group"
 
     ret["group"] = (
         g_info.get("environment group") or g_info.get("group") or g_info.get("name")
@@ -2701,9 +2703,13 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
                         target_found = True
                         # The difference here from dnf (above) is that this line
                         # also contains the first package of this section.
+                        # Have to pull out the package name, but not changing the case
+                        rematch_dnf5 = re.match( r"^.*:\s*(.*?)$", line)
                         # Let line be the match we found, and then simply
                         # continue on, where we'll add this to the appropriate group
-                        line = match_dnf5.group(2)
+                        # Can't fail...
+                        if rematch_dnf5:
+                            line = rematch_dnf5.group(1)
 
             if target_found:
                 if expand and ret["type"] == "environment group":

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2512,8 +2512,28 @@ def group_list():
         "available language groups:": "available languages",
     }
 
+    if _yum() in ("dnf5"):
+        out = __salt__["cmd.run_stdout"](
+            [_yum(), "group","list", "--hidden"], output_loglevel="trace", python_shell=False
+        )
+
+        for line in salt.utils.itertools.split(out, "\n"):
+            line_lc = line.lower()
+            # split line into 3 parts: ID (no spaces), Name (contains spaces), and
+            # Installed (one of 'yes' or 'no')
+            match = re.match(r"^(\S+?)\s+(.+?)\s*(yes|no)$" ,line_lc)
+            if match:
+                pkg_id, pkg_name, pkg_installed = match.groups()
+                if pkg_id not in ("id"):
+                    if pkg_installed in ("yes"):
+                        ret["installed"].append(pkg_id)
+                    else:
+                        ret["available"].append(pkg_id)
+        return ret
+
+    # else: not dnf5
     out = __salt__["cmd.run_stdout"](
-        [_yum(), "group", "list", "--hidden"], output_loglevel="trace", python_shell=False
+        [_yum(), "grouplist", "hidden"], output_loglevel="trace", python_shell=False
     )
     key = None
     for line in salt.utils.itertools.split(out, "\n"):
@@ -2615,7 +2635,10 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
         }
     )
 
-    cmd = [_yum(), "--quiet"] + options + ["group", "info", name]
+    if _yum() in ("dnf5"):
+        cmd = [_yum(), "--quiet"] + options + ["group", "info", name]
+    else:
+        cmd = [_yum(), "--quiet"] + options + ["groupinfo", name]
     out = __salt__["cmd.run_stdout"](cmd, output_loglevel="trace", python_shell=False)
 
     g_info = {}

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2513,7 +2513,7 @@ def group_list():
     }
 
     out = __salt__["cmd.run_stdout"](
-        [_yum(), "group", "list", "hidden"], output_loglevel="trace", python_shell=False
+        [_yum(), "group", "list", "--hidden"], output_loglevel="trace", python_shell=False
     )
     key = None
     for line in salt.utils.itertools.split(out, "\n"):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2512,7 +2512,7 @@ def group_list():
         "available language groups:": "available languages",
     }
 
-    if _yum() in ("dnf5"):
+    if _yum() == "dnf5":
         out = __salt__["cmd.run_stdout"](
             [_yum(), "group", "list", "--hidden"],
             output_loglevel="trace",
@@ -2526,8 +2526,8 @@ def group_list():
             match = re.match(r"^(\S+?)\s+(.+?)\s*(yes|no)$", line_lc)
             if match:
                 pkg_id, pkg_name, pkg_installed = match.groups()
-                if pkg_id not in ("id"):
-                    if pkg_installed in ("yes"):
+                if pkg_id != "id":
+                    if pkg_installed == "yes":
                         ret["installed"].append(pkg_id)
                     else:
                         ret["available"].append(pkg_id)
@@ -2637,7 +2637,7 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
         }
     )
 
-    if _yum() in ("dnf5"):
+    if _yum() == "dnf5":
         cmd = [_yum(), "--quiet"] + options + ["group", "info", name]
     else:
         cmd = [_yum(), "--quiet"] + options + ["groupinfo", name]
@@ -2704,7 +2704,7 @@ def group_info(name, expand=False, ignore_groups=None, **kwargs):
                         # The difference here from dnf (above) is that this line
                         # also contains the first package of this section.
                         # Have to pull out the package name, but not changing the case
-                        rematch_dnf5 = re.match( r"^.*:\s*(.*?)$", line)
+                        rematch_dnf5 = re.match(r"^.*:\s*(.*?)$", line)
                         # Let line be the match we found, and then simply
                         # continue on, where we'll add this to the appropriate group
                         # Can't fail...

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3327,25 +3327,25 @@ def test_67975_dnf5_group_info():
     """
     patch_yum = patch("salt.modules.yumpkg._yum", Mock(return_value="dnf5"))
     expected = {
-            'mandatory': [
-                "libreoffice-calc",
-                "libreoffice-emailmerge",
-                "libreoffice-graphicfilter",
-                "libreoffice-impress",
-                "libreoffice-writer",
-                ],
-            'optional': [
-                "libreoffice-base",
-                "libreoffice-draw",
-                "libreoffice-math",
-                "libreoffice-pyuno",
-                ], 
-            'default': [], 
-            'conditional': [], 
-            'group': 'LibreOffice', 
-            'id': 'libreoffice', 
-            'description': 'LibreOffice Productivity Suite'
-            }
+        'mandatory': [
+            "libreoffice-calc",
+            "libreoffice-emailmerge",
+            "libreoffice-graphicfilter",
+            "libreoffice-impress",
+            "libreoffice-writer",
+            ],
+        'optional': [
+            "libreoffice-base",
+            "libreoffice-draw",
+            "libreoffice-math",
+            "libreoffice-pyuno",
+            ],
+        'default': [],
+        'conditional': [],
+        'group': 'LibreOffice',
+        'id': 'libreoffice',
+        'description': 'LibreOffice Productivity Suite'
+    }
     cmd_out = """Id                   : libreoffice
      Name                 : LibreOffice
      Description          : LibreOffice Productivity Suite
@@ -3365,10 +3365,11 @@ def test_67975_dnf5_group_info():
                           : libreoffice-pyuno"""
     with patch_yum:
         with patch.dict(
-                yumpkg.__salt__, {"cmd.run_stdout": MagicMock(return_value=cmd_out)}
-            ):
+            yumpkg.__salt__, {"cmd.run_stdout": MagicMock(return_value=cmd_out)}
+        ):
             info = yumpkg.group_info("libreoffice")
             assert info == expected
+
 
 def test_67975_dnf5_group_list():
     patch_yum = patch("salt.modules.yumpkg._yum", Mock(return_value="dnf5"))
@@ -3380,7 +3381,8 @@ bar                  Bar package             no
 brackets             Just (testing) yes     yes
 cleaners             Mop and bucket         yes
 last                 But not least           no\
-    """)
+    """
+    )
     patch_grplist = patch.dict(yumpkg.__salt__, {"cmd.run_stdout": mock_out})
     with patch_yum:
         with patch_grplist:
@@ -3393,4 +3395,3 @@ last                 But not least           no\
         "available languages": {}, 
     }
     assert result == expected
-

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3342,6 +3342,7 @@ def test_67975_dnf5_group_info():
         ],
         "default": [],
         "conditional": [],
+        "type": "package group",
         "group": "LibreOffice",
         "id": "libreoffice",
         "description": "LibreOffice Productivity Suite",

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3319,3 +3319,51 @@ def test_normalize_name_with_arch_x86_64_v2():
         assert yumpkg.normalize_name("chrony.x86_64") == "chrony.x86_64"
     with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
         assert yumpkg.normalize_name("rootfiles.noarch") == "rootfiles"
+
+
+def test_67975_dnf5_group_info():
+    """
+    Test yumpkg.group_info parsing for dnf5 format
+    """
+    expected = {
+            'mandatory': [
+                "libreoffice-calc",
+                "libreoffice-emailmerge",
+                "libreoffice-graphicfilter",
+                "libreoffice-impress",
+                "libreoffice-writer",
+                ],
+            'optional': [
+                "libreoffice-base",
+                "libreoffice-draw",
+                "libreoffice-math",
+                "libreoffice-pyuno",
+                ],
+            'default': [],
+            'conditional': [],
+            'group': 'LibreOffice',
+            'id': 'libreoffice',
+            'description': 'LibreOffice Productivity Suite'
+            }
+    cmd_out = """Id                   : libreoffice
+     Name                 : LibreOffice
+     Description          : LibreOffice Productivity Suite
+     Installed            : yes
+     Order                :
+     Langonly             :
+     Uservisible          : yes
+     Repositories         : @System
+     Mandatory packages   : libreoffice-calc
+                          : libreoffice-emailmerge
+                          : libreoffice-graphicfilter
+                          : libreoffice-impress
+                          : libreoffice-writer
+     Optional packages    : libreoffice-base
+                          : libreoffice-draw
+                          : libreoffice-math
+                          : libreoffice-pyuno"""
+    with patch.dict(
+        yumpkg.__salt__, {"cmd.run_stdout": MagicMock(return_value=cmd_out)}
+    ):
+        info = yumpkg.group_info("libreoffice")
+        assert info == expected

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3333,18 +3333,18 @@ def test_67975_dnf5_group_info():
             "libreoffice-graphicfilter",
             "libreoffice-impress",
             "libreoffice-writer",
-            ],
+        ],
         "optional": [
             "libreoffice-base",
             "libreoffice-draw",
             "libreoffice-math",
             "libreoffice-pyuno",
-            ],
+        ],
         "default": [],
         "conditional": [],
         "group": "LibreOffice",
         "id": "libreoffice",
-        "description": "LibreOffice Productivity Suite"
+        "description": "LibreOffice Productivity Suite",
     }
     cmd_out = """Id                   : libreoffice
      Name                 : LibreOffice

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3327,24 +3327,24 @@ def test_67975_dnf5_group_info():
     """
     patch_yum = patch("salt.modules.yumpkg._yum", Mock(return_value="dnf5"))
     expected = {
-        'mandatory': [
+        "mandatory": [
             "libreoffice-calc",
             "libreoffice-emailmerge",
             "libreoffice-graphicfilter",
             "libreoffice-impress",
             "libreoffice-writer",
             ],
-        'optional': [
+        "optional": [
             "libreoffice-base",
             "libreoffice-draw",
             "libreoffice-math",
             "libreoffice-pyuno",
             ],
-        'default': [],
-        'conditional': [],
-        'group': 'LibreOffice',
-        'id': 'libreoffice',
-        'description': 'LibreOffice Productivity Suite'
+        "default": [],
+        "conditional": [],
+        "group": "LibreOffice",
+        "id": "libreoffice",
+        "description": "LibreOffice Productivity Suite"
     }
     cmd_out = """Id                   : libreoffice
      Name                 : LibreOffice
@@ -3388,10 +3388,10 @@ last                 But not least           no\
         with patch_grplist:
             result = yumpkg.group_list()
     expected = {
-        "installed": ["brackets","cleaners"],
-        "available": ["foo","bar"],
+        "installed": ["brackets", "cleaners"],
+        "available": ["foo", "bar"],
         "installed environments": [],
         "available environments": [],
-        "available languages": {}, 
+        "available languages": {},
     }
     assert result == expected

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3325,6 +3325,7 @@ def test_67975_dnf5_group_info():
     """
     Test yumpkg.group_info parsing for dnf5 format
     """
+    patch_yum = patch("salt.modules.yumpkg._yum", Mock(return_value="dnf5"))
     expected = {
             'mandatory': [
                 "libreoffice-calc",
@@ -3338,11 +3339,11 @@ def test_67975_dnf5_group_info():
                 "libreoffice-draw",
                 "libreoffice-math",
                 "libreoffice-pyuno",
-                ],
-            'default': [],
-            'conditional': [],
-            'group': 'LibreOffice',
-            'id': 'libreoffice',
+                ], 
+            'default': [], 
+            'conditional': [], 
+            'group': 'LibreOffice', 
+            'id': 'libreoffice', 
             'description': 'LibreOffice Productivity Suite'
             }
     cmd_out = """Id                   : libreoffice
@@ -3362,8 +3363,34 @@ def test_67975_dnf5_group_info():
                           : libreoffice-draw
                           : libreoffice-math
                           : libreoffice-pyuno"""
-    with patch.dict(
-        yumpkg.__salt__, {"cmd.run_stdout": MagicMock(return_value=cmd_out)}
-    ):
-        info = yumpkg.group_info("libreoffice")
-        assert info == expected
+    with patch_yum:
+        with patch.dict(
+                yumpkg.__salt__, {"cmd.run_stdout": MagicMock(return_value=cmd_out)}
+            ):
+            info = yumpkg.group_info("libreoffice")
+            assert info == expected
+
+def test_67975_dnf5_group_list():
+    patch_yum = patch("salt.modules.yumpkg._yum", Mock(return_value="dnf5"))
+    mock_out = MagicMock(
+        return_value="""\
+ID                   Name             Installed
+foo                  Foo package             no
+bar                  Bar package             no
+brackets             Just (testing) yes     yes
+cleaners             Mop and bucket         yes
+last                 But not least           no\
+    """)
+    patch_grplist = patch.dict(yumpkg.__salt__, {"cmd.run_stdout": mock_out})
+    with patch_yum:
+        with patch_grplist:
+            result = yumpkg.group_list()
+    expected = {
+        "installed": ["brackets","cleaners"],
+        "available": ["foo","bar"],
+        "installed environments": [],
+        "available environments": [],
+        "available languages": {}, 
+    }
+    assert result == expected
+


### PR DESCRIPTION
'grouplist' and 'groupinfo' are each now two words. 'group' and 'group-id' have been replaced with 'name' and 'id', so check for those too.

### What does this PR do?
Improve support for installing via groups with dnf5 on Fedora 41/42.  Issue found when attempting to run salt 3007 on Fedora 42.  Problem also exists in master/main, so starting there.

### What issues does this PR fix or reference?
Fixes salt failing on a Fedora 41/42 install when (e.g.) installing KDE Fonts via a group:
```
Fonts:
  pkg.group_installed
```
The name of the group doesn't seem to matter -- all groups fail, as 'groupinfo' and 'grouplist' have been deprecated since dnf5 as shipped with Fedora 41.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
