### PR TITLE
PillarCache: reimplement using salt.cache 

### DIFF
--- a/changelog/68030.changed.md
+++ b/changelog/68030.changed.md
@@ -1,0 +1,3 @@
+PillarCache: reimplement using salt.cache
+fix minion data cache organization/move pillar and grains to dedicated cache banks
+salt.cache: allow cache.store() to set expires per key

--- a/changelog/68030.fixed.md
+++ b/changelog/68030.fixed.md
@@ -1,0 +1,1 @@
+salt.key: check_minion_cache performance optimization

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -76,6 +76,7 @@ def fetch(bank, key, cachedir):
     inkey = False
     key_file = salt.utils.path.join(cachedir, os.path.normpath(bank), f"{key}.p")
     if not os.path.isfile(key_file):
+        log.debug('Cache file "%s" does not exist', key_file)
         # The bank includes the full filename, and the key is inside the file
         key_file = salt.utils.path.join(cachedir, os.path.normpath(bank) + ".p")
         inkey = True

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1679,13 +1679,10 @@ class LocalClient:
                         ).connected_ids()
                     if (
                         self.opts["minion_data_cache"]
-                        and salt.cache.factory(self.opts).contains(
-                            f"minions/{id_}", "data"
-                        )
+                        and salt.cache.factory(self.opts).contains("grains", id_)
                         and connected_minions
                         and id_ not in connected_minions
                     ):
-
                         yield {
                             id_: {
                                 "out": "no_return",

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1024,6 +1024,8 @@ VALID_OPTS = immutabletypes.freeze(
         "request_server_aes_session": int,
         # Minimum authentication protocol version to accept from minions
         "minimum_auth_version": int,
+        # optional cache driver for pillar cache
+        "pillar.cache_driver": (type(None), str),
     }
 )
 
@@ -1335,6 +1337,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "encryption_algorithm": "OAEP-SHA1",
         "signing_algorithm": "PKCS1v15-SHA1",
         "keys.cache_driver": "localfs_key",
+        "pillar.cache_driver": None,
     }
 )
 
@@ -1693,6 +1696,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "request_server_aes_session": 0,
         "request_server_ttl": 0,
         "minimum_auth_version": 3,
+        "pillar.cache_driver": None,
     }
 )
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -789,7 +789,6 @@ class RemoteFuncs:
         )
         data = pillar.compile_pillar()
         if self.opts.get("minion_data_cache", False):
-            self.cache.store("pillar", load["id"], data)
             self.cache.store("grains", load["id"], load["grains"])
             if self.opts.get("minion_data_cache_events") is True:
                 self.event.fire_event(

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -624,7 +624,7 @@ class RemoteFuncs:
         minions = _res["minions"]
         minion_side_acl = {}  # Cache minion-side ACL
         for minion in minions:
-            mine_data = self.cache.fetch(f"minions/{minion}", "mine")
+            mine_data = self.cache.fetch("mine", minion)
             if not isinstance(mine_data, dict):
                 continue
             for function in functions_allowed:
@@ -675,8 +675,8 @@ class RemoteFuncs:
         if self.opts.get("minion_data_cache", False) or self.opts.get(
             "enforce_mine_cache", False
         ):
-            cbank = "minions/{}".format(load["id"])
-            ckey = "mine"
+            ckey = load["id"]
+            cbank = "mine"
             new_data = load["data"]
             if not load.get("clear", False):
                 data = self.cache.fetch(cbank, ckey)
@@ -694,8 +694,8 @@ class RemoteFuncs:
         if self.opts.get("minion_data_cache", False) or self.opts.get(
             "enforce_mine_cache", False
         ):
-            cbank = "minions/{}".format(load["id"])
-            ckey = "mine"
+            cbank = "mine"
+            ckey = load["id"]
             try:
                 data = self.cache.fetch(cbank, ckey)
                 if not isinstance(data, dict):
@@ -716,7 +716,7 @@ class RemoteFuncs:
         if self.opts.get("minion_data_cache", False) or self.opts.get(
             "enforce_mine_cache", False
         ):
-            return self.cache.flush("minions/{}".format(load["id"]), "mine")
+            return self.cache.flush("mine", load["id"])
         return True
 
     def _file_recv(self, load):
@@ -789,11 +789,8 @@ class RemoteFuncs:
         )
         data = pillar.compile_pillar()
         if self.opts.get("minion_data_cache", False):
-            self.cache.store(
-                "minions/{}".format(load["id"]),
-                "data",
-                {"grains": load["grains"], "pillar": data},
-            )
+            self.cache.store("pillar", load["id"], data)
+            self.cache.store("grains", load["id"], load["grains"])
             if self.opts.get("minion_data_cache_events") is True:
                 self.event.fire_event(
                     {"comment": "Minion data cache refresh"},

--- a/salt/key.py
+++ b/salt/key.py
@@ -474,21 +474,28 @@ class Key:
         Optionally, pass in a list of minions which should have their caches
         preserved. To preserve all caches, set __opts__['preserve_minion_cache']
         """
+        if self.opts.get("preserve_minion_cache", False):
+            return
+
         if preserve_minions is None:
             preserve_minions = []
+        preserve_minions = set(preserve_minions)
+
         keys = self.list_keys()
-        minions = []
-        for key, val in keys.items():
-            minions.extend(val)
-        if not self.opts.get("preserve_minion_cache", False):
-            # we use a new cache instance here as we dont want the key cache
-            cache = salt.cache.factory(self.opts)
-            for bank in ["grains", "pillar"]:
-                clist = cache.list(bank)
-                if clist:
-                    for minion in clist:
-                        if minion not in minions and minion not in preserve_minions:
-                            cache.flush(bank, minion)
+
+        for val in keys.values():
+            preserve_minions.update(val)
+
+        # we use a new cache instance here as we dont want the key cache
+        cache = salt.cache.factory(self.opts)
+
+        for bank in ["grains", "pillar"]:
+            clist = set(cache.list(bank))
+            for minion in clist - preserve_minions:
+                # pillar optionally encodes pillarenv in the key as minion:$pillarenv
+                if ":" in minion and minion.split(":")[0] in preserve_minions:
+                    continue
+                cache.flush(bank, minion)
 
     def check_master(self):
         """

--- a/salt/key.py
+++ b/salt/key.py
@@ -483,11 +483,12 @@ class Key:
         if not self.opts.get("preserve_minion_cache", False):
             # we use a new cache instance here as we dont want the key cache
             cache = salt.cache.factory(self.opts)
-            clist = cache.list(self.ACC)
-            if clist:
-                for minion in clist:
-                    if minion not in minions and minion not in preserve_minions:
-                        cache.flush(f"{self.ACC}/{minion}")
+            for bank in ["grains", "pillar"]:
+                clist = cache.list(bank)
+                if clist:
+                    for minion in clist:
+                        if minion not in minions and minion not in preserve_minions:
+                            cache.flush(bank, minion)
 
     def check_master(self):
         """

--- a/salt/master.py
+++ b/salt/master.py
@@ -1765,11 +1765,9 @@ class AESFuncs(TransportMethods):
         data = pillar.compile_pillar()
         self.fs_.update_opts()
         if self.opts.get("minion_data_cache", False):
-            self.masterapi.cache.store(
-                "minions/{}".format(load["id"]),
-                "data",
-                {"grains": load["grains"], "pillar": data},
-            )
+            self.masterapi.cache.store("grains", load["id"], load["grains"])
+            self.masterapi.cache.store("pillar", load["id"], data)
+
             if self.opts.get("minion_data_cache_events") is True:
                 self.event.fire_event(
                     {"Minion data cache refresh": load["id"]},

--- a/salt/master.py
+++ b/salt/master.py
@@ -724,16 +724,6 @@ class Master(SMaster):
         if not self.opts["fileserver_backend"]:
             errors.append("No fileserver backends are configured")
 
-        # Check to see if we need to create a pillar cache dir
-        if self.opts["pillar_cache"] and not os.path.isdir(
-            os.path.join(self.opts["cachedir"], "pillar_cache")
-        ):
-            try:
-                with salt.utils.files.set_umask(0o077):
-                    os.mkdir(os.path.join(self.opts["cachedir"], "pillar_cache"))
-            except OSError:
-                pass
-
         if self.opts.get("git_pillar_verify_config", True):
             try:
                 git_pillars = [
@@ -1766,7 +1756,6 @@ class AESFuncs(TransportMethods):
         self.fs_.update_opts()
         if self.opts.get("minion_data_cache", False):
             self.masterapi.cache.store("grains", load["id"], load["grains"])
-            self.masterapi.cache.store("pillar", load["id"], data)
 
             if self.opts.get("minion_data_cache_events") is True:
                 self.event.fire_event(

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -177,7 +177,7 @@ def _load_minion(minion_id, cache):
         6: sorted(ipaddress.IPv6Address(addr) for addr in grains.get("ipv6", [])),
     }
 
-    mine = cache.fetch(f"minions/{minion_id}", "mine")
+    mine = cache.fetch("mine", minion_id)
 
     return grains, pillar, addrs, mine
 

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -96,8 +96,7 @@ def show_pillar(minion="*", **kwargs):
 
     pillar = salt.pillar.Pillar(__opts__, grains, id_, saltenv, pillarenv=pillarenv)
 
-    compiled_pillar = pillar.compile_pillar()
-    return compiled_pillar
+    return pillar.compile_pillar()
 
 
 def clear_pillar_cache(minion="*", **kwargs):
@@ -116,7 +115,7 @@ def clear_pillar_cache(minion="*", **kwargs):
 
     """
 
-    if not __opts__.get("pillar_cache"):
+    if not (__opts__.get("pillar_cache") or __opts__.get("minion_data_cache")):
         log.info("The pillar_cache is set to False or not enabled.")
         return False
 
@@ -126,7 +125,6 @@ def clear_pillar_cache(minion="*", **kwargs):
     pillarenv = kwargs.pop("pillarenv", None)
     saltenv = kwargs.pop("saltenv", "base")
 
-    pillar_cache = {}
     for tgt in ret.get("minions", []):
         id_, grains, _ = salt.utils.minions.get_minion_data(tgt, __opts__)
 
@@ -141,15 +139,7 @@ def clear_pillar_cache(minion="*", **kwargs):
         )
         pillar.clear_pillar()
 
-        if __opts__.get("pillar_cache_backend") == "memory":
-            _pillar_cache = pillar.cache
-        else:
-            _pillar_cache = pillar.cache._dict
-
-        if tgt in _pillar_cache and _pillar_cache[tgt]:
-            pillar_cache[tgt] = _pillar_cache.get(tgt).get(pillarenv)
-
-    return pillar_cache
+    return {}
 
 
 def show_pillar_cache(minion="*", **kwargs):
@@ -168,7 +158,7 @@ def show_pillar_cache(minion="*", **kwargs):
 
     """
 
-    if not __opts__.get("pillar_cache"):
+    if not (__opts__.get("pillar_cache") or __opts__.get("minion_data_cache")):
         log.info("The pillar_cache is set to False or not enabled.")
         return False
 
@@ -179,25 +169,14 @@ def show_pillar_cache(minion="*", **kwargs):
     saltenv = kwargs.pop("saltenv", "base")
 
     pillar_cache = {}
+
     for tgt in ret.get("minions", []):
         id_, grains, _ = salt.utils.minions.get_minion_data(tgt, __opts__)
-
-        for key in kwargs:
-            grains[key] = kwargs[key]
-
-        if grains is None:
-            grains = {"fqdn": minion}
-
+        # we could use the pillar from above, but its not pillarenv aware
         pillar = salt.pillar.PillarCache(
             __opts__, grains, id_, saltenv, pillarenv=pillarenv
-        )
-
-        if __opts__.get("pillar_cache_backend") == "memory":
-            _pillar_cache = pillar.cache
-        else:
-            _pillar_cache = pillar.cache._dict
-
-        if tgt in _pillar_cache and _pillar_cache[tgt]:
-            pillar_cache[tgt] = _pillar_cache[tgt].get(pillarenv)
+        ).cached_pillar()
+        if pillar:
+            pillar_cache[tgt] = pillar
 
     return pillar_cache

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -239,11 +239,11 @@ class MasterPillarUtil:
             )
             return mine_data
         if not minion_ids:
-            minion_ids = self.cache.list("minions")
+            minion_ids = self.cache.list("grains")
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
-            mdata = self.cache.fetch(f"minions/{minion_id}", "mine")
+            mdata = self.cache.fetch("mine", minion_id)
             if isinstance(mdata, dict):
                 mine_data[minion_id] = mdata
         return mine_data
@@ -257,23 +257,24 @@ class MasterPillarUtil:
             log.debug("Skipping cached data because minion_data_cache is not enabled.")
             return grains, pillars
         if not minion_ids:
-            minion_ids = self.cache.list("minions")
+            minion_ids = self.cache.list("grains")
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
-            mdata = self.cache.fetch(f"minions/{minion_id}", "data")
-            if not isinstance(mdata, dict):
-                log.warning(
-                    "cache.fetch should always return a dict. ReturnedType: %s,"
-                    " MinionId: %s",
-                    type(mdata).__name__,
-                    minion_id,
-                )
-                continue
-            if "grains" in mdata:
-                grains[minion_id] = mdata["grains"]
-            if "pillar" in mdata:
-                pillars[minion_id] = mdata["pillar"]
+            for bank in ["grains", "pillar"]:
+                mdata = self.cache.fetch(bank, minion_id)
+                if not isinstance(mdata, dict):
+                    log.warning(
+                        "cache.fetch should always return a dict. ReturnedType: %s,"
+                        " MinionId: %s",
+                        type(mdata).__name__,
+                        minion_id,
+                    )
+                    continue
+                if bank == "grains":
+                    grains[minion_id] = mdata
+                if bank == "pillar":
+                    pillars[minion_id] = mdata
         return grains, pillars
 
     def _get_live_minion_grains(self, minion_ids):
@@ -545,10 +546,12 @@ class MasterPillarUtil:
         else:
             # Unless both clear_pillar and clear_grains are True, we need
             # to read in the pillar/grains data since they are both stored
-            # in the same file, 'data.p'
+            # in the the minion data cache
             grains, pillars = self._get_cached_minion_data(*minion_ids)
         try:
-            c_minions = self.cache.list("minions")
+            # we operate under the assumption that grains should be sufficient
+            # for minion list
+            c_minions = self.cache.list("grains")
             for minion_id in minion_ids:
                 if not salt.utils.verify.valid_id(self.opts, minion_id):
                     continue
@@ -556,29 +559,25 @@ class MasterPillarUtil:
                 if minion_id not in c_minions:
                     # Cache bank for this minion does not exist. Nothing to do.
                     continue
-                bank = f"minions/{minion_id}"
+
                 minion_pillar = pillars.pop(minion_id, False)
                 minion_grains = grains.pop(minion_id, False)
-                if (
-                    (clear_pillar and clear_grains)
-                    or (clear_pillar and not minion_grains)
-                    or (clear_grains and not minion_pillar)
-                ):
-                    # Not saving pillar or grains, so just delete the cache file
-                    self.cache.flush(bank, "data")
-                elif clear_pillar and minion_grains:
-                    self.cache.store(bank, "data", {"grains": minion_grains})
-                elif clear_grains and minion_pillar:
-                    self.cache.store(bank, "data", {"pillar": minion_pillar})
+
+                if clear_pillar:
+                    self.cache.flush("pillar", minion_id)
+
+                if clear_grains:
+                    self.cache.flush("grains", minion_id)
+
                 if clear_mine:
                     # Delete the whole mine file
-                    self.cache.flush(bank, "mine")
+                    self.cache.flush("mine", minion_id)
                 elif clear_mine_func is not None:
                     # Delete a specific function from the mine file
-                    mine_data = self.cache.fetch(bank, "mine")
+                    mine_data = self.cache.fetch("mine", minion_id)
                     if isinstance(mine_data, dict):
                         if mine_data.pop(clear_mine_func, False):
-                            self.cache.store(bank, "mine", mine_data)
+                            self.cache.store("mine", minion_id, mine_data)
         except OSError:
             return True
         return True

--- a/tests/pytests/integration/modules/test_pillar.py
+++ b/tests/pytests/integration/modules/test_pillar.py
@@ -351,6 +351,8 @@ def test_pillar_refresh_pillar_items(salt_cli, salt_minion, key_pillar):
     with key_pillar(key) as key_pillar_instance:
         # A pillar.items call sees the pillar right away because a
         # refresh_pillar event is fired.
+        # Calling refresh_pillar to update in-memory pillars
+        key_pillar_instance.refresh_pillar()
         ret = salt_cli.run("pillar.items", minion_tgt=salt_minion.id)
         assert ret.returncode == 0
         val = ret.data

--- a/tests/pytests/unit/daemons/masterapi/test_remote_funcs.py
+++ b/tests/pytests/unit/daemons/masterapi/test_remote_funcs.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import salt.config
@@ -5,6 +7,7 @@ import salt.daemons.masterapi as masterapi
 import salt.utils.platform
 from tests.support.mock import MagicMock, patch
 
+log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.slow_test,
 ]
@@ -18,7 +21,7 @@ class FakeCache:
         self.data[bank, key] = value
 
     def fetch(self, bank, key):
-        return self.data[bank, key]
+        return self.data.get((bank, key), None)
 
 
 @pytest.fixture
@@ -39,7 +42,7 @@ def test_mine_get(funcs, tgt_type_key="tgt_type"):
     - the correct check minions method is called
     - the correct cache key is subsequently used
     """
-    funcs.cache.store("minions/webserver", "mine", dict(ip_addr="2001:db8::1:3"))
+    funcs.cache.store("mine", "webserver", dict(ip_addr="2001:db8::1:3"))
     with patch(
         "salt.utils.minions.CkMinions._check_compound_minions",
         MagicMock(return_value=dict(minions=["webserver"], missing=[])),
@@ -75,8 +78,8 @@ def test_mine_get_dict_str(funcs, tgt_type_key="tgt_type"):
     - the correct cache key is subsequently used
     """
     funcs.cache.store(
-        "minions/webserver",
         "mine",
+        "webserver",
         dict(ip_addr="2001:db8::1:3", ip4_addr="127.0.0.1"),
     )
     with patch(
@@ -108,8 +111,8 @@ def test_mine_get_dict_list(funcs, tgt_type_key="tgt_type"):
     - the correct cache key is subsequently used
     """
     funcs.cache.store(
-        "minions/webserver",
         "mine",
+        "webserver",
         dict(ip_addr="2001:db8::1:3", ip4_addr="127.0.0.1"),
     )
     with patch(
@@ -136,8 +139,8 @@ def test_mine_get_acl_allowed(funcs):
     in the client-side ACL that was stored in the mine data.
     """
     funcs.cache.store(
-        "minions/webserver",
         "mine",
+        "webserver",
         {
             "ip_addr": {
                 salt.utils.mine.MINE_ITEM_ACL_DATA: "2001:db8::1:4",
@@ -174,8 +177,8 @@ def test_mine_get_acl_rejected(funcs):
     no data being sent back (just as if the entry wouldn't exist).
     """
     funcs.cache.store(
-        "minions/webserver",
         "mine",
+        "webserver",
         {
             "ip_addr": {
                 salt.utils.mine.MINE_ITEM_ACL_DATA: "2001:db8::1:4",

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -137,16 +137,15 @@ def test_pillar_envs_path_substitution(env, temp_salt_minion, tmp_path):
 def test_pillar_get_cache_disk(temp_salt_minion, caplog):
     # create faked path for cache
     with pytest.helpers.temp_directory() as temp_path:
-        tmp_cachedir = Path(str(temp_path) + "/pillar_cache/")
-        tmp_cachedir.mkdir(parents=True)
-        assert tmp_cachedir.exists()
-        tmp_cachefile = Path(str(temp_path) + "/pillar_cache/" + temp_salt_minion.id)
+        opts = temp_salt_minion.config.copy()
+        tmp_cachefile = Path(str(temp_path)) / "pillar" / f"{temp_salt_minion.id}.p"
+        tmp_cachefile.parent.mkdir(parents=True)
         tmp_cachefile.touch()
         assert tmp_cachefile.exists()
 
-        opts = temp_salt_minion.config.copy()
         opts["pillarenv"] = None
         opts["pillar_cache"] = True
+        opts["minion_data_cache"] = False
         opts["cachedir"] = str(temp_path)
 
         caplog.at_level(logging.DEBUG)
@@ -156,25 +155,23 @@ def test_pillar_get_cache_disk(temp_salt_minion, caplog):
             minion_id=temp_salt_minion.id,
             saltenv="base",
         )
-        fresh_pillar = pillar.fetch_pillar()
-        assert not (
-            f"Error reading cache file at '{tmp_cachefile}': Unpack failed: incomplete input"
-            in caplog.messages
-        )
+        fresh_pillar = pillar.compile_pillar()
+        assert "Unpack failed: incomplete input" not in caplog.messages
         assert fresh_pillar == {}
 
 
 def test_pillar_fetch_pillar_override_skipped(temp_salt_minion, caplog):
     with pytest.helpers.temp_directory() as temp_path:
-        tmp_cachedir = Path(str(temp_path) + "/pillar_cache/")
-        tmp_cachedir.mkdir(parents=True)
-        assert tmp_cachedir.exists()
-        tmp_cachefile = Path(str(temp_path) + "/pillar_cache/" + temp_salt_minion.id)
-        assert tmp_cachefile.exists() is False
+        opts = temp_salt_minion.config.copy()
+        tmp_cachefile = Path(str(temp_path)) / "pillar" / f"{temp_salt_minion.id}.p"
+        tmp_cachefile.parent.mkdir(parents=True)
+        tmp_cachefile.touch()
+        assert tmp_cachefile.exists()
 
         opts = temp_salt_minion.config.copy()
         opts["pillarenv"] = None
         opts["pillar_cache"] = True
+        opts["minion_data_cache"] = False
         opts["cachedir"] = str(temp_path)
 
         pillar_override = {"inline_pillar": True}
@@ -188,8 +185,11 @@ def test_pillar_fetch_pillar_override_skipped(temp_salt_minion, caplog):
             pillar_override=pillar_override,
         )
 
-        fresh_pillar = pillar.fetch_pillar()
-        assert fresh_pillar == {}
+        fresh_pillar = pillar.compile_pillar()
+        assert "inline_pillar" in fresh_pillar
+
+        pillar_cache = pillar.cache.fetch("pillar", f"{temp_salt_minion.id}:base")
+        assert "inline_pillar" not in pillar_cache
 
 
 def test_remote_pillar_timeout(temp_salt_minion, tmp_path):

--- a/tests/pytests/unit/utils/test_minions.py
+++ b/tests/pytests/unit/utils/test_minions.py
@@ -22,7 +22,7 @@ def test_connected_ids():
     )
     minion = "minion"
     ips = {"203.0.113.1", "203.0.113.2", "127.0.0.1"}
-    mdata = {"grains": {"ipv4": ips, "ipv6": []}}
+    mdata = {"ipv4": ips, "ipv6": []}
     patch_net = patch("salt.utils.network.local_port_tcp", return_value=ips)
     patch_list = patch("salt.cache.Cache.list", return_value=[minion])
     patch_fetch = patch("salt.cache.Cache.fetch", return_value=mdata)
@@ -51,8 +51,8 @@ def test_connected_ids_remote_minions():
     minion2 = "minion2"
     minion2_ip = "192.168.2.10"
     minion_ips = {"203.0.113.1", "203.0.113.2", "127.0.0.1"}
-    mdata = {"grains": {"ipv4": minion_ips, "ipv6": []}}
-    mdata2 = {"grains": {"ipv4": [minion2_ip], "ipv6": []}}
+    mdata = {"ipv4": minion_ips, "ipv6": []}
+    mdata2 = {"ipv4": [minion2_ip], "ipv6": []}
     patch_net = patch("salt.utils.network.local_port_tcp", return_value=minion_ips)
     patch_remote_net = patch(
         "salt.utils.network.remote_port_tcp", return_value={minion2_ip}


### PR DESCRIPTION
commit 8fd858ddf69c6ad000f0c31fcdff5feff599e939 (HEAD -> cachepillar, origin/cachepillar)
Author: Matt Phillips <mphillips81@bloomberg.net>
Date:   Thu Apr 4 17:51:13 2024 -0400

    PillarCache: reimplement using salt.cache

    took the liberty of making it a proper subclass in the process. this now
    uses the salt.cache infrastructure such that it can be driven by the
    base cache driver or a different one if so desired. functionality should
    be equivalent, including using the base bank=pillar key=minion_id for
    merged pillar, such that minion_data_cache can take advantage of the
    same cache. because we are updating the cache at the source, we no
    longer need to update the cache in master/masterapi.

commit 4b20c8ded6e7d7983e981e94edae8f9fc5d935b0
Author: Matt Phillips <mphillips81@bloomberg.net>
Date:   Thu Aug 1 19:36:36 2019 -0400

    fix minion data cache organization

    previously 'bank' was minions/$minion, and key was 'data', which was a
    merge of both pillar and grains. rather than do that, we organize pillar
    and grains into separate banks for better index optimizations for
    backends that can take advantage of it. it also just makes more sense
    this way

commit fac04fccb3e6e46bcd2185003b0ff452f1e23644
Author: Matt Phillips <mphillips81@bloomberg.net>
Date:   Tue Apr 15 11:55:10 2025 -0400

    salt.cache: allow cache.store() to set expires per key

    rather than force a cache.cache() interface and a uniform expiry across
    the cache, we add a more common per store() expiry that can also be used
    instead or in addition to the original cache-wide expiry.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
