### PR TITLE
Improve SL Micro 6.2 detection

### DIFF
--- a/changelog/68247.added.md
+++ b/changelog/68247.added.md
@@ -1,0 +1,1 @@
+Implement SL Micro 6.2 detection to fill the grains with proper values.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2479,6 +2479,18 @@ def _legacy_linux_distribution_data(grains, os_release, lsb_has_error):
         grains["oscodename"] = oscodename
     if "os" not in grains:
         grains["os"] = _derive_os_grain(grains["osfullname"])
+    if "SUSE_SUPPORT_PRODUCT" in os_release and "SUSE_SUPPORT_PRODUCT_VERSION":
+        # It's a workaround for very specific case of SL Micro 6.2
+        # SL Micro 6.2 is different than prevoius ones and identifies itself
+        # as SLES-16, but transactional. This workaround was made to make the grains
+        # of SL Micro 6.2 aligned with the previous versions.
+        grains["oscodename"] = os_release.get(
+            "SUSE_PRETTY_NAME",
+            f"{os_release['SUSE_SUPPORT_PRODUCT']} {os_release['SUSE_SUPPORT_PRODUCT_VERSION']}",
+        )
+        grains["osrelease"] = os_release["SUSE_SUPPORT_PRODUCT_VERSION"]
+        if os_release["SUSE_SUPPORT_PRODUCT"] == "SUSE Linux Micro":
+            grains["osfullname"] = "SL-Micro"
     # this assigns family names based on the os name
     # family defaults to the os name if not found
     grains["os_family"] = _OS_FAMILY_MAP.get(grains["os"], grains["os"])

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -863,6 +863,34 @@ def test_suse_os_grains_tumbleweed():
 
 
 @pytest.mark.skip_unless_on_linux
+def test_suse_os_grains_slmicro62():
+    """
+    Test if OS grains are parsed correctly in SL Micro 6.2
+    """
+    _os_release_data = {
+        "NAME": "SLES",
+        "VERSION": "16.0",
+        "VERSION_ID": "16.0",
+        "PRETTY_NAME": "SUSE Linux Enterprise Server 16.0",
+        "ID": "sles",
+        "ANSI_COLOR": "0;32",
+        "CPE_NAME": "cpe:/o:suse:sles:16:16.0",
+        "SUSE_SUPPORT_PRODUCT": "SUSE Linux Micro",
+        "SUSE_SUPPORT_PRODUCT_VERSION": "6.2",
+        "SUSE_PRETTY_NAME": "SUSE Linux Micro 6.2",
+    }
+    expectation = {
+        "oscodename": "SUSE Linux Micro 6.2",
+        "osfullname": "SL-Micro",
+        "osrelease": "6.2",
+        "osrelease_info": (6, 2),
+        "osmajorrelease": 6,
+        "osfinger": "SL-Micro-6",
+    }
+    _run_suse_os_grains_tests(_os_release_data, {}, expectation)
+
+
+@pytest.mark.skip_unless_on_linux
 def test_debian_9_os_grains():
     """
     Test if OS grains are parsed correctly in Debian 9 "stretch"


### PR DESCRIPTION
### What does this PR do?

`SL Micro 6.2` is detected as `SLES 16` as it's just a different flavor of `SLES 16` the different way as it was with `SL Micro 6.1` and previous versions, and provides the following grains:
```
    os:
        SUSE
    os_family:
        Suse
    osarch:
        x86_64
    oscodename:
        SUSE Linux Enterprise Server 16.0
    osfinger:
        SLES-16
    osfullname:
        SLES
    osmajorrelease:
        16
    osrelease:
        16.0
    osrelease_info:
        - 16
        - 0
```

This PR improves `SL Micro 6.2` detection and provides the following grains instead:
```
    os:
        SUSE
    os_family:
        Suse
    osarch:
        x86_64
    oscodename:
        SUSE Linux Micro 6.2
    osfinger:
        SL-Micro-6
    osfullname:
        SL-Micro
    osmajorrelease:
        6
    osrelease:
        6.2
    osrelease_info:
        - 6
        - 2
```

### What issues does this PR fix or reference?
Tracks: https://github.com/openSUSE/salt/pull/725

### Previous Behavior
`SL Micro 6.2` is detected as `SLES 16`

### New Behavior
The grains are aligned with `SL Micro 6.1`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
