### PR TITLE
Handle powershell commands that are wrapped in parens

### DIFF
--- a/changelog/67190.fixed.md
+++ b/changelog/67190.fixed.md
@@ -1,0 +1,1 @@
+Fixes an issue running powershell commands that begin with parenthesis

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -303,7 +303,22 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
 
         # Commands that are a specific keyword behave differently. They fail if
         # you add a "&" to the front. Add those here as we find them:
-        keywords = ["(", "$", "&", ".", "Configuration", "try"]
+        keywords = [
+            "(",
+            "[",
+            "$",
+            "&",
+            ".",
+            "data",
+            "do",
+            "for",
+            "foreach",
+            "if",
+            "trap",
+            "while",
+            "try",
+            "Configuration",
+        ]
 
         for keyword in keywords:
             if cmd.lower().startswith(keyword.lower()):

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -303,7 +303,7 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
 
         # Commands that are a specific keyword behave differently. They fail if
         # you add a "&" to the front. Add those here as we find them:
-        keywords = ["$", "&", ".", "Configuration", "try"]
+        keywords = ["(", "$", "&", ".", "Configuration", "try"]
 
         for keyword in keywords:
             if cmd.lower().startswith(keyword.lower()):

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1069,9 +1069,38 @@ def test_prep_powershell_cmd_no_powershell():
         ("Write-Host foo", "& Write-Host foo"),
         ("$PSVersionTable", "$PSVersionTable"),
         ("try {this} catch {that}", "try {this} catch {that}"),
+        ("[bool]@{value = 0}", "[bool]@{value = 0}"),
         (
             "(Get-Date(Get-Date).ToUniversalTime() -UFormat %s)",
             "(Get-Date(Get-Date).ToUniversalTime() -UFormat %s)",
+        ),
+        (
+            "if (1 -eq 1) { exit 0 } else { exit 1 }",
+            "if (1 -eq 1) { exit 0 } else { exit 1 }",
+        ),
+        (
+            "do { $count++; $a++; } while ($x[$a] -ne 0)",
+            "do { $count++; $a++; } while ($x[$a] -ne 0)",
+        ),
+        (
+            "while ($val -ne 3) { $val++; Write-Host $val }",
+            "while ($val -ne 3) { $val++; Write-Host $val }",
+        ),
+        (
+            "trap { 'Error found.' }",
+            "trap { 'Error found.' }",
+        ),
+        (
+            "for ($i=1; $i -le 10; $i++) { Write-Host $i }",
+            "for ($i=1; $i -le 10; $i++) { Write-Host $i }",
+        ),
+        (
+            "foreach ($file in Get-ChildItem) { Write-Host $file }",
+            "foreach ($file in Get-ChildItem) { Write-Host $file }",
+        ),
+        (
+            'data { if ($null) { "To get help for this cmdlet, type Get-Help New-Dictionary." } }',
+            'data { if ($null) { "To get help for this cmdlet, type Get-Help New-Dictionary." } }',
         ),
     ],
 )

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1069,6 +1069,10 @@ def test_prep_powershell_cmd_no_powershell():
         ("Write-Host foo", "& Write-Host foo"),
         ("$PSVersionTable", "$PSVersionTable"),
         ("try {this} catch {that}", "try {this} catch {that}"),
+        (
+            "(Get-Date(Get-Date).ToUniversalTime() -UFormat %s)",
+            "(Get-Date(Get-Date).ToUniversalTime() -UFormat %s)",
+        ),
     ],
 )
 @pytest.mark.skip_unless_on_windows


### PR DESCRIPTION
### What does this PR do?
Fixes the "_prep_powershell_cmd" function to handle powershell commands that are wrapped in paranthesis.

### What issues does this PR fix or reference?
Fixes #67190 

### Previous Behavior
Powershell failed to run the command

### New Behavior
Powershell runs the command and returns the result

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes