### PR TITLE
3006.x:  logging regression: fix loglines/findCaller introspection

### DIFF
--- a/changelog/68057.fixed.md
+++ b/changelog/68057.fixed.md
@@ -1,0 +1,1 @@
+logging regression: fix loglines/findCaller introspection

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -280,6 +280,10 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, metaclass=LoggingMixinMeta):
         else:
             extra["exc_info_on_loglevel"] = exc_info_on_loglevel
 
+        # this is required for log lines to work as expected because we are
+        # adding a stackframe with this function
+        stacklevel = stacklevel + 1
+
         try:
             LOGGING_LOGGER_CLASS._log(
                 self,


### PR DESCRIPTION
### What does this PR do?
python 3.8 changed the way it was inferring loglines from the callstack; the stacklevel was exposed as a way around this to tell logging to ignore an arbitrary level of frames ontop of the 1 it knows about.

I tried writing a test but for whatever reason caplog / salt-test-factories doesn't exhibit the same behavior as directly running via CLI. this should be easily reproducible though.

this PR ports https://github.com/saltstack/salt/pull/68042 to 3006.x

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
