### PR TITLE
Strip CRLF from headers before parsing

### DIFF
--- a/changelog/68328.fixed.md
+++ b/changelog/68328.fixed.md
@@ -1,0 +1,1 @@
+Fixed cp.cache_file when using Tornado > 6.4

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -237,6 +237,28 @@ def test_setstate(file_client, mocked_opts):
     assert file_client.opts == mocked_opts
 
 
+@pytest.mark.parametrize(
+    "header,result",
+    [
+        ("HTTP/1.1 200 OK\r\n", True),
+        ("HTTP/1.1 200 OK\n\n", True),
+        ("HTTP/1.1 200 OK", True),
+        ("HTTP/1.1 200", None),
+        ("HTT/1.1 200 OK\r\n", None),
+        ("HTT/1.1 200 OK", None),
+    ],
+)
+def test_on_header(file_client, header, result):
+    """
+    Test that on_header function works with HTTP headers
+    with or without the trailing whitespace.
+    """
+    write_body = [None, False, None, None]
+
+    file_client._on_header(header, write_body, False, False)
+    assert write_body[0] == result
+
+
 def test_get_url_with_hash(client_opts):
     """
     Test get_url function with a URL containing a hash character.


### PR DESCRIPTION
### What does this PR do?

After Tornado 6.4, 6.5 and later break compatibility in the `parse_response_start_line`, which no longer accepts CRLF. See [0] for more information.

This change ensures that fileclient tests (and functionality) do not break when you decide to upgrade Tornado :).

[0] https://github.com/tornadoweb/tornado/pull/3540

### What issues does this PR fix or reference?

### Previous Behavior
Fileclient download functionality (used e.g. in `cp.cache_file`) is broken with Tornado > 6.4.

### New Behavior
Fileclient download functionality works with Tornado > 6.4.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
