### PR TITLE
Update relenv to 0.20.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -433,7 +433,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "onedir"
@@ -450,7 +450,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -466,7 +466,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -483,7 +483,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "onedir"
@@ -504,7 +504,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -451,7 +451,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -468,7 +468,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "onedir"
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -443,7 +443,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -461,7 +461,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "onedir"
@@ -483,7 +483,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.20.5"
+      relenv-version: "0.20.6"
       python-version: "3.10.18"
       ci-python-version: "3.11"
       source: "src"

--- a/changelog/68311.fixed.md
+++ b/changelog/68311.fixed.md
@@ -1,0 +1,1 @@
+Revert change to store cargo home as a temporary directory

--- a/changelog/68317.fixed.md
+++ b/changelog/68317.fixed.md
@@ -1,0 +1,1 @@
+Update openssl FIPS provider to 3.1.2 (certified until 2030)

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.18"
-relenv_version: "0.20.5"
+relenv_version: "0.20.6"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04


### PR DESCRIPTION
### What does this PR do?

- Upgrade relenv to 0.20.6
- Fixes #68311 by reverting cargo home location
- Fixes #68317 upgrade openssl fips provider to 3.1.2