### PR TITLE
[3006.x] Allow subdirs in GitFS find_file check

### DIFF
--- a/changelog/68072.fixed.md
+++ b/changelog/68072.fixed.md
@@ -1,0 +1,1 @@
+Fix GitFS file_find for file in sub-directories

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -3282,14 +3282,18 @@ class GitFS(GitBase):
             return fnd
 
         # dest = salt.utils.path.join(self.cache_root, "refs", tgt_env, path)
-        dest = salt.utils.verify.clean_join(self.cache_root, "refs", tgt_env, path)
+        dest = salt.utils.verify.clean_join(
+            self.cache_root, "refs", tgt_env, path, subdir=True
+        )
         hashes_glob = salt.utils.verify.clean_join(
-            self.hash_cachedir, tgt_env, f"{path}.hash.*"
+            self.hash_cachedir, tgt_env, f"{path}.hash.*", subdir=True
         )
         blobshadest = salt.utils.verify.clean_join(
-            self.hash_cachedir, tgt_env, f"{path}.hash.blob_sha1"
+            self.hash_cachedir, tgt_env, f"{path}.hash.blob_sha1", subdir=True
         )
-        lk_fn = salt.utils.verify.clean_join(self.hash_cachedir, tgt_env, f"{path}.lk")
+        lk_fn = salt.utils.verify.clean_join(
+            self.hash_cachedir, tgt_env, f"{path}.lk", subdir=True
+        )
         destdir = os.path.dirname(dest)
         hashdir = os.path.dirname(blobshadest)
         if not os.path.isdir(destdir):

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -334,3 +334,31 @@ def test_find_file_bad_env(tmp_path):
     gitfs = salt.utils.gitfs.GitFS(opts, remotes)
     with pytest.raises(salt.exceptions.SaltValidationError):
         gitfs.find_file("asdf", tgt_env="asd/../../../sdf")
+
+
+def test_find_file_subdir(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "refs").mkdir()
+    (root / "refs" / "base").mkdir()
+    opts = {
+        "cachedir": f"{tmp_path / 'cache'}",
+        "gitfs_user": "",
+        "gitfs_password": "",
+        "gitfs_pubkey": "",
+        "gitfs_privkey": "",
+        "gitfs_passphrase": "",
+        "gitfs_insecure_auth": False,
+        "gitfs_refspecs": salt.config._DFLT_REFSPECS,
+        "gitfs_ssl_verify": True,
+        "gitfs_branch": "master",
+        "gitfs_base": "master",
+        "gitfs_root": "",
+        "gitfs_env": "",
+        "gitfs_fallback": "",
+    }
+    remotes = []
+    gitfs = salt.utils.gitfs.GitFS(opts, remotes)
+    gitfs.cache_root = str(root)
+    ret = gitfs.find_file("foo/init.sls")
+    assert ret == {"path": "", "rel": ""}


### PR DESCRIPTION
Allow subdirs in GitFS find_file check when validating for directory traversals.

#68072
