### PR TITLE
3006.x nightly fix

### DIFF
--- a/tests/pytests/functional/modules/test_dockermod.py
+++ b/tests/pytests/functional/modules/test_dockermod.py
@@ -49,7 +49,7 @@ def container(salt_factories, state_tree):
 
     factory = salt_factories.get_container(
         random_string("python-3-"),
-        image_name="ghcr.io/saltstack/salt-ci-containers/python:3",
+        image_name="ghcr.io/saltstack/salt-ci-containers/python:3.10",
         container_run_kwargs={
             "ports": {"8500/tcp": None},
             "entrypoint": "tail -f /dev/null",
@@ -60,6 +60,15 @@ def container(salt_factories, state_tree):
     )
 
     with factory.started():
+        # The dockermod modules determines it's python by running 'python
+        # --version'. There is currently no way to change this. As of August
+        # 2025 our container has a default python of 3.13 wich will cause these
+        # tests to break. Working around this until one of the following
+        # happens; dockermod supports using an alternate python, the containers
+        # are fixed to have the default python correspond to the container
+        # being requested, our codebase supports python 3.13.
+        factory.run("unlink", "/usr/bin/python3")
+        factory.run("ln", "-s", "/usr/bin/python3", "/usr/bin/python3.10")
         yield factory
 
 


### PR DESCRIPTION
The default python interpereter in our containers has changed since
debian 13 has been released. Work around the shortcommings of our
containers and dockermod.