### PR TITLE
[TECH DEBT] Drop old tech debt related pypi proxy ref from triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,11 +6,6 @@ on:
     types: [opened]
 
 
-env:
-  PIP_INDEX_URL: https://pypi-proxy.saltstack.net/root/local/+simple/
-  PIP_EXTRA_INDEX_URL: https://pypi.org/simple
-
-
 permissions:
   contents: read
 


### PR DESCRIPTION
### What does this PR do?

Drop old tech debt related pypi proxy ref from triage workflow