### PR TITLE
[3006.x] Bump relenv version to 0.19.2

### DIFF
--- a/.github/actions/setup-relenv/action.yml
+++ b/.github/actions/setup-relenv/action.yml
@@ -48,6 +48,7 @@ runs:
       env:
         RELENV_FETCH_VERSION: "${{ inputs.version }}"
       run: |
+        python3 -m pip install relenv[toolchain]
         python3 -m relenv toolchain fetch --arch=${{ inputs.arch }}
 
     - name: Fetch Native Python Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -427,7 +427,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -427,7 +427,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -462,7 +462,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -477,7 +477,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -497,7 +497,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -462,7 +462,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -477,7 +477,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -497,7 +497,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -447,7 +447,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -462,7 +462,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -447,7 +447,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -462,7 +462,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -452,7 +452,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -468,7 +468,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -489,7 +489,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.0"
+      relenv-version: "0.19.1"
       python-version: "3.10.17"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -452,7 +452,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -468,7 +468,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -489,7 +489,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.19.1"
+      relenv-version: "0.19.2"
       python-version: "3.10.17"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.17"
-relenv_version: "0.19.0"
+relenv_version: "0.19.1"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.17"
-relenv_version: "0.19.1"
+relenv_version: "0.19.2"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -352,7 +352,6 @@ authors = [
 ]
 
 man_pages = [
-    ("contents", "salt", "Salt Documentation", authors, 7),
     ("ref/cli/salt", "salt", "salt", authors, 1),
     ("ref/cli/salt-master", "salt-master", "salt-master Documentation", authors, 1),
     ("ref/cli/salt-minion", "salt-minion", "salt-minion Documentation", authors, 1),

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -25,6 +25,7 @@ override_dh_auto_build:
 	export PY=$$(build/onedir/venv/bin/python3 -c 'import sys; sys.stdout.write("{}.{}".format(*sys.version_info)); sys.stdout.flush()') \
 		&& build/onedir/venv/bin/python3 -m pip install -r requirements/static/ci/py$${PY}/tools.txt
 	build/onedir/venv/bin/relenv fetch --python=$${SALT_PYTHON_VERSION}
+	build/onedir/venv/bin/pip3 install relenv[toolchain]
 	build/onedir/venv/bin/relenv toolchain fetch
 	build/onedir/venv/bin/tools pkg build onedir-dependencies --arch $${SALT_PACKAGE_ARCH} --relenv-version=$${SALT_RELENV_VERSION} --python-version $${SALT_PYTHON_VERSION} --package-name build/onedir/salt --platform linux
 

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -179,6 +179,7 @@ cd $RPM_BUILD_DIR
   export PY=$(build/venv/bin/python3 -c 'import sys; sys.stdout.write("{}.{}".format(*sys.version_info)); sys.stdout.flush()')
   build/venv/bin/python3 -m pip install -r %{_salt_src}/requirements/static/ci/py${PY}/tools.txt
   build/venv/bin/relenv fetch --python=${SALT_PYTHON_VERSION}
+  build/venv/bin/pip3 install relenv[toolchain]
   build/venv/bin/relenv toolchain fetch
   cd %{_salt_src}
 	$RPM_BUILD_DIR/build/venv/bin/tools pkg build onedir-dependencies --arch ${SALT_PACKAGE_ARCH} --relenv-version=${SALT_RELENV_VERSION} --python-version ${SALT_PYTHON_VERSION} --package-name $RPM_BUILD_DIR/build/salt --platform linux


### PR DESCRIPTION
- Upgrade relenv to 0.19.1 which no longer requires ppbt.
- Stop generating huge man.7 page #64255.
