### PR TITLE
decrease number of minion key checks

### DIFF
--- a/changelog/68195.fixed.md
+++ b/changelog/68195.fixed.md
@@ -1,0 +1,2 @@
+salt.crypt.AsyncAuth and salt.crypt.SAuth read the private key from the
+filesystem a single time.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1033,6 +1033,9 @@ class AsyncAuth:
         return self._private_key
 
     @salt.utils.decorators.memoize
+    def _gen_token(self, key, token):
+        return private_encrypt(key, token)
+
     def gen_token(self, clear_tok):
         """
         Encrypt a string with the minion private key to verify identity
@@ -1042,7 +1045,7 @@ class AsyncAuth:
         :return: Encrypted token
         :rtype: str
         """
-        return private_encrypt(self.get_keys(), clear_tok)
+        return self._gen_token(self.get_keys(), clear_tok)
 
     def minion_sign_in_payload(self):
         """
@@ -1411,6 +1414,7 @@ class SAuth(AsyncAuth):
         self.token = salt.utils.stringutils.to_bytes(Crypticle.generate_key_string())
         self.pub_path = os.path.join(self.opts["pki_dir"], "minion.pub")
         self.rsa_path = os.path.join(self.opts["pki_dir"], "minion.pem")
+        self._private_key = None
         self._creds = None
         if "syndic_master" in self.opts:
             self.mpub = "syndic_master.pub"

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -613,10 +613,15 @@ class AsyncAuth:
 
     @classmethod
     def __key(cls, opts, io_loop=None):
+        keypath = os.path.join(opts["pki_dir"], "minion.pem")
+        keytime = "0"
+        if os.path.exists(keypath):
+            keytime = str(os.path.getmtime(keypath))
         return (
             opts["pki_dir"],  # where the keys are stored
             opts["id"],  # minion ID
             opts["master_uri"],  # master ID
+            keytime,
         )
 
     # has to remain empty for singletons, since __init__ will *always* be called

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -636,6 +636,7 @@ class AsyncAuth:
         self.token = salt.utils.stringutils.to_bytes(Crypticle.generate_key_string())
         self.pub_path = os.path.join(self.opts["pki_dir"], "minion.pub")
         self.rsa_path = os.path.join(self.opts["pki_dir"], "minion.pem")
+        self._private_key = None
         if self.opts["__role"] == "syndic":
             self.mpub = "syndic_master.pub"
         else:
@@ -1015,22 +1016,23 @@ class AsyncAuth:
         :rtype: Crypto.PublicKey.RSA._RSAobj
         :return: The RSA keypair
         """
-        # Make sure all key parent directories are accessible
-        user = self.opts.get("user", "root")
-        salt.utils.verify.check_path_traversal(self.opts["pki_dir"], user)
+        if self._private_key is None:
+            # Make sure all key parent directories are accessible
+            user = self.opts.get("user", "root")
+            salt.utils.verify.check_path_traversal(self.opts["pki_dir"], user)
 
-        if not os.path.exists(self.rsa_path):
-            log.info("Generating keys: %s", self.opts["pki_dir"])
-            gen_keys(
-                self.opts["pki_dir"],
-                "minion",
-                self.opts["keysize"],
-                self.opts.get("user"),
-            )
-        key = PrivateKey(self.rsa_path, None)
-        log.debug("Loaded minion key: %s", self.rsa_path)
-        return key
+            if not os.path.exists(self.rsa_path):
+                log.info("Generating keys: %s", self.opts["pki_dir"])
+                gen_keys(
+                    self.opts["pki_dir"],
+                    "minion",
+                    self.opts["keysize"],
+                    self.opts.get("user"),
+                )
+            self._private_key = PrivateKey(self.rsa_path, None)
+        return self._private_key
 
+    @salt.utils.decorators.memoize
     def gen_token(self, clear_tok):
         """
         Encrypt a string with the minion private key to verify identity

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import salt.crypt as crypt
@@ -56,12 +58,13 @@ async def test_auth_aes_key_rotation(minion_root, io_loop):
         "acceptance_wait_time": 60,
         "acceptance_wait_time_max": 60,
     }
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
     credskey = (
         opts["pki_dir"],  # where the keys are stored
         opts["id"],  # minion ID
         opts["master_uri"],  # master ID
+        str(os.path.getmtime(os.path.join(opts["pki_dir"], "minion.pem"))),
     )
-    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
 
     aes = crypt.Crypticle.generate_key_string()
     session = crypt.Crypticle.generate_key_string()
@@ -126,11 +129,6 @@ def test_sauth_aes_key_rotation(minion_root, io_loop):
         "acceptance_wait_time": 60,
         "acceptance_wait_time_max": 60,
     }
-    credskey = (
-        opts["pki_dir"],  # where the keys are stored
-        opts["id"],  # minion ID
-        opts["master_uri"],  # master ID
-    )
     crypt.gen_keys(pki_dir, "minion", opts["keysize"])
 
     aes = crypt.Crypticle.generate_key_string()

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -2,6 +2,7 @@ import pytest
 
 import salt.crypt as crypt
 import salt.exceptions
+from tests.support.mock import patch
 
 
 @pytest.fixture
@@ -188,3 +189,46 @@ def test_get_key_with_evict_bad_key(tmp_path):
     key_path.write_text("asdfasoiasdofaoiu0923jnoiausbd98sb9")
     with pytest.raises(salt.exceptions.InvalidKeyError):
         crypt._get_key_with_evict(str(key_path), 1, None)
+
+
+def test_async_auth_cache_private_key(minion_root, io_loop):
+
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+    }
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    # The private key is cached.
+    assert isinstance(auth._private_key, crypt.PrivateKey)
+
+    # get_keys returns the cached instance
+    _id = id(auth._private_key)
+    assert _id == id(auth.get_keys())
+
+
+def test_async_auth_cache_token(minion_root, io_loop):
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+    }
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    with patch("salt.crypt.private_encrypt") as moc:
+        auth.gen_token("salt")
+        auth.gen_token("salt")
+        moc.assert_called_once()


### PR DESCRIPTION
Authentication classes should not read the private key from the filesystem more than one time. This PR caches the private key per auth class instance. We're also memoizing the gen_token method since it can be expensive.

#68195
