### PR TITLE
modules/aptpkg.py: correct handling of foreign-only-arch packages

### DIFF
--- a/changelog/66940.fixed.md
+++ b/changelog/66940.fixed.md
@@ -1,0 +1,1 @@
+modules.aptpkg: correct handling of foreign-arch packages

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -436,6 +436,7 @@ def parse_arch(name):
 
 
 def latest_version(*names, **kwargs):
+    # pylint: disable=W0640
     """
     .. versionchanged:: 3007.0
 
@@ -471,13 +472,11 @@ def latest_version(*names, **kwargs):
         )
     fromrepo = kwargs.pop("fromrepo", None)
     cache_valid_time = kwargs.pop("cache_valid_time", 0)
+    names = list(names)
 
     if not names:
         return ""
-    ret = {}
-    # Initialize the dict with empty strings
-    for name in names:
-        ret[name] = ""
+    ret = {name: "" for name in names}  # Initialize the dict with empty strings
     pkgs = list_pkgs(versions_as_list=True)
     repo = ["-o", f"APT::Default-Release={fromrepo}"] if fromrepo else None
 
@@ -495,9 +494,16 @@ def latest_version(*names, **kwargs):
 
     candidates = {}
     for line in salt.utils.itertools.split(out["stdout"], "\n"):
-        if line.endswith(":") and line[:-1] in short_names:
-            this_pkg = names[short_names.index(line[:-1])]
-        elif "Candidate" in line:
+        line = line.strip()
+        if line.endswith(":") and not line.startswith("Version table"):
+            if any(
+                [
+                    line[:-1] in names,  # native package
+                    line[:-1].split(":")[0] in short_names,  # foreign package by name
+                ]
+            ):
+                this_pkg = line[:-1]
+        elif line.startswith("Candidate"):
             candidate = ""
             comps = line.split()
             if len(comps) >= 2:
@@ -506,26 +512,48 @@ def latest_version(*names, **kwargs):
                     candidate = ""
             candidates[this_pkg] = candidate
 
-    for name in names:
-        installed = pkgs.get(name, [])
-        if not installed:
-            ret[name] = candidates.get(name, "")
-        elif installed and show_installed:
-            ret[name] = candidates.get(name, "")
-        elif candidates.get(name):
-            # If there are no installed versions that are greater than or equal
-            # to the install candidate, then the candidate is an upgrade, so
-            # add it to the return dict
-            if not any(
-                salt.utils.versions.compare(
-                    ver1=x,
-                    oper=">=",
-                    ver2=candidates.get(name, ""),
-                    cmp_func=version_cmp,
+    _extensions, _pops = [], []
+    while True:
+        for name in names:
+            # no native package found, extend with possible foreign arch ones
+            if name not in candidates:
+                _extensions.extend(
+                    filter(lambda pkg: pkg.startswith(f"{name}:"), candidates)
                 )
-                for x in installed
-            ):
+
+                # since foreign packages are returned only when faced with a lack of
+                # native ones, remove the original package name; this does, however,
+                # risk a case of returning multiple foreign arch packages
+                _pops.append(name)
+
+            # continue with populating entries as usual
+            installed = pkgs.get(name, [])
+            if not installed:
                 ret[name] = candidates.get(name, "")
+            elif installed and show_installed:
+                ret[name] = candidates.get(name, "")
+            elif candidates.get(name):
+                # If there are no installed versions that are greater than or equal
+                # to the install candidate, then the candidate is an upgrade, so
+                # add it to the return dict
+                if not any(
+                    salt.utils.versions.compare(
+                        ver1=x,
+                        oper=">=",
+                        ver2=candidates.get(name, ""),
+                        cmp_func=version_cmp,
+                    )
+                    for x in installed
+                ):
+                    ret[name] = candidates.get(name, "")
+
+        if not any([_extensions, _pops]):
+            break
+
+        names.extend(_extensions)
+        _extensions.clear()
+        list(map(names.remove, _pops))
+        _pops.clear()
 
     # Return a string if only one package name passed
     if len(names) == 1:

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -2328,7 +2328,38 @@ def test_latest_version_calls_aptcache_once_per_run():
     ):
         ret = aptpkg.latest_version("sudo", "unzip", refresh=False)
     mock_apt_cache.assert_called_once()
-    assert ret == {"sudo": "6.0-23+deb10u3", "unzip": ""}
+    assert ret == {"sudo": "1.8.27-1+deb10u5", "unzip": "6.0-23+deb10u3"}
+
+
+def test_latest_version_with_exclusive_foreign_arch_pkg():
+    """
+    Test behavior with foreign architecture packages
+    """
+    _short_name, _foreign_arch = "wine32", "i386"
+    mock_list_pkgs = MagicMock(
+        return_value={
+            _short_name: "10.0~repack-5",
+            f"{_short_name}:{_foreign_arch}": "10.0~repack-6",
+        }
+    )
+    apt_cache_ret = {
+        "stdout": textwrap.dedent(
+            f"""{_short_name}:{_foreign_arch}:
+              Installed: (none)
+              Candidate: 10.0~repack-6
+              Version table:
+                 10.0~repack-6 500
+                    500 http://deb.debian.org/debian testing/main {_foreign_arch} Packages
+            """
+        )
+    }
+    mock_apt_cache = MagicMock(return_value=apt_cache_ret)
+    with patch("salt.modules.aptpkg._call_apt", mock_apt_cache), patch(
+        "salt.modules.aptpkg.list_pkgs", mock_list_pkgs
+    ):
+        ret = aptpkg.latest_version("wine32", refresh=False)
+    mock_apt_cache.assert_called_once()
+    assert ret == "10.0~repack-6"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #66940

### Previous Behavior
Querying foreign-arch-only packages raises `UnboundLocalError` when setting candidate versions in `aptpkg.latest_version()`. This is most notably visible with `wine32`.

### New Behavior
I've currently implemented the bugfix as matching the package short name without architecture specification, but I'm open to other ideas of addressing it.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
