### PR TITLE
file.py changes message incorrect when file is managed and not replaced

### DIFF
--- a/changelog/68052.fixed.md
+++ b/changelog/68052.fixed.md
@@ -1,0 +1,1 @@
+this fixes when a file is managed, and the same file is cleaned, an incorrect message is displayed saying "removed: Removed due to clean" when the file isn't actually removed

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1040,7 +1040,7 @@ def _check_directory(
 
         def _check_changes(fname):
             path = os.path.join(root, fname)
-            if path in keep:
+            if any(path in s for s in keep):
                 return {}
             else:
                 if not salt.utils.stringutils.check_include_exclude(

--- a/tests/pytests/functional/states/file/test_directory.py
+++ b/tests/pytests/functional/states/file/test_directory.py
@@ -5,6 +5,7 @@ import pytest
 import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.win_dacl
 import salt.utils.win_functions
 
 pytestmark = [
@@ -290,6 +291,64 @@ def test_directory_clean_require_in(modules, tmp_path, state_tree):
     assert wrong_file.exists() is False
 
 
+def test_directory_clean_require_in_good_message(modules, tmp_path, state_tree):
+    """
+    file.directory test with clean=True and require_in file,
+    the comment cannot be "removed": "Removed due to clean"
+    """
+    name = tmp_path / "b-directory"
+    name.mkdir()
+    if IS_WINDOWS:
+        principal = salt.utils.win_functions.get_current_user()
+        salt.utils.win_dacl.set_owner(obj_name=str(name), principal=principal)
+    dir = name / "one"
+    dir.mkdir()
+    good_file = dir / "good-file"
+    good_file.write_text("good")
+
+    assert good_file.exists()
+    assert good_file.is_file()
+
+    assert name.exists()
+    assert name.is_dir()
+
+    assert dir.exists()
+    assert dir.is_dir()
+
+    sls_contents = """
+    some_dir:
+      file.directory:
+        - name: {name}
+        - clean: true
+
+    {good_file}:
+      file.managed:
+        - require_in:
+          - file: some_dir
+    """.format(
+        name=name, good_file=good_file
+    )
+
+    with pytest.helpers.temp_file("clean-require-in.sls", sls_contents, state_tree):
+        ret = modules.state.sls("clean-require-in")
+        expected_file = f"File {good_file} exists with proper permissions. No changes made."
+        for state_run in ret:
+            print("changes", state_run.changes)
+            if IS_WINDOWS:
+                if state_run.changes:
+                    expected_dir = f"Directory {name} updated"
+                else:
+                    expected_dir = f"Directory {name} is in the correct state"
+            else:
+                expected_dir = f"The directory {name} is in the correct state"
+            assert dir.exists()
+            assert good_file.exists()
+            assert good_file.read_text() == "good"
+            assert (
+                state_run.comment == expected_file or state_run.comment == expected_dir
+            )
+
+            
 def test_directory_clean_require_in_with_id(modules, tmp_path, state_tree):
     """
     file.directory test with clean=True and require_in file with an ID


### PR DESCRIPTION
### What does this PR do?
when a file is managed, and the same file is cleaned, and incorrect message is displayed saying "removed:    Removed due to clean" when the file isn't actually removed
### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68052

### Previous Behavior
Remove this section if not relevant

### New Behavior
it no longer displays the incorrect message

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
