### PR TITLE
Fix lint requirements for 3.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,3 +27,7 @@ urllib3>=2.5.0; python_version >= '3.10'
 
 jaraco.text>=4.0.0
 jaraco.functools>=4.1.0
+timelib>=0.2.5; python_version < '3.11'
+timelib>=0.3.0; python_version >= '3.11'
+frozenlist>=1.3.0; python_version < '3.11'
+frozenlist>=1.5.0; python_version >= '3.11'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -188,9 +188,11 @@ flaky==3.8.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -693,11 +695,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -133,8 +133,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -488,9 +490,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -55,6 +55,10 @@ distro==1.5.0
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -215,6 +219,10 @@ tempora==4.1.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   portend
+timelib==0.3.0 ; python_version < "3.11"
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -132,8 +132,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -478,10 +480,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -190,9 +190,11 @@ filelock==3.0.12
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -669,11 +671,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -141,8 +141,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -521,10 +523,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -123,8 +123,10 @@ filelock==3.8.0
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.3
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -464,9 +466,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -180,9 +180,11 @@ flaky==3.8.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -648,11 +650,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -126,8 +126,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -453,9 +455,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -55,6 +55,10 @@ distro==1.5.0
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -215,6 +219,10 @@ tempora==4.1.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   portend
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -128,8 +128,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -448,10 +450,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 trustme==1.1.0

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -186,9 +186,11 @@ filelock==3.0.12
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -627,11 +629,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -137,8 +137,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -491,10 +493,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tornado==6.1

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -119,8 +119,10 @@ filelock==3.8.0
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.3
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -460,9 +462,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -175,9 +175,11 @@ flaky==3.8.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -643,11 +645,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -122,8 +122,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -449,9 +451,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -51,6 +51,10 @@ distro==1.5.0
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -211,6 +215,10 @@ tempora==4.1.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   portend
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -124,8 +124,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -444,10 +446,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 trustme==1.1.0

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -181,9 +181,11 @@ filelock==3.0.12
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -622,11 +624,11 @@ textfsm==1.1.3
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -133,8 +133,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -487,10 +489,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tornado==6.1

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -115,8 +115,10 @@ filelock==3.8.0
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.3
+frozenlist==1.7.0 ; python_version >= "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -456,9 +458,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.3.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -198,9 +198,11 @@ flaky==3.8.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==0.18.3
@@ -740,11 +742,11 @@ textfsm==1.1.0
     #   napalm
     #   netmiko
     #   ntc-templates
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -139,8 +139,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==0.18.3
@@ -528,9 +530,10 @@ textfsm==1.1.0
     #   napalm
     #   netmiko
     #   ntc-templates
-timelib==0.2.5
+timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -55,6 +55,10 @@ distro==1.5.0
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -219,6 +223,10 @@ tempora==4.1.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   portend
+timelib==0.3.0 ; python_version < "3.11"
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.8.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -138,8 +138,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==0.18.3
@@ -518,10 +520,10 @@ textfsm==1.1.0
     #   napalm
     #   netmiko
     #   ntc-templates
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -191,9 +191,11 @@ filelock==3.0.12
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==0.18.3
@@ -700,11 +702,11 @@ textfsm==1.1.0
     #   napalm
     #   netmiko
     #   ntc-templates
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -142,8 +142,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==0.18.3
@@ -551,10 +553,10 @@ textfsm==1.1.0
     #   napalm
     #   netmiko
     #   ntc-templates
-timelib==0.2.5
+timelib==0.3.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -125,8 +125,10 @@ filelock==3.0.12
     # via virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
-frozenlist==1.3.0
+frozenlist==1.7.0 ; python_version < "3.11"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 future==1.0.0
@@ -468,9 +470,10 @@ tempora==4.1.1
     #   portend
 textfsm==1.1.3
     # via -r requirements/static/ci/common.in
-timelib==0.2.5
+timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/pkg/freebsd.in
+++ b/requirements/static/pkg/freebsd.in
@@ -7,6 +7,5 @@ pyopenssl>=23.2.0
 python-dateutil>=2.8.0
 python-gnupg>=0.4.4
 setproctitle>=1.2.3
-timelib>=0.2.5
 distro>=1.3.0
 importlib-metadata>=3.3.0

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -7,7 +7,6 @@ python-dateutil>=2.8.0
 python-gnupg>=0.4.4
 rpm-vercmp
 setproctitle>=1.2.3
-timelib>=0.2.5
 importlib-metadata>=3.3.0
 cryptography>=42.0.0
 more-itertools>=9.1.0

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -32,6 +32,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -131,8 +133,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/darwin.txt
+timelib==0.2.5 ; python_version < "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/darwin.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -33,6 +33,8 @@ distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+timelib==0.2.5 ; python_version < "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -31,6 +31,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+timelib==0.3.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -33,6 +33,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -134,8 +136,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/windows.txt
+timelib==0.2.5 ; python_version < "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/windows.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -32,6 +32,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -131,8 +133,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/darwin.txt
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/darwin.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -33,6 +33,8 @@ distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+timelib==0.3.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -31,6 +31,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+timelib==0.3.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -33,6 +33,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -134,8 +136,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/windows.txt
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/windows.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -30,6 +30,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -129,8 +131,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/darwin.txt
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/darwin.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -31,6 +31,8 @@ distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -113,8 +115,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+timelib==0.3.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -29,6 +29,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -113,8 +115,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+timelib==0.3.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -31,6 +31,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version >= "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -132,8 +134,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/windows.txt
+timelib==0.3.0 ; python_version >= "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/windows.txt
 urllib3==2.5.0 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -32,6 +32,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -131,8 +133,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/darwin.txt
+timelib==0.2.5 ; python_version < "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/darwin.txt
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -33,6 +33,8 @@ distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+timelib==0.3.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -31,6 +31,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 idna==3.7
     # via requests
 immutables==0.21
@@ -115,8 +117,8 @@ six==1.16.0
     #   python-dateutil
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+timelib==0.3.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -33,6 +33,8 @@ cryptography==42.0.5
     #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
+frozenlist==1.7.0 ; python_version < "3.11"
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.41
@@ -135,8 +137,10 @@ smmap==4.0.0
     # via gitdb
 tempora==4.1.1
     # via portend
-timelib==0.2.5
-    # via -r requirements/windows.txt
+timelib==0.2.5 ; python_version < "3.11"
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/windows.txt
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
### What does this PR do?

Fix requirements for running lint under python 3.11