### PR TITLE
Add persist_home to user.present

### DIFF
--- a/changelog/68322.fixed.md
+++ b/changelog/68322.fixed.md
@@ -1,0 +1,1 @@
+Fixed user.present not having capability to persist home directory by adding persist_home flag.

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -294,6 +294,7 @@ def present(
     remove_groups=True,
     home=None,
     createhome=True,
+    persist_home=False,
     password=None,
     hash_password=False,
     enforce_password=True,
@@ -392,6 +393,10 @@ def present(
 
             Additionally, parent directories will *not* be created. The parent
             directory for ``home`` must already exist.
+
+    persist_home : False
+        If set to ``True`` and not on Windows or Darwin, move contents of the
+        home directory to the new location
 
     nologinit : False
         If set to ``True``, it will not add the user to lastlog and faillog
@@ -716,7 +721,7 @@ def present(
             if __grains__["kernel"] in ("Darwin", "Windows"):
                 __salt__["user.chhome"](name, val)
             else:
-                __salt__["user.chhome"](name, val, persist=False)
+                __salt__["user.chhome"](name, val, persist=persist_home)
 
         _homedir_changed = False
         if "home" in changes:

--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -314,6 +314,27 @@ def test_user_present_home_directory_created(modules, states, username, createho
     assert pathlib.Path(user_info["home"]).is_dir() is createhome
 
 
+@pytest.mark.skip_on_windows(reason="windows minion does not support persist_home")
+@pytest.mark.skip_on_darwin(reason="Mac minion does not support persist_home")
+@pytest.mark.parametrize("persist_home", [True, False])
+def test_user_present_home_directory_persisted(
+    modules, states, existing_account, user_home, persist_home
+):
+    """
+    It ensures that the home directory is persisted when home changed.
+    """
+    pathlib.Path(existing_account.info.home, "testfile").touch()
+    ret = states.user.present(
+        name=existing_account.username, home=str(user_home), persist_home=persist_home
+    )
+    assert ret.result is True
+
+    user_info = modules.user.info(existing_account.info.name)
+    assert user_info
+
+    assert pathlib.Path(user_info["home"], "testfile").is_file() is persist_home
+
+
 @pytest.mark.skip_on_darwin(reason="groups/gid not fully supported")
 @pytest.mark.skip_on_windows(reason="groups/gid not fully supported")
 def test_user_present_change_gid_but_keep_group(


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #68322 

### Previous Behavior
No capability to preserve the existing home directory of the user when changing the home location.

### New Behavior
persist_home flag can be set to True to move the existing home directory to the new location

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
