### PR TITLE
Emulate when needed

### DIFF
--- a/tools/container.py
+++ b/tools/container.py
@@ -1,10 +1,14 @@
 import os
 import pathlib
+import platform
 import tempfile
 
 from ptscripts import Context, command_group
 
 cmd = command_group(name="container", help="Container Commands", description=__doc__)
+
+
+architecture = platform.machine().lower()
 
 
 def has_network(ctx, name):
@@ -33,9 +37,10 @@ def create_network(ctx, name):
     arguments={
         "image": {"help": "Name the container image to use."},
         "name": {"help": "Name the container being created.", "default": ""},
+        "platform": {"help": "The platform to run tests as,", "default": ""},
     },
 )
-def create(ctx: Context, image: str, name: str = ""):
+def create(ctx: Context, image: str, name: str = "", platform: str = ""):
     onci = "GITHUB_WORKFLOW" in os.environ
     workdir = "/salt"
     home = "/root"
@@ -87,6 +92,13 @@ def create(ctx: Context, image: str, name: str = ""):
         "-v",
         f"{tmpdir}:/var/lib/docker",
     ]
+    if platform:
+        if platform == "aarch64" or platform == "arm64":
+            if architecture == "x86_64":
+                cmd.extend(["--platform", "linux/arm64/v8"])
+        elif platform == "x86_64":
+            if "arm" in architecture or "aarch64" in architecture:
+                cmd.extend(["--platform", "linux/amd64"])
     for key in env:
         cmd.extend(["-e", f"{key}={env[key]}"])
     if onci:

--- a/tools/container.py
+++ b/tools/container.py
@@ -99,6 +99,27 @@ def create(ctx: Context, image: str, name: str = "", platform: str = ""):
         elif platform == "x86_64":
             if "arm" in architecture or "aarch64" in architecture:
                 cmd.extend(["--platform", "linux/amd64"])
+    if "--platform" in cmd:
+        proc = ctx.run(*["docker", "image", "ls"], capture=True, check=True)
+        if "multiarch/qemu-user-static" not in proc.stdout.decode():
+            ctx.info(
+                "Installing multiarch/qemu-user-static image for emulation support"
+            )
+            ctx.run(
+                *[
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--privileged",
+                    "multiarch/qemu-user-static",
+                    "--reset",
+                    "-p",
+                    "yes",
+                ],
+                capture=True,
+                check=True,
+            )
+
     for key in env:
         cmd.extend(["-e", f"{key}={env[key]}"])
     if onci:


### PR DESCRIPTION
Adding an optional platform param to docker create tool. This will enable emulation for testing things locally when needed.
