### PR TITLE
Fix failing zeromq tests on 3007.x

### DIFF
--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -966,7 +966,7 @@ async def test_req_chan_decode_data_dict_entry_v2_bad_signature(
     client.transport.send = mocksend
 
     # Minion should try to authenticate on bad signature
-    @salt.ext.tornado.gen.coroutine
+    @tornado.gen.coroutine
     def mockauthenticate():
         pass
 


### PR DESCRIPTION
### What does this PR do?
Fixes a failing test on 3007.x branch. The decorator was pointing to the `salt.ext.tornado`. I think we're using normal tornado now