### PR TITLE
More responsive timeout and lock release

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -321,10 +321,7 @@ class AsyncReqChannel:
         :param dict load: A load to send across the wire
         :param int timeout: The number of seconds on a response before failing
         """
-        ret = yield self.transport.send(
-            self._package_load(load),
-            timeout=timeout,
-        )
+        ret = yield self.transport.send(self._package_load(load), timeout=timeout)
 
         raise salt.ext.tornado.gen.Return(ret)
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -861,7 +861,6 @@ class AsyncAuth:
         with the publication port and the shared AES key.
 
         """
-
         auth_timeout = self.opts.get("auth_timeout", None)
         if auth_timeout is not None:
             timeout = auth_timeout

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -657,7 +657,14 @@ class AsyncReqMessageClient:
                             self.close()
                             self.connect()
                             break
-                        yield salt.ext.tornado.gen.sleep(backoff())
+                        try:
+                            yield salt.ext.tornado.gen.with_timeout(
+                                backoff(),
+                                future,
+                                quiet_exceptions=(SaltReqTimeoutError,),
+                            )
+                        except salt.ext.tornado.gen.TimeoutError:
+                            pass
             if not future.done():
                 data = salt.payload.loads(recv)
                 future.set_result(data)

--- a/tests/pytests/functional/states/test_service.py
+++ b/tests/pytests/functional/states/test_service.py
@@ -14,6 +14,7 @@ pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.destructive_test,
     pytest.mark.slow_test,
+    pytest.mark.skip_if_not_root,
 ]
 
 

--- a/tests/pytests/functional/transport/tcp/test_pub_server.py
+++ b/tests/pytests/functional/transport/tcp/test_pub_server.py
@@ -28,7 +28,6 @@ async def test_pub_channel(master_opts, minion_opts, io_loop):
         payloads.append(payload)
 
     def on_recv(message):
-        print("ON RECV")
         publishes.append(message)
 
     thread = threading.Thread(
@@ -43,7 +42,6 @@ async def test_pub_channel(master_opts, minion_opts, io_loop):
     await client.connect(master_opts["publish_port"])
     client.on_recv(on_recv)
 
-    print("Publish message")
     server.publish({"meh": "bah"})
 
     start = time.monotonic()

--- a/tests/pytests/functional/transport/zeromq/test_request_client.py
+++ b/tests/pytests/functional/transport/zeromq/test_request_client.py
@@ -90,19 +90,26 @@ async def test_request_channel_issue_65265(io_loop, request_client, minion_opts,
             """
             ret = None
             with pytest.raises(salt.exceptions.SaltReqTimeoutError):
-                yield request_client.send("foo", timeout=1)
+                yield request_client.send("foo", timeout=3)
             send_complete.set()
             return ret
+
+        # A value of 1 means un-locked, 0 means locked.
+        locked = request_client.message_client.lock._block._value
+        assert locked == 1
 
         start = time.monotonic()
         io_loop.spawn_callback(send_request)
 
+        await salt.ext.tornado.gen.sleep(1.5)
+        locked = request_client.message_client.lock._block._value
+        assert locked == 0
+
         await send_complete.wait()
 
         # Ensure the lock was released when the request timed out.
-
         locked = request_client.message_client.lock._block._value
-        assert locked == 0
+        assert locked == 1
     finally:
         stream.close()
 

--- a/tests/pytests/functional/transport/zeromq/test_request_client.py
+++ b/tests/pytests/functional/transport/zeromq/test_request_client.py
@@ -59,9 +59,6 @@ async def test_request_channel_issue_64627(io_loop, request_client, minion_opts,
 
 
 async def test_request_channel_issue_65265(io_loop, request_client, minion_opts, port):
-    import time
-
-    import salt.ext.tornado.platform
 
     minion_opts["master_uri"] = f"tcp://127.0.0.1:{port}"
 
@@ -93,22 +90,10 @@ async def test_request_channel_issue_65265(io_loop, request_client, minion_opts,
             send_complete.set()
             return ret
 
-        # A value of 1 means un-locked, 0 means locked.
-        locked = request_client.message_client.lock._block._value
-        assert locked == 1
-
-        start = time.monotonic()
         io_loop.spawn_callback(send_request)
-
-        await salt.ext.tornado.gen.sleep(1.5)
-        locked = request_client.message_client.lock._block._value
-        assert locked == 0
 
         await send_complete.wait()
 
-        # Ensure the lock was released when the request timed out.
-        locked = request_client.message_client.lock._block._value
-        assert locked == 1
     finally:
         stream.close()
 

--- a/tests/pytests/functional/transport/zeromq/test_request_client.py
+++ b/tests/pytests/functional/transport/zeromq/test_request_client.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 import pytest
@@ -127,7 +126,7 @@ async def test_request_channel_issue_65265(io_loop, request_client, minion_opts,
     stream = zmq.eventloop.zmqstream.ZMQStream(socket, io_loop=io_loop)
     try:
         stream.on_recv_stream(req_handler)
-        send_complete = asyncio.Event()
+        await salt.ext.tornado.gen.sleep(1)
 
         ret = await request_client.send("foo", timeout=1)
         assert ret == "bar"

--- a/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
+++ b/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
@@ -27,7 +27,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def inotify_test_path(tmp_path_factory):
     test_path = tmp_path_factory.mktemp("inotify-tests")
     try:
@@ -36,7 +36,7 @@ def inotify_test_path(tmp_path_factory):
         shutil.rmtree(str(test_path), ignore_errors=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def setup_beacons(mm_master_1_salt_cli, salt_mm_minion_1, inotify_test_path):
     start_time = time.time()
     try:
@@ -87,9 +87,9 @@ def setup_beacons(mm_master_1_salt_cli, salt_mm_minion_1, inotify_test_path):
 def test_beacons_duplicate_53344(
     event_listener,
     inotify_test_path,
-    salt_mm_minion_1,
     salt_mm_master_1,
     salt_mm_master_2,
+    salt_mm_minion_1,
     setup_beacons,
 ):
     # We have to wait beacon first execution that would configure the inotify watch.

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1672,12 +1672,13 @@ async def test_client_send_recv_on_cancelled_error(minion_opts):
         minion_opts, "tcp://127.0.0.1:4506"
     )
 
+    result_future = MagicMock(**{"done.return_value": True})
     mock_future = MagicMock(**{"done.return_value": True})
 
     try:
         client.socket = AsyncMock()
         client.socket.recv.side_effect = zmq.eventloop.future.CancelledError
-        await client._send_recv({"meh": "bah"}, mock_future)
+        await client._send_recv({"meh": "bah"}, mock_future, result_future)
 
         mock_future.set_exception.assert_not_called()
     finally:
@@ -1689,11 +1690,12 @@ async def test_client_send_recv_on_exception(minion_opts):
         minion_opts, "tcp://127.0.0.1:4506"
     )
 
+    result_future = MagicMock(**{"done.return_value": True})
     mock_future = MagicMock(**{"done.return_value": True})
 
     try:
         client.socket = None
-        await client._send_recv({"meh": "bah"}, mock_future)
+        await client._send_recv({"meh": "bah"}, mock_future, result_future)
 
         mock_future.set_exception.assert_not_called()
     finally:


### PR DESCRIPTION
Fixing lock condition test in test. Make sure the lock release happens as soon as the timeout happens rather than after a potential wait time by waiting on the timeout future instead of a fixed amount of time.

#65265

