### PR TITLE
Report major&minor version for NixOS

### DIFF
--- a/changelog/68230.fixed.md
+++ b/changelog/68230.fixed.md
@@ -1,0 +1,1 @@
+Made osfinger report major&minor version for NixOS

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2547,7 +2547,7 @@ def _osrelease_data(os, osfullname, osrelease):
         os_name = osfullname
     grains["osfinger"] = "{}-{}".format(
         os_name,
-        osrelease if os in ("Ubuntu", "Pop") else grains["osrelease_info"][0],
+        osrelease if os in ("Ubuntu", "Pop", "NixOS") else grains["osrelease_info"][0],
     )
 
     return grains

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1649,6 +1649,50 @@ def test_openeuler_os_grains():
     _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
+@pytest.mark.skip_unless_on_linux
+def test_nixos_os_grains():
+    """
+    Test that OS grains are parsed correctly for NixOS
+    """
+    # /etc/os-release data taken from NixOS 25.05
+    _os_release_data = {
+        "ANSI_COLOR": "0;38;2;126;186;228",
+        "BUG_REPORT_URL": "https://github.com/NixOS/nixpkgs/issues",
+        "BUILD_ID": "25.05.807313.59e69648d345",
+        "CPE_NAME": "cpe:/o:nixos:nixos:25.05",
+        "DEFAULT_HOSTNAME": "nixos",
+        "DOCUMENTATION_URL": "https://nixos.org/learn.html",
+        "HOME_URL": "https://nixos.org/",
+        "ID": "nixos",
+        "ID_LIKE": "",
+        "IMAGE_ID": "",
+        "IMAGE_VERSION": "",
+        "LOGO": "nix-snowflake",
+        "NAME": "NixOS",
+        "PRETTY_NAME": "NixOS 25.05 (Warbler)",
+        "SUPPORT_END": "2025-12-31",
+        "SUPPORT_URL": "https://nixos.org/community.html",
+        "VARIANT": "",
+        "VARIANT_ID": "",
+        "VENDOR_NAME": "NixOS",
+        "VENDOR_URL": "https://nixos.org/",
+        "VERSION": "25.05 (Warbler)",
+        "VERSION_CODENAME": "warbler",
+        "VERSION_ID": "25.05",
+    }
+    expectation = {
+        "os": "NixOS",
+        "os_family": "NixOS",
+        "oscodename": "warbler",
+        "osfullname": "NixOS",
+        "osrelease": "25.05",
+        "osrelease_info": (25, 5),
+        "osmajorrelease": 25,
+        "osfinger": "NixOS-25.05",
+    }
+    _run_os_grains_tests(_os_release_data, {}, expectation)
+
+
 @pytest.mark.skip_unless_on_windows
 def test_windows_platform_data():
     """


### PR DESCRIPTION
NixOS versions are similar to Ubuntu -- it releases twice a year, and the version numbers are just the year and month of the release. Given that, report the osfinger grain with the full release.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes version reporting on NixOS

### Previous Behavior

`osfinger` reported a version like `NixOS-25`

### New Behavior

`osfinger` reports a version like `NixOS-25.05`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No