### PR TITLE
fix(debian-ip): include all mapped options as valid options

### DIFF
--- a/changelog/58210.fixed.md
+++ b/changelog/58210.fixed.md
@@ -1,0 +1,1 @@
+Render post/pre up/down and hwaddr options for debian-ip. See #58210 and #57820.

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -12,12 +12,13 @@
   } -%}
 {% set concat_opts = ['dns_nameservers'] -%}
 {% set valid_opts = [
-  'autoconf', 'privext', 'dhcp', 'hwaddress', 'vlan_raw_device', 'address', 'addresses', 'netmask',
+  'autoconf', 'privext', 'dhcp', 'hwaddress', 'hwaddr', 'vlan_raw_device', 'address', 'addresses', 'netmask',
   'metric', 'gateway', 'pointopoint', 'scope', 'hostname', 'media', 'leasehours', 'leasetime',
   'vendor', 'client', 'bootfile', 'server', 'mode', 'endpoint', 'dstaddr', 'local', 'ttl', 'mtu',
   'provider', 'unit', 'options', 'master', 'dns_nameservers', 'wireless_mode', 'wpa_ap_scan',
   'wpa_conf', 'wpa_driver', 'wpa_group', 'wpa_key_mgmt', 'wpa_pairwise', 'wpa_proto', 'wpa_psk',
-  'wpa_roam', 'wpa_ssid', 'accept_ra'
+  'wpa_roam', 'wpa_ssid', 'accept_ra', 'up_cmds', 'down_cmds', 'pre_up_cmds', 'post_up_cmds',
+  'pre_down_cmds', 'post_down_cmds'
   ] -%}
 {% if data.enabled %}auto {{ name }}
 {% endif %}{% if data.hotplug %}allow-hotplug {{ name }}


### PR DESCRIPTION
### What does this PR do?

For debian-ip, not all options get rendered in the final `interfaces` file.

The valid_opts list must be a superset of the keys of the optmap map for the mappted options to get rendered.

This commit adds the missing options to the valid_opts list.

### What issues does this PR fix or reference?
Fixes #58210 and #57820.

### Previous Behavior
Given
```
    enp0sbeef:
        ----------
        network:
            |_
              ----------
              enabled:
                  True
            |_
              ----------
              type:
                  eth
            |_
              ----------
              proto:
                  static
            |_
              ----------
              ipaddr:
                  10.0.0.25/24
            |_
              ----------
              post_up_cmds:
                  - echo "hi"
```

`/etc/network/interfaces`
```
    auto enp0sbeef
    iface enp0sbeef inet static
        address 10.0.0.25/24
```

### New Behavior
Given
```
    enp0sbeef:
        ----------
        network:
            |_
              ----------
              enabled:
                  True
            |_
              ----------
              type:
                  eth
            |_
              ----------
              proto:
                  static
            |_
              ----------
              ipaddr:
                  10.0.0.25/24
            |_
              ----------
              post_up_cmds:
                  - echo "hi"
```

`/etc/network/interfaces`
```
    auto enp0sbeef
    iface enp0sbeef inet static
        address 10.0.0.25/24
        post-up echo "hi"
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated
  - Added in the 3006.x support branch #68359 

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
