### PR TITLE
Update bootstrap URLs quickstart.rst

### DIFF
--- a/doc/topics/tutorials/quickstart.rst
+++ b/doc/topics/tutorials/quickstart.rst
@@ -31,7 +31,7 @@ for any OS with a Bourne shell:
 
 .. code-block:: bash
 
-    curl -L https://bootstrap.saltstack.com -o bootstrap_salt.sh
+    curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh -o bootstrap_salt.sh
     sudo sh bootstrap_salt.sh
 
 Before run the script, it is a good practice to verify the checksum of the downloaded
@@ -40,7 +40,7 @@ file. You can verify the checksum with SHA256 by running this command:
 .. code-block:: bash
 
     test $(sha256sum bootstrap_salt.sh | awk '{print $1}') \
-       = $(curl -sL https://bootstrap.saltproject.io/sha256 | cat -) \
+       = $(curl -sL https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh.sha256 | cat -) \
        && echo "OK" \
        || echo "File does not match checksum"
 
@@ -53,7 +53,7 @@ file. You can verify the checksum with SHA256 by running this command:
 
     .. code-block:: bash
 
-        curl -L https://bootstrap.saltproject.io | sudo sh -s --
+        curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh -s --
 
 See the `salt-bootstrap`_ documentation for other one liners. When using `Vagrant`_
 to test out salt, the `Vagrant salt provisioner`_ will provision the VM for you.


### PR DESCRIPTION
use GitHub URLs to download bootstrap files

### What does this PR do?
change URLs to current download location of bootstrap script and sha

### What issues does this PR fix or reference?
Fixes "masterless" quickstart failure caused by deprecated URLs.

### Previous Behavior
Tried to download script from https://bootstrap.saltproject.io and failed.

### New Behavior
Downloads script from https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
(and .sha256)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
