### PR TITLE
Ensure test value returns only boolean values

### DIFF
--- a/changelog/68121.fixed.md
+++ b/changelog/68121.fixed.md
@@ -1,0 +1,1 @@
+Fix `test mode` causing unintended execution when non-boolean values are passed.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -152,7 +152,10 @@ class LoadedFunc:
         if hasattr(mod, "__opts__"):
             if not isinstance(mod.__opts__, salt.loader.context.NamedLoaderContext):
                 if "test" in self.loader.opts:
-                    mod.__opts__["test"] = self.loader.opts["test"]
+                    if self.loader.opts["test"] is False:
+                        mod.__opts__["test"] = False
+                    else:
+                        mod.__opts__["test"] = True
                     set_test = True
         if self.loader.inject_globals:
             run_func = global_injector_decorator(self.loader.inject_globals)(run_func)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -488,8 +488,8 @@ def _get_test_value(test=None, **kwargs):
             ret = True
         else:
             ret = __opts__.get("test", None)
-    else:
-        ret = test
+    elif test is False:
+        ret = False
     return ret
 
 

--- a/tests/pytests/unit/loader/test_lazy.py
+++ b/tests/pytests/unit/loader/test_lazy.py
@@ -27,6 +27,9 @@ def loader_dir(tmp_path):
 
     def get_context(key):
         return __context__[key]
+
+    def get_opts(key):
+        return __opts__.get(key, None)
     """
     with pytest.helpers.temp_file(
         "mod_a.py", directory=tmp_path, contents=mod_contents
@@ -140,3 +143,23 @@ def test_loader_pack_opts_not_overwritten(loader_dir):
     assert "foo" not in loader.pack["__opts__"]
     assert "baz" in loader.pack["__opts__"]
     assert loader.pack["__opts__"]["baz"] == "bif"
+
+
+@pytest.mark.parametrize(
+    "test_value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("abc", True),
+        (123, True),
+    ],
+)
+def test_loaded_func_ensures_test_boolean(loader_dir, test_value, expected):
+    """
+    Functions loaded from LazyLoader's item lookups are LoadedFunc objects
+    """
+    opts = {"optimization_order": [0, 1, 2], "test": test_value}
+    loader = salt.loader.lazy.LazyLoader([loader_dir], opts)
+    loaded_fun = loader["mod_a.get_opts"]
+    ret = loaded_fun("test")
+    assert ret is expected

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -2,9 +2,20 @@
     Unit tests for the salt.modules.state module
 """
 
+import pytest
+
 import salt.loader.context
-import salt.modules.state
+import salt.modules.config as config
+import salt.modules.state as state
 from tests.support.mock import patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        state: {"__salt__": {"config.get": config.get}, "__opts__": {"test": True}},
+        config: {"__opts__": {}},
+    }
 
 
 def test_get_initial_pillar():
@@ -17,5 +28,20 @@ def test_get_initial_pillar():
     opts = {"__cli": "salt-call", "pillarenv": "base"}
     with patch("salt.modules.state.__pillar__", named_ctx, create=True):
         with patch("salt.modules.state.__opts__", opts, create=True):
-            pillar = salt.modules.state._get_initial_pillar(opts)
+            pillar = state._get_initial_pillar(opts)
             assert pillar == pillar_data
+
+
+def test_check_test_value_is_boolean():
+    """
+    Ensure that the test value is always returned as a boolean
+    """
+    with patch.dict(state.__opts__, {"test": True}, create=True):
+        assert state._get_test_value() is True
+        assert state._get_test_value(True) is True
+        assert state._get_test_value(False) is False
+        assert state._get_test_value("test") is True
+        assert state._get_test_value(123) is True
+
+    with patch.dict(state.__opts__, {"test": False}, create=True):
+        assert state._get_test_value() is False


### PR DESCRIPTION
### What does this PR do?
Normalize test value to strictly boolean output

### What issues does this PR fix or reference?
Fixes #68121 

### Previous Behavior
Previously, "truthy" but non-boolean values passed to the `test` argument could lead to unintended actual state changes due to inconsistent `if test is True:` checks within Salt modules.

### New Behavior
This change ensures the test value consistently returns only boolean `True` or `False`, guaranteeing reliable test mode enforcement regardless of the input's original type.

1. `_get_test_value` function
   - for positional arguments, kwargs
2. lazy loader
   - for config

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
