### PR TITLE
Fix max_depth not respected in file.directory state

### DIFF
--- a/changelog/55306.fixed.md
+++ b/changelog/55306.fixed.md
@@ -1,0 +1,1 @@
+Fixed max_depth not respected in file.directory state

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3528,12 +3528,21 @@ def _depth_limited_walk(top, max_depth=None):
     Walk the directory tree under root up till reaching max_depth.
     With max_depth=None (default), do not limit depth.
     """
+    top_depth = top.rstrip(os.path.sep).count(os.path.sep)
+
     for root, dirs, files in salt.utils.path.os_walk(top):
+        rel_depth = root.rstrip(os.path.sep).count(os.path.sep) - top_depth
+
         if max_depth is not None:
-            rel_depth = root.count(os.path.sep) - top.count(os.path.sep)
             if rel_depth >= max_depth:
-                del dirs[:]
-        yield (str(root), list(dirs), list(files))
+                # This clear does nothing because os_walk returns copies of data from os.walk,
+                # so modifying this list has no effect on recursion.
+                # If os_walk ever returns the "real" dirs list, this will speed up execution
+                # by preventing recursion into directories deeper than max_depth.
+                dirs.clear()
+                continue
+
+        yield (str(root), dirs.copy(), files.copy())
 
 
 def directory(

--- a/tests/pytests/functional/states/file/test_directory.py
+++ b/tests/pytests/functional/states/file/test_directory.py
@@ -86,30 +86,22 @@ def test_directory_max_depth(file, tmp_path):
         return salt.utils.files.normalize_mode(oct(name.stat().st_mode & 0o777))
 
     top = tmp_path / "top_dir"
+    top_file = top / "top_file"
     sub = top / "sub_dir"
+    sub_file = sub / "sub_file"
     subsub = sub / "sub_sub_dir"
+    subsub_file = subsub / "subsub_file"
     dirs = [top, sub, subsub]
+    files = [top_file, sub_file, subsub_file]
 
-    initial_mode = "0111"
+    initial_mode = "0110"
     changed_mode = "0555"
 
-    # Check that we are not just running photon but the kernel matches. This
-    # check should fail if we are in a photon container running on and os other
-    # than photon.
-    if salt.utils.platform.is_photonos() and _kernel_check("photon"):
-        initial_modes = {
-            0: {sub: "0750", subsub: "0110"},
-            1: {sub: "0110", subsub: "0110"},
-            2: {sub: "0110", subsub: "0110"},
-        }
-    else:
-        initial_modes = {
-            0: {sub: "0755", subsub: "0111"},
-            1: {sub: "0111", subsub: "0111"},
-            2: {sub: "0111", subsub: "0111"},
-        }
+    for folder in dirs:
+        folder.mkdir(mode=int(initial_mode, 8))
 
-    subsub.mkdir(mode=int(initial_mode, 8), exist_ok=True, parents=True)
+    for _file in files:
+        _file.touch(mode=int(initial_mode, 8))
 
     for depth in range(3):
         ret = file.directory(
@@ -121,9 +113,12 @@ def test_directory_max_depth(file, tmp_path):
         assert ret.result is True
         for changed_dir in dirs[0 : depth + 1]:
             assert changed_mode == _get_oct_mode(changed_dir)
+        for changed_file in files[0:depth]:
+            assert changed_mode == _get_oct_mode(changed_file)
         for untouched_dir in dirs[depth + 1 :]:
-            _mode = initial_modes[depth][untouched_dir]
-            assert _mode == _get_oct_mode(untouched_dir)
+            assert initial_mode == _get_oct_mode(untouched_dir)
+        for untouched_file in files[depth:]:
+            assert initial_mode == _get_oct_mode(untouched_file)
 
 
 @pytest.mark.skip_on_windows


### PR DESCRIPTION
### What does this PR do?
This fixes the max_depth parameter being ignored when using file.directory state and recursion

### What issues does this PR fix or reference?
Fixes: #55306

### Previous Behavior
Instead of intended behaviour (only modifying sub-directories and/or sub-files to a certain depth level, it modified every single file in the given path recursively.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
