### PR TITLE
Fix syndic event flood

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -760,4 +760,6 @@ allowed-3rd-party-modules=msgpack,
                           pytestskipmarkers,
                           cryptography,
                           aiohttp,
-                          pytest_timeout
+                          pytest_timeout,
+                          salt,
+                          tests

--- a/changelog/61845.fixed.md
+++ b/changelog/61845.fixed.md
@@ -1,0 +1,1 @@
+Fix event flood by ensuring we do not retry sending the event indefinitely to the Master of Masters.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -5381,6 +5381,22 @@ send events to all connected masters.
 
     syndic_forward_all_events: False
 
+.. conf_master:: syndic_retries
+
+``syndic_retries``
+------------------
+
+.. versionadded:: 3006.16
+
+Default: ``3``
+
+The maximum number of retries for a syndic return attempt to the Master of Masters.
+If multiple Master of Masters listed, it will attempt this number of retries for
+each master in the list.
+
+.. code-block:: yaml
+
+    syndic_retries: 4
 
 .. _peer-publish-settings:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -441,6 +441,8 @@ VALID_OPTS = immutabletypes.freeze(
         "return_retry_timer_max": int,
         # Configures amount of return retries
         "return_retry_tries": int,
+        # Configures amount of retries for Syndic to Master of Masters
+        "syndic_retries": int,
         # Specify one or more returners in which all events will be sent to. Requires that the returners
         # in question have an event_return(event) function!
         "event_return": (list, str),
@@ -1230,6 +1232,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "return_retry_timer": 5,
         "return_retry_timer_max": 10,
         "return_retry_tries": 3,
+        "syndic_retries": 3,
         "random_reauth_delay": 10,
         "winrepo_source_dir": "salt://win/repo-ng/",
         "winrepo_dir": os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, "win", "repo"),

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3,6 +3,7 @@ Routines to set up a minion
 """
 
 import binascii
+import collections
 import contextlib
 import copy
 import functools
@@ -3622,6 +3623,8 @@ class SyndicManager(MinionBase):
         # List of delayed job_rets which was unable to send for some reason and will be resend to
         # any available master
         self.delayed = []
+        # Keep track of retries for Syndics between multiple Master of Masters
+        self.tries = collections.defaultdict(int)
         # Active pub futures: {master_id: (future, [job_ret, ...]), ...}
         self.pub_futures = {}
 
@@ -3758,9 +3761,17 @@ class SyndicManager(MinionBase):
                     )
                     self._mark_master_dead(master)
                     del self.pub_futures[master]
-                    # Add not sent data to the delayed list and try the next master
-                    self.delayed.extend(data)
+                    self.tries[master] += 1
+                    if self.tries[master] < self.opts.get("syndic_retries", 3):
+                        # Add not sent data to the delayed list and try the next master
+                        self.delayed.extend(data)
+                    else:
+                        self.tries = collections.defaultdict(int)
+                        return True
                     continue
+                else:
+                    self.tries = collections.defaultdict(int)
+
             future = getattr(syndic_future.result(), func)(
                 values, "_syndic_return", timeout=self._return_retry_timer(), sync=False
             )

--- a/tests/pytests/unit/syndic/test_syndic.py
+++ b/tests/pytests/unit/syndic/test_syndic.py
@@ -1,0 +1,231 @@
+"""
+Tests for the SyndicManager and Syndic classes in minion.py
+"""
+
+import collections
+
+import salt.exceptions
+import salt.minion
+from tests.support.mock import MagicMock, call
+
+
+def _syndic_manager(opts=None):
+    if not opts:
+        opts = {
+            "conf_file": "conf/minion",
+            "acceptance_wait_time": 10,
+            "acceptance_wait_time_max": 20,
+            "syndic_failover": "ordered",
+            "syndic_retries": 3,
+        }
+    syndic_manager = salt.minion.SyndicManager(opts)
+    syndic_manager._syndics = {
+        "master1": MagicMock(),
+        "master2": MagicMock(),
+    }
+    syndic_manager.pub_futures = {}
+    return syndic_manager
+
+
+def test_forward_events_return_pub_syndic_with_exception(caplog):
+    """
+    Test _return_pub_syndic when an exception is thrown 10 times.
+    """
+    syndic_manager = _syndic_manager()
+    master1, master2 = "master1", "master2"
+    tries = 0
+    for _master in [master1, master2]:
+        syndic_manager._syndics[_master].done.return_value = True
+        syndic_manager._syndics[_master].exception.return_value = False
+
+    syndic_manager.job_rets = {
+        master1: {
+            "salt/job/1234/ret/salt-minion": {
+                "__fun__": "test.ping",
+                "__jid__": "1234",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion"},
+            }
+        },
+        master2: {
+            "salt/job/5678/ret/salt-minion2": {
+                "__fun__": "test.ping",
+                "__jid__": "5678",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion2"},
+            }
+        },
+    }
+    syndic_manager._mark_master_dead = MagicMock()
+    while tries < 10:
+        for _master in [master1, master2]:
+            syndic_manager.pub_futures[_master] = (
+                MagicMock(side_effect=[salt.exceptions.SaltClientTimeout]),
+                [4],
+            )
+
+        syndic_manager._forward_events()
+        tries += 1
+
+    assert caplog.text.count("Unable to call") == 5
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master1)) == 3
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master2)) == 2
+    assert syndic_manager.tries == collections.defaultdict(int)
+    assert syndic_manager._syndics[_master].result()._return_pub_multi.call_count == 1
+
+
+def test_forward_events_return_pub_syndic_with_exception_once(caplog):
+    """
+    Test _return_pub_syndic when an exception is thrown 1 time.
+    """
+    syndic_manager = _syndic_manager()
+    master1, master2 = "master1", "master2"
+    tries = 0
+    for _master in [master1, master2]:
+        syndic_manager._syndics[_master].done.return_value = True
+        syndic_manager._syndics[_master].exception.return_value = False
+        syndic_manager._syndics[
+            _master
+        ].result.return_value.return_pub_multi.return_value = MagicMock()
+    syndic_manager.pub_futures[master1] = (
+        MagicMock(side_effect=[salt.exceptions.SaltClientTimeout]),
+        [4],
+    )
+
+    syndic_manager.job_rets = {
+        master1: {
+            "salt/job/1234/ret/salt-minion": {
+                "__fun__": "test.ping",
+                "__jid__": "1234",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion"},
+            }
+        },
+        master2: {
+            "salt/job/5678/ret/salt-minion2": {
+                "__fun__": "test.ping",
+                "__jid__": "5678",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion2"},
+            }
+        },
+    }
+
+    mock_multi = MagicMock()
+    mock_multi.done.return_value = True
+    mock_multi.exception.return_value = False
+    syndic_manager._mark_master_dead = MagicMock()
+    while tries < 10:
+        if tries >= 1:
+            syndic_manager.pub_futures[master1] = (
+                mock_multi,
+                [4],
+            )
+        syndic_manager._forward_events()
+        tries += 1
+
+    assert caplog.text.count("Unable to call") == 2
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master1)) == 1
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master2)) == 1
+    assert syndic_manager.tries == collections.defaultdict(int)
+    assert syndic_manager._syndics[master1].result()._return_pub_multi.call_count == 2
+    assert syndic_manager._syndics[master2].result()._return_pub_multi.call_count == 1
+
+
+def test_forward_events_return_pub_syndic_exception_syndic_retries_set(caplog):
+    """
+    Test _return_pub_syndic when an exception is thrown 10 times
+    and syndic_retries is set to 5
+    """
+    opts = {
+        "conf_file": "conf/minion",
+        "acceptance_wait_time": 10,
+        "acceptance_wait_time_max": 20,
+        "syndic_failover": "ordered",
+        "syndic_retries": 5,
+    }
+
+    syndic_manager = _syndic_manager(opts)
+    master1, master2 = "master1", "master2"
+    master1, master2 = "master1", "master2"
+    tries = 0
+    for _master in [master1, master2]:
+        syndic_manager._syndics[_master].done.return_value = True
+        syndic_manager._syndics[_master].exception.return_value = False
+
+    syndic_manager.job_rets = {
+        master1: {
+            "salt/job/1234/ret/salt-minion": {
+                "__fun__": "test.ping",
+                "__jid__": "1234",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion"},
+            }
+        },
+        master2: {
+            "salt/job/5678/ret/salt-minion2": {
+                "__fun__": "test.ping",
+                "__jid__": "5678",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion2"},
+            }
+        },
+    }
+    syndic_manager._mark_master_dead = MagicMock()
+    while tries < 10:
+        for _master in [master1, master2]:
+            syndic_manager.pub_futures[_master] = (
+                MagicMock(side_effect=[salt.exceptions.SaltClientTimeout]),
+                [4],
+            )
+
+        syndic_manager._forward_events()
+        tries += 1
+
+    assert caplog.text.count("Unable to call") == 9
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master1)) == 5
+    assert syndic_manager._mark_master_dead.call_args_list.count(call(master2)) == 4
+    assert syndic_manager.tries == collections.defaultdict(int)
+    assert syndic_manager._syndics[_master].result()._return_pub_multi.call_count == 1
+
+
+def test_delayed_queue_prevents_memory_leak():
+    """
+    Test that self.delayed doesn't grow indefinitely when masters repeatedly fail
+    """
+    syndic_manager = _syndic_manager()
+
+    syndic_manager.job_rets = {
+        "master1": {
+            "salt/job/1234/ret/salt-minion": {
+                "__fun__": "test.ping",
+                "__jid__": "1234",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion"},
+            }
+        },
+        "master2": {
+            "salt/job/5678/ret/salt-minion2": {
+                "__fun__": "test.ping",
+                "__jid__": "5678",
+                "__load__": {"cmd": "publish", "tgt": "salt-minion2"},
+            }
+        },
+    }
+
+    syndic_manager._mark_master_dead = MagicMock()
+
+    for master in syndic_manager._syndics:
+        syndic_manager._syndics[master].done.return_value = True
+        syndic_manager._syndics[master].exception.return_value = False
+
+    initial_delayed_size = len(syndic_manager.delayed)
+
+    for cycle in range(10):
+        for master in syndic_manager._syndics:
+            syndic_manager.pub_futures[master] = (
+                MagicMock(side_effect=[salt.exceptions.SaltClientTimeout]),
+                [{"test_data": f"cycle_{cycle}"}],
+            )
+
+        syndic_manager._forward_events()
+
+    # After retry exhaustion, delayed should be cleared (not growing indefinitely)
+    final_delayed_size = len(syndic_manager.delayed)
+
+    assert final_delayed_size <= initial_delayed_size + (
+        3 * len(syndic_manager._syndics)
+    )


### PR DESCRIPTION
### What does this PR do?
Fix event flood by ensuring we do not retry sending the event indefinitely to the Master of Masters. Also the self.delayed dictionary was increasing when it couldn't send the event to the Master of Masters.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/61845

### Previous Behavior
When using syndic architecture and running `salt '*' test.ping` we would see a constant event flood where the syndics would continually retry sending the event back to the Master of Masters. This would continue indefinitely until restarting services, even though the Salt Master does indeed eventually get the event, but just needs time to process the events. This backoff ensures we don't continually flood our master of masters indefinitly. This fix alongside adjusting our `return_retry_timer` and `return_retry_timer_max` settings resolved the issue.

### New Behavior
When running `salt '*' test.ping` we do not see our systems become unusable and the master of masters is able to handle all event returns.

### Merge requirements satisfied?
- [ x ] Docs
- [ x ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ x ] Tests written/updated