### PR TITLE
fix `datetime.utcnow` deprecation

### DIFF
--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -16,7 +16,7 @@ def _utc_now():
     """
     Helper method so tests do not have to patch the built-in method.
     """
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(datetime.UTC)
 
 
 def gen_jid(opts):


### PR DESCRIPTION
Fixes the deprecation warning:

> `/usr/lib/python3.13/site-packages/salt/utils/jid.py:19`: DeprecationWarning: `datetime.datetime.utcnow()` is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: `datetime.datetime.now(datetime.UTC)`.

Apologies, I ignored the template because this is very minor.

Untested.

Related: https://github.com/saltstack/salt/pull/67943