### PR TITLE
File.recurse#68052

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1040,7 +1040,7 @@ def _check_directory(
 
         def _check_changes(fname):
             path = os.path.join(root, fname)
-            if path in keep:
+            if any(path in s for s in keep):
                 return {}
             else:
                 if not salt.utils.stringutils.check_include_exclude(

--- a/tests/pytests/functional/states/file/test_directory.py
+++ b/tests/pytests/functional/states/file/test_directory.py
@@ -290,6 +290,7 @@ def test_directory_clean_require_in(modules, tmp_path, state_tree):
     assert wrong_file.exists() is False
 
 
+@pytest.mark.skip_on_windows
 def test_directory_clean_require_in_good_message(modules, tmp_path, state_tree):
     """
     file.directory test with clean=True and require_in file,

--- a/tests/pytests/functional/states/file/test_directory.py
+++ b/tests/pytests/functional/states/file/test_directory.py
@@ -295,12 +295,11 @@ def test_directory_clean_require_in_good_message(modules, tmp_path, state_tree):
     file.directory test with clean=True and require_in file,
     the comment cannot be "removed": "Removed due to clean"
     """
-    name = tmp_path / "a-directory"
+    name = tmp_path / "b-directory"
     name.mkdir()
     dir = name / "one"
     dir.mkdir()
     good_file = dir / "good-file"
-    print("good file", good_file)
 
     sls_contents = """
     some_dir:


### PR DESCRIPTION
### What does this PR do?
this is for incorrect comment when file.recurse with "clean: true" reports changes when none are done

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68052

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant
correct comment is displayed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
