### PR TITLE
[3006.x] Use "sys executable" on "test_return_retries::test_pillar_timeout" test

### DIFF
--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 import pytest
@@ -62,14 +63,12 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 @pytest.mark.slow_test
 @pytest.mark.timeout_unless_on_windows(180)
 def test_pillar_timeout(salt_master_factory, tmp_path):
-    cmd = 'print(\'{"foo": "bar"}\');\n'
-
     with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
-        fp.write(cmd)
+        fp.write('print(\'{"foo": "bar"}\');\n')
 
     master_overrides = {
         "ext_pillar": [
-            {"cmd_json": f"python {tmp_path / 'script.py'}"},
+            {"cmd_json": f"{sys.executable} {tmp_path / 'script.py'}"},
         ],
         "auto_accept": True,
         "worker_threads": 2,
@@ -122,9 +121,8 @@ def test_pillar_timeout(salt_master_factory, tmp_path):
     with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), (
         sls_tempfile
     ):
-        cmd = 'import time; time.sleep(6); print(\'{"foo": "bang"}\');\n'
         with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
-            fp.write(cmd)
+            fp.write('import time; time.sleep(6); print(\'{"foo": "bang"}\');\n')
         proc = cli.run("state.sls", sls_name, minion_tgt="*")
         # At least one minion should have a Pillar timeout
         assert proc.returncode == 1


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue on `test_return_retries::test_pillar_timeout` on systems that does not have `python` binary but instead uses `python3`, `python311` or any form for the Python CLI. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
