### PR TITLE
Add ceph to the specialFSes to match on name for set_fstab

### DIFF
--- a/changelog/68207.changed.md
+++ b/changelog/68207.changed.md
@@ -1,0 +1,1 @@
+Added ceph to the specialFSes to match on name for set_fstab

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -845,6 +845,7 @@ def set_fstab(
                 "nfs4",
                 "glusterfs",
                 "btrfs",
+                "ceph",
             ]
         )
 


### PR DESCRIPTION
### What does this PR do?
Add cephfs to the set of FSes that are being matched by name instead of device in set_fstab

### What issues does this PR fix or reference?
It's common to have multiple cephfs'es in fstab that share the same device. Currently `match_on: name` must be explicitly set to correctly handle this case.

### Previous Behavior
`match_on: name` is required to be explicitly set when adding multiple cephfs mountpoints that share the same device

### New Behavior
`match_on: auto` default value is sufficient

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs (specialFSes doesn't seem to be documented)
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated 

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->

Closes #68207
