### PR TITLE
Use the name instead of the description to identify interfaces

### DIFF
--- a/changelog/58138.fixed.md
+++ b/changelog/58138.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue with the win_network salt.util to select interfaces
+by name instead of description.

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -171,11 +171,17 @@ def _get_base_properties(i_face):
 
 
 def _get_ip_base_properties(i_face):
-    ip_properties = i_face.GetIPProperties()
+    ip_properties = i_face.GetIPProperties()  # DNS Properties
+    ipv4_properties = ip_properties.GetIPv4Properties()  # DHCP Properties
     return {
+        # DNS
         "dns_suffix": ip_properties.DnsSuffix,
         "dns_enabled": ip_properties.IsDnsEnabled,
         "dynamic_dns_enabled": ip_properties.IsDynamicDnsEnabled,
+        # DHCP
+        "dhcp_enabled": ipv4_properties.IsDhcpEnabled,
+        "forwarding_enabled": ipv4_properties.IsForwardingEnabled,
+        "wins_enabled": ipv4_properties.UsesWins,
     }
 
 
@@ -348,10 +354,13 @@ def get_interface_info_dot_net_formatted():
     i_faces = {}
     for i_face in interfaces:
         if interfaces[i_face]["status"] == "Up":
-            name = interfaces[i_face]["description"]
-            i_faces.setdefault(name, {}).update(
-                {"hwaddr": interfaces[i_face]["physical_address"], "up": True}
-            )
+            name = i_face
+            i_faces.setdefault(name, {}).update({
+                "description": interfaces[i_face]["description"],
+                "hwaddr": interfaces[i_face]["physical_address"],
+                "up": True,
+                "dhcp_enabled": interfaces[i_face]["dhcp_enabled"],
+            })
             for ip in interfaces[i_face].get("ip_addresses", []):
                 i_faces[name].setdefault("inet", []).append(
                     {

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -355,12 +355,14 @@ def get_interface_info_dot_net_formatted():
     for i_face in interfaces:
         if interfaces[i_face]["status"] == "Up":
             name = i_face
-            i_faces.setdefault(name, {}).update({
-                "description": interfaces[i_face]["description"],
-                "hwaddr": interfaces[i_face]["physical_address"],
-                "up": True,
-                "dhcp_enabled": interfaces[i_face]["dhcp_enabled"],
-            })
+            i_faces.setdefault(name, {}).update(
+                {
+                    "description": interfaces[i_face]["description"],
+                    "hwaddr": interfaces[i_face]["physical_address"],
+                    "up": True,
+                    "dhcp_enabled": interfaces[i_face]["dhcp_enabled"],
+                }
+            )
             for ip in interfaces[i_face].get("ip_addresses", []):
                 i_faces[name].setdefault("inet", []).append(
                     {

--- a/tests/pytests/functional/utils/test_win_network.py
+++ b/tests/pytests/functional/utils/test_win_network.py
@@ -1,0 +1,30 @@
+"""
+Test the win_network util
+"""
+
+import pytest
+
+import salt.utils.win_network as win_network
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+def test__get_ip_base_properties():
+    interfaces = win_network._get_network_interfaces()
+    for interface in interfaces:
+        base_properties = win_network._get_ip_base_properties(interface)
+        assert "dhcp_enabled" in base_properties
+        assert "forwarding_enabled" in base_properties
+        assert "wins_enabled" in base_properties
+
+
+def test_get_interface_info_dot_net_formatted():
+    interfaces = win_network.get_interface_info_dot_net_formatted()
+    for interface in interfaces:
+        assert "description" in interfaces[interface]
+        assert "hwaddr" in interfaces[interface]
+        assert "up" in interfaces[interface]
+        assert "dhcp_enabled" in interfaces[interface]

--- a/tests/pytests/unit/utils/test_win_network.py
+++ b/tests/pytests/unit/utils/test_win_network.py
@@ -48,6 +48,9 @@ def mock_ip_base():
             "dns_enabled": False,
             "dns_suffix": "",
             "dynamic_dns_enabled": False,
+            "dhcp_enabled": False,
+            "forwarding_enabled": False,
+            "wins_enabled": False,
         }
     )
 
@@ -148,9 +151,11 @@ def test_get_interface_info_dot_net(
         "Ethernet": {
             "alias": "Ethernet",
             "description": "Dell GigabitEthernet",
+            "dhcp_enabled": False,
             "dns_enabled": False,
             "dns_suffix": "",
             "dynamic_dns_enabled": False,
+            "forwarding_enabled": False,
             "id": "{C5F468C0-DD5F-4C2B-939F-A411DCB5DE16}",
             "ip_addresses": [
                 {
@@ -200,6 +205,7 @@ def test_get_interface_info_dot_net(
             "receive_only": False,
             "status": "Up",
             "type": "Ethernet",
+            "wins_enabled": False,
         }
     }
 
@@ -233,14 +239,16 @@ def test_get_network_info(
     mock_wins,
 ):
     expected = {
-        "Dell GigabitEthernet": {
+        "Ethernet": {
+            "description": "Dell GigabitEthernet",
+            "dhcp_enabled": False,
             "hwaddr": "02:D5:F1:DD:31:E0",
             "inet": [
                 {
                     "address": "172.18.87.49",
                     "broadcast": "172.18.87.63",
                     "gateway": "192.168.0.1",
-                    "label": "Dell GigabitEthernet",
+                    "label": "Ethernet",
                     "netmask": "255.255.255.240",
                 }
             ],


### PR DESCRIPTION
### What does this PR do?
Uses the interface name as shown in "Advanced network settings" to identify network interfaces on Windows.

### What issues does this PR fix or reference?
Fixes #58138 

### Previous Behavior
The interface description was used, which was usually something long and complicated, and couldn't be changed.

### New Behavior
No uses the actual name as found in the NetworkInformation.NetworkInterfaces library.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
