### PR TITLE
bad key logs useful message instead of traceback

### DIFF
--- a/changelog/68190.fixed.md
+++ b/changelog/68190.fixed.md
@@ -1,0 +1,1 @@
+Log a useful error if the minion's key is overwritten with bad data; instead of a traceback.

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -426,7 +426,11 @@ class AsyncPubChannel:
         self.opts = opts
         self.io_loop = io_loop
         self.auth = auth
-        self.token = self.auth.gen_token(b"salt")
+        try:
+            # This loads or generates the minion's public key.
+            self.token = self.auth.gen_token(b"salt")
+        except salt.exceptions.InvalidKeyError as exc:
+            raise salt.exceptions.SaltClientError(str(exc))
         self.transport = transport
         self._closing = False
         self._reconnected = False

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -332,10 +332,15 @@ def _get_key_with_evict(path, timestamp, passphrase):
     else:
         password = None
     with salt.utils.files.fopen(path, "rb") as f:
-        return serialization.load_pem_private_key(
-            f.read(),
-            password=password,
-        )
+        try:
+            return serialization.load_pem_private_key(
+                f.read(),
+                password=password,
+            )
+        except ValueError:
+            raise InvalidKeyError("Encountered bad RSA public key")
+        except cryptography.exceptions.UnsupportedAlgorithm:
+            raise InvalidKeyError("Unsupported key algorithm")
 
 
 def get_rsa_key(path, passphrase):

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -1,6 +1,7 @@
 import pytest
 
 import salt.crypt as crypt
+import salt.exceptions
 
 
 @pytest.fixture
@@ -180,3 +181,10 @@ def test_sauth_aes_key_rotation(minion_root, io_loop):
     assert isinstance(auth._creds, dict)
     assert auth._creds["aes"] == aes1
     assert auth._creds["session"] == session1
+
+
+def test_get_key_with_evict_bad_key(tmp_path):
+    key_path = tmp_path / "key"
+    key_path.write_text("asdfasoiasdofaoiu0923jnoiausbd98sb9")
+    with pytest.raises(salt.exceptions.InvalidKeyError):
+        crypt._get_key_with_evict(str(key_path), 1, None)


### PR DESCRIPTION
When the minion's key is overwritten with bad data, log a useful message instead of traceback. Handle the error in a consistant way accross salt.minion, salt.channel.client, and salt.crypt.


### What issues does this PR fix or reference?

Fixes #68190

