### PR TITLE
Enable signing macos packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -284,29 +284,6 @@ jobs:
       - ${{ matrix.arch == 'arm64' && 'macos-14' || 'macos-13' }}
 
     steps:
-      - name: Check Package Signing Enabled
-        shell: bash
-        id: check-pkg-sign
-        run: |
-          if [ "${{ inputs.sign-macos-packages }}" == "true" ]; then
-            if [ "${{ (secrets.MAC_SIGN_APPLE_ACCT != '' && contains(fromJSON('["nightly", "staging"]'), inputs.environment)) && 'true' || 'false' }}" != "true" ]; then
-              MSG="Secrets for signing packages are not available. The packages created will NOT be signed."
-              echo "${MSG}"
-              echo "${MSG}" >> "${GITHUB_STEP_SUMMARY}"
-              echo "sign-pkgs=false" >> "$GITHUB_OUTPUT"
-            else
-              MSG="The packages created WILL be signed."
-              echo "${MSG}"
-              echo "${MSG}" >> "${GITHUB_STEP_SUMMARY}"
-              echo "sign-pkgs=true" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            MSG="The sign-macos-packages input is false. The packages created will NOT be signed."
-            echo "${MSG}"
-            echo "${MSG}" >> "${GITHUB_STEP_SUMMARY}"
-            echo "sign-pkgs=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -331,7 +308,7 @@ jobs:
           path: artifacts/
 
       - name: Prepare Package Signing
-        if: ${{ steps.check-pkg-sign.outputs.sign-pkgs == 'true' }}
+        if: ${{ inputs.sign-macos-packages == 'true' }}
         run: |
           echo ${{ secrets.MAC_SIGN_DEV_APP_CERT_B64 }} | base64 --decode > app-cert.p12
           echo ${{ secrets.MAC_SIGN_DEV_INSTALL_CERT_B64 }} | base64 --decode > install-cert.p12
@@ -363,7 +340,7 @@ jobs:
                 '--onedir salt-{0}-onedir-macos-{1}.tar.xz --salt-version {0} {2}',
                 inputs.salt-version,
                 matrix.arch,
-                steps.check-pkg-sign.outputs.sign-pkgs == 'true' && '--sign' || ''
+                inputs.sign-macos-packages == 'true' && '--sign' || ''
               )
               ||
               format('--salt-version {0}', inputs.salt-version)


### PR DESCRIPTION
### What does this PR do?
Fix some of the logic to get the mac signing to trigger when building macOS packages.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
