### PR TITLE
[3007.x] Docker test fixes

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -2345,7 +2345,8 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
             return {}
         elif f"..{os.sep}" in salt.utils.stringutils.to_unicode(member.path):
             return {}
-    s_pkg.extractall(root)  # nosec
+    # Using nosec below because we've validated the files above.
+    s_pkg.extractall(root, filter="data")  # nosec
     s_pkg.close()
     lowstate_json = os.path.join(root, "lowstate.json")
     with salt.utils.files.fopen(lowstate_json, "r") as fp_:

--- a/salt/state.py
+++ b/salt/state.py
@@ -168,9 +168,9 @@ def _calculate_fake_duration():
     Generate a NULL duration for when states do not run
     but we want the results to be consistent.
     """
-    utc_start_time = datetime.datetime.utcnow()
+    utc_start_time = datetime.datetime.now(datetime.UTC)
     local_start_time = utc_start_time - (
-        datetime.datetime.utcnow() - datetime.datetime.now()
+        datetime.datetime.now(datetime.UTC) - datetime.datetime.now()
     )
     utc_finish_time = datetime.datetime.utcnow()
     start_time = local_start_time.time().isoformat()

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -16,7 +16,7 @@ def _utc_now():
     """
     Helper method so tests do not have to patch the built-in method.
     """
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(datetime.UTC)
 
 
 def gen_jid(opts):


### PR DESCRIPTION
Our python docker container now has 3.13 in which some deprecated functionality has been removed. Make changes needed to account for the differences.
