### PR TITLE
Fix incorrect units for recon_default and recon_max in master trouble…

### DIFF
--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -257,10 +257,10 @@ service.
 .. note::
     recon_default:
 
-    The average number of seconds to wait between reconnection attempts.
+    The average number of milliseconds to wait between reconnection attempts.
 
     recon_max:
-       The maximum number of seconds to wait between reconnection attempts.
+       The maximum number of milliseconds to wait between reconnection attempts.
 
     recon_randomize:
         A flag to indicate whether the recon_default value should be randomized.


### PR DESCRIPTION
### What does this PR do?
Fixes incorrect units in the troubleshooting documentation for ```recon_default``` and ```recon_max``.
The documentation lists them as being ```seconds``` when they should be ```milliseconds```.

### What issues does this PR fix or reference?
Fixes #67071

### Merge requirements satisfied?
- [X] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No