### PR TITLE
[3006.x] Minion connectivity

### DIFF
--- a/changelog/68079.fixed.md
+++ b/changelog/68079.fixed.md
@@ -1,0 +1,1 @@
+Fix minion connectivity issues by ensuring auth notices refreshed session token

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -810,7 +810,10 @@ class AsyncAuth:
                     self._creds = creds
                     self._crypticle = Crypticle(self.opts, creds["aes"])
                     self._session_crypticle = Crypticle(self.opts, creds["session"])
-                elif self._creds["aes"] != creds["aes"]:
+                elif (
+                    self._creds["aes"] != creds["aes"]
+                    or self._creds["session"] != creds["session"]
+                ):
                     log.debug("%s The master's aes key has changed.", self)
                     AsyncAuth.creds_map[key] = creds
                     self._creds = creds

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1479,7 +1479,10 @@ class SAuth(AsyncAuth):
                 self._creds = creds
                 self._crypticle = Crypticle(self.opts, creds["aes"])
                 self._session_crypticle = Crypticle(self.opts, creds["session"])
-            elif self._creds["aes"] != creds["aes"]:
+            elif (
+                self._creds["aes"] != creds["aes"]
+                or self._creds["session"] != creds["session"]
+            ):
                 log.error("%s The master's aes key has changed.", self)
                 self._creds = creds
                 self._crypticle = Crypticle(self.opts, creds["aes"])

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -881,13 +881,15 @@ class MinionBase:
                                 self.opts["master"] = proto_data["master"]
                                 return
 
-    def _return_retry_timer(self):
+    def _return_retry_timer(self, max=False):
         """
         Based on the minion configuration, either return a randomized timer or
         just return the value of the return_retry_timer.
         """
         msg = "Minion return retry timer set to %s seconds"
         if self.opts.get("return_retry_timer_max"):
+            if max:
+                return self.opts["return_retry_timer_max"]
             try:
                 random_retry = random.randint(
                     self.opts["return_retry_timer"], self.opts["return_retry_timer_max"]
@@ -2154,7 +2156,11 @@ class Minion(MinionBase):
             else:
                 log.warning("The metadata parameter must be a dictionary. Ignoring.")
         if minion_instance.connected:
-            minion_instance._return_pub(ret)
+            minion_instance._return_pub(
+                ret,
+                timeout=minion_instance.opts["return_retry_tries"]
+                * minion_instance._return_retry_timer(max=True),
+            )
 
         # Add default returners from minion config
         # Should have been converted to comma-delimited string already

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -18,6 +18,16 @@ def key_data():
     ]
 
 
+@pytest.fixture
+def minion_root(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "etc").mkdir()
+    (root / "etc" / "salt").mkdir()
+    (root / "etc" / "salt" / "pki").mkdir()
+    yield root
+
+
 @pytest.mark.parametrize("linesep", ["\r\n", "\r", "\n"])
 def test__clean_key(key_data, linesep):
     tst_key = linesep.join(key_data)
@@ -31,3 +41,142 @@ def test__clean_key_mismatch(key_data, linesep):
     tst_key = tst_key.replace("5", "4")
     chk_key = "\n".join(key_data)
     assert crypt.clean_key(tst_key) != crypt.clean_key(chk_key)
+
+
+async def test_auth_aes_key_rotation(minion_root, io_loop):
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+    }
+    credskey = (
+        opts["pki_dir"],  # where the keys are stored
+        opts["id"],  # minion ID
+        opts["master_uri"],  # master ID
+    )
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
+
+    aes = crypt.Crypticle.generate_key_string()
+    session = crypt.Crypticle.generate_key_string()
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    async def mock_sign_in(*args, **kwargs):
+        return mock_sign_in.response
+
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes,
+        "session": session,
+    }
+    auth.sign_in = mock_sign_in
+
+    assert credskey not in auth.creds_map
+
+    await auth.authenticate()
+
+    assert credskey in auth.creds_map
+    assert auth.creds_map[credskey]["aes"] == aes
+    assert auth.creds_map[credskey]["session"] == session
+
+    aes1 = crypt.Crypticle.generate_key_string()
+
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes1,
+        "session": session,
+    }
+
+    await auth.authenticate()
+
+    assert credskey in auth.creds_map
+    assert auth.creds_map[credskey]["aes"] == aes1
+    assert auth.creds_map[credskey]["session"] == session
+
+    session1 = crypt.Crypticle.generate_key_string()
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes1,
+        "session": session1,
+    }
+
+    await auth.authenticate()
+
+    assert credskey in auth.creds_map
+    assert auth.creds_map[credskey]["aes"] == aes1
+    assert auth.creds_map[credskey]["session"] == session1
+
+
+def test_sauth_aes_key_rotation(minion_root, io_loop):
+
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+    }
+    credskey = (
+        opts["pki_dir"],  # where the keys are stored
+        opts["id"],  # minion ID
+        opts["master_uri"],  # master ID
+    )
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
+
+    aes = crypt.Crypticle.generate_key_string()
+    session = crypt.Crypticle.generate_key_string()
+
+    auth = crypt.SAuth(opts, io_loop)
+
+    def mock_sign_in(*args, **kwargs):
+        return mock_sign_in.response
+
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes,
+        "session": session,
+    }
+    auth.sign_in = mock_sign_in
+
+    assert auth._creds is None
+
+    auth.authenticate()
+
+    assert isinstance(auth._creds, dict)
+    assert auth._creds["aes"] == aes
+    assert auth._creds["session"] == session
+
+    aes1 = crypt.Crypticle.generate_key_string()
+
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes1,
+        "session": session,
+    }
+
+    auth.authenticate()
+
+    assert isinstance(auth._creds, dict)
+    assert auth._creds["aes"] == aes1
+    assert auth._creds["session"] == session
+
+    session1 = crypt.Crypticle.generate_key_string()
+    mock_sign_in.response = {
+        "enc": "pub",
+        "aes": aes1,
+        "session": session1,
+    }
+
+    auth.authenticate()
+
+    assert isinstance(auth._creds, dict)
+    assert auth._creds["aes"] == aes1
+    assert auth._creds["session"] == session1


### PR DESCRIPTION
Allow send_req_async to wait longer when sending a return back to the master. The minion should wait at least as long as the max possible return timeout.

#68079