### PR TITLE
Add force option to win_pkg

### DIFF
--- a/changelog/68102.added.md
+++ b/changelog/68102.added.md
@@ -1,2 +1,2 @@
-Added the ability to pass for to pkg.install on Windows to force run the
-installer
+Added a new `force` option to pkg.install on Windows to force the installer
+to run even if the package is already installed

--- a/changelog/68102.added.md
+++ b/changelog/68102.added.md
@@ -1,0 +1,2 @@
+Added the ability to pass for to pkg.install on Windows to force run the
+installer

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1471,6 +1471,13 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
             .. versionadded:: 2016.11.0
 
+        force (bool):
+            If ``True``, the installation will run whether the package is
+            already installed or not. If ``False``, the installation will not
+            run if the correct version of the package is already installed.
+
+            .. versionadded:: 3006.15
+
     Returns:
         dict: Return a dict containing the new package names and versions. If
         the package is already installed, an empty dict is returned.
@@ -1603,12 +1610,13 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # If the version was not passed, version_num will be None
         if not version_num:
             if pkg_name in old:
-                log.debug(
-                    "pkg.install: '%s' version '%s' is already installed",
-                    pkg_name,
-                    old[pkg_name][0],
-                )
-                continue
+                if not kwargs.get("force", False):
+                    log.debug(
+                        "pkg.install: '%s' version '%s' is already installed",
+                        pkg_name,
+                        old[pkg_name][0],
+                    )
+                    continue
             # Get the most recent version number available from winrepo.p
             # May also return `latest` or an empty string
             version_num = _get_latest_pkg_version(pkginfo)
@@ -1621,12 +1629,13 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # Check if the version is already installed
         if version_num in old.get(pkg_name, []):
             # Desired version number already installed
-            log.debug(
-                "pkg.install: '%s' version '%s' is already installed",
-                pkg_name,
-                version_num,
-            )
-            continue
+            if not kwargs.get("force", False):
+                log.debug(
+                    "pkg.install: '%s' version '%s' is already installed",
+                    pkg_name,
+                    version_num,
+                )
+                continue
         # If version number not installed, is the version available?
         elif version_num != "latest" and version_num not in pkginfo:
             log.error("Version %s not found for package %s", version_num, pkg_name)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1475,6 +1475,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             If ``True``, the installation will run whether the package is
             already installed or not. If ``False``, the installation will not
             run if the correct version of the package is already installed.
+            Default is ``False``.
 
             .. versionadded:: 3006.15
 

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -193,6 +193,29 @@ def test_pkg_install_existing():
         assert expected == result
 
 
+def test_pkg_install_existing_force_true():
+    """
+    test pkg.install when the package is already installed
+    and force=True
+    """
+    ret_reg = {"Nullsoft Install System": "3.03"}
+    # The 2nd time it's run, pkg.list_pkgs uses with stringify
+    se_list_pkgs = {"nsis": ["3.03"]}
+    with patch.object(win_pkg, "list_pkgs", return_value=se_list_pkgs), patch.object(
+        win_pkg, "_get_reg_software", return_value=ret_reg
+    ), patch.dict(
+        win_pkg.__salt__,
+        {
+            "cmd.run_all": MagicMock(return_value={"retcode": 0}),
+            "cp.cache_file": MagicMock(return_value="C:\\fake\\path.exe"),
+            "cp.is_cached": MagicMock(return_value=True),
+        },
+    ):
+        expected = {"nsis": {"install status": "success"}}
+        result = win_pkg.install(name="nsis", force=True)
+        assert expected == result
+
+
 def test_pkg_install_latest():
     """
     test pkg.install when the package is already installed


### PR DESCRIPTION
### What does this PR do?
Add the ability to force an installer to run by passing `force=True` to `pkg.install`

### What issues does this PR fix or reference?
Fixes #68102 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
