### PR TITLE
[wip] Handle git@github.com/.. style remotes

### DIFF
--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -334,3 +334,15 @@ def test_find_file_bad_env(tmp_path):
     gitfs = salt.utils.gitfs.GitFS(opts, remotes)
     with pytest.raises(salt.exceptions.SaltValidationError):
         gitfs.find_file("asdf", tgt_env="asd/../../../sdf")
+
+
+@pytest.mark.parametrize(
+    "remote,valid",
+    [
+        ("git@github.com/saltstack/salt", True),
+        ("https://github.com/salttack/salt.git", True),
+        ("https://github.com/\nsaltstack/salt.git", False),
+    ],
+)
+def test_remote_validation(remote, valid):
+    assert salt.utils.gitfs.GitFS.validate_remote(remote) is valid


### PR DESCRIPTION
Handle `git@github.com/saltsack/salt` style remote definitions. Try to detect these types of remotes and prepend `ssh://` before validating the remote validates as a URL.

#68069