### PR TITLE
Remove ensurepip from packages

### DIFF
--- a/pkg/common/env-cleanup-rules.yml
+++ b/pkg/common/env-cleanup-rules.yml
@@ -5,8 +5,9 @@ common:
     - "**/site-packages/ansible/plugins/test/**"
   dir_patterns: &common_dir_patterns
     - "**/__pycache__"
-    - "**/lib/python3.*/test"
+    - "**/lib/python3.*/ensurepip"
     - "**/lib/python3.*/idlelib"
+    - "**/lib/python3.*/test"
     - "**/lib/python3.*/tkinter"
     - "**/lib/python3.*/turtledemo"
     - "**/site-packages/test"
@@ -46,6 +47,7 @@ ci:
     dir_patterns: &ci_windows_dir_patterns
       - *common_dir_patterns
       - "**/artifacts/salt/configs"
+      - "**/lib/ensurepip"
       - "**/site-packages/adodbapi"
       - "**/site-packages/isapi"
       - "**/site-packages/pythonwin"


### PR DESCRIPTION
### What does this PR do?
Removes ensurepip from packages. Pip is already installed in the Salt Relenv environment, so ensurepip is no longer needed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
