### PR TITLE
Fix loader handling of sys.modules

### DIFF
--- a/changelog/68281.fixed.md
+++ b/changelog/68281.fixed.md
@@ -1,0 +1,1 @@
+Fixed loader handling of already loaded modules, thereby fixed an interaction between the `x509_v2` state module and any following state having a `prereq` on a `file` state


### PR DESCRIPTION
### What does this PR do?

Makes the LazyLoader reload already loaded modules instead of replacing them.

### What issues does this PR fix or reference?

Fixes: https://github.com/saltstack/salt/issues/68281

### Previous Behavior

Since https://github.com/saltstack/salt/commit/e57901290ec46dfe600fd2e7cd4aa3983875f8cd (https://github.com/saltstack/salt/pull/65032), a new loader always created new modules and overwrote existing ones in `sys.modules`.
This could cause unexpected behavior because parts of the loader code assumed that a cached function in their `_dict` always belongs to the corresponding module in `sys.modules` (details: https://github.com/saltstack/salt/issues/68281#issuecomment-3215827601)

### New Behavior

Modules are reloaded instead of replaced when possible, which aligns with the behavior in 3006.x (I think, please feel free to correct me and let's see what the test suite says).

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes