### PR TITLE
Fix issue with commands passed as list to cmd.run

### DIFF
--- a/changelog/67190.fixed.md
+++ b/changelog/67190.fixed.md
@@ -1,1 +1,2 @@
-Fixes an issue running powershell commands that begin with parenthesis
+Fixes an issue running powershell commands that begin with parenthesis or
+other commands that do not require an ampersand

--- a/changelog/68095.fixed.md
+++ b/changelog/68095.fixed.md
@@ -1,0 +1,2 @@
+Fixes an issue on Windows where cmd.run wasn't handling commands sent as a
+list

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -441,10 +441,6 @@ def _run(
     # The powershell binary is "powershell"
     # The powershell core binary is "pwsh"
     # you can also pass a path here as long as the binary name is one of the two
-    print("*" * 80)
-    print("BEFORE")
-    print(cmd)
-    print("-" * 80)
     if salt.utils.platform.is_windows():
         if runas:
             if not HAS_WIN_RUNAS:
@@ -454,8 +450,6 @@ def _run(
             cmd = _prep_powershell_cmd(shell, cmd, encoded_cmd)
         else:
             cmd = salt.platform.win.prepend_cmd(cmd)
-        print(cmd)
-        print("*" * 80)
 
     env = _parse_env(env)
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -431,6 +431,10 @@ def _run(
     # The powershell binary is "powershell"
     # The powershell core binary is "pwsh"
     # you can also pass a path here as long as the binary name is one of the two
+    print("*" * 80)
+    print("BEFORE")
+    print(cmd)
+    print("-" * 80)
     if salt.utils.platform.is_windows():
         if runas:
             if not HAS_WIN_RUNAS:
@@ -440,6 +444,8 @@ def _run(
             cmd = _prep_powershell_cmd(shell, cmd, encoded_cmd)
         else:
             cmd = salt.platform.win.prepend_cmd(cmd)
+        print(cmd)
+        print("*" * 80)
 
     # munge the cmd and cwd through the template
     (cmd, cwd) = _render_cmd(cmd, cwd, template, saltenv, pillarenv, pillar_override)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -417,7 +417,7 @@ def _run(
         if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
             msg = f"The shell {shell} is not available"
             raise CommandExecutionError(msg)
-    elif use_vt:  # Memoization so not much overhead
+    elif use_vt:  # Memozation so not much overhead
         raise CommandExecutionError("VT not available on windows")
     else:
         if windows_codepage:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -417,7 +417,7 @@ def _run(
         if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
             msg = f"The shell {shell} is not available"
             raise CommandExecutionError(msg)
-    elif use_vt:  # Memozation so not much overhead
+    elif use_vt:  # Memoization so not much overhead
         raise CommandExecutionError("VT not available on windows")
     else:
         if windows_codepage:

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -300,8 +300,7 @@ def compile_config(
     cmd.append(
         r"| Where-Object FullName -match '(?<!\.meta)\.mof$' "
         "| Select-Object -Property FullName, Extension, Exists, "
-        "@{Name='LastWriteTime';Expression={Get-Date ($_.LastWriteTime) "
-        "-Format g}}"
+        "@{Name='LastWriteTime';Expression={Get-Date ($_.LastWriteTime) -Format g}}"
     )
 
     cmd = " ".join(cmd)

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1369,6 +1369,8 @@ def prepend_cmd(cmd):
     # builtin commands such as echo
     first_cmd = cmd[0].split("\\")[-1].strip("\"'")
 
+    cmd = " ".join(cmd)
+
     # Known builtin cmd commands
     known_builtins = [
         "assoc",
@@ -1415,19 +1417,19 @@ def prepend_cmd(cmd):
         "::",
     ]
 
-    # The command itself needs to be quoted itself if prepending c
-    joined_cmd = " ".join(cmd)
-
     # If the first command is one of the known builtin commands or if it is a
-    # binary that can't be found, we'll prepend cmd /c
+    # binary that can't be found, we'll prepend cmd /c. The command itself needs
+    # to be quoted
     if first_cmd in known_builtins or salt.utils.path.which(first_cmd) is None:
-        cmd = ["cmd", "/c", f'"{joined_cmd}"']
+        log.debug("Command is either builtin or not found: %s", first_cmd)
+        cmd = f'cmd /c "{cmd}"'
 
-    # There are a few other things we need to check for that require cmd. If the
-    # cmd contains any of the following, we'll need to make sure it runs in cmd.
+    # There are a few more things we need to check that require cmd. If the cmd
+    # contains any of the following, we'll need to make sure it runs in cmd.
     # We'll add to this list as more things are discovered.
     check = ["&&", "||"]
-    if "cmd" not in cmd[0] and any(chk in cmd for chk in check):
-        cmd = ["cmd", "/c", f'"{joined_cmd}"']
+    if "cmd" not in cmd and any(chk in cmd for chk in check):
+        log.debug("Found logic that requires cmd: %s", check)
+        cmd = f'cmd /c "{cmd}"'
 
-    return " ".join(cmd)
+    return cmd

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1360,7 +1360,7 @@ def prepend_cmd(cmd):
         elif item.startswith('"'):
             item = item.replace("'", '\\"')
         # If there are spaces in item, wrap it in "
-        elif " " in item:
+        elif " " in item and "=" not in item:
             item = f'"{item}"'
         new_cmd.append(item)
     cmd = new_cmd

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -270,13 +270,7 @@ def shlex_split(s, **kwargs):
     Only split if variable is a string
     """
     if isinstance(s, str):
-        # On PY2, shlex.split will fail with unicode types if there are
-        # non-ascii characters in the string. So, we need to make sure we
-        # invoke it with a str type, and then decode the resulting string back
-        # to unicode to return it.
-        return salt.utils.data.decode(
-            shlex.split(salt.utils.stringutils.to_str(s), **kwargs)
-        )
+        return shlex.split(s, **kwargs)
     else:
         return s
 

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -393,10 +393,11 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.run with quoted command
         """
-        cmd = """echo 'SELECT * FROM foo WHERE bar="baz"' """
-        expected_result = 'SELECT * FROM foo WHERE bar="baz"'
         if salt.utils.platform.is_windows():
-            expected_result = "'SELECT * FROM foo WHERE bar=\"baz\"'"
+            cmd = """echo SELECT * FROM foo WHERE bar="baz" """
+        else:
+            cmd = """echo 'SELECT * FROM foo WHERE bar="baz"' """
+        expected_result = 'SELECT * FROM foo WHERE bar="baz"'
         result = self.run_function("cmd.run_stdout", [cmd]).strip()
         self.assertEqual(result, expected_result)
 

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -670,11 +670,15 @@ def test_run_all_output_loglevel_debug(caplog):
     stdout = b"test"
     proc = MagicMock(return_value=MockTimedProc(stdout=stdout))
 
-    msg = "Executing command 'some' in directory"
+    if salt.utils.platform.is_windows():
+        expected = "Executing command 'cmd' in directory"
+    else:
+        expected = "Executing command 'some' in directory"
     with patch("salt.utils.timed_subprocess.TimedProc", proc):
         with caplog.at_level(logging.DEBUG, logger="salt.modules.cmdmod"):
             ret = cmdmod.run_all("some command", output_loglevel="debug")
-        assert msg in caplog.text
+        result = caplog.text
+        assert expected in result
 
     assert ret["stdout"] == salt.utils.stringutils.to_unicode(stdout)
 
@@ -1116,15 +1120,17 @@ def test_prep_powershell_cmd(cmd, parsed):
         ret = cmdmod._prep_powershell_cmd(
             win_shell="powershell", cmd=cmd, encoded_cmd=False
         )
-        expected = [
-            '"C:\\powershell.exe"',
-            "-NonInteractive",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            f'"{parsed}"',
-        ]
+        expected = " ".join(
+            [
+                '"C:\\powershell.exe"',
+                "-NonInteractive",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                f'"{parsed}"',
+            ],
+        )
         assert ret == expected
 
 
@@ -1142,15 +1148,17 @@ def test_prep_powershell_cmd_encoded():
         ret = cmdmod._prep_powershell_cmd(
             win_shell="powershell", cmd=e_cmd, encoded_cmd=True
         )
-        expected = [
-            '"C:\\powershell.exe"',
-            "-NonInteractive",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-EncodedCommand",
-            f'"{e_cmd}"',
-        ]
+        expected = " ".join(
+            [
+                '"C:\\powershell.exe"',
+                "-NonInteractive",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-EncodedCommand",
+                f'"{e_cmd}"',
+            ],
+        )
         assert ret == expected
 
 
@@ -1167,15 +1175,17 @@ def test_prep_powershell_cmd_script():
         ret = cmdmod._prep_powershell_cmd(
             win_shell="powershell", cmd=script, encoded_cmd=False
         )
-        expected = [
-            '"C:\\powershell.exe"',
-            "-NonInteractive",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            f'"& {script}; exit $LASTEXITCODE"',
-        ]
+        expected = " ".join(
+            [
+                '"C:\\powershell.exe"',
+                "-NonInteractive",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                f'"& {script}; exit $LASTEXITCODE"',
+            ],
+        )
         assert ret == expected
 
 

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -429,9 +429,10 @@ def test_pkg_install_log_message(caplog):
             version="3.03",
             extra_install_flags="-e True -test_flag True",
         )
+        for x in caplog.messages:
+            print(x)
         assert (
-            'PKG : cmd: C:\\WINDOWS\\system32\\cmd.exe /c "runme.exe" /s -e '
-            "True -test_flag True"
+            'PKG : cmd: "runme.exe" /s -e True -test_flag True'
         ).lower() in [x.lower() for x in caplog.messages]
         assert "PKG : pwd: ".lower() in [x.lower() for x in caplog.messages]
         assert "PKG : retcode: 0" in caplog.messages
@@ -651,7 +652,7 @@ def test_pkg_remove_log_message(caplog):
             pkgs=["firebox"],
         )
         assert (
-            'PKG : cmd: C:\\WINDOWS\\system32\\cmd.exe /c "%program.exe" /S'
+            'PKG : cmd: "%program.exe" /S'
         ).lower() in [x.lower() for x in caplog.messages]
         assert "PKG : pwd: ".lower() in [x.lower() for x in caplog.messages]
         assert "PKG : retcode: 0" in caplog.messages

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -431,9 +431,9 @@ def test_pkg_install_log_message(caplog):
         )
         for x in caplog.messages:
             print(x)
-        assert (
-            'PKG : cmd: "runme.exe" /s -e True -test_flag True'
-        ).lower() in [x.lower() for x in caplog.messages]
+        assert 'PKG : cmd: "runme.exe" /s -e True -test_flag True'.lower() in [
+            x.lower() for x in caplog.messages
+        ]
         assert "PKG : pwd: ".lower() in [x.lower() for x in caplog.messages]
         assert "PKG : retcode: 0" in caplog.messages
 
@@ -651,9 +651,9 @@ def test_pkg_remove_log_message(caplog):
         win_pkg.remove(
             pkgs=["firebox"],
         )
-        assert (
-            'PKG : cmd: "%program.exe" /S'
-        ).lower() in [x.lower() for x in caplog.messages]
+        assert 'PKG : cmd: "%program.exe" /S'.lower() in [
+            x.lower() for x in caplog.messages
+        ]
         assert "PKG : pwd: ".lower() in [x.lower() for x in caplog.messages]
         assert "PKG : retcode: 0" in caplog.messages
 

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -21,6 +21,15 @@ pytestmark = [
         ('cmd /c "echo foo"', 'cmd /c "echo foo"'),
         ("whoami && echo foo", 'cmd /c "whoami && echo foo"'),
         ("whoami || echo foo", 'cmd /c "whoami || echo foo"'),
+        ("icacls 'C:\\Program Files'", 'icacls "C:\\Program Files"'),
+        (
+            "icacls 'C:\\Program Files' && echo 1",
+            'cmd /c "icacls "C:\\Program Files" && echo 1"',
+        ),
+        (
+            ["secedit", "/export", "/cfg", "C:\\A Path\\with\\a\\space"],
+            'secedit /export /cfg "C:\\A Path\\with\\a\\space"',
+        ),
     ],
 )
 def test_prepend_cmd(command, expected):


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with passing commands as lists to `cmd.run` on Windows. Handles some additional `cmd.run` behavior on Windows.

### What issues does this PR fix or reference?
Fixes #68095 (list as cmd)
Fixes #68096 (cmd.run behavior) Fixes some of the failing commands here, but more work needs to be done.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
