### PR TITLE
Handle Junction Points on Windows with file.readlink

### DIFF
--- a/changelog/54484.fixed.md
+++ b/changelog/54484.fixed.md
@@ -1,0 +1,1 @@
+Return target path for symlinks and junctions on Windows

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4000,7 +4000,7 @@ def readlink(path, canonicalize=False):
     if not os.path.isabs(path):
         raise SaltInvocationError(f"Path to link must be absolute: {path}")
 
-    if not os.path.islink(path):
+    if not salt.utils.path.islink(path):
         raise SaltInvocationError(f"A valid link was not specified: {path}")
 
     if canonicalize:

--- a/tests/pytests/functional/utils/test_path.py
+++ b/tests/pytests/functional/utils/test_path.py
@@ -48,7 +48,9 @@ def junction(tmp_path):
     assert target.is_dir()
     junction = tmp_path / "junction"
     cmd = ["cmd", "/c", "mklink", "/j", str(junction), str(target)]
-    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True
+    )
     assert not junction.is_symlink()
     assert junction.is_dir()
     yield junction

--- a/tests/pytests/functional/utils/test_path.py
+++ b/tests/pytests/functional/utils/test_path.py
@@ -1,0 +1,65 @@
+"""
+Test the salt.utils.path Salt Util
+"""
+
+import subprocess
+
+import pytest
+
+import salt.utils.path
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture
+def symlink_file(tmp_path):
+    target = tmp_path / "tgt_symlink"
+    target.write_text("this is the symlink target")
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(target)
+    assert symlink.is_symlink()
+    assert symlink.read_text() == "this is the symlink target"
+    yield symlink
+
+
+@pytest.fixture
+def symlink_dir(tmp_path):
+    target = tmp_path / "tgt_symlink"
+    target.mkdir()
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(target)
+    assert symlink.is_symlink()
+    yield symlink
+
+
+@pytest.fixture
+def junction(tmp_path):
+    """
+    Create a directory and a junction to that directory.
+    """
+    target = tmp_path / "tgt_junction"
+    target.mkdir()
+    junction = tmp_path / "junction"
+    cmd = ["cmd", "/c", "mklink", "/j", str(junction), str(target)]
+    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    assert junction.is_symlink() is False
+    yield junction
+
+
+def test_islink_symlink_file(symlink_file):
+    assert salt.utils.path.islink(str(symlink_file))
+
+
+def test_islink_symlink_dir(symlink_dir):
+    assert salt.utils.path.islink(str(symlink_dir))
+
+
+@pytest.mark.skip_unless_on_windows
+def test_islink_junction(junction):
+    """
+    Junctions are only a thing on Windows, but they are the equivalent of a
+    symlink. They just apply to directories
+    """
+    assert salt.utils.path.islink(str(junction))

--- a/tests/pytests/functional/utils/test_path.py
+++ b/tests/pytests/functional/utils/test_path.py
@@ -17,10 +17,12 @@ pytestmark = [
 def symlink_file(tmp_path):
     target = tmp_path / "tgt_symlink"
     target.write_text("this is the symlink target")
+    assert target.is_file()
     symlink = tmp_path / "symlink"
     symlink.symlink_to(target)
     assert symlink.is_symlink()
     assert symlink.read_text() == "this is the symlink target"
+    assert symlink.is_file()
     yield symlink
 
 
@@ -28,9 +30,11 @@ def symlink_file(tmp_path):
 def symlink_dir(tmp_path):
     target = tmp_path / "tgt_symlink"
     target.mkdir()
+    assert target.is_dir()
     symlink = tmp_path / "symlink"
     symlink.symlink_to(target)
     assert symlink.is_symlink()
+    assert symlink.is_dir()
     yield symlink
 
 
@@ -41,10 +45,12 @@ def junction(tmp_path):
     """
     target = tmp_path / "tgt_junction"
     target.mkdir()
+    assert target.is_dir()
     junction = tmp_path / "junction"
     cmd = ["cmd", "/c", "mklink", "/j", str(junction), str(target)]
     subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    assert junction.is_symlink() is False
+    assert not junction.is_symlink()
+    assert junction.is_dir()
     yield junction
 
 


### PR DESCRIPTION
### What does this PR do?
Handle Junction Points on Windows when using `file.readlink`. Fixes the `salt.utils.path` Salt util to detect Junction Points as links. Makes the `file.readlink` function use the salt util instead of `os.path.islink`.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/54484

### Previous Behavior
Junction points returned an error

### New Behavior
Junction points return the target path

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes