### PR TITLE
Fix broken runner mine on some masters.

### DIFF
--- a/changelog/68188.fixed.md
+++ b/changelog/68188.fixed.md
@@ -1,0 +1,1 @@
+fixes salt runner mine.get not returning value if allow_tgt is defined in mine function

--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -18,7 +18,7 @@ def get(tgt, fun, tgt_type="glob"):
     """
     masterapi = salt.daemons.masterapi.RemoteFuncs(__opts__)
     load = {
-        "id": __opts__["id"],
+        "id": __opts__["id"].removesuffix("_master"),
         "fun": fun,
         "tgt": tgt,
         "tgt_type": tgt_type,

--- a/tests/pytests/integration/runners/test_mine.py
+++ b/tests/pytests/integration/runners/test_mine.py
@@ -1,0 +1,77 @@
+"""
+integration tests for the mine runner
+"""
+
+import pytest
+
+import salt.config
+import salt.runners.mine as mine_runner
+from tests.support.mock import patch
+
+
+@pytest.fixture(scope="module")
+def mine(runners):
+    return runners.mine
+
+
+@pytest.fixture(scope="module")
+def minion_opts():
+    return salt.config.minion_config(None)
+
+
+@pytest.fixture(scope="module")
+def pillar_tree(salt_master, salt_call_cli, salt_run_cli, salt_minion):
+    top_file = """
+    base:
+      '*':
+        - mine
+    """
+
+    mine_file = """
+    mine_functions:
+      test_fun:
+        mine_function: cmd.run
+        cmd: 'echo hello test'
+      test_no_allow:
+        mine_function: cmd.run
+        cmd: 'echo hello no allow'
+    """
+
+    top_tempfile = salt_master.pillar_tree.base.temp_file("top.sls", top_file)
+    mine_tempfile = salt_master.pillar_tree.base.temp_file("mine.sls", mine_file)
+    try:
+        with top_tempfile, mine_tempfile:
+            ret = salt_call_cli.run("saltutil.refresh_pillar", wait=True)
+            assert ret.returncode == 0
+            assert ret.data is True
+            ret = salt_run_cli.run("mine.update", salt_minion.id)
+            assert ret.returncode == 0
+            ret = salt_call_cli.run("pillar.items")
+            assert ret.returncode == 0
+            yield
+    finally:
+        ret = salt_call_cli.run("saltutil.refresh_pillar", wait=True)
+        assert ret.returncode == 0
+        assert ret.data is True
+        ret = salt_run_cli.run("mine.update", salt_minion.id)
+        assert ret.returncode == 0
+
+
+@pytest.mark.usefixtures("pillar_tree")
+def test_allow_tgt(salt_run_cli, salt_minion, minion_opts):
+    tgt = salt_minion.id
+    fun = "test_fun"
+    with patch("salt.runners.mine.__opts__", minion_opts, create=True):
+        ret = mine_runner.get(tgt, fun)
+
+    ret = salt_run_cli.run("mine.get", tgt, fun)
+    assert ret.data == {salt_minion.id: "hello test"}
+
+
+@pytest.mark.usefixtures("pillar_tree")
+def test_no_allow_tgt(salt_run_cli, salt_minion):
+    tgt = salt_minion.id
+    fun = "test_no_allow"
+
+    ret = salt_run_cli.run("mine.get", tgt, fun)
+    assert ret.data == {salt_minion.id: "hello no allow"}

--- a/tests/pytests/integration/runners/test_mine.py
+++ b/tests/pytests/integration/runners/test_mine.py
@@ -9,6 +9,7 @@ import pytest
 def salt_minion_id():
     return "test-mine"
 
+
 @pytest.fixture(scope="session")
 def master_id():
     master_id = "test-mine"


### PR DESCRIPTION
### What does this PR do?
when allow_tgt is used as a runner mine.get argument, it now works

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68188

### Previous Behavior
Allow_tgt argument in runner mine.get would cause it to return no data

### New Behavior


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
