### PR TITLE
(3007.x) Ensure test value returns only boolean values

### DIFF
--- a/changelog/68121.fixed.md
+++ b/changelog/68121.fixed.md
@@ -1,0 +1,1 @@
+Fix `test mode` causing unintended execution when non-boolean values are passed.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -193,7 +193,10 @@ class LoadedCoro(LoadedFunc):
         if hasattr(mod, "__opts__"):
             if not isinstance(mod.__opts__, salt.loader.context.NamedLoaderContext):
                 if "test" in self.loader.opts:
-                    mod.__opts__["test"] = self.loader.opts["test"]
+                    if self.loader.opts["test"] is False:
+                        mod.__opts__["test"] = False
+                    else:
+                        mod.__opts__["test"] = True
                     set_test = True
         if self.loader.inject_globals:
             run_func = global_injector_decorator(self.loader.inject_globals)(run_func)

--- a/tests/pytests/unit/loader/test_lazy.py
+++ b/tests/pytests/unit/loader/test_lazy.py
@@ -33,6 +33,9 @@ def loader_dir(tmp_path):
 
     def get_opts(key):
         return __opts__.get(key, None)
+
+    async def get_opts_async(key):
+        return __opts__.get(key, None)
     """
     with pytest.helpers.temp_file(
         "mod_a.py", directory=tmp_path, contents=mod_contents
@@ -173,4 +176,24 @@ def test_loaded_func_ensures_test_boolean(loader_dir, test_value, expected):
     loader = salt.loader.lazy.LazyLoader([loader_dir], opts)
     loaded_fun = loader["mod_a.get_opts"]
     ret = loaded_fun("test")
+    assert ret is expected
+
+
+@pytest.mark.parametrize(
+    "test_value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("abc", True),
+        (123, True),
+    ],
+)
+async def test_loaded_coro_ensures_test_boolean(loader_dir, test_value, expected):
+    """
+    Coroutines loaded from LazyLoader's item lookups are LoadedCoro objects
+    """
+    opts = {"optimization_order": [0, 1, 2], "test": test_value}
+    loader = salt.loader.lazy.LazyLoader([loader_dir], opts)
+    loaded_coro = loader["mod_a.get_opts_async"]
+    ret = await loaded_coro("test")
     assert ret is expected


### PR DESCRIPTION
### What does this PR do?
> This PR for the 3007.x branch applies the same modifications to `LoadedCoro` as the changes I previously submitted(#68122).

Normalize test value to strictly boolean output

### What issues does this PR fix or reference?
Fixes #68121 

### Previous Behavior
For more details, please refer to the previous PR, #68122.

### New Behavior
For more details, please refer to the previous PR, #68122.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
