### PR TITLE
[3006.x] Use jscript instead of vscript

### DIFF
--- a/changelog/67982.fixed.md
+++ b/changelog/67982.fixed.md
@@ -1,0 +1,2 @@
+Use a Jscript Custom Action to stop the salt-minion service on Windows instead
+of a VBscript Custom Action due to future deprecation and security issues

--- a/pkg/windows/msi/Product.wxs
+++ b/pkg/windows/msi/Product.wxs
@@ -148,10 +148,13 @@ IMCAC - Immediate Custom Action - It's immediate
     Another application has exclusive access to the file \salt\var\log\salt\minion
     Please shut down the application
     -->
-    <CustomAction Id="stopSalt" Script="vbscript">
-      On error resume next
-      Set objShell = CreateObject("WScript.Shell")
-      objShell.Run "net stop salt-minion", 0, true
+    <CustomAction Id="stopSalt" Script="jscript">
+      try {
+        var objShell = new ActiveXObject("WScript.Shell");
+        objShell.Run("net stop salt-minion", 0, true);
+      } catch (e) {
+        // Handle error if needed
+      }
     </CustomAction>
 
     <!-- This is the import statement for the Custom Actions:


### PR DESCRIPTION
### What does this PR do?
VBscript is being deprecated in Windows. It is also blocked by many hardening systems due to security vulnerabilities. In light of this, this PR attempts to use Jscript instead.

### What issues does this PR fix or reference?
Fixes #67982 

### Previous Behavior
The MSI installer attempted to stop the salt-minion service using a VBscript custom action.

### New Behavior
The MSI installer now stops the salt-minion service using a Jscript custom action.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes