### PR TITLE
Add subsystem filter to "udev.exportdb" execution module function

### DIFF
--- a/changelog/68047.added.md
+++ b/changelog/68047.added.md
@@ -1,0 +1,1 @@
+Add subsystem filter to "udev.exportdb" execution module function

--- a/salt/modules/udev.py
+++ b/salt/modules/udev.py
@@ -9,7 +9,7 @@ import logging
 
 import salt.modules.cmdmod
 import salt.utils.path
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 __salt__ = {
     "cmd.run_all": salt.modules.cmdmod.run_all,
@@ -162,16 +162,36 @@ def links(dev):
     return info(dev).get("S", None)
 
 
-def exportdb():
-    """
-    Return all the udev database
+def _filter_subsystems(udevadm_info, subsystems):
+    """Filter udevadm_info, keep entries that match any of the passed subsystems."""
+
+    ret = []
+    for entry in udevadm_info:
+        if entry["E"]["SUBSYSTEM"] in subsystems:
+            ret.append(entry)
+    return ret
+
+
+def exportdb(subsystems=None):
+    """Return the complete udev database.
+
+    :param list subsystems: This parameter limits the returned data to specified
+        subsystems such as "pci", "usb", "block", etc.
+
+        .. versionadded :: 3008
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' udev.exportdb
+        salt '*' udev.exportdb subsystems='[usb, block]'
+
     """
+
+    if subsystems is not None:
+        if not isinstance(subsystems, list):
+            raise SaltInvocationError("subsystems must be a list")
 
     cmd = "udevadm info --export-db"
     udev_result = __salt__["cmd.run_all"](cmd, output_loglevel="quiet")
@@ -179,4 +199,8 @@ def exportdb():
     if udev_result["retcode"]:
         raise CommandExecutionError(udev_result["stderr"])
 
-    return _parse_udevadm_info(udev_result["stdout"])
+    ret = _parse_udevadm_info(udev_result["stdout"])
+    if subsystems is not None:
+        ret = _filter_subsystems(ret, subsystems)
+
+    return ret

--- a/salt/modules/udev.py
+++ b/salt/modules/udev.py
@@ -178,7 +178,7 @@ def exportdb(subsystems=None):
     :param list subsystems: This parameter limits the returned data to specified
         subsystems such as "pci", "usb", "block", etc.
 
-        .. versionadded :: 3008
+        .. versionadded :: 3008.0
 
     CLI Example:
 

--- a/tests/pytests/unit/modules/test_udev.py
+++ b/tests/pytests/unit/modules/test_udev.py
@@ -186,3 +186,63 @@ def test_normalize_info():
         "some": "data",
         "key": ["value", "here"],
     }
+
+
+def test_udev_subsystem_filter():
+    udev_db = [
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00",
+            "E": {
+                "MODALIAS": "acpi:LNXPWRBN:",
+                "SUBSYSTEM": "acpi",
+                "DRIVER": "button",
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00",
+            },
+        },
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2",
+            "E": {
+                "SUBSYSTEM": "input",
+                "PRODUCT": "19/0/1/0",
+                "PHYS": '"LNXPWRBN/button/input0"',
+                "NAME": '"Power Button"',
+                "ID_INPUT": 1,
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2",
+                "MODALIAS": "input:b0019v0000p0001e0000-e0,1,k74,ramlsfw",
+                "ID_PATH_TAG": "acpi-LNXPWRBN_00",
+                "TAGS": ":seat:",
+                "PROP": 0,
+                "ID_FOR_SEAT": "input-acpi-LNXPWRBN_00",
+                "KEY": "10000000000000 0",
+                "USEC_INITIALIZED": 2010022,
+                "ID_PATH": "acpi-LNXPWRBN:00",
+                "EV": 3,
+                "ID_INPUT_KEY": 1,
+            },
+        },
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2",
+            "E": {
+                "SUBSYSTEM": "input",
+                "XKBLAYOUT": "us",
+                "MAJOR": 13,
+                "ID_INPUT": 1,
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2",
+                "ID_PATH_TAG": "acpi-LNXPWRBN_00",
+                "DEVNAME": "/dev/input/event2",
+                "TAGS": ":power-switch:",
+                "BACKSPACE": "guess",
+                "MINOR": 66,
+                "USEC_INITIALIZED": 2076101,
+                "ID_PATH": "acpi-LNXPWRBN:00",
+                "XKBMODEL": "pc105",
+                "ID_INPUT_KEY": 1,
+            },
+            "N": "input/event2",
+        },
+    ]
+
+    filtered = udev._filter_subsystems(udev_db, ["acpi", "usb"])
+
+    assert len(filtered) == 1
+    assert filtered[0]["P"] == "/devices/LNXSYSTM:00/LNXPWRBN:00"


### PR DESCRIPTION
### What does this PR do?
Add a _subsystem_ filter to `udev.exportdb`. udev databases can be very large and exceed [`max_event_size`](https://docs.saltproject.io/en/3006/ref/configuration/minion.html#max-event-size), triggering `salt.utils.dicttrim.trim_dict()`.

This PR adds a new argument, which is a list of subsystems. `udev.exportdb`'s output is filtered, keeping only data for the specified subsystems.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
