### PR TITLE
Allow events to be processed in the minion after the signal handler has been invoked

### DIFF
--- a/changelog/68183.fixed.md
+++ b/changelog/68183.fixed.md
@@ -1,0 +1,2 @@
+Fixed MinionManager.stop() to allow processing of minion event bus when called, to allow jobs returns from `service.restart salt-minion no_block=True` to reach
+master.

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -225,8 +225,11 @@ class Minion(
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         # escalate signal to the process manager processes
         if hasattr(self.minion, "stop"):
-            self.minion.stop(signum)
-        super()._handle_signals(signum, sigframe)
+            # If the minion has a stop method, call it - this is the case for
+            # MinionManager
+            self.minion.stop(signum, super()._handle_signals)
+        else:
+            super()._handle_signals(signum, sigframe)
 
     # pylint: disable=no-member
     def prepare(self):
@@ -405,7 +408,7 @@ class ProxyMinion(
 
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         # escalate signal to the process manager processes
-        self.minion.stop(signum)
+        self.minion.stop(signum, super()._handle_signals)
         super()._handle_signals(signum, sigframe)
 
     # pylint: disable=no-member

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1220,7 +1220,9 @@ class MinionManager(MinionBase):
         Called from cli.daemons.Minion._handle_signals().
         Adds stop_async as callback to the io_loop to prevent blocking.
         """
-        self.io_loop.add_callback(self.stop_async, signum, parent_sig_handler)
+        self.io_loop.add_callback(  # pylint: disable=not-callable
+            self.stop_async, signum, parent_sig_handler
+        )
 
     @salt.ext.tornado.gen.coroutine
     def stop_async(self, signum, parent_sig_handler):

--- a/tests/pytests/unit/conftest.py
+++ b/tests/pytests/unit/conftest.py
@@ -27,7 +27,6 @@ def minion_opts(tmp_path):
     opts["fips_mode"] = FIPS_TESTRUN
     opts["encryption_algorithm"] = "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
     opts["signing_algorithm"] = "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
-    opts["sock_dir"] = tmp_path / "sock"
     return opts
 
 

--- a/tests/pytests/unit/conftest.py
+++ b/tests/pytests/unit/conftest.py
@@ -27,6 +27,7 @@ def minion_opts(tmp_path):
     opts["fips_mode"] = FIPS_TESTRUN
     opts["encryption_algorithm"] = "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
     opts["signing_algorithm"] = "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+    opts["sock_dir"] = tmp_path / "sock"
     return opts
 
 

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1171,11 +1171,16 @@ async def test_connect_master_general_exception_error(minion_opts, connect_maste
     assert minion.connect_master.calls == 2
 
 
-async def test_minion_manager_async_stop(io_loop, minion_opts):
+async def test_minion_manager_async_stop(io_loop, minion_opts, tmp_path):
     """
     Ensure MinionManager's stop method works correctly and calls the
     stop_async method
     """
+
+    # Setup sock_dir with short path
+    minion_opts["sock_dir"] = str(tmp_path / "sock")
+
+    # Create a MinionManager instance with a mock minion
     mm = salt.minion.MinionManager(minion_opts)
     minion = MagicMock(name="minion")
     parent_signal_handler = MagicMock(name="parent_signal_handler")

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1,6 +1,8 @@
 import copy
 import logging
 import os
+import signal
+import time
 import uuid
 
 import pytest
@@ -1167,3 +1169,54 @@ async def test_connect_master_general_exception_error(minion_opts, connect_maste
     # The first call raised an error which caused minion.destroy to get called,
     # the second call is a success.
     assert minion.connect_master.calls == 2
+
+
+async def test_minion_manager_async_stop(io_loop, minion_opts):
+    """
+    Ensure MinionManager's stop method works correctly and calls the
+    stop_async method
+    """
+    mm = salt.minion.MinionManager(minion_opts)
+    minion = MagicMock(name="minion")
+    parent_signal_handler = MagicMock(name="parent_signal_handler")
+    mm.minions.append(minion)
+
+    # Set up event publisher and event
+    mm._bind()
+    assert mm.event_publisher is not None
+    assert mm.event is not None
+
+    # Check io_loop is running
+    assert mm.io_loop._running
+
+    # Set up values for event to send
+    load = {"key": "value"}
+    ret = {}
+
+    # Connect to minion event bus
+    with salt.utils.event.get_event("minion", opts=minion_opts, listen=True) as event:
+
+        # call stop to start stopping the minion
+        # mm.stop(signal.SIGTERM, parent_signal_handler)
+        mm.stop(signal.SIGTERM, parent_signal_handler)
+
+        # Fire an event and ensure we can still read it back while the minion
+        # is stopping
+        await event.fire_event_async(load, "test_event", timeout=1)
+        start = time.time()
+        while time.time() - start < 5:
+            ret = event.get_event(tag="test_event", wait=0.3)
+            if ret:
+                break
+            await salt.ext.tornado.gen.sleep(0.3)
+    assert "key" in ret
+    assert ret["key"] == "value"
+
+    # Sleep to allow stop_async to complete
+    await salt.ext.tornado.gen.sleep(5)
+
+    # Ensure stop_async has been called
+    minion.destroy.assert_called_once()
+    parent_signal_handler.assert_called_once_with(signal.SIGTERM, None)
+    assert mm.event_publisher is None
+    assert mm.event is None


### PR DESCRIPTION
### What does this PR do?
Modifies the behaviour of the `MinionManager.stop()` function which is called from the signal handler in `cli.daemons.Minion()` so that it allows the io_loop to run. This allows minions to handle events on the minion event bus before being shut down.

### What issues does this PR fix or reference?
Fixes #68183

### Previous Behavior
When calling `salt <minion> service.stop salt-minion no_block=True`, the result of the job would be sent as an event on the minion event bus, but would not be returned to the master as the signal handler was non-async so blocked any further processing. 

This would lead to an error due to no return on the master:
```bash
# salt salt-dev1 service.restart salt-minion no_block=True
salt-dev1:
    Minion did not return. [No response]
    The minions may not have all finished running and any remaining minions will return upon completion. To look up the return data for this job later, run the following command:

    salt-run jobs.lookup_jid 20250714111342562766
ERROR: Minions returned with non-zero exit code
# salt-run jobs.lookup_jid 20250714111342562766
```
and an exception on the minion:

```bash
2025-07-14 11:13:42,724 [salt.loaded.int.module.cmdmod:481 ][INFO    ][43501] Executing command /usr/bin/systemd-run in directory '/root'
2025-07-14 11:13:42,754 [salt.loaded.int.module.cmdmod:974 ][DEBUG   ][43501] stderr: Running as unit: run-r61cd83bc2ece4cb4b2766266ff87fd90.scope; invocation ID: a149b1e649cd4ea392d31fe2ca20762b
2025-07-14 11:13:42,754 [salt.transport.ipc:361 ][DEBUG   ][43373] Closing IPCMessageClient instance
2025-07-14 11:13:42,754 [salt.minion      :2301][INFO    ][43501] Returning information for job: 20250714111342562766
2025-07-14 11:13:42,755 [salt.channel.client:374 ][DEBUG   ][43373] Closing AsyncReqChannel instance
2025-07-14 11:13:42,755 [salt.utils.event :312 ][DEBUG   ][43501] SaltEvent PUB socket URI: /var/run/salt/minion/minion_event_43fd0ec500_pub.ipc
2025-07-14 11:13:42,755 [salt.utils.event :313 ][DEBUG   ][43501] SaltEvent PULL socket URI: /var/run/salt/minion/minion_event_43fd0ec500_pull.ipc
2025-07-14 11:13:42,756 [salt.transport.ipc:361 ][DEBUG   ][43373] Closing IPCMessageSubscriber instance
2025-07-14 11:13:42,757 [salt.utils.parsers:1062][WARNING ][43373] Minion received a SIGTERM. Exiting.
2025-07-14 11:13:42,758 [salt.utils.event :823 ][DEBUG   ][43501] Sending event: tag = __master_req_channel_payload/231a384f-4af6-4751-ab2a-388cea909b21/127.0.0.1; data = {'cmd': '_return', 'id': 'salt-dev1', 'success': True, 'return': True, 'retcode': 0, 'jid': '20250714111342562766', 'fun': 'service.restart', 'fun_args': ['salt-minion', {'__kwarg__': True, 'no_block': True}], 'user': 'sudo_barney', '_stamp': '2025-07-14T11:13:42.758443'}
2025-07-14 11:13:42,757 [salt.cli.daemons :82  ][INFO    ][43373] Shutting down the Salt Minion
2025-07-14 11:14:12,784 [salt.transport.ipc:361 ][DEBUG   ][43501] Closing IPCMessageSubscriber instance
2025-07-14 11:14:12,785 [salt.transport.ipc:361 ][DEBUG   ][43501] Closing IPCMessageClient instance
2025-07-14 11:14:12,785 [salt.utils.process:1004][ERROR   ][43501] An un-handled exception from the multiprocessing process 'ProcessPayload(jid=20250714111342562766)' was caught:
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/process.py", line 999, in wrapped_run_func
    return run_func()
  File "/opt/saltstack/salt/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 1929, in _target
    run_func(minion_instance, opts, data)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 1923, in run_func
    return Minion._thread_return(minion_instance, opts, data)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 2159, in _thread_return
    minion_instance._return_pub(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 2391, in _return_pub
    ret_val = self._send_req_sync(load, timeout=timeout)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 1652, in _send_req_sync
    raise TimeoutError("Request timed out")
TimeoutError: Request timed out
```

### New Behavior
The minion now returns correctly:

```bash
# salt -linfo salt-dev1 service.restart salt-minion no_block=True
salt-dev1:
    True
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with SSH key?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
