### PR TITLE
win_runas fixes/enhancements

### DIFF
--- a/changelog/68157.added.md
+++ b/changelog/68157.added.md
@@ -1,0 +1,1 @@
+win_runas: support cmdmod parameters bg, env, redirect_stderr, timeout

--- a/changelog/68157.fixed.md
+++ b/changelog/68157.fixed.md
@@ -1,0 +1,2 @@
+win_runas: fix output decoding exceptions
+win_runas: ensure opened handles are closed

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1216,6 +1216,9 @@ def run(
 
         .. versionadded:: 2016.3.0
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param dict env: Environment variables to be set prior to execution.
 
         .. note::
@@ -1230,6 +1233,9 @@ def run(
             When using environment variables on Window's, case-sensitivity
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -1290,6 +1296,9 @@ def run(
 
     :param int timeout: A timeout in seconds for the executed process to return.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
@@ -1298,6 +1307,9 @@ def run(
         the retcode and output is desired. Default is ``True``
 
         .. versionadded:: 3006.9
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool encoded_cmd: Specify if the supplied command is encoded.
         Only applies to shell 'powershell' and 'pwsh'.
@@ -1537,6 +1549,9 @@ def shell(
     :param bool bg: If True, run command in background and do not await or
         deliver its results
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param dict env: Environment variables to be set prior to execution.
 
         .. note::
@@ -1551,6 +1566,9 @@ def shell(
             When using environment variables on Window's, case-sensitivity
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -1611,6 +1629,9 @@ def shell(
 
     :param int timeout: A timeout in seconds for the executed process to
         return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -1810,6 +1831,9 @@ def run_stdout(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -1869,6 +1893,9 @@ def run_stdout(
 
     :param int timeout: A timeout in seconds for the executed process to
         return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -2044,6 +2071,9 @@ def run_stderr(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -2103,6 +2133,9 @@ def run_stderr(
 
     :param int timeout: A timeout in seconds for the executed process to
         return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -2280,6 +2313,9 @@ def run_all(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -2340,6 +2376,9 @@ def run_all(
     :param int timeout: A timeout in seconds for the executed process to
         return.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
@@ -2374,6 +2413,9 @@ def run_all(
 
         .. versionadded:: 2015.8.2
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 
@@ -2383,6 +2425,9 @@ def run_all(
         deliver its results
 
         .. versionadded:: 2016.3.6
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
@@ -2557,6 +2602,9 @@ def retcode(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -2601,6 +2649,9 @@ def retcode(
         skip logging the output if the command has a nonzero exit code.
 
     :param int timeout: A timeout in seconds for the executed process to return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
       more interactively to the console and the logs. This is experimental.
@@ -2844,6 +2895,9 @@ def script(
     :param bool bg: If True, run script in background and do not await or
         deliver its results
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param dict env: Environment variables to be set prior to execution.
 
         .. note::
@@ -2858,6 +2912,9 @@ def script(
             When using environment variables on Window's, case-sensitivity
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param str template: If this setting is applied then the named templating
         engine will be used to render the downloaded file. Currently jinja,
@@ -2907,6 +2964,9 @@ def script(
     :param int timeout: If the command has not terminated after timeout
         seconds, send the subprocess sigterm, and if sigterm is ignored, follow
         up with sigkill
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -3162,6 +3222,9 @@ def script_retcode(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param str template: If this setting is applied then the named templating
         engine will be used to render the downloaded file. Currently jinja,
         mako, and wempy are supported.
@@ -3201,6 +3264,9 @@ def script_retcode(
     :param int timeout: If the command has not terminated after timeout
         seconds, send the subprocess sigterm, and if sigterm is ignored, follow
         up with sigkill
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -4066,6 +4132,9 @@ def powershell(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -4119,6 +4188,9 @@ def powershell(
         .. versionadded:: 2018.3.0
 
     :param int timeout: A timeout in seconds for the executed process to return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -4408,6 +4480,9 @@ def powershell_all(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -4453,6 +4528,9 @@ def powershell_all(
 
     :param int timeout: A timeout in seconds for the executed process to
         return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
@@ -4777,6 +4855,9 @@ def run_bg(
             matters, i.e. Window's uses `Path` as opposed to `PATH` for other
             systems.
 
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -4793,6 +4874,9 @@ def run_bg(
     :param str umask: The umask (in octal) to use when running the command.
 
     :param int timeout: A timeout in seconds for the executed process to return.
+
+        .. versionchanged:: 3007.7
+            Supported on Windows when running a command as an alternate user.
 
     .. warning::
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -42,7 +42,18 @@ SYSTEM_SID = "S-1-5-18"
 LOCAL_SRV_SID = "S-1-5-19"
 NETWORK_SRV_SID = "S-1-5-19"
 
+# STARTUPINFO
+STARTF_USESHOWWINDOW = 0x00000001
+STARTF_USESTDHANDLES = 0x00000100
+
+# dwLogonFlags
 LOGON_WITH_PROFILE = 0x00000001
+
+# Process Creation Flags
+CREATE_NEW_CONSOLE = 0x00000010
+CREATE_NO_WINDOW = 0x08000000
+CREATE_SUSPENDED = 0x00000004
+CREATE_UNICODE_ENVIRONMENT = 0x00000400
 
 WINSTA_ALL = (
     win32con.WINSTA_ACCESSCLIPBOARD
@@ -1094,7 +1105,6 @@ def set_user_perm(obj, perm, sid):
     sd = win32security.GetUserObjectSecurity(obj, info)
     dacl = sd.GetSecurityDescriptorDacl()
     ace_cnt = dacl.GetAceCount()
-    found = False
     for idx in range(0, ace_cnt):
         (aceType, aceFlags), ace_mask, ace_sid = dacl.GetAce(idx)
         ace_exists = (
@@ -1150,7 +1160,7 @@ def CreateProcessWithTokenW(
         startupinfo = STARTUPINFO()
     if currentdirectory is not None:
         currentdirectory = ctypes.create_unicode_buffer(currentdirectory)
-    if environment is not None:
+    if environment is not None and isinstance(environment, dict):
         environment = ctypes.pointer(environment_string(environment))
     process_info = PROCESS_INFORMATION()
     ret = advapi32.CreateProcessWithTokenW(
@@ -1322,7 +1332,7 @@ def CreateProcessWithLogonW(
         commandline = ctypes.create_unicode_buffer(commandline)
     if startupinfo is None:
         startupinfo = STARTUPINFO()
-    if environment is not None:
+    if environment is not None and isinstance(environment, dict):
         environment = ctypes.pointer(environment_string(environment))
     process_info = PROCESS_INFORMATION()
     advapi32.CreateProcessWithLogonW(

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -70,12 +70,6 @@ class TimedProc:
                 if not isinstance(args, (list, tuple, str)):
                     # Handle corner case where someone does a 'cmd.run 3'
                     args = str(args)
-            # Ensure that environment variables are strings
-            for key, val in kwargs.get("env", {}).items():
-                if not isinstance(val, str):
-                    kwargs["env"][key] = str(val)
-                if not isinstance(key, str):
-                    kwargs["env"][str(key)] = kwargs["env"].pop(key)
             args = salt.utils.data.decode(args)
             self.process = subprocess.Popen(args, **kwargs)
         self.command = args

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, TimedProcTimeoutError
 
 try:
     import psutil
@@ -28,6 +28,7 @@ try:
     import win32process
     import win32profile
     import win32security
+    import winerror
 
     import salt.platform.win
 
@@ -49,6 +50,15 @@ def __virtual__():
         return False, "This utility requires pywin32 and psutil"
 
     return "win_runas"
+
+
+def close_handle(handle):
+    if handle is not None:
+        try:
+            win32api.CloseHandle(handle)
+        except pywintypes.error as exc:
+            if exc.winerror != winerror.ERROR_INVALID_HANDLE:
+                raise
 
 
 def split_username(username):
@@ -88,7 +98,63 @@ def create_env(user_token, inherit, timeout=1):
         raise exc
 
 
-def runas(cmd, username, password=None, cwd=None):
+def create_default_env(username):
+    """
+    Creates an environment with default values.
+    """
+    result = {}
+
+    systemdrive = os.environ.get("SystemDrive", r"C:")
+    defaults = {
+        "ALLUSERSPROFILE": r"C:\ProgramData",
+        "CommonProgramFiles": r"C:\Program Files\Common Files",
+        "CommonProgramFiles(x86)": r"C:\Program Files (x86)\Common Files",
+        "CommonProgramW6432": r"C:\Program Files\Common Files",
+        "ComputerName": None,
+        "ComSpec": r"C:\Windows\system32\cmd.exe",
+        "DriverData": r"C:\Windows\System32\Drivers\DriverData",
+        "NUMBER_OF_PROCESSORS": None,
+        "OS": None,
+        "Path": r"C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0"
+        "\\",
+        "PATHEXT": r".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC",
+        "PROCESSOR_ARCHITECTURE": None,
+        "PROCESSOR_IDENTIFIER": None,
+        "PROCESSOR_LEVEL": None,
+        "PROCESSOR_REVISION": None,
+        "ProgramData": r"C:\ProgramData",
+        "ProgramFiles": r"C:\Program Files",
+        "ProgramFiles(x86)": r"C:\Program Files (x86)",
+        "ProgramW6432": r"C:\Program Files",
+        "PROMPT": r"$P$G",
+        "PSModulePath": r"%ProgramFiles%\WindowsPowerShell\Modules;%SystemRoot%\system32\WindowsPowerShell\v1.0\Modules",
+        "PUBLIC": r"C:\Users\Public",
+        "SystemDrive": systemdrive,
+        "SystemRoot": r"C:\Windows",
+        "USERDOMAIN": None,
+        "windir": r"C:\Windows",
+    }
+    user_specific = {
+        "APPDATA": rf"{systemdrive}\Users\{username}\AppData\Roaming",
+        "HOMEDRIVE": systemdrive,
+        "HOMEPATH": rf"\Users\{username}",
+        "LOCALAPPDATA": rf"{systemdrive}\Users\{username}\AppData\Local",
+        "TEMP": rf"{systemdrive}\Users\{username}\AppData\Local\Temp",
+        "TMP": rf"{systemdrive}\Users\{username}\AppData\Local\Temp",
+        "USERNAME": rf"{username}",
+        "USERPROFILE": rf"{systemdrive}\Users\{username}",
+    }
+    # set default variables based on the current user
+    for key, val in defaults.items():
+        item = os.environ.get(key, val)
+        if key is not None:
+            result.update({key: item})
+    # set user specific variables
+    result.update(user_specific)
+    return result
+
+
+def runas(cmd, username, password=None, **kwargs):
     """
     Run a command as another user. If the process is running as an admin or
     system account this method does not require a password. Other non
@@ -131,7 +197,7 @@ def runas(cmd, username, password=None, cwd=None):
     # runas.
     if not impersonation_token:
         log.debug("No impersonation token, using unprivileged runas")
-        return runas_unpriv(cmd, username, password, cwd)
+        return runas_unpriv(cmd, username, password, **kwargs)
 
     if domain == "NT AUTHORITY":
         # Logon as a system level account, SYSTEM, LOCAL SERVICE, or NETWORK
@@ -187,40 +253,55 @@ def runas(cmd, username, password=None, cwd=None):
     # Run the process without showing a window.
     creationflags = (
         win32process.CREATE_NO_WINDOW
-        | win32process.CREATE_NEW_CONSOLE
         | win32process.CREATE_SUSPENDED
+        | win32process.CREATE_UNICODE_ENVIRONMENT
     )
 
-    flags = win32con.STARTF_USESTDHANDLES
-    flags |= win32con.STARTF_USESHOWWINDOW
-    startup_info = salt.platform.win.STARTUPINFO(
-        dwFlags=flags,
-        hStdInput=stdin_read.handle,
-        hStdOutput=stdout_write.handle,
-        hStdError=stderr_write.handle,
-    )
+    flags = win32con.STARTF_USESHOWWINDOW | win32con.STARTF_USESTDHANDLES
+    startup_args = {
+        "dwFlags": flags,
+        "hStdInput": stdin_read.handle,
+        "hStdOutput": stdout_write.handle,
+    }
+    if kwargs.get("redirect_stderr", False):
+        startup_args.update({"hStdError": stdout_write.handle})
+    else:
+        startup_args.update({"hStdError": stderr_write.handle})
+    startup_info = salt.platform.win.STARTUPINFO(**startup_args)
 
     # Create the environment for the user
     env = create_env(user_token, False)
+    if kwargs.get("env", {}):
+        env.update(kwargs["env"])
+
+    # Set an optional timeout
+    timeout = kwargs.get("timeout", None)
+    if timeout:
+        timeout = timeout * 1000
+    else:
+        timeout = win32event.INFINITE
+
+    wait = not kwargs.get("bg", False)
 
     hProcess = None
+    hThread = None
+    result = None
+    ret = {}
     try:
         # Start the process in a suspended state.
         process_info = salt.platform.win.CreateProcessWithTokenW(
             int(user_token),
-            logonflags=1,
+            logonflags=salt.platform.win.LOGON_WITH_PROFILE,
             applicationname=None,
             commandline=cmd,
-            currentdirectory=cwd,
             creationflags=creationflags,
-            startupinfo=startup_info,
             environment=env,
+            currentdirectory=kwargs.get("cwd"),
+            startupinfo=startup_info,
         )
-
         hProcess = process_info.hProcess
         hThread = process_info.hThread
         dwProcessId = process_info.dwProcessId
-        dwThreadId = process_info.dwThreadId
 
         # We don't use these so let's close the handle
         salt.platform.win.kernel32.CloseHandle(stdin_write.handle)
@@ -228,41 +309,51 @@ def runas(cmd, username, password=None, cwd=None):
         salt.platform.win.kernel32.CloseHandle(stderr_write.handle)
 
         ret = {"pid": dwProcessId}
+
         # Resume the process
         psutil.Process(dwProcessId).resume()
 
-        # Wait for the process to exit and get its return code.
-        if (
-            win32event.WaitForSingleObject(hProcess, win32event.INFINITE)
-            == win32con.WAIT_OBJECT_0
-        ):
-            exitcode = win32process.GetExitCodeProcess(hProcess)
-            ret["retcode"] = exitcode
+        if wait:
+            # Wait for the process to exit and get its return code
+            result = win32event.WaitForSingleObject(hProcess, timeout)
+            if result == win32con.WAIT_TIMEOUT:
+                win32process.TerminateProcess(hProcess, 1)
+            if result == win32con.WAIT_OBJECT_0:
+                exitcode = win32process.GetExitCodeProcess(hProcess)
+                ret["retcode"] = exitcode
 
-        # Read standard out
-        fd_out = msvcrt.open_osfhandle(stdout_read.handle, os.O_RDONLY | os.O_TEXT)
-        with os.fdopen(fd_out, "r") as f_out:
-            stdout = f_out.read()
-            ret["stdout"] = stdout.strip()
+            # Read standard out
+            fd_out = msvcrt.open_osfhandle(stdout_read.handle, os.O_RDONLY | os.O_TEXT)
+            with os.fdopen(fd_out, "rb") as f_out:
+                stdout = f_out.read()
+                ret["stdout"] = stdout
 
-        # Read standard error
-        fd_err = msvcrt.open_osfhandle(stderr_read.handle, os.O_RDONLY | os.O_TEXT)
-        with os.fdopen(fd_err, "r") as f_err:
-            stderr = f_err.read()
-            ret["stderr"] = stderr
+            # Read standard error
+            fd_err = msvcrt.open_osfhandle(stderr_read.handle, os.O_RDONLY | os.O_TEXT)
+            with os.fdopen(fd_err, "rb") as f_err:
+                stderr = f_err.read()
+                ret["stderr"] = stderr
     finally:
-        if hProcess is not None:
-            salt.platform.win.kernel32.CloseHandle(hProcess)
-        win32api.CloseHandle(th)
-        win32api.CloseHandle(user_token)
-        if impersonation_token:
+        close_handle(hProcess)
+        close_handle(hThread)
+        close_handle(th)
+        close_handle(user_token)
+        if impersonation_token is not None:
             win32security.RevertToSelf()
-        win32api.CloseHandle(impersonation_token)
+        close_handle(impersonation_token)
+        close_handle(stdin_read.handle)
+        close_handle(stdout_read.handle)
+        close_handle(stderr_read.handle)
+
+    if result == win32con.WAIT_TIMEOUT:
+        raise TimedProcTimeoutError(
+            "{} : Timed out after {} seconds".format(cmd, kwargs["timeout"])
+        )
 
     return ret
 
 
-def runas_unpriv(cmd, username, password, cwd=None):
+def runas_unpriv(cmd, username, password, **kwargs):
     """
     Runas that works for non-privileged users
     """
@@ -278,33 +369,66 @@ def runas_unpriv(cmd, username, password, cwd=None):
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)
 
-    # Create a pipe to set as stdout in the child. The write handle needs to be
-    # inheritable.
-    c2pread, c2pwrite = salt.platform.win.CreatePipe(
-        inherit_read=False,
-        inherit_write=True,
-    )
-    errread, errwrite = salt.platform.win.CreatePipe(
-        inherit_read=False,
-        inherit_write=True,
-    )
-
     # Create inheritable copy of the stdin
     stdin = salt.platform.win.kernel32.GetStdHandle(
         salt.platform.win.STD_INPUT_HANDLE,
     )
-    dupin = salt.platform.win.DuplicateHandle(srchandle=stdin, inherit=True)
+    stdin_read_handle = salt.platform.win.DuplicateHandle(srchandle=stdin, inherit=True)
 
-    # Get startup info structure
-    flags = win32con.STARTF_USESTDHANDLES
-    flags |= win32con.STARTF_USESHOWWINDOW
-    startup_info = salt.platform.win.STARTUPINFO(
-        dwFlags=flags,
-        hStdInput=dupin,
-        hStdOutput=c2pwrite,
-        hStdError=errwrite,
+    # Create a pipe to set as stdout in the child. The write handle needs to be
+    # inheritable.
+    stdout_read_handle, stdout_write_handle = salt.platform.win.CreatePipe(
+        inherit_read=False,
+        inherit_write=True,
+    )
+    stderr_read_handle, stderr_write_handle = salt.platform.win.CreatePipe(
+        inherit_read=False,
+        inherit_write=True,
     )
 
+    # Run the process without showing a window.
+    creationflags = (
+        salt.platform.win.CREATE_NO_WINDOW
+        | salt.platform.win.CREATE_UNICODE_ENVIRONMENT
+    )
+
+    # Get startup info structure
+    flags = (
+        salt.platform.win.STARTF_USESHOWWINDOW | salt.platform.win.STARTF_USESTDHANDLES
+    )
+    startup_args = {
+        "dwFlags": flags,
+        "hStdInput": stdin_read_handle,
+        "hStdOutput": stdout_write_handle,
+    }
+    if kwargs.get("redirect_stderr", False):
+        startup_args.update({"hStdError": stdout_write_handle})
+    else:
+        startup_args.update({"hStdError": stderr_write_handle})
+    startup_info = salt.platform.win.STARTUPINFO(**startup_args)
+
+    # Create the environment for the user
+    env = kwargs.get("env", None)
+    if env:
+        # Unprivileged users won't be able to call CreateEnvironmentBlock.
+        # Create an environment block with sane defaults instead
+        env = create_default_env(username)
+        env.update(kwargs["env"])
+        env = salt.platform.win.environment_string(env)
+
+    # Set an optional timeout
+    timeout = kwargs.get("timeout", None)
+    if timeout:
+        timeout = timeout * 1000
+    else:
+        timeout = win32event.INFINITE
+
+    wait = not kwargs.get("bg", False)
+
+    hProcess = None
+    hThread = None
+    result = None
+    ret = {}
     try:
         # Run command and return process info structure
         process_info = salt.platform.win.CreateProcessWithLogonW(
@@ -312,43 +436,59 @@ def runas_unpriv(cmd, username, password, cwd=None):
             domain=domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
+            applicationname=None,
             commandline=cmd,
+            creationflags=creationflags,
+            environment=env,
+            currentdirectory=kwargs.get("cwd"),
             startupinfo=startup_info,
-            currentdirectory=cwd,
         )
-        salt.platform.win.kernel32.CloseHandle(process_info.hThread)
+        hProcess = process_info.hProcess
+        hThread = process_info.hThread
+        dwProcessId = process_info.dwProcessId
+
+        # We don't use these so let's close the handle
+        salt.platform.win.kernel32.CloseHandle(stdin_read_handle)
+        salt.platform.win.kernel32.CloseHandle(stdout_write_handle)
+        salt.platform.win.kernel32.CloseHandle(stderr_write_handle)
+
+        ret = {"pid": dwProcessId}
+
+        if wait:
+            # Wait for the process to exit and get its return code
+            result = salt.platform.win.kernel32.WaitForSingleObject(hProcess, timeout)
+            if result == win32con.WAIT_TIMEOUT:
+                salt.platform.win.kernel32.TerminateProcess(hProcess, 1)
+            elif result == win32con.WAIT_OBJECT_0:
+                exitcode = salt.platform.win.wintypes.DWORD()
+                salt.platform.win.kernel32.GetExitCodeProcess(
+                    hProcess, ctypes.byref(exitcode)
+                )
+                ret["retcode"] = exitcode.value
+
+            # Read Standard out
+            fd_out = msvcrt.open_osfhandle(stdout_read_handle, os.O_RDONLY | os.O_TEXT)
+            with os.fdopen(fd_out, "rb") as f_out:
+                stdout = f_out.read()
+                ret["stdout"] = stdout
+
+            # Read Standard error
+            fd_err = msvcrt.open_osfhandle(stderr_read_handle, os.O_RDONLY | os.O_TEXT)
+            with os.fdopen(fd_err, "rb") as f_err:
+                stderr = f_err.read()
+                ret["stderr"] = stderr
     finally:
-        salt.platform.win.kernel32.CloseHandle(dupin)
-        salt.platform.win.kernel32.CloseHandle(c2pwrite)
-        salt.platform.win.kernel32.CloseHandle(errwrite)
+        if hProcess is not None:
+            salt.platform.win.kernel32.CloseHandle(hProcess)
+        if hThread is not None:
+            salt.platform.win.kernel32.CloseHandle(hThread)
+        if not wait:
+            salt.platform.win.kernel32.CloseHandle(stdout_read_handle)
+            salt.platform.win.kernel32.CloseHandle(stderr_read_handle)
 
-    # Initialize ret and set first element
-    ret = {"pid": process_info.dwProcessId}
-
-    # Get Standard Out
-    fd_out = msvcrt.open_osfhandle(c2pread, os.O_RDONLY | os.O_TEXT)
-    with os.fdopen(fd_out, "r") as f_out:
-        ret["stdout"] = f_out.read()
-
-    # Get Standard Error
-    fd_err = msvcrt.open_osfhandle(errread, os.O_RDONLY | os.O_TEXT)
-    with os.fdopen(fd_err, "r") as f_err:
-        ret["stderr"] = f_err.read()
-
-    # Get Return Code
-    if (
-        salt.platform.win.kernel32.WaitForSingleObject(
-            process_info.hProcess, win32event.INFINITE
+    if result == win32con.WAIT_TIMEOUT:
+        raise TimedProcTimeoutError(
+            "{} : Timed out after {} seconds".format(cmd, kwargs["timeout"])
         )
-        == win32con.WAIT_OBJECT_0
-    ):
-        exitcode = salt.platform.win.wintypes.DWORD()
-        salt.platform.win.kernel32.GetExitCodeProcess(
-            process_info.hProcess, ctypes.byref(exitcode)
-        )
-        ret["retcode"] = exitcode.value
-
-    # Close handle to process
-    salt.platform.win.kernel32.CloseHandle(process_info.hProcess)
 
     return ret

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -53,6 +53,9 @@ def __virtual__():
 
 
 def close_handle(handle):
+    """
+    Tries to close an object handle
+    """
     if handle is not None:
         try:
             win32api.CloseHandle(handle)

--- a/tests/pytests/functional/modules/cmd/test_powershell.py
+++ b/tests/pytests/functional/modules/cmd/test_powershell.py
@@ -207,5 +207,6 @@ def test_cmd_run_encoded_cmd_runas(shell, account, cmd, expected, encoded_cmd):
         encoded_cmd=encoded_cmd,
         runas=account.username,
         password=account.password,
+        redirect_stderr=False,
     )
     assert ret == expected

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -8,6 +8,7 @@ import pytest
 
 import salt.modules.win_useradd as win_useradd
 import salt.utils.win_runas as win_runas
+from salt.exceptions import TimedProcTimeoutError
 
 try:
     import salt.platform.win
@@ -54,7 +55,7 @@ def test_compound_runas(user, cmd, expected):
         username=user.username,
         password=user.password,
     )
-    assert expected in result["stdout"]
+    assert expected in result["stdout"].decode()
 
 
 @pytest.mark.parametrize(
@@ -73,32 +74,130 @@ def test_compound_runas_unpriv(user, cmd, expected):
         username=user.username,
         password=user.password,
     )
-    assert expected in result["stdout"]
+    assert expected in result["stdout"].decode()
 
 
 def test_runas_str_user(user):
     result = win_runas.runas(
         cmd="whoami", username=user.username, password=user.password
     )
-    assert user.username in result["stdout"]
+    assert user.username in result["stdout"].decode()
 
 
 def test_runas_int_user(int_user):
     result = win_runas.runas(
         cmd="whoami", username=int(int_user.username), password=int_user.password
     )
-    assert str(int_user.username) in result["stdout"]
+    assert str(int_user.username) in result["stdout"].decode()
 
 
 def test_runas_unpriv_str_user(user):
     result = win_runas.runas_unpriv(
         cmd="whoami", username=user.username, password=user.password
     )
-    assert user.username in result["stdout"]
+    assert user.username in result["stdout"].decode()
 
 
 def test_runas_unpriv_int_user(int_user):
     result = win_runas.runas_unpriv(
         cmd="whoami", username=int(int_user.username), password=int_user.password
     )
-    assert str(int_user.username) in result["stdout"]
+    assert str(int_user.username) in result["stdout"].decode()
+
+
+def test_runas_redirect_stderr(user):
+    expected = "invalidcommand"
+    result = win_runas.runas(
+        cmd=f'cmd /c "{expected}"',
+        username=user.username,
+        password=user.password,
+        redirect_stderr=True,
+    )
+    assert isinstance(result["pid"], int)
+    assert result["retcode"] == 1
+    assert expected in result["stdout"].decode()
+    assert result["stderr"].decode() == ""
+
+
+def test_runas_unpriv_redirect_stderr(user):
+    expected = "invalidcommand"
+    result = win_runas.runas_unpriv(
+        cmd=f'cmd /c "{expected}"',
+        username=user.username,
+        password=user.password,
+        redirect_stderr=True,
+    )
+    assert isinstance(result["pid"], int)
+    assert result["retcode"] == 1
+    assert expected in result["stdout"].decode()
+    assert result["stderr"].decode() == ""
+
+
+def test_runas_env(user):
+    expected = "foo"
+    result = win_runas.runas(
+        cmd='cmd /c "echo %FOO%"',
+        username=user.username,
+        password=user.password,
+        env={"FOO": expected},
+    )
+    assert result["stdout"].decode().strip() == expected
+
+
+def test_runas_unpriv_env(user):
+    expected = "foo"
+    result = win_runas.runas_unpriv(
+        cmd='cmd /c "echo %FOO%"',
+        username=user.username,
+        password=user.password,
+        env={"FOO": expected},
+    )
+    assert result["stdout"].decode().strip() == expected
+
+
+def test_runas_timeout(user):
+    timeout = 1
+    with pytest.raises(TimedProcTimeoutError):
+        result = win_runas.runas(
+            cmd='powershell -command "sleep 10"',
+            username=user.username,
+            password=user.password,
+            timeout=timeout,
+        )
+
+
+def test_runas_unpriv_timeout(user):
+    timeout = 1
+    with pytest.raises(TimedProcTimeoutError):
+        result = win_runas.runas_unpriv(
+            cmd='powershell -command "sleep 10"',
+            username=user.username,
+            password=user.password,
+            timeout=timeout,
+        )
+
+
+def test_runas_wait(user):
+    result = win_runas.runas(
+        cmd='cmd /c "timeout /t 10"',
+        username=user.username,
+        password=user.password,
+        bg=True,
+    )
+    assert isinstance(result["pid"], int)
+    assert "retcode" not in result
+    assert "stdout" not in result
+    assert "stderr" not in result
+
+
+def test_runas_unpriv_wait(user):
+    result = win_runas.runas_unpriv(
+        cmd='cmd /c "timeout /t 10"',
+        username=user.username,
+        password=user.password,
+        bg=True,
+    )
+    assert isinstance(result["pid"], int)
+    assert "retcode" not in result
+    assert "stdout" not in result
+    assert "stderr" not in result


### PR DESCRIPTION
### What does this PR do?

**Unify result processing for `timed_subprocess.TimedProc` and `win_runas.runas`**

- use the same code path for both functions
- fix stdout/stderr decoding exceptions with runas as previously UTF-8 was assumed

**win_runas.runas and win_runas.runas_unpriv**

- support the parameter `env` to pass custom environment variables
- support the parameter `redirect_stderr` to redirect stderr to stdout
- support the parameter `timeout` to abort execution and kill the process after a timeout
- support the parameter `bg` to run a command in background without waiting for the result
- ensure opened handles are closed

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
