### PR TITLE
Allow saltmod.state to run masterless when ssh is enabled

### DIFF
--- a/changelog/68116.fixed.md
+++ b/changelog/68116.fixed.md
@@ -1,0 +1,1 @@
+Fix that the state `saltmod.state` can be used on a masterless minion with salt-ssh like `saltmod.function` currently does.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -335,7 +335,7 @@ def state(
         cmd_kw["failhard"] = True
 
     masterless = __opts__["__role"] == "minion" and __opts__["file_client"] == "local"
-    if not masterless:
+    if not masterless or ssh:
         _fire_args({"type": "state", "tgt": tgt, "name": name, "args": cmd_kw})
         cmd_ret = __salt__["saltutil.cmd"](tgt, fun, **cmd_kw)
     else:


### PR DESCRIPTION
### What does this PR do?

This change will allow a masterless minion to run the state `salt.state` on a remote minion via salt-ssh.

### What issues does this PR fix or reference?
Fixes #68116

### Previous Behavior
Not able to use `saltmod.state` on a masterless minion with `ssh` set to `True`.

### New Behavior
Fix that it's able to use `ssh: True` on the state `saltmod.state` on a masterless minion.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
