### PR TITLE
Systemd service no block handling for salt-minion service

### DIFF
--- a/changelog/68212.fixed.md
+++ b/changelog/68212.fixed.md
@@ -1,0 +1,1 @@
+Modifies systemd_service.{restart,stop} to default to using no_block=True when the service being stopped or restarted is the salt-minion.

--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -51,6 +51,7 @@ VALID_UNIT_TYPES = (
     "path",
     "timer",
 )
+SALT_MINION_SERVICE = "salt-minion.service"
 
 # Define the module's virtual name
 __virtualname__ = "service"
@@ -378,6 +379,26 @@ def _unit_file_changed(name):
     """
     status = _systemctl_status(name)["stdout"].lower()
     return "'systemctl daemon-reload'" in status
+
+
+def _salt_minion_service(name):
+    """
+    Returns True if the service name is the salt-minion service, otherwise
+    returns False.
+    """
+    return _canonical_unit_name(name) == SALT_MINION_SERVICE
+
+
+def _no_block_default(name, no_block):
+    """
+    Return the default value for no_block if it is not set.
+
+    Defaults to True if the service is the salt-minion service, otherwise
+    defaults to False.
+    """
+    if no_block is None:
+        return True if _salt_minion_service(name) else False
+    return no_block
 
 
 def systemctl_reload():
@@ -846,7 +867,7 @@ def start(name, no_block=False, unmask=False, unmask_runtime=False):
     return True
 
 
-def stop(name, no_block=False):
+def stop(name, no_block=None):
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -863,8 +884,15 @@ def stop(name, no_block=False):
 
     no_block : False
         Set to ``True`` to stop the service using ``--no-block``.
+        Defaults to ``True`` for the salt-minion service.
 
         .. versionadded:: 2017.7.0
+
+        .. versionchanged:: 3006.15
+            The default value for this argument has changed if the service is
+            the salt-minion service, where it now defaults to ``True`` to
+            prevent a deadlock with the minion waiting for the service to stop
+            before exiting.
 
     CLI Example:
 
@@ -872,6 +900,7 @@ def stop(name, no_block=False):
 
         salt '*' service.stop <service name>
     """
+    no_block = _no_block_default(name, no_block)
     _check_for_unit_changes(name)
     # Using cmd.run_all instead of cmd.retcode here to make unit tests easier
     return (
@@ -883,7 +912,7 @@ def stop(name, no_block=False):
     )
 
 
-def restart(name, no_block=False, unmask=False, unmask_runtime=False):
+def restart(name, no_block=None, unmask=False, unmask_runtime=False):
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -900,8 +929,15 @@ def restart(name, no_block=False, unmask=False, unmask_runtime=False):
 
     no_block : False
         Set to ``True`` to restart the service using ``--no-block``.
+        Defaults to ``True`` for the salt-minion service.
 
         .. versionadded:: 2017.7.0
+
+        .. versionchanged:: 3006.15
+            The default value for this argument has changed if the service is
+            the salt-minion service, where it now defaults to ``True``
+            to prevent a deadlock with the minion waiting for the service to
+            stop before exiting.
 
     unmask : False
         Set to ``True`` to remove an indefinite mask before attempting to
@@ -925,6 +961,7 @@ def restart(name, no_block=False, unmask=False, unmask_runtime=False):
 
         salt '*' service.restart <service name>
     """
+    no_block = _no_block_default(name, no_block)
     _check_for_unit_changes(name)
     _check_unmask(name, unmask, unmask_runtime)
     ret = __salt__["cmd.run_all"](

--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -862,7 +862,7 @@ def stop(name, no_block=False):
     Stop the specified service with systemd
 
     no_block : False
-        Set to ``True`` to start the service using ``--no-block``.
+        Set to ``True`` to stop the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
 
@@ -899,7 +899,7 @@ def restart(name, no_block=False, unmask=False, unmask_runtime=False):
     Restart the specified service with systemd
 
     no_block : False
-        Set to ``True`` to start the service using ``--no-block``.
+        Set to ``True`` to restart the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
 
@@ -1015,7 +1015,7 @@ def force_reload(name, no_block=True, unmask=False, unmask_runtime=False):
     Force-reload the specified service with systemd
 
     no_block : False
-        Set to ``True`` to start the service using ``--no-block``.
+        Set to ``True`` to force_reload the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
 
@@ -1122,7 +1122,7 @@ def enable(
     Enable the named service to start when the system boots
 
     no_block : False
-        Set to ``True`` to start the service using ``--no-block``.
+        Set to ``True`` to enable the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
 
@@ -1203,7 +1203,7 @@ def disable(
     Disable the named service to not start when the system boots
 
     no_block : False
-        Set to ``True`` to start the service using ``--no-block``.
+        Set to ``True`` to disable the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
 

--- a/tests/pytests/unit/modules/test_systemd_service.py
+++ b/tests/pytests/unit/modules/test_systemd_service.py
@@ -1,0 +1,109 @@
+import pytest
+
+import salt.modules.systemd_service as systemd_service
+import salt.utils.systemd
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.skip_unless_on_linux,
+]
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {systemd_service: {}}
+
+
+@pytest.mark.parametrize(
+    "service_name, expected",
+    [
+        ("salt-minion", True),
+        ("salt-minion.service", True),
+        ("other-service", False),
+    ],
+)
+def test_salt_minion_service(service_name, expected):
+    """
+    Test the _salt_minion_service function to ensure it correctly identifies
+    the salt-minion service name.
+    """
+    assert systemd_service._salt_minion_service(service_name) is expected
+
+
+@pytest.mark.parametrize(
+    "service_name, no_block, expected",
+    [
+        ("salt-minion", None, True),
+        ("other-service", None, False),
+        ("salt-minion", False, False),
+        ("other-service", False, False),
+        ("salt-minion", True, True),
+        ("other-service", True, True),
+    ],
+)
+def test_no_block_default(service_name, no_block, expected):
+    """
+    Test the _no_block_default function to ensure it returns the correct
+    default value for the no_block argument based on the service name.
+    """
+    assert systemd_service._no_block_default(service_name, no_block) is expected
+
+
+@pytest.mark.skipif(not salt.utils.systemd.booted(), reason="Requires systemd")
+@pytest.mark.parametrize(
+    "operation,expected_command",
+    [
+        ("restart", "restart"),
+        ("stop", "stop"),
+    ],
+)
+def test_operation_no_block_default(operation, expected_command):
+    """
+    Test restart/stop functions to ensure they use the correct default value for
+    no_block when operating on the salt-minion service.
+    """
+    mock_none = MagicMock(return_value=None)
+    mock_true = MagicMock(return_value=True)
+    mock_run_all_success = MagicMock(
+        return_value={"retcode": 0, "stdout": "", "stderr": "", "pid": 12345}
+    )
+
+    with patch.dict(
+        systemd_service.__salt__,
+        {"cmd.run_all": mock_run_all_success, "config.get": mock_true},
+    ) as mock_salt, patch.object(
+        systemd_service, "_check_for_unit_changes", mock_none
+    ), patch.object(
+        systemd_service, "_check_unmask", mock_none
+    ), patch(
+        "salt.utils.path.which", lambda x: "/usr/bin/" + x
+    ):
+        # Get the function to test based on the operation parameter
+        operation_func = getattr(systemd_service, operation)
+
+        # Test salt-minion.service (should include --no-block)
+        assert operation_func("salt-minion.service")
+        mock_salt["cmd.run_all"].assert_called_with(
+            [
+                "/usr/bin/systemd-run",
+                "--scope",
+                "/usr/bin/systemctl",
+                "--no-block",
+                expected_command,
+                "salt-minion.service",
+            ],
+            python_shell=False,
+        )
+
+        # Test other.service (should not include --no-block)
+        assert operation_func("other.service")
+        mock_salt["cmd.run_all"].assert_called_with(
+            [
+                "/usr/bin/systemd-run",
+                "--scope",
+                "/usr/bin/systemctl",
+                expected_command,
+                "other.service",
+            ],
+            python_shell=False,
+        )

--- a/tests/pytests/unit/modules/test_systemd_service.py
+++ b/tests/pytests/unit/modules/test_systemd_service.py
@@ -57,11 +57,15 @@ def test_no_block_default(service_name, no_block, expected):
         ("stop", "stop"),
     ],
 )
-def test_operation_no_block_default(operation, expected_command):
+def test_operation_no_block_default(operation, expected_command, grains):
     """
     Test restart/stop functions to ensure they use the correct default value for
     no_block when operating on the salt-minion service.
     """
+
+    if grains["osfinger"] == "Amazon Linux-2":
+        pytest.skip("Amazon Linux 2 CI containers do not support systemd fully")
+
     mock_none = MagicMock(return_value=None)
     mock_true = MagicMock(return_value=True)
     mock_run_all_success = MagicMock(


### PR DESCRIPTION
### What does this PR do?

Modifies `systemd_service.{restart,stop}` to default to using `no_block=True` when the service being stopped or restarted is the salt-minion.

If you don't pass `no_block=True`, the minion blocks waiting for systemd to restart the service, while systemd is waiting for the minion to exit. Eventually, after systemd hits its timeout (defaulting to 90secs) it will kill the salt minion processes.

Behaviour for other services should remain the same and the functions will still honour the value of `no_block` if passed as an argument.

When combined with #68209 this should lead to a much better default behaviour when calling `service.restart` on the salt-minion service.

### Previous Behavior
When calling `service.restart` or `service.stop` on the salt-minion service, you would have to add `no_block=True` otherwise the salt-minion service and system would deadlock until systemd eventually killed the minion processes.

### New Behavior
If called on the salt-minion service, `service.restart` and `service.stop` default to `no_block=True`. For other services, default remains `no_block=False`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with SSH key?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
