### PR TITLE
disks grain: fix exception on Windows

### DIFF
--- a/changelog/68184.fixed.md
+++ b/changelog/68184.fixed.md
@@ -1,0 +1,1 @@
+grains.disks: fix exception with incompatible output of Get-PhysicalDisk

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -169,13 +169,19 @@ def _windows_disks():
         drive_info = [drive_info]
 
     for drive in drive_info:
+        media_type = drive.get("MediaType")
         # Make sure we have a valid drive type
-        if drive["MediaType"].lower() not in ["hdd", "ssd", "scm", "unspecified"]:
-            log.trace(f'Unknown media type: {drive["MediaType"]}')
+        if media_type is None or media_type.lower() not in [
+            "hdd",
+            "ssd",
+            "scm",
+            "unspecified",
+        ]:
+            log.trace(f"Unknown media type: {media_type}")
             continue
         device = rf'\\.\PhysicalDrive{drive["DeviceID"]}'
         ret["disks"].append(device)
-        if drive["MediaType"].lower() == "ssd":
+        if media_type.lower() == "ssd":
             ret["ssds"].append(device)
 
     return ret

--- a/tests/pytests/unit/grains/test_disks.py
+++ b/tests/pytests/unit/grains/test_disks.py
@@ -56,6 +56,39 @@ def test__windows_disks_list():
         assert result == expected
 
 
+def test__windows_disks_without_mediatype_dict():
+    """
+    test grains._windows_disks with a single disk missing the MediaType property
+    returned as a dict
+    Should return empty lists
+    """
+    devices = {"DeviceID": 0, "MediaType": None}
+    mock_powershell = MagicMock(return_value=devices)
+
+    with patch.dict(disks.__salt__, {"cmd.powershell": mock_powershell}):
+        expected = {"disks": [], "ssds": []}
+        result = disks._windows_disks()
+        assert result == expected
+
+
+def test__windows_disks_without_mediatype_list():
+    """
+    test grains._windows_disks with multiple disks missing the MediaType property
+    as a list of dicts
+    Should return empty lists
+    """
+    devices = [
+        {"DeviceID": 0, "MediaType": None},
+        {"DeviceID": 1, "MediaType": None},
+    ]
+    mock_powershell = MagicMock(return_value=devices)
+
+    with patch.dict(disks.__salt__, {"cmd.powershell": mock_powershell}):
+        expected = {"disks": [], "ssds": []}
+        result = disks._windows_disks()
+        assert result == expected
+
+
 def test__windows_disks_empty():
     """
     Test grains._windows_disks when nothing is returned


### PR DESCRIPTION
### What does this PR do?

Running `Get-PhysicalDisk` does not return a `MediaType` property on Windows Server 2012. This causes an exception when loading the disks grain.

```
[CRITICAL] Failed to load grains defined in grain file disks.disks in function <LoadedFunc name='disks.disks'>, error:
Traceback (most recent call last):
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\loader\__init__.py", line 1188, in grains
    ret = funcs[key](**kwargs)
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\loader\lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\loader\lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\loader\lazy.py", line 1260, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\grains\disks.py", line 34, in disks
    return _windows_disks()
  File "C:\Program Files\Salt Project\Salt\Lib\site-packages\salt\grains\disks.py", line 173, in _windows_disks
    if drive["MediaType"].lower() not in ["hdd", "ssd", "scm", "unspecified"]:
AttributeError: 'NoneType' object has no attribute 'lower'
```



### Previous Behavior

Loading the disks grain fails and causes an AttributeError.

### New Behavior

Loading the disks grain fails silently.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No