### PR TITLE
Honor environment variables test slugs

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -748,13 +748,19 @@ def workflow_config(
         full = True
         requested_slugs = _environment_slugs(
             ctx,
-            tools.utils.get_cicd_shared_context()["full-testrun-slugs"],
+            os.environ.get(
+                "FULL_TESTRUN_SLUGS",
+                tools.utils.get_cicd_shared_context()["full-testrun-slugs"],
+            ),
             labels,
         )
     else:
         requested_slugs = _environment_slugs(
             ctx,
-            tools.utils.get_cicd_shared_context()["pr-testrun-slugs"],
+            os.environ.get(
+                "PR_TESTRUN_SLUGS",
+                tools.utils.get_cicd_shared_context()["pr-testrun-slugs"],
+            ),
             labels,
         )
 


### PR DESCRIPTION
Allow FULL_TESTRUN_SLUGS and PR_TESTRUN_SLUGS to configure slugs. This is useful for private repositories to run a different set of OSes in the test suite.
