### PR TITLE
[3006.x] Disconnect clients that are not consuming

### DIFF
--- a/changelog/68114.fixed.md
+++ b/changelog/68114.fixed.md
@@ -1,0 +1,1 @@
+Disconnect ipc clients that stop consuming

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -374,6 +374,22 @@ Set the default timeout for the salt command and api.
 
 .. conf_master:: loop_interval
 
+.. conf_minion:: ipc_write_timeout
+
+``ipc_write_timeout``
+---------------------
+
+.. versionadded:: 3006.11
+
+Default: ``15``
+
+How many seconds the event publisher process will wait after a client stops
+responding before the client will be disconnected.
+
+.. code-block:: yaml
+
+    ipc_write_timeout: 15
+
 ``loop_interval``
 -----------------
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1663,12 +1663,9 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "fileserver_interval": 3600,
         "features": {},
         "publish_signing_algorithm": "PKCS1v15-SHA1",
-<<<<<<< HEAD
         "request_server_aes_session": 0,
         "request_server_ttl": 0,
-=======
         "ipc_write_timeout": salt.defaults.IPC_WRITE_TIMEOUT,
->>>>>>> f1de671598e (Ipc leak fix)
     }
 )
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -14,6 +14,7 @@ import urllib.parse
 from copy import deepcopy
 
 import salt.crypt
+import salt.defaults
 import salt.defaults.exitcodes
 import salt.exceptions
 import salt.features
@@ -1004,6 +1005,7 @@ VALID_OPTS = immutabletypes.freeze(
         "publish_signing_algorithm": str,
         "request_server_ttl": int,
         "request_server_aes_session": int,
+        "ipc_write_timeout": int,
     }
 )
 
@@ -1661,8 +1663,12 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "fileserver_interval": 3600,
         "features": {},
         "publish_signing_algorithm": "PKCS1v15-SHA1",
+<<<<<<< HEAD
         "request_server_aes_session": 0,
         "request_server_ttl": 0,
+=======
+        "ipc_write_timeout": salt.defaults.IPC_WRITE_TIMEOUT,
+>>>>>>> f1de671598e (Ipc leak fix)
     }
 )
 

--- a/salt/defaults/__init__.py
+++ b/salt/defaults/__init__.py
@@ -60,3 +60,5 @@ It's used to differentiate from `None`, `True`, `False` which, in some
 cases are proper defaults and are also proper values to pass.
 """
 NOT_SET = _Constant("NOT_SET")
+
+IPC_WRITE_TIMEOUT = 15

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -2,11 +2,13 @@
 IPC transport classes
 """
 
+import datetime
 import errno
 import logging
 import socket
 import time
 
+import salt.defaults
 import salt.ext.tornado
 import salt.ext.tornado.concurrent
 import salt.ext.tornado.gen
@@ -533,8 +535,18 @@ class IPCMessagePublisher:
 
     @salt.ext.tornado.gen.coroutine
     def _write(self, stream, pack):
+        timeout = self.opts.get("ipc_write_timeout", salt.defaults.IPC_WRITE_TIMEOUT)
         try:
-            yield stream.write(pack)
+            yield salt.ext.tornado.gen.with_timeout(
+                datetime.timedelta(seconds=timeout),
+                stream.write(pack),
+                quiet_exceptions=(StreamClosedError,),
+            )
+        except salt.ext.tornado.gen.TimeoutError:
+            log.trace("Failed to relay event to client after %d seconds", timeout)
+            if not stream.closed():
+                stream.close()
+            self.streams.discard(stream)
         except StreamClosedError:
             log.trace("Client disconnected from IPC %s", self.socket_path)
             self.streams.discard(stream)
@@ -698,7 +710,9 @@ class IPCMessageSubscriber(IPCClient):
                 self._read_stream_future = None
             except Exception as exc:  # pylint: disable=broad-except
                 log.error(
-                    "Exception occurred in Subscriber while handling stream: %s", exc
+                    "Exception occurred in Subscriber while handling stream: %s",
+                    exc,
+                    exc_info_on_level=logging.DEBUG,
                 )
                 self._read_stream_future = None
                 exc_to_raise = exc

--- a/tests/pytests/functional/master/test_event_publisher.py
+++ b/tests/pytests/functional/master/test_event_publisher.py
@@ -1,0 +1,186 @@
+import logging
+import random
+import threading
+import time
+
+import psutil
+import pytest
+
+import salt.config
+import salt.utils.event
+
+log = logging.getLogger()  # __name__)
+
+
+@pytest.fixture
+def stop_event():
+    """
+    Event used to signal starting and stopping of test
+    """
+    evt = threading.Event()
+    try:
+        yield evt
+    finally:
+        log.info("Clear threading event")
+        evt.clear()
+
+
+@pytest.fixture
+def opts(tmp_path):
+    """
+    opts needed for master events
+    """
+    opts = salt.config.master_config("")
+    sock_dir = tmp_path / "sock"
+    sock_dir.mkdir()
+    opts["sock_dir"] = str(sock_dir)
+    return opts
+
+
+@pytest.fixture
+def process_manager():
+    """
+    Process manager fixture.
+
+    Terminates process manager processes on teardown.
+    """
+    process_manager = salt.utils.process.ProcessManager(wait_for_kill=5)
+    try:
+        yield process_manager
+    finally:
+        log.info("Terminate process manager processes")
+        process_manager.terminate()
+
+
+@pytest.fixture
+def publisher(process_manager, opts):
+    """
+    Event Publisher process.
+    """
+    proc = process_manager.add_process(
+        salt.utils.event.EventPublisher,
+        args=(opts,),
+        name="EventPublisher",
+    )
+    yield proc
+
+
+def _publish_target(evt, opts):
+    """
+    Publish many large events to the event publisher
+    """
+    n = 0
+    event = salt.utils.event.get_event("master", opts=opts, listen=False)
+    log.info("Waiting for start event")
+    evt.wait(5)
+    log.info("Start publishing")
+    try:
+        while evt.is_set():
+            n += 1
+            size = random.randint(500, 5000)
+            event.fire_event({"n": n, "data": "0" * size}, "/meh")
+            time.sleep(0.02)
+    finally:
+        event.destroy()
+
+
+@pytest.fixture
+def publish(opts, stop_event):
+    """
+    Run publish events in thread.
+    """
+    log.info("Publiash fixture")
+    thread = threading.Thread(
+        target=_publish_target,
+        args=(
+            stop_event,
+            opts,
+        ),
+    )
+    thread.start()
+    time.sleep(0.2)
+    try:
+        yield thread
+    finally:
+        log.info("Join publish thread")
+        thread.join()
+
+
+def _listeners_target(evt, opts):
+    """
+    Create a hand full of listening events.
+
+    Each listener will pull a single event of the event bus and the stop
+    comsuming.
+    """
+    log.info("Listener wait start")
+    evt.wait(5)
+    time.sleep(0.2)
+    listeners = []
+    for i in range(5):
+        listeners.append(salt.utils.event.get_event("master", opts=opts, listen=True))
+    try:
+        for n, listener in enumerate(listeners):
+            log.info("Wait for event")
+            e = listener.get_event()
+            log.info("Listener %d Got event %r", n, e)
+            assert e
+        while evt.is_set():
+            time.sleep(0.02)
+    finally:
+        log.info("Destroy listeners")
+        for listener in listeners:
+            listener.destroy()
+
+
+@pytest.fixture
+def listeners(opts, stop_event):
+    """
+    Non consuming listeners
+    """
+    thread = threading.Thread(
+        target=_listeners_target,
+        args=(
+            stop_event,
+            opts,
+        ),
+    )
+    thread.start()
+    time.sleep(0.2)
+    try:
+        yield thread
+    finally:
+        log.info("Join listeners thread")
+        thread.join()
+
+
+def test_publisher_mem(publisher, publish, listeners, stop_event):
+    """
+    Test event publisher memory consumption.
+    """
+    start = time.time()
+
+    # Memory consumption before any publishing happens
+    baseline = psutil.Process(publisher.pid).memory_info().rss / 1024**2
+    log.info("Baseline is %d MB", baseline)
+    stop_event.set()
+    log.info("Stop event has been set")
+    try:
+        # After the loader tests run we have a baseline of almost 300MB
+        # assert baseline < 150
+        leak_threshold = baseline + (baseline * 0.5)
+        while time.time() - start < 60:
+            assert publisher.is_alive()
+            mem = psutil.Process(publisher.pid).memory_info().rss / 1024**2
+            log.info(
+                "Publisher process memory consuption %d MB after %d seconds",
+                mem,
+                time.time() - start,
+            )
+            assert mem < leak_threshold
+            time.sleep(1)
+    # except Exception as exc:
+    #    log.exception("WTF")
+    finally:
+        log.info("test_publisher_mem finished succesfully")
+        stop_event.clear()


### PR DESCRIPTION
Prevents the master EventPublisher process from endlessly consuming memory if a client stops consuming. If we're unable to send an event to the client after the `ipc_write_timeout` time, disconnect the client to re-claim memory. This PR also adds a regression test case for this issue.