### PR TITLE
Do not make tests to fail when "pygit2" is not present

### DIFF
--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -11,6 +11,16 @@ import salt.utils.platform
 from tests.support.mock import patch
 from tests.support.runtests import RUNTIME_VARS
 
+try:
+    import pygit2  # pylint: disable=unused-import
+
+    HAS_PYGIT2 = True
+except ImportError:
+    HAS_PYGIT2 = False
+
+
+skipif_no_pygit2 = pytest.mark.skipif(not HAS_PYGIT2, reason="Missing pygit2")
+
 
 @pytest.fixture
 def encrypted_requests(tmp_path):
@@ -280,6 +290,7 @@ def allowed_funcs(tmp_path):
     return salt.master.AESFuncs(opts=opts)
 
 
+@skipif_no_pygit2
 def test_on_demand_allowed_command_injection(allowed_funcs, tmp_path, caplog):
     """
     Verify on demand pillars validate remote urls

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -265,6 +265,7 @@ def test_get_cachedir_basename_pygit2(_prepare_provider):
     assert "_" == _prepare_provider.get_cache_basename()
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -288,6 +289,7 @@ def test_find_file(tmp_path):
     assert gitfs.find_file("asdf") == {"path": "", "rel": ""}
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_bad_path(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -312,6 +314,7 @@ def test_find_file_bad_path(tmp_path):
         gitfs.find_file("sdf/../../../asdf")
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_bad_env(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -382,6 +385,7 @@ def test_remote_to_url(remote, result):
     assert salt.utils.gitfs.GitFS.remote_to_url(remote) == result
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_subdir(tmp_path):
     root = tmp_path / "root"
     root.mkdir()


### PR DESCRIPTION
### What does this PR do?

This PR fixes some tests failures when `pygit2` is not present in the testing host. As we do with other `gitfs` related tests, we simply skip the tests when `pygit2` is not present:

```console
10:01:47  [31mFAILED[0m tests/pytests/unit/test_master.py::[1mtest_on_demand_allowed_command_injection[0m - salt.exceptions.FileserverConfigError: Failed to load git_pillar
10:01:47  [31mFAILED[0m tests/pytests/unit/utils/test_gitfs.py::[1mtest_find_file[0m - salt.exceptions.FileserverConfigError: Failed to load gitfs
10:01:47  [31mFAILED[0m tests/pytests/unit/utils/test_gitfs.py::[1mtest_find_file_bad_path[0m - salt.exceptions.FileserverConfigError: Failed to load gitfs
10:01:47  [31mFAILED[0m tests/pytests/unit/utils/test_gitfs.py::[1mtest_find_file_bad_env[0m - salt.exceptions.FileserverConfigError: Failed to load gitfs
10:01:47  [31mFAILED[0m tests/pytests/unit/utils/test_gitfs.py::[1mtest_find_file_subdir[0m - salt.exceptions.FileserverConfigError: Failed to load gitfs
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
