### PR TITLE
Remove ppbt after building the salt onedir

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -283,7 +283,9 @@ def _install_requirements(
     onedir=False,
 ):
     if onedir and IS_LINUX:
-        session_run_always(session, "python3", "-m", "pip", "install", "ppbt")
+        session_run_always(
+            session, "python3", "-m", "pip", "install", "relenv[toolchain]"
+        )
 
     if not _upgrade_pip_setuptools_and_wheel(session):
         return False
@@ -1269,6 +1271,8 @@ def decompress_dependencies(session):
     session.log("Finding broken 'python' symlinks and configs under '.nox/' ...")
     for dirname in os.scandir(REPO_ROOT / ".nox"):
         scan_path = REPO_ROOT.joinpath(".nox", dirname, scripts_dir_name)
+
+        # Fix the values of the directories in a pyvenv.cfg file.
         config = pathlib.Path(dirname) / "pyvenv.cfg"
         values = {}
         if config.exists():
@@ -1290,6 +1294,7 @@ def decompress_dependencies(session):
                     fp.write(f"{key} = {values[key]}\n")
         else:
             session.log(f"{config} does not exist")
+
         script_paths = {str(p): p for p in os.scandir(scan_path)}
         fixed_shebang = f"#!{scan_path / 'python'}"
         for key in sorted(script_paths):

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -574,12 +574,14 @@ def onedir_dependencies(
         env["OPENSSL_DIR"] = f"{dest}"
 
     if platform == "linux":
+        # This installs the ppbt package. We'll remove it after installing all
+        # of our python packages.
         ctx.run(
             str(python_bin),
             "-m",
             "pip",
             "install",
-            "ppbt",
+            "relenv[toolchain]",
         )
 
     version_info = ctx.run(
@@ -790,6 +792,19 @@ def salt_onedir(
         dst = pathlib.Path(site_packages) / fname
         ctx.info(f"Copying '{src.relative_to(tools.utils.REPO_ROOT)}' to '{dst}' ...")
         shutil.copyfile(src, dst)
+
+    if platform == "linux":
+        # The ppbt package is very large. It is only needed when installing
+        # python modules that need to be compiled. Do not ship ppbt by default,
+        # it can be installed later if needed.
+        ctx.run(
+            str(python_executable),
+            "-m",
+            "pip",
+            "uninstall",
+            "-y",
+            "ppbt",
+        )
 
 
 def _check_pkg_build_files_exist(ctx: Context, **kwargs):


### PR DESCRIPTION
Reduce our tarball and package size by ensuring we don't ship the toolchain