### PR TITLE
Prepare salt.utils.process for python 3.14

### DIFF
--- a/changelog/68148.changed.md
+++ b/changelog/68148.changed.md
@@ -1,1 +1,2 @@
 Update packaged python from 3.10 to 3.11
+Fix multiprocessing handling for python 3.14

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -237,12 +237,16 @@ def is_aarch64():
 
 def spawning_platform():
     """
-    Returns True if multiprocessing.get_start_method(allow_none=False) returns "spawn"
+    Returns True if multiprocessing.get_start_method(allow_none=False) != "fork"
+    ("spawn" or "forkserver")
 
     This is the default for Windows Python >= 3.4 and macOS on Python >= 3.8.
     Salt, however, will force macOS to spawning by default on all python versions
+    Starting with Python 3.14, Linux also defaults to not "fork", but it uses
+    (new) "forkserver" instead of "spawn". Functionally, it's very similar as
+    far as Salt is concerned (process state is not inherited).
     """
-    return multiprocessing.get_start_method(allow_none=False) == "spawn"
+    return multiprocessing.get_start_method(allow_none=False) != "fork"
 
 
 def get_machine_identifier():


### PR DESCRIPTION
### What does this PR do?
Python 3.14 changed multiprocessing method from 'fork' to 'forkserver' on Linux too:
https://github.com/python/cpython/issues/84559

This leads to issue similar to when Python 3.8 changed it on Mac OS: https://github.com/saltstack/salt/issues/57742

Change the condition to check for != 'fork' instead of == 'spawn'.

**Question**: should `salt.util.platform.spawning_platform()` be changed instead? `forkserver` isn't exactly the same as `spawn`, but it's more similar to it than to `fork`.

### What issues does this PR fix or reference?
Related to https://github.com/saltstack/salt/issues/68148

### Previous Behavior
Fails similar to https://github.com/saltstack/salt/issues/57742 on Linux with Python 3.14 (Fedora 43 beta)

### New Behavior
Doesn't crash anymore

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
