### PR TITLE
[WIP] cmd state module fixes

### DIFF
--- a/changelog/68298.fixed.md
+++ b/changelog/68298.fixed.md
@@ -1,0 +1,1 @@
+Fix passing arguments between the cmd state and execution modules

--- a/changelog/68301.changed.md
+++ b/changelog/68301.changed.md
@@ -1,0 +1,2 @@
+Expose paramter python_shell to allow disabling shell functionality for the cmd state module.
+Allow passing args to the cmd state module for cmd.run.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2729,17 +2729,23 @@ def script(
         located on the master in the directory named spam, and is called eggs,
         the source string is salt://spam/eggs
 
-    :param str args: String of command line args to pass to the script. Only
-        used if no args are specified as part of the `name` argument. To pass a
-        string containing spaces in YAML, you will need to doubly-quote it.
-        Additionally, if you need to pass falsey values (e.g., "0", "", "False"),
-        you should doubly-quote them to ensure they are correctly interpreted:
+    :param list|str args: List or string of command line args to pass to the script.
+        A list should be preferred to avoid issues with quoting and special
+        characters. To pass a string containing spaces in YAML, you will need to
+        doubly-quote it. Additionally, if you need to pass falsey values
+        (e.g., "0", "", "False"), you should doubly-quote them to ensure they are
+        correctly interpreted:
 
         .. code-block:: bash
 
+            salt myminion cmd.script salt://foo.sh "['arg1','arg two','arg3']"
             salt myminion cmd.script salt://foo.sh "arg1 'arg two' arg3"
             salt myminion cmd.script salt://foo.sh "''0''"
             salt myminion cmd.script salt://foo.sh "''False''"
+
+        .. versionchanged:: 3006.15
+
+            Support a list of command line args.
 
     :param str cwd: The directory from which to execute the command. Defaults
         to the directory returned from Python's tempfile.mkstemp.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2998,7 +2998,7 @@ def script(
     if isinstance(args, (list, tuple)):
         new_cmd = [path, *args] if args else [path]
     else:
-        new_cmd = [path, str(args)] if args else [path]
+        new_cmd = [path, *salt.utils.args.shlex_split(args)] if args else [path]
 
     ret = {}
     try:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -362,6 +362,12 @@ def wait(
     shell
         The shell to use for execution, defaults to /bin/sh
 
+    python_shell
+        Use the shell as the program to execute. Set to False to disable shell
+        features, such as pipes or redirection
+
+        .. versionadded:: 3006.16
+
     env
         A list of environment variables to be set prior to execution.
         Example:
@@ -517,6 +523,12 @@ def wait_script(
     shell
         The shell to use for execution, defaults to the shell grain
 
+    python_shell
+        Use the shell as the program to execute. Set to True to use shell features,
+        such as pipes or redirection
+
+        .. versionadded:: 3006.16
+
     env
         A list of environment variables to be set prior to execution.
         Example:
@@ -651,8 +663,19 @@ def run(
        refer to the :ref:`cmdmod documentation <cmdmod-module>`.
 
     name
-        The command to execute, remember that the command will execute with the
-        path and permissions of the salt-minion.
+        The command or program to execute. When running a program, consider
+        disabling shell features with ``python_shell`` and using ``args`` if required.
+        Otherwise character escaping and quoting needs to be handled manually.
+        Remember that the command will execute with the path and permissions of the
+        salt-minion.
+
+    args
+        List or string of command line args to pass to the executable. A list should
+        be preferred to avoid issues with quoting and special characters. To pass a
+        string containing spaces in YAML, you will need to doubly-quote it: "arg1
+        'arg two' arg3"
+
+        .. versionadded:: 3006.16
 
     cwd
         The current working directory to execute the command in, defaults to
@@ -667,6 +690,12 @@ def run(
 
     shell
         The shell to use for execution, defaults to the shell grain
+
+    python_shell
+        Use the shell as the program to execute. Set to False to disable shell
+        features, such as pipes or redirection
+
+        .. versionadded:: 3006.16
 
     env
         A list of environment variables to be set prior to execution.
@@ -941,6 +970,16 @@ def script(
         Either "cmd arg1 arg2 arg3..." (cmd is not used) or a source
         "salt://...".
 
+    args
+        List or string of command line args to pass to the executable. A list should
+        be preferred to avoid issues with quoting and special characters. To pass a
+        string containing spaces in YAML, you will need to doubly-quote it: "arg1
+        'arg two' arg3"
+
+        .. versionchanged:: 3006.15
+
+            Support a list of command line args.
+
     cwd
         The current working directory to execute the command in, defaults to
         /root
@@ -975,7 +1014,18 @@ def script(
         parameter will be ignored on non-Windows platforms.
 
     shell
-        The shell to use for execution. The default is set in grains['shell']
+        The shell to use for execution. Defaults to the shell grain if python_shell
+        is True. Examples: /bin/sh, cmd.exe
+
+        .. versionchanged:: 3006.16
+
+            Unset by default to run programs without using a shell
+
+    python_shell
+        Use the shell as the program to execute. Set to True to use shell features,
+        such as pipes or redirection
+
+        .. versionadded:: 3006.16
 
     env
         A list of environment variables to be set prior to execution.
@@ -1032,12 +1082,6 @@ def script(
     timeout
         If the command has not terminated after timeout seconds, send the
         subprocess sigterm, and if sigterm is ignored, follow up with sigkill
-
-    args
-        String of command line args to pass to the script.  Only used if no
-        args are specified as part of the `name` argument. To pass a string
-        containing spaces in YAML, you will need to doubly-quote it:  "arg1
-        'arg two' arg3"
 
     creates
         Only run if the file specified by ``creates`` do not exist. If you

--- a/tests/integration/files/file/base/echo.ps1
+++ b/tests/integration/files/file/base/echo.ps1
@@ -1,0 +1,5 @@
+param (
+    [string]$a,
+    [string]$b
+)
+Write-Output "a: $a, b: $b"

--- a/tests/integration/files/file/base/echo.sh
+++ b/tests/integration/files/file/base/echo.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+echo "a: $1, b: $2"


### PR DESCRIPTION
### What does this PR do?

Change the behavior of the cmd state module.

### What issues does this PR fix or reference?

#68156
#68298

### Previous Behavior

- shell functionality was enforced
- no clear separation between the program to be executed and the arguments in `cmd.run`
- integration tests were skipped on Windows
- broken argument processing

### New Behavior

- shell functionality can be changed via the `python_shell` parameter and is disabled by default for `cmd.script` (handled in the execution module)
- `cmd.run` supports the `args` parameter to avoid quoting and escaping issues when running programs
- additional integration tests
- fix argument processing

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No