### PR TITLE
Simplify utils.find_json function

### DIFF
--- a/changelog/68258.fixed.md
+++ b/changelog/68258.fixed.md
@@ -1,0 +1,1 @@
+Simplied and sped up `utils.json.find_json` function

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -2,6 +2,7 @@
 Functions to work with JSON
 """
 
+import contextlib
 import json
 import logging
 
@@ -24,66 +25,25 @@ def __split(raw):
     return raw.splitlines()
 
 
-def find_json(raw):
+def find_json(s: str):
+    """Pass in a string and load JSON within it.
+
+    The string may contain non-JSON text before and after the JSON document.
+
+    Raises ValueError if no valid JSON was found.
     """
-    Pass in a raw string and load the json when it starts. This allows for a
-    string to start or end with garbage but the JSON be cleanly loaded
-    """
-    ret = {}
-    lines = __split(raw)
-    lengths = list(map(len, lines))
-    starts = []
-    ends = []
+    decoder = json.JSONDecoder()
 
-    # Search for possible starts and ends of the json fragments
-    for ind, line in enumerate(lines):
-        line = line.lstrip()
-        line = line[0] if line else line
-        if line == "{" or line == "[":
-            starts.append((ind, line))
-        if line == "}" or line == "]":
-            ends.append((ind, line))
+    # We look for the beginning of JSON objects / arrays and let raw_decode() handle
+    # extraneous data at the end.
+    for idx, char in enumerate(s):
+        if char == "{" or char == "[":
+            # JSONDecodeErrors are expected on stray '{'/'[' in the non-JSON part
+            with contextlib.suppress(json.JSONDecodeError):
+                data, _ = decoder.raw_decode(s[idx:])
+                return data
 
-    # List all the possible pairs of starts and ends,
-    # and fill the length of each block to sort by size after
-    starts_ends = []
-    for start, start_char in starts:
-        for end, end_br in reversed(ends):
-            if end > start and (
-                (start_char == "{" and end_br == "}")
-                or (start_char == "[" and end_br == "]")
-            ):
-                starts_ends.append((start, end, sum(lengths[start : end + 1])))
-
-    # Iterate through all the possible pairs starting from the largest
-    starts_ends.sort(key=lambda x: (x[2], x[1] - x[0], x[0]), reverse=True)
-    for start, end, _ in starts_ends:
-        # Try filtering non-JSON text right after the last closing character
-        end_str = lines[end].lstrip()[0]
-        working = "\n".join(lines[start:end]) + end_str
-        try:
-            ret = json.loads(working)
-            return ret
-        except ValueError:
-            continue
-
-    # Fall back to old implementation for backward compatibility
-    # expecting json after the text
-    for ind, _ in enumerate(lines):
-        try:
-            working = "\n".join(lines[ind:])
-        except UnicodeDecodeError:
-            working = "\n".join(salt.utils.data.decode(lines[ind:]))
-
-        try:
-            ret = json.loads(working)
-        except ValueError:
-            continue
-        if ret:
-            return ret
-    if not ret:
-        # Not json, raise an error
-        raise ValueError
+    raise ValueError
 
 
 def import_json():

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -49,6 +49,18 @@ class JSONTestCase(TestCase):
         )
     )
 
+    def test_find_json_unbalanced_brace_in_string(self):
+        test_sample_json = '{"title": "I like curly braces like this one:{"}'
+        expected_ret = {"title": "I like curly braces like this one:{"}
+        ret = salt.utils.json.find_json(test_sample_json)
+        self.assertDictEqual(ret, expected_ret)
+
+    def test_find_json_unbalanced_square_bracket_in_string(self):
+        test_sample_json = '{"title": "I like square brackets like this one:["}'
+        expected_ret = {"title": "I like square brackets like this one:["}
+        ret = salt.utils.json.find_json(test_sample_json)
+        self.assertDictEqual(ret, expected_ret)
+
     def test_find_json(self):
         test_sample_json = """
                             {


### PR DESCRIPTION
### What does this PR do?

Instead of trying to parse all combinations of json blobs to find the largest valid one, track open JSON objects / lists and try to parse them one-by-one, ordered by size.

This approach prioritizes speed over correctness. We don't track strings inside JSON, i.e. strings with odd numbers of opening/closing brackets/braces break the algorithm.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68258

### Previous Behavior

Parsing long JSON strings takes a lot of time.

### New Behavior

Parsing long JSON strings is quick.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
