### PR TITLE
Fix 66568: Prevent unclosed TCP channels and avoid additional errors

### DIFF
--- a/changelog/66568.fixed.md
+++ b/changelog/66568.fixed.md
@@ -1,0 +1,1 @@
+Fix closing of TCP transport channels and avoid additional errors

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -557,7 +557,9 @@ class AsyncPubChannel:
             yield self.send_id(self.token, self._reconnected)
             self.connected = True
             if self.event:
-                self.event.fire_event({"master": self.opts["master"]}, "__master_connected")
+                self.event.fire_event(
+                    {"master": self.opts["master"]}, "__master_connected"
+                )
             if self._reconnected:
                 # On reconnects, fire a master event to notify that the minion is
                 # available.

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -556,7 +556,8 @@ class AsyncPubChannel:
             # may have been restarted
             yield self.send_id(self.token, self._reconnected)
             self.connected = True
-            self.event.fire_event({"master": self.opts["master"]}, "__master_connected")
+            if self.event:
+                self.event.fire_event({"master": self.opts["master"]}, "__master_connected")
             if self._reconnected:
                 # On reconnects, fire a master event to notify that the minion is
                 # available.

--- a/tests/pytests/functional/transport/server/test_request_server.py
+++ b/tests/pytests/functional/transport/server/test_request_server.py
@@ -44,10 +44,16 @@ async def test_request_server(
     try:
 
         ret = await req_client.send({"req": "test"})
+        if transport == "tcp":
+            assert req_client.task is not None
         assert [reqmsg] == requests
         assert repmsg == ret
     finally:
         req_client.close()
+        if transport == "tcp":
+            # Ensure that issue 68277 is fixed
+            assert req_client.task is None or req_client.task.done()
+            assert req_client._closing
         req_server.close()
 
     # Yield to loop in order to allow background close methods to finish.


### PR DESCRIPTION
### What does this PR do?

Properly close TCP transports to prevent unclosed transport errors as well as task is destroyed but is still pending warnings/errors. I also changed a log line to debug from error to match the same error throughout the file.

### What issues does this PR fix or reference?
Fixes #66568. I'm not 100% sure this fixes all issues with the TCP transport, but it at least gets us a lot closer and prevents tons of errors in Salt 3007.6 for us.

### Previous Behavior
See #66568 for errors.

### New Behavior
Clean highstates with no errors.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [n/a] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated - extended existing test to ensure that asyncio tasks were cleaned up. I tested this without the fix and get an error, so I know it is confirming the fix.

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
