### PR TITLE
pkgrepo: account for 'name' attr being part of the state

### DIFF
--- a/changelog/68107.fixed.md
+++ b/changelog/68107.fixed.md
@@ -1,0 +1,1 @@
+pkgrepo.managed not applying changes / account for 'name' attr being part of the state

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -413,7 +413,8 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
             )
             return ret
 
-    repo = name
+    kwargs["name"] = repo = name
+
     if __grains__["os"] in ("Ubuntu", "Mint"):
         if ppa is not None:
             # overload the name/repo value for PPAs cleanly
@@ -437,9 +438,6 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
 
         if "humanname" in kwargs:
             kwargs["name"] = kwargs.pop("humanname")
-        if "name" not in kwargs:
-            # Fall back to the repo name if humanname not provided
-            kwargs["name"] = repo
 
         kwargs["enabled"] = (
             not salt.utils.data.is_true(disabled)

--- a/tests/pytests/unit/states/test_pkgrepo.py
+++ b/tests/pytests/unit/states/test_pkgrepo.py
@@ -18,6 +18,26 @@ def configure_loader_modules():
     }
 
 
+def test_name_change():
+    """
+    Test when only the key_url is changed that a change is triggered
+    """
+    kwargs = {
+        "name": "deb http://apt.example.com/{{grains['os'] | lower}} {{grains['oscodename']}} main",
+        "disabled": False,
+        "key_url": "https://mock/changed_gpg.key",
+    }
+
+    new = kwargs.copy()
+    new["name"] = (
+        "deb [arch=amd64] http://apt.example.com/{{grains['os'] | lower}} {{grains['oscodename']}} main"
+    )
+
+    with patch.dict(pkgrepo.__salt__, {"pkg.get_repo": MagicMock(return_value=kwargs)}):
+        ret = pkgrepo.managed(**new)
+        assert ret["changes"] == {"name": {"old": kwargs["name"], "new": new["name"]}}
+
+
 def test_new_key_url():
     """
     Test when only the key_url is changed that a change is triggered


### PR DESCRIPTION
### What issues does this PR fix or reference?
fixes #21369.  'name' of repo wasn't being tracked for changes as it was getting special handling due to being outside of the states kwargs. I'm not 100% sure that name is safe across all repo types this state manages, but it fixes the root issue referenced, and I'm pretty sure it's ok.


### Previous Behavior
'name' changes were not accounted for in highstates.

### New Behavior
'name' changes now are accounted for.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
