### PR TITLE
[3006.x] Docker test fixes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,3 +27,5 @@ urllib3>=2.5.0; python_version >= '3.10'
 
 jaraco.text>=4.0.0
 jaraco.functools>=4.1.0
+
+backports.ssl-match-hostname

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -49,6 +49,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -37,6 +37,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -12,6 +12,10 @@ autocommand==2.2.2
     #   jaraco.text
 babel==2.9.1
     # via sphinx
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -34,6 +34,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -58,6 +58,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -40,6 +40,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -26,6 +26,10 @@ autocommand==2.2.2
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -45,6 +45,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -35,6 +35,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -12,6 +12,10 @@ autocommand==2.2.2
     #   jaraco.text
 babel==2.9.1
     # via sphinx
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -32,6 +32,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -54,6 +54,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -38,6 +38,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -24,6 +24,10 @@ autocommand==2.2.2
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -45,6 +45,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -35,6 +35,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.39.3

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -12,6 +12,10 @@ autocommand==2.2.2
     #   jaraco.text
 babel==2.9.1
     # via sphinx
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 certifi==2024.7.4 ; python_version >= "3.10"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -32,6 +32,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -54,6 +54,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -38,6 +38,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -24,6 +24,10 @@ autocommand==2.2.2
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
 bcrypt==4.1.2
     # via -r requirements/static/ci/common.in
 boto3==1.39.3

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -49,6 +49,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -37,6 +37,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -12,6 +12,10 @@ autocommand==2.2.2
     #   jaraco.text
 babel==2.9.1
     # via sphinx
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -34,6 +34,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -50,6 +50,11 @@ backports.entry-points-selectable==1.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -36,6 +36,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -28,6 +28,10 @@ autocommand==2.2.2
     #   jaraco.text
 backports.entry-points-selectable==1.1.0
     # via virtualenv
+backports.ssl-match-hostname==3.7.0.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
 backports.tarfile==1.2.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -8,6 +8,8 @@ apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -8,6 +8,8 @@ apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2024.7.4 ; python_version >= "3.10"

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -8,6 +8,8 @@ apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 certifi==2024.7.4 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 certifi==2024.7.4 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 certifi==2024.7.4 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 certifi==2024.7.4 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -8,6 +8,8 @@ apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2023.07.22 ; python_version < "3.10"

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2023.07.22 ; python_version < "3.10"

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2023.07.22 ; python_version < "3.10"

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -6,6 +6,8 @@
 #
 autocommand==2.2.2
     # via jaraco.text
+backports.ssl-match-hostname==3.7.0.1
+    # via -r requirements/base.txt
 backports.tarfile==1.2.0
     # via jaraco.context
 certifi==2023.07.22 ; python_version < "3.10"

--- a/salt/ext/tornado/netutil.py
+++ b/salt/ext/tornado/netutil.py
@@ -48,7 +48,9 @@ except ImportError:
 if PY3:
     xrange = range
 
-if hasattr(ssl, 'match_hostname') and hasattr(ssl, 'CertificateError'):  # python 3.2+
+if sys.version_info > (3,12):
+    ssl_match_hostname = SSLCertificateError = None  # type: ignore
+elif hasattr(ssl, 'match_hostname') and hasattr(ssl, 'CertificateError'):  # python 3.2+
     ssl_match_hostname = ssl.match_hostname
     SSLCertificateError = ssl.CertificateError
 elif ssl is None:

--- a/salt/ext/tornado/netutil.py
+++ b/salt/ext/tornado/netutil.py
@@ -48,9 +48,7 @@ except ImportError:
 if PY3:
     xrange = range
 
-if sys.version_info > (3,12):
-    ssl_match_hostname = SSLCertificateError = None  # type: ignore
-elif hasattr(ssl, 'match_hostname') and hasattr(ssl, 'CertificateError'):  # python 3.2+
+if hasattr(ssl, 'match_hostname') and hasattr(ssl, 'CertificateError'):  # python 3.2+
     ssl_match_hostname = ssl.match_hostname
     SSLCertificateError = ssl.CertificateError
 elif ssl is None:

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -2345,7 +2345,8 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
             return {}
         elif f"..{os.sep}" in salt.utils.stringutils.to_unicode(member.path):
             return {}
-    s_pkg.extractall(root)  # nosec
+    # Using nosec below because we've validated the files above.
+    s_pkg.extractall(root, filter="data")  # nosec
     s_pkg.close()
     lowstate_json = os.path.join(root, "lowstate.json")
     with salt.utils.files.fopen(lowstate_json, "r") as fp_:

--- a/salt/state.py
+++ b/salt/state.py
@@ -34,6 +34,7 @@ import salt.syspaths as syspaths
 import salt.utils.args
 import salt.utils.crypt
 import salt.utils.data
+import salt.utils.dateutils
 import salt.utils.decorators.state
 import salt.utils.dictupdate
 import salt.utils.event
@@ -166,9 +167,9 @@ def _calculate_fake_duration():
     Generate a NULL duration for when states do not run
     but we want the results to be consistent.
     """
-    utc_start_time = datetime.datetime.utcnow()
+    utc_start_time = salt.utils.dateutils.utcnow()
     local_start_time = utc_start_time - (
-        datetime.datetime.utcnow() - datetime.datetime.now()
+        salt.utils.dateutils.utcnow() - datetime.datetime.now()
     )
     utc_finish_time = datetime.datetime.utcnow()
     start_time = local_start_time.time().isoformat()

--- a/salt/utils/dateutils.py
+++ b/salt/utils/dateutils.py
@@ -87,3 +87,14 @@ def total_seconds(td):
     method which does not exist in versions of Python < 2.7.
     """
     return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
+
+def utcnow():
+    """
+    Helper method so tests do not have to patch the built-in method.
+    """
+    try:
+        return datetime.datetime.now(datetime.UTC)
+    except AttributeError:
+        # Backwards compatability
+        return datetime.datetime.utcnow()

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -8,15 +8,9 @@ import os
 from calendar import month_abbr as months
 
 import salt.utils.stringutils
+from salt.utils.dateutils import utcnow as _utc_now
 
 LAST_JID_DATETIME = None
-
-
-def _utc_now():
-    """
-    Helper method so tests do not have to patch the built-in method.
-    """
-    return datetime.datetime.utcnow()
 
 
 def gen_jid(opts):

--- a/tests/pytests/unit/modules/state/test_state.py
+++ b/tests/pytests/unit/modules/state/test_state.py
@@ -280,7 +280,7 @@ class MockTarFile:
         return [MockTarFile]
 
     @staticmethod
-    def extractall(data):
+    def extractall(data, *args, **kwargs):
         """
         Mock extractall method
         """


### PR DESCRIPTION
Our python docker container now has 3.13 in which some deprecated functionality has been removed. Make changes needed to account for the differences.
