### PR TITLE
[3006.x] Fix cp.push module function and its integration test

### DIFF
--- a/changelog/67941.fixed.md
+++ b/changelog/67941.fixed.md
@@ -1,0 +1,1 @@
+Fix cp.push module function and its integration test

--- a/changelog/68087.fixed.md
+++ b/changelog/68087.fixed.md
@@ -1,0 +1,1 @@
+Fix file_recv path verification to allow subdirs used by cp.push

--- a/salt/master.py
+++ b/salt/master.py
@@ -1566,7 +1566,12 @@ class AESFuncs(TransportMethods):
         rpath = os.path.join(self.opts["cachedir"], "minions", load["id"], "files")
         cpath = os.path.join(rpath, normpath)
         # One last safety check here
-        if not salt.utils.verify.clean_path(rpath, cpath):
+        if not salt.utils.verify.clean_path(
+            rpath,
+            cpath,
+            subdir=True,
+            realpath=not self.opts["fileserver_followsymlinks"],
+        ):
             log.warning(
                 "Attempt to write received file outside of master cache "
                 "directory! Requested path: %s. Access denied.",

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -979,7 +979,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
         "tok": auth.gen_token(b"salt"),
     }
 
-    with salt.channel.client.ReqChannel.factory(__opts__) as channel:
+    with salt.channel.client.ReqChannel.factory(__opts__.value()) as channel:
         with salt.utils.files.fopen(path, "rb") as fp_:
             init_send = False
             while True:

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -608,14 +608,11 @@ class CPModuleTest(ModuleCase):
         try:
             self.run_function("cp.push", [log_to_xfer])
             tgt_cache_file = os.path.join(
-                RUNTIME_VARS.TMP,
-                "master-minion-root",
-                "cache",
+                RUNTIME_VARS.RUNTIME_CONFIGS["master"]["cachedir"],
                 "minions",
                 "minion",
                 "files",
-                RUNTIME_VARS.TMP,
-                log_to_xfer,
+                os.path.splitdrive(os.path.normpath(log_to_xfer.lstrip(os.sep)))[1],
             )
             self.assertTrue(
                 os.path.isfile(tgt_cache_file), "File was not cached on the master"

--- a/tests/pytests/unit/modules/test_cp.py
+++ b/tests/pytests/unit/modules/test_cp.py
@@ -142,7 +142,9 @@ def test_push():
     ), patch.multiple(
         "salt.modules.cp",
         _auth=MagicMock(**{"return_value.gen_token.return_value": "token"}),
-        __opts__={"id": "abc", "file_buffer_size": 10},
+        __opts__=salt.loader.dunder.__opts__.with_default(
+            {"id": "abc", "file_buffer_size": 10}
+        ),
     ), patch(
         "salt.utils.files.fopen", mock_open(read_data=b"content")
     ) as m_open, patch(


### PR DESCRIPTION
### What does this PR do?
* fixes cp.push by adding a needed change that was missed in recent changes of the `__opts__` loader dunder in https://github.com/saltstack/salt/pull/66879
* also fixes an issue with the integration test, that caused it to be undetected
* fix file_recv path verification for subdirs (broken because of CVE fix in 3006.12 & 3007.4: https://github.com/saltstack/salt/commit/c4ad23f0f3132d8d8a88f19fa537dc42cf21b215)

### What issues does this PR fix or reference?
Fixes #67941 #68087 