### PR TITLE
Add Fedora 42 to test CI, drop Fedora 40

### DIFF
--- a/changelog/68132.added.md
+++ b/changelog/68132.added.md
@@ -1,0 +1,1 @@
+Added Fedora 42 to test CI, and dropped Fedora 40, in accordance with Fedora OS support policy.

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -3,7 +3,7 @@ mock >= 3.0.0
 docker >= 7.1.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'
 pytest >= 7.2.0
-pytest-salt-factories >= 1.0.0
+pytest-salt-factories >= 1.0.5
 pytest-helpers-namespace >= 2019.1.8
 pytest-subtests
 pytest-timeout >= 2.3.1

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -494,7 +494,7 @@ pytest-custom-exit-code==0.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt
@@ -504,7 +504,7 @@ pytest-httpserver==1.0.8
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -352,14 +352,14 @@ pyserial==3.4
     # via junos-eznc
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -343,14 +343,14 @@ pyserial==3.4
     # via junos-eznc
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -361,14 +361,14 @@ pyserial==3.4
     # via junos-eznc
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -329,7 +329,7 @@ pytest-helpers-namespace==2021.12.29
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -458,7 +458,7 @@ pytest-custom-exit-code==0.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt
@@ -468,7 +468,7 @@ pytest-httpserver==1.0.8
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -323,14 +323,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -320,14 +320,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -338,14 +338,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -325,7 +325,7 @@ pytest-helpers-namespace==2021.12.29
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -453,7 +453,7 @@ pytest-custom-exit-code==0.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
@@ -463,7 +463,7 @@ pytest-httpserver==1.0.8
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -319,14 +319,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -316,14 +316,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -334,14 +334,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -321,7 +321,7 @@ pytest-helpers-namespace==2021.12.29
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.9.7 ; python_version >= "3.10"
     # via

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -530,7 +530,7 @@ pytest-custom-exit-code==0.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt
@@ -540,7 +540,7 @@ pytest-httpserver==1.0.8
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -381,14 +381,14 @@ pyserial==3.4
     #   netmiko
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -372,14 +372,14 @@ pyserial==3.4
     #   netmiko
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -383,14 +383,14 @@ pyserial==3.4
     #   netmiko
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -324,14 +324,14 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
-pytest-helpers-namespace==2021.4.29
+pytest-helpers-namespace==2021.12.29
     # via
     #   -r requirements/pytest.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
 pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
-pytest-salt-factories==1.0.1
+pytest-salt-factories==1.0.5
     # via -r requirements/pytest.txt
 pytest-shell-utilities==1.8.0 ; python_version <= "3.9"
     # via

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2477,7 +2477,7 @@ def test_get_yum_config(grains):
         # This one seems to be in all of them...
         # If this ever breaks in the future, we'll need to get more specific
         # than os_family
-        setting = "installonly_limit"
+        setting = "reposdir"
     result = yumpkg._get_yum_config()
     assert setting in result
 

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -118,10 +118,10 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
             ),
             Linux(
-                slug="fedora-40",
-                display_name="Fedora 40",
+                slug="fedora-42",
+                display_name="Fedora 42",
                 arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:fedora-40",
+                container="ghcr.io/saltstack/salt-ci-containers/testing:fedora-42",
             ),
             # Linux(slug="opensuse-15", display_name="Opensuse 15", arch="x86_64"),
             Linux(


### PR DESCRIPTION
### What does this PR do?

- Add Fedora 42 to test CI, drop Fedora 40
- Upgrade `pytest-salt-factories` to drop `dsa` due to no longer being supported in newer versions of OpenSSH (ex. the version included in Fedora 42)
- Update yum pkg tests to use a more universal yum config that exists, by default, across all systems using yum

### What issues does this PR fix or reference?
Fixes #67182

