### PR TITLE
46255 fix minion.restart

### DIFF
--- a/changelog/46255.fixed.md
+++ b/changelog/46255.fixed.md
@@ -1,0 +1,3 @@
+Fixes issue with the `minion.restart` function not working with systemd. Will
+now detect if the system is using systemd or is a Windows system and use
+`service.restart` instead.

--- a/changelog/68225.added.md
+++ b/changelog/68225.added.md
@@ -1,0 +1,2 @@
+Adds support for creating a scheduled job to restart the minion if the initial
+attempt at restarting it via `minion.restart` has failed.

--- a/salt/modules/minion.py
+++ b/salt/modules/minion.py
@@ -3,14 +3,19 @@ Module to provide information about minions and handle killing and restarting
 minions
 """
 
+import datetime
+import logging
 import os
 import sys
 import time
 
 import salt.key
 import salt.utils.data
+import salt.utils.path
 import salt.utils.systemd
 from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
 
 # Don't shadow built-ins.
 __func_alias__ = {"list_": "list"}
@@ -32,6 +37,75 @@ def _is_windows_system():
     Check if the system is Windows
     """
     return __grains__.get("kernel") == "Windows"
+
+
+def _schedule_retry_systemd(retry_delay):
+    """
+    Schedule a retry for the minion restart on systemd systems
+    """
+    if not _is_systemd_system():
+        return False
+
+    # systemd-run --on-active=180 bash -c "systemctl is-active salt-minion || systemctl start salt-minion"
+    cmd = [
+        salt.utils.path.which("systemd-run"),
+        f"--on-active={retry_delay}",
+        "/bin/sh",
+        "-c",
+        "systemctl is-active salt-minion || systemctl start salt-minion",
+    ]
+
+    out = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if out["retcode"] != 0:
+        raise CommandExecutionError(out["stderr"])
+    return out
+
+
+def _schedule_retry_windows(retry_delay):
+    """
+    Schedule a retry for the minion restart on Windows systems
+    """
+    if not _is_windows_system():
+        return False
+
+    when = datetime.datetime.now() + datetime.timedelta(seconds=retry_delay)
+    cmd = salt.utils.path.which("powershell.exe")
+    args = "-ExecutionPolicy Bypass -NoProfile -WindowStyle Hidden -Command \"if ((Get-Service -Name salt-minion).Status -ne 'Running') { Start-Service -Name salt-minion }\""
+    out = __salt__["task.create_task"](
+        name="retry-minion-restart",
+        user_name="System",
+        force=True,
+        action_type="Execute",
+        cmd=cmd,
+        arguments=args,
+        trigger_type="Once",
+        start_date=when.strftime("%Y-%m-%d"),
+        start_time=when.strftime("%H:%M:%S"),
+    )
+    if not out:
+        raise CommandExecutionError("Failed to add retry task")
+    return out
+
+
+def _schedule_retry(retry_delay):
+    """
+    Schedule a retry for the minion restart
+
+    """
+
+    try:
+        int(retry_delay)
+    except (ValueError, TypeError):
+        raise CommandExecutionError(
+            "Invalid retry_delay value: {}. Must be a number of seconds.".format(
+                retry_delay
+            )
+        )
+    if _is_systemd_system():
+        return _schedule_retry_systemd(retry_delay)
+    elif _is_windows_system():
+        return _schedule_retry_windows(retry_delay)
+    return False
 
 
 def list_():
@@ -156,31 +230,31 @@ def kill(timeout=15):
     return ret
 
 
-def restart(systemd=True, win_service=True):
+def restart(systemd=True, win_service=True, schedule_retry=False, retry_delay=180):
     """
     Restart the salt minion.
 
     The method to restart the minion will be chosen as follows:
 
-    - If ``minion_restart_command`` is set in the minion configuration then
-    the command specified will be used to restart the minion.
+        If ``minion_restart_command`` is set in the minion configuration then
+        the command specified will be used to restart the minion.
 
-    - If the minion is running as a systemd service then the minion will be
-    restarted using the systemd_service module, unless ``systemd`` is
-    set to ``False``
+        If the minion is running as a systemd service then the minion will be
+        restarted using the systemd_service module, unless ``systemd`` is
+        set to ``False``
 
-    - If the minion is running as a Windows service then the minion will be
-    restarted using the win_service module, unless ``win_service`` is
-    set to ``False``
+        If the minion is running as a Windows service then the minion will be
+        restarted using the win_service module, unless ``win_service`` is
+        set to ``False``
 
-    - If the salt-minion process is running in daemon mode (the ``-d``
-    argument is present in ``argv``) then the minion will be killed and
-    restarted using the same command line arguments, if possible.
+        If the salt-minion process is running in daemon mode (the ``-d``
+        argument is present in ``argv``) then the minion will be killed and
+        restarted using the same command line arguments, if possible.
 
-    - If the salt-minion process is running in the foreground (the ``-d``
-    argument is not present in ``argv``) then the minion will be killed but not
-    restarted. This behavior is intended for minion processes that are managed
-    by a process supervisor.
+        If the salt-minion process is running in the foreground (the ``-d``
+        argument is not present in ``argv``) then the minion will be killed but
+        not restarted. This behavior is intended for minion processes that are
+        managed by a process supervisor.
 
     systemd
         If set to ``False`` then systemd will not be used to restart the minion.
@@ -190,7 +264,58 @@ def restart(systemd=True, win_service=True):
         If set to ``False`` then the Windows service manager will not be used to
         restart the minion. Defaults to ``True``.
 
-    CLI Example:
+    schedule_retry
+        If set to ``True`` then a scheduled job will be added to start the
+        minion if it has failed to restart after the retry_delay
+
+    retry_delay
+        The amount of time to wait before attempting to start the minion if it
+        has failed to restart. Defaults to 180 seconds.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt minion[12] minion.restart
+
+        minion1:
+        ----------
+            comment:
+                - Using systemctl to restart salt-minion
+                - Service restart successful
+            killed:
+                None
+            restart:
+                ----------
+            retcode:
+                0
+            service_restart:
+                ----------
+                result:
+                    True
+        minion2:
+            ----------
+            comment:
+                - Using windows service manager to restart salt-minion
+                - Service restart successful
+            killed:
+                None
+            restart:
+                ----------
+            retcode:
+                0
+            service_restart:
+                ----------
+                result:
+                    True
+
+    The result shows that ``minion1`` was restarted using systemd and
+    ``minion2`` was restarted using the Windows service manager. The
+    ``service_restart`` field indicates the result of the service restart
+    operation. The ``killed`` field is ``None`` because the minion was restarted
+    using the service manager and not by killing the process. The ``restart``
+    field is empty because the minion was restarted using the service manager
+    and not by running the command line arguments of the minion process.
 
     .. code-block:: bash
 
@@ -305,21 +430,70 @@ def restart(systemd=True, win_service=True):
 
     if not restart_cmd:
         if systemd and _is_systemd_system():
+            schedule_retry_failed = False
             try:
+                if schedule_retry:
+                    ret["service_restart"]["schedule_retry"] = {}
+
+                    schedule_retry_failed = True
+                    sched = _schedule_retry(retry_delay)
+                    schedule_retry_failed = False
+
+                    ret["service_restart"]["schedule_retry"]["detail"] = sched.get(
+                        "stderr", ""
+                    )
+                    ret["service_restart"]["schedule_retry"]["delay"] = retry_delay
+                    comment.append(
+                        "Scheduled retry for minion restart in {} seconds".format(
+                            retry_delay
+                        )
+                    )
+
                 ret["service_restart"]["result"] = __salt__["service.restart"](
                     "salt-minion", no_block=True
                 )
+                comment.append("Service restart successful")
             except CommandExecutionError as e:
-                comment.append("Service restart failed")
+                comment.append(
+                    "Adding scheduled retry failed"
+                    if schedule_retry_failed
+                    else "Service restart failed"
+                )
                 ret["service_restart"]["result"] = False
                 ret["service_restart"]["stderr"] = str(e)
                 ret["retcode"] = salt.defaults.exitcodes.EX_SOFTWARE
+
         elif win_service and _is_windows_system():
-            ret["service_restart"]["result"] = __salt__["service.restart"](
-                "salt-minion"
-            )
-            if not ret["service_restart"]:
-                comment.append("Service restart failed")
+            schedule_retry_failed = False
+            try:
+                if schedule_retry:
+                    ret["service_restart"]["schedule_retry"] = {}
+
+                    schedule_retry_failed = True
+                    sched = _schedule_retry(retry_delay)
+                    schedule_retry_failed = False
+
+                    ret["service_restart"]["schedule_retry"]["delay"] = retry_delay
+                    comment.append(
+                        "Scheduled retry for minion restart in {} seconds".format(
+                            retry_delay
+                        )
+                    )
+
+                ret["service_restart"]["result"] = __salt__["service.restart"](
+                    "salt-minion"
+                )
+                if not ret["service_restart"]:
+                    raise CommandExecutionError("Failed to restart salt-minion service")
+                comment.append("Service restart successful")
+            except CommandExecutionError as e:
+                comment.append(
+                    "Adding scheduled retry failed"
+                    if schedule_retry_failed
+                    else "Service restart failed"
+                )
+                ret["service_restart"]["result"] = False
+                ret["service_restart"]["stderr"] = str(e)
                 ret["retcode"] = salt.defaults.exitcodes.EX_SOFTWARE
 
     if comment:

--- a/tests/pytests/unit/modules/test_minion.py
+++ b/tests/pytests/unit/modules/test_minion.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 
@@ -91,6 +92,108 @@ def test_is_windows_system():
         assert minion._is_windows_system() is False
 
 
+def test_schedule_retry_systemd():
+    """Test creating a scheduled retry for minion on Linux systems"""
+    with patch("salt.modules.minion._is_systemd_system", return_value=False):
+        assert minion._schedule_retry_systemd(60) is False
+    with patch("salt.modules.minion._is_systemd_system", return_value=True):
+        with patch("salt.utils.path.which", return_value="/usr/bin/systemd-run"):
+
+            mock_cmd_run_all = MagicMock(return_value={"retcode": 0})
+            with patch.dict(minion.__salt__, {"cmd.run_all": mock_cmd_run_all}):
+                assert minion._schedule_retry_systemd(60)
+
+                call_args = mock_cmd_run_all.call_args
+                call_args_cmd = call_args[0][0]
+                assert call_args_cmd[0] == "/usr/bin/systemd-run"
+                assert call_args_cmd[1] == "--on-active=60"
+                assert (
+                    call_args_cmd[-1]
+                    == "systemctl is-active salt-minion || systemctl start salt-minion"
+                )
+
+
+def test_schedule_retry_windows():
+    """Test creating a scheduled retry for minion on Windows systems"""
+
+    with patch("salt.modules.minion._is_windows_system", return_value=False):
+        assert minion._schedule_retry_windows(60) is False
+
+    fixed_time = datetime.datetime(2025, 1, 15, 14, 30, 0)
+    expected_schedule_time = fixed_time + datetime.timedelta(seconds=60)
+
+    with patch("salt.modules.minion._is_windows_system", return_value=True):
+        with patch("salt.modules.minion.datetime") as mock_datetime:
+            mock_datetime.datetime.now.return_value = fixed_time
+            mock_datetime.timedelta = datetime.timedelta
+
+            mock_create_task = MagicMock(return_value=True)
+
+            with patch.dict(minion.__salt__, {"task.create_task": mock_create_task}):
+                assert minion._schedule_retry(60)
+
+                call_args = mock_create_task.call_args
+
+                assert call_args.kwargs[
+                    "start_date"
+                ] == expected_schedule_time.strftime("%Y-%m-%d")
+                assert call_args.kwargs[
+                    "start_time"
+                ] == expected_schedule_time.strftime("%H:%M:%S")
+                assert call_args.kwargs["name"] == "retry-minion-restart"
+
+
+def test_schedule_retry_invalid_delay():
+    """Test _schedule_retry with invalid delay"""
+
+    with pytest.raises(minion.CommandExecutionError):
+        minion._schedule_retry("invalid_delay")
+
+
+@pytest.mark.parametrize(
+    "is_systemd,is_windows,expected_result,systemd_called,windows_called",
+    [
+        (False, False, False, False, False),  # Neither systemd nor windows
+        (True, False, None, True, False),  # Systemd system
+        (False, True, None, False, True),  # Windows system
+    ],
+    ids=["neither", "systemd", "windows"],
+)
+def test_schedule_retry_dispatch(
+    is_systemd, is_windows, expected_result, systemd_called, windows_called
+):
+    """Test _schedule_retry dispatching"""
+
+    mock_schedule_retry_systemd = MagicMock()
+    mock_schedule_retry_windows = MagicMock()
+
+    with patch(
+        "salt.modules.minion._schedule_retry_systemd", mock_schedule_retry_systemd
+    ), patch(
+        "salt.modules.minion._schedule_retry_windows", mock_schedule_retry_windows
+    ), patch(
+        "salt.modules.minion._is_systemd_system", return_value=is_systemd
+    ), patch(
+        "salt.modules.minion._is_windows_system", return_value=is_windows
+    ):
+        result = minion._schedule_retry(60)
+
+        # Check return value for the "neither" case
+        if expected_result is not None:
+            assert result is expected_result
+
+        # Check mock calls
+        if systemd_called:
+            mock_schedule_retry_systemd.assert_called_once_with(60)
+        else:
+            mock_schedule_retry_systemd.assert_not_called()
+
+        if windows_called:
+            mock_schedule_retry_windows.assert_called_once_with(60)
+        else:
+            mock_schedule_retry_windows.assert_not_called()
+
+
 # Tests of minion.restart()
 
 
@@ -144,7 +247,7 @@ def test_minion_restart_service_systems(
     assert_service_restart_called(
         mock_salt_functions,
         expected_service_call["service_name"],
-        **expected_service_call["kwargs"]
+        **expected_service_call["kwargs"],
     )
 
 
@@ -216,3 +319,220 @@ def test_minion_restart_non_service_systems(
             )
         else:
             mock_salt_functions["cmd.run_all"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "is_systemd,is_windows,retry_delay",
+    [
+        (True, False, None),  # systemd with default delay
+        (True, False, 300),  # systemd with custom delay
+        (False, True, None),  # Windows with default delay
+        (False, True, 60),  # Windows with custom delay
+    ],
+)
+def test_minion_restart_with_schedule_retry_success(
+    is_systemd,
+    is_windows,
+    retry_delay,
+    mock_system_detection,
+    mock_salt_functions,
+):
+    """Test minion.restart with schedule_retry enabled - success case"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = is_systemd
+    mock_windows.return_value = is_windows
+
+    # Mock _schedule_retry to return success
+    mock_schedule_retry_result = {"stderr": "success output"}
+    with patch(
+        "salt.modules.minion._schedule_retry", return_value=mock_schedule_retry_result
+    ) as mock_schedule_retry:
+
+        result = (
+            minion.restart(schedule_retry=True, retry_delay=retry_delay)
+            if retry_delay is not None
+            else minion.restart(schedule_retry=True)
+        )
+        retry_delay = retry_delay if retry_delay is not None else 180
+
+        # Verify _schedule_retry was called with correct delay
+        mock_schedule_retry.assert_called_once_with(retry_delay)
+
+        # Verify service.restart was called
+        mock_salt_functions["service.restart"].assert_called_once()
+
+        # Verify return structure contains schedule_retry info
+        assert "service_restart" in result
+        assert "schedule_retry" in result["service_restart"]
+        assert result["service_restart"]["schedule_retry"]["delay"] == retry_delay
+
+        # Check systemd-specific details
+        if is_systemd:
+            assert "detail" in result["service_restart"]["schedule_retry"]
+            assert (
+                result["service_restart"]["schedule_retry"]["detail"]
+                == "success output"
+            )
+
+        # Verify comment mentions the scheduled retry
+        assert "comment" in result
+        expected_comment = (
+            f"Scheduled retry for minion restart in {retry_delay} seconds"
+        )
+        assert expected_comment in result["comment"]
+
+        # Verify successful restart
+        assert result["retcode"] == 0
+
+
+@pytest.mark.parametrize(
+    "is_systemd,is_windows",
+    [
+        (True, False),  # systemd
+        (False, True),  # Windows
+    ],
+)
+def test_minion_restart_with_schedule_retry_failure(
+    is_systemd,
+    is_windows,
+    mock_system_detection,
+    mock_salt_functions,
+):
+    """Test minion.restart with schedule_retry enabled - failure case"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = is_systemd
+    mock_windows.return_value = is_windows
+
+    # Mock _schedule_retry to raise an exception
+    with patch(
+        "salt.modules.minion._schedule_retry",
+        side_effect=minion.CommandExecutionError("Failed to add retry task"),
+    ) as mock_schedule_retry:
+
+        result = minion.restart(schedule_retry=True, retry_delay=120)
+
+        # Verify _schedule_retry was called
+        mock_schedule_retry.assert_called_once_with(120)
+
+        # Verify service.restart was not called after schedule_retry failure
+        mock_salt_functions["service.restart"].assert_not_called()
+
+        # Verify error handling
+        assert result["retcode"] != 0
+        assert "service_restart" in result
+        assert result["service_restart"]["result"] is False
+        assert "stderr" in result["service_restart"]
+        assert "Failed to add retry task" in result["service_restart"]["stderr"]
+
+        # Verify error comment
+        assert "comment" in result
+        assert "Adding scheduled retry failed" in result["comment"]
+
+
+def test_minion_restart_without_schedule_retry(
+    mock_system_detection,
+    mock_salt_functions,
+):
+    """Test minion.restart with schedule_retry disabled (default behavior)"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = True
+    mock_windows.return_value = False
+
+    with patch("salt.modules.minion._schedule_retry") as mock_schedule_retry:
+
+        result = minion.restart(schedule_retry=False)
+
+        # Verify _schedule_retry was not called
+        mock_schedule_retry.assert_not_called()
+
+        # Verify service.restart was called normally
+        mock_salt_functions["service.restart"].assert_called_once()
+
+        # Verify no schedule_retry info in result
+        assert "service_restart" in result
+        assert "schedule_retry" not in result["service_restart"]
+
+        # Verify successful restart
+        assert result["retcode"] == 0
+
+
+@pytest.mark.parametrize(
+    "is_systemd,is_windows",
+    [
+        (True, False),  # systemd
+        (False, True),  # Windows
+    ],
+)
+def test_minion_restart_schedule_retry_service_restart_failure(
+    is_systemd,
+    is_windows,
+    mock_system_detection,
+    mock_salt_functions,
+):
+    """Test minion.restart when schedule_retry succeeds but service.restart fails"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = is_systemd
+    mock_windows.return_value = is_windows
+
+    # Mock successful _schedule_retry
+    mock_schedule_retry_result = {"stderr": "retry scheduled"}
+
+    # Mock service.restart to fail
+    mock_salt_functions["service.restart"].side_effect = minion.CommandExecutionError(
+        "Service restart failed"
+    )
+
+    with patch(
+        "salt.modules.minion._schedule_retry", return_value=mock_schedule_retry_result
+    ) as mock_schedule_retry:
+
+        result = minion.restart(schedule_retry=True, retry_delay=90)
+
+        # Verify _schedule_retry was called successfully
+        mock_schedule_retry.assert_called_once_with(90)
+
+        # Verify service.restart was attempted
+        mock_salt_functions["service.restart"].assert_called_once()
+
+        # Verify schedule_retry info is still in result despite service failure
+        assert "service_restart" in result
+        assert "schedule_retry" in result["service_restart"]
+        assert result["service_restart"]["schedule_retry"]["delay"] == 90
+
+        # Verify service failure is handled
+        assert result["retcode"] != 0
+        assert result["service_restart"]["result"] is False
+        assert "Service restart failed" in result["comment"]
+
+        # Verify schedule retry comment is still present
+        assert "Scheduled retry for minion restart in 90 seconds" in result["comment"]
+
+
+def test_minion_restart_schedule_retry_non_service_system(
+    mock_system_detection,
+    mock_salt_functions,
+    mock_minion_kill,
+):
+    """Test that schedule_retry is ignored on non-service systems"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = False
+    mock_windows.return_value = False
+
+    with patch("salt.modules.minion._schedule_retry") as mock_schedule_retry:
+        with patch.object(sys, "argv", ["/usr/bin/salt-minion"]):
+
+            result = minion.restart(schedule_retry=True, retry_delay=60)
+
+            # Verify _schedule_retry was not called on non-service systems
+            mock_schedule_retry.assert_not_called()
+
+            # Verify kill was called instead
+            mock_minion_kill.assert_called_once()
+
+            # Verify no service_restart info
+            assert "service_restart" not in result or not result["service_restart"]

--- a/tests/pytests/unit/modules/test_minion.py
+++ b/tests/pytests/unit/modules/test_minion.py
@@ -1,0 +1,218 @@
+import os
+import sys
+
+import pytest
+
+import salt.modules.minion as minion
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {minion: {}}
+
+
+# Test command fixtures
+@pytest.fixture
+def sample_restart_command():
+    return ["/bin/some_command", "arg1", "arg2"]
+
+
+@pytest.fixture
+def daemon_argv():
+    return ["/usr/bin/salt-minion", "-d"]
+
+
+@pytest.fixture
+def regular_argv():
+    return ["/usr/bin/salt-minion"]
+
+
+# Helper functions for common assertions
+def assert_service_restart_called(mock_salt_dict, service_name, **kwargs):
+    """Helper to assert service.restart was called with expected args"""
+    mock_salt_dict["service.restart"].assert_called_once_with(service_name, **kwargs)
+
+
+def assert_no_service_calls(mock_service_dict, mock_kill, mock_cmd_dict):
+    """Helper to assert service.restart was not called"""
+    mock_service_dict["service.restart"].assert_not_called()
+    mock_kill.assert_called_once()
+
+
+# Mock fixtures
+@pytest.fixture
+def mock_system_detection():
+    """Mock functions to detect systemd and Windows systems"""
+    with patch("salt.modules.minion._is_systemd_system") as mock_systemd, patch(
+        "salt.modules.minion._is_windows_system"
+    ) as mock_windows:
+        yield mock_systemd, mock_windows
+
+
+@pytest.fixture
+def mock_minion_kill():
+    """Mock the minion.kill function"""
+    ret = {"retcode": 0, "killed": 1234}
+    with patch("salt.modules.minion.kill", return_value=ret) as mock_kill:
+        yield mock_kill
+
+
+@pytest.fixture
+def mock_salt_functions():
+    """Mock salt functions used in minion.restart"""
+    mocks = {
+        "cmd.run_all": MagicMock(),
+        "service.restart": MagicMock(),
+        "config.get": MagicMock(return_value=False),
+    }
+    with patch.dict(minion.__salt__, mocks):
+        yield mocks
+
+
+def test_is_systemd_systemd():
+    """Test if the system is a systemd system"""
+    with patch.dict(minion.__grains__, {"kernel": "Linux"}):
+        with patch("salt.utils.systemd.booted", return_value=True):
+            assert minion._is_systemd_system() is True
+        with patch("salt.utils.systemd.booted", return_value=False):
+            assert minion._is_systemd_system() is False
+
+    with patch.dict(minion.__grains__, {"kernel": "Windows"}):
+        assert minion._is_systemd_system() is False
+
+
+def test_is_windows_system():
+    """Test if the system is a Windows system"""
+    with patch.dict(minion.__grains__, {"kernel": "Windows"}):
+        assert minion._is_windows_system() is True
+
+    with patch.dict(minion.__grains__, {"kernel": "Linux"}):
+        assert minion._is_windows_system() is False
+
+
+# Tests of minion.restart()
+
+
+def test_minion_restart_with_custom_command(
+    mock_minion_kill, mock_salt_functions, sample_restart_command
+):
+    """Test behavior when minion_restart_command is configured"""
+    mock_salt_functions["config.get"].return_value = sample_restart_command
+
+    minion.restart()
+
+    # Should call minion.kill()
+    mock_minion_kill.assert_called_once()
+
+    # Should call cmd.run_all with the custom command
+    mock_salt_functions["cmd.run_all"].assert_called_once_with(
+        sample_restart_command, env=os.environ
+    )
+
+
+@pytest.mark.parametrize(
+    "is_systemd,is_windows,expected_service_call",
+    [
+        (True, False, {"service_name": "salt-minion", "kwargs": {"no_block": True}}),
+        (False, True, {"service_name": "salt-minion", "kwargs": {}}),
+    ],
+)
+def test_minion_restart_service_systems(
+    is_systemd,
+    is_windows,
+    expected_service_call,
+    mock_system_detection,
+    mock_minion_kill,
+    mock_salt_functions,
+):
+    """Test behavior on systemd and Windows systems"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = is_systemd
+    mock_windows.return_value = is_windows
+
+    minion.restart()
+
+    # Should not call minion.kill
+    mock_minion_kill.assert_not_called()
+
+    # Should not call cmd.run_all
+    mock_salt_functions["cmd.run_all"].assert_not_called()
+
+    # Should call service.restart with expected parameters
+    assert_service_restart_called(
+        mock_salt_functions,
+        expected_service_call["service_name"],
+        **expected_service_call["kwargs"]
+    )
+
+
+@pytest.mark.parametrize(
+    "systemd_override,win_service_override",
+    [
+        (False, None),  # systemd=False
+        (None, False),  # win_service=False
+    ],
+)
+def test_minion_restart_service_override(
+    systemd_override,
+    win_service_override,
+    mock_system_detection,
+    mock_minion_kill,
+    mock_salt_functions,
+    regular_argv,
+):
+    """Test behavior when service parameters are explicitly disabled"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = True if systemd_override is not None else False
+    mock_windows.return_value = True if win_service_override is not None else False
+
+    with patch.object(sys, "argv", regular_argv):
+        kwargs = {}
+        if systemd_override is not None:
+            kwargs["systemd"] = systemd_override
+        if win_service_override is not None:
+            kwargs["win_service"] = win_service_override
+
+        minion.restart(**kwargs)
+
+        # Should use minion.kill instead of service.restart when overridden
+        mock_minion_kill.assert_called_once()
+        mock_salt_functions["service.restart"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "argv,should_call_cmd_run",
+    [
+        (["/usr/bin/salt-minion", "-d"], True),
+        (["/usr/bin/salt-minion"], False),
+    ],
+)
+def test_minion_restart_non_service_systems(
+    argv,
+    should_call_cmd_run,
+    mock_system_detection,
+    mock_minion_kill,
+    mock_salt_functions,
+):
+    """Test behavior on non-systemd/Windows systems"""
+
+    mock_systemd, mock_windows = mock_system_detection
+    mock_systemd.return_value = False
+    mock_windows.return_value = False
+
+    with patch.object(sys, "argv", argv):
+        minion.restart()
+
+        # Should always call kill on non systemd/Windows systems and not service.restart
+        mock_minion_kill.assert_called_once()
+        mock_salt_functions["service.restart"].assert_not_called()
+
+        if should_call_cmd_run:
+            mock_salt_functions["cmd.run_all"].assert_called_once_with(
+                argv, env=os.environ
+            )
+        else:
+            mock_salt_functions["cmd.run_all"].assert_not_called()


### PR DESCRIPTION
### What does this PR do?

Adds support to `minion.restart` to detect if the minion is running under systemd or the Windows service manager.  If so, it will use `service.restart` to restart the minion rather than killing and attempting to restart it.

If `minion_restart_command` is set it will follow the old behaviour and use that command to handle the restart.

If `minion_restart_command` isn't set and systemd/windows aren't detected, preserves the old behaviour of looking at `sys.argv` and either just killing the minion process or killing it and attempting to restart the process with the same args if `-d` (for daemon mode) is in `sys.argv`. Whilst I can see that the former option may be useful if running the minion under another process supervisor, I'm not really sure how the killing and starting the a new process could ever work... I've left it in for the moment, but it should maybe be removed in 3008.

### What issues does this PR fix or reference?
Fixes #46255

### Previous Behavior
Calling `minion.restart` on a systemd based system would not work - it would just kill the minion process

### New Behavior
Calling `minion.restart on a systemd based system will now use `service.restart` to restart the minion process. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with SSH?
Yes
<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
