### PR TITLE
[3006.x] Fix checking of non-url style git remotes

### DIFF
--- a/changelog/68069.fixed.md
+++ b/changelog/68069.fixed.md
@@ -1,0 +1,1 @@
+Handle git@github.com:saltstack/salt style remotes in remote url validation

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -3311,14 +3311,18 @@ class GitFS(GitBase):
             return fnd
 
         # dest = salt.utils.path.join(self.cache_root, "refs", tgt_env, path)
-        dest = salt.utils.verify.clean_join(self.cache_root, "refs", tgt_env, path)
+        dest = salt.utils.verify.clean_join(
+            self.cache_root, "refs", tgt_env, path, subdir=True
+        )
         hashes_glob = salt.utils.verify.clean_join(
-            self.hash_cachedir, tgt_env, f"{path}.hash.*"
+            self.hash_cachedir, tgt_env, f"{path}.hash.*", subdir=True
         )
         blobshadest = salt.utils.verify.clean_join(
-            self.hash_cachedir, tgt_env, f"{path}.hash.blob_sha1"
+            self.hash_cachedir, tgt_env, f"{path}.hash.blob_sha1", subdir=True
         )
-        lk_fn = salt.utils.verify.clean_join(self.hash_cachedir, tgt_env, f"{path}.lk")
+        lk_fn = salt.utils.verify.clean_join(
+            self.hash_cachedir, tgt_env, f"{path}.lk", subdir=True
+        )
         destdir = os.path.dirname(dest)
         hashdir = os.path.dirname(blobshadest)
         if not os.path.isdir(destdir):

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2594,22 +2594,31 @@ class GitBase:
             )
 
     @staticmethod
-    def validate_remote(remote):
+    def remote_to_url(remote):
         """
-        Validate a remote repository config.
+        Convert a remote to a URL
 
         Remotes should be in url format with the exception of some ssh remotes
         which can be in a `git@...` format. This method handles the special ssh
-        remote case by converting to `ssh://` style prior to url validation.
+        remote case by converting to `ssh://` style URLs.
         """
-        name, url = split_name(remote)
-        pattern = r"^([^@]+)@([^:]+):(.+)$"
-        if match := re.match(pattern, url):
+        pattern = r"^([^@:/]+)@([^:]+):(.+)$"
+        if match := re.match(pattern, remote):
             user, host, path = match.groups()
             if not path.startswith("/"):
                 path = f"/{path}"
             url = f"ssh://{user}@{host}{path}"
+            return url
+        return remote
 
+    @staticmethod
+    def validate_remote(remote):
+        """
+        Validate a remote repository config.
+
+        """
+        _, remote = split_name(remote)
+        url = GitFS.remote_to_url(remote)
         if salt.utils.verify.url(url):
             return True
         return False

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -169,25 +169,6 @@ PYGIT2_MINVER = Version("0.20.3")
 LIBGIT2_MINVER = Version("0.20.0")
 
 
-def split_name(remote):
-    """
-    Given a string determine if it is a url or a name and url combination.
-
-    Examples:
-
-       None, "https://github.com/saltstack/salt.git" == split_name("https://github.com/saltstack/salt.git")
-
-       "__env__", "https://github.com/saltstack/salt.git" == split_name("__env__ https://github.com/saltstack/salt.git")
-    """
-    parts = remote.split(" ", 1)
-    if len(parts) == 1:
-        return None, remote
-    maybename, maybeurl = parts
-    if not salt.utils.verify.url(maybename):
-        return maybename, maybeurl
-    return None, remote
-
-
 def enforce_types(key, val):
     """
     Force params to be strings unless they should remain a different type
@@ -2593,8 +2574,27 @@ class GitBase:
                 global_only,
             )
 
-    @staticmethod
-    def remote_to_url(remote):
+    @classmethod
+    def split_name(cls, remote):
+        """
+        Given a string determine if it is a url or a name and url combination.
+
+        Examples:
+
+           None, "https://github.com/saltstack/salt.git" == split_name("https://github.com/saltstack/salt.git")
+
+           "__env__", "https://github.com/saltstack/salt.git" == split_name("__env__ https://github.com/saltstack/salt.git")
+        """
+        parts = remote.split(" ", 1)
+        if len(parts) == 1:
+            return None, remote
+        maybename, maybeurl = parts
+        if not salt.utils.verify.url(maybename):
+            return maybename, maybeurl
+        return None, remote
+
+    @classmethod
+    def remote_to_url(cls, remote):
         """
         Convert a remote to a URL
 
@@ -2611,14 +2611,14 @@ class GitBase:
             return url
         return remote
 
-    @staticmethod
-    def validate_remote(remote):
+    @classmethod
+    def validate_remote(cls, remote):
         """
         Validate a remote repository config.
 
         """
-        _, remote = split_name(remote)
-        url = GitFS.remote_to_url(remote)
+        _, remote = cls.split_name(remote)
+        url = cls.remote_to_url(remote)
         if salt.utils.verify.url(url):
             return True
         return False
@@ -2688,7 +2688,7 @@ class GitBase:
                 if not remote:
                     remotes.remove(remote)
             else:
-                if not self.validate_remote(key):
+                if not self.validate_remote(remote):
                     log.warning("Found bad url data %r", remote)
                     remotes.remove(remote)
                     continue

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -346,6 +346,8 @@ def test_find_file_bad_env(tmp_path):
         ("ssh://git@github.com:22/saltstack/salt.git", True),
         ("https://github.com/salttack/salt.git", True),
         ("https://github.com/\nsaltstack/salt.git", False),
+        ("https://git:mypassword@github.com/saltstack/salt.git", True),
+        ("file:///srv/git/salt.git", True),
     ],
 )
 def test_remote_validation(remote, valid):
@@ -369,6 +371,11 @@ def test_remote_validation(remote, valid):
             "https://github.com/salttack/salt.git",
             "https://github.com/salttack/salt.git",
         ),
+        (
+            "https://git:mypassword@github.com/saltstack/salt.git",
+            "https://git:mypassword@github.com/saltstack/salt.git",
+        ),
+        ("file:///srv/git/salt.git", "file:///srv/git/salt.git"),
     ],
 )
 def test_remote_to_url(remote, result):

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -341,9 +341,35 @@ def test_find_file_bad_env(tmp_path):
     [
         ("git@github.com:/saltstack/salt", True),
         ("git@github.com:saltstack/salt", True),
+        ("git@github.com/saltstack/salt", False),
+        ("ssh://git@github.com/saltstack/salt.git", True),
+        ("ssh://git@github.com:22/saltstack/salt.git", True),
         ("https://github.com/salttack/salt.git", True),
         ("https://github.com/\nsaltstack/salt.git", False),
     ],
 )
 def test_remote_validation(remote, valid):
     assert salt.utils.gitfs.GitFS.validate_remote(remote) is valid
+
+
+@pytest.mark.parametrize(
+    "remote,result",
+    [
+        ("git@github.com:/saltstack/salt", "ssh://git@github.com/saltstack/salt"),
+        ("git@github.com:saltstack/salt", "ssh://git@github.com/saltstack/salt"),
+        (
+            "ssh://git@github.com/saltstack/salt.git",
+            "ssh://git@github.com/saltstack/salt.git",
+        ),
+        (
+            "ssh://git@github.com:22/saltstack/salt.git",
+            "ssh://git@github.com:22/saltstack/salt.git",
+        ),
+        (
+            "https://github.com/salttack/salt.git",
+            "https://github.com/salttack/salt.git",
+        ),
+    ],
+)
+def test_remote_to_url(remote, result):
+    assert salt.utils.gitfs.GitFS.remote_to_url(remote) == result

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -339,7 +339,8 @@ def test_find_file_bad_env(tmp_path):
 @pytest.mark.parametrize(
     "remote,valid",
     [
-        ("git@github.com/saltstack/salt", True),
+        ("git@github.com:/saltstack/salt", True),
+        ("git@github.com:saltstack/salt", True),
         ("https://github.com/salttack/salt.git", True),
         ("https://github.com/\nsaltstack/salt.git", False),
     ],

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -334,3 +334,15 @@ def test_find_file_bad_env(tmp_path):
     gitfs = salt.utils.gitfs.GitFS(opts, remotes)
     with pytest.raises(salt.exceptions.SaltValidationError):
         gitfs.find_file("asdf", tgt_env="asd/../../../sdf")
+
+
+@pytest.mark.parametrize(
+    "remote,valid",
+    [
+        ("git@github.com/saltstack/salt", True),
+        ("https://github.com/salttack/salt.git", True),
+        ("https://github.com/\nsaltstack/salt.git", False),
+    ],
+)
+def test_remote_validation(remote, valid):
+    assert salt.utils.gitfs.GitFS.validate_remote(remote) is valid


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #68069

### Previous Behavior

Gitfs failing to work with non-url style git remotes

### New Behavior

Takes @dwoz's WIP PR #68082 and fixes it up so it handles `git@githost.com:/some/repo` and `git@githost.com:some/repo` correctly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
