### PR TITLE
Missing debian ip options

### DIFF
--- a/changelog/58210.fixed.md
+++ b/changelog/58210.fixed.md
@@ -1,0 +1,1 @@
+Render post/pre up/down and hwaddr options for debian-ip. See #58210 and #57820.

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -12,12 +12,13 @@
   } -%}
 {% set concat_opts = ['dns_nameservers'] -%}
 {% set valid_opts = [
-  'autoconf', 'privext', 'dhcp', 'hwaddress', 'vlan_raw_device', 'address', 'addresses', 'netmask',
+  'autoconf', 'privext', 'dhcp', 'hwaddress', 'hwaddr', 'vlan_raw_device', 'address', 'addresses', 'netmask',
   'metric', 'gateway', 'pointopoint', 'scope', 'hostname', 'media', 'leasehours', 'leasetime',
   'vendor', 'client', 'bootfile', 'server', 'mode', 'endpoint', 'dstaddr', 'local', 'ttl', 'mtu',
   'provider', 'unit', 'options', 'master', 'dns_nameservers', 'wireless_mode', 'wpa_ap_scan',
   'wpa_conf', 'wpa_driver', 'wpa_group', 'wpa_key_mgmt', 'wpa_pairwise', 'wpa_proto', 'wpa_psk',
-  'wpa_roam', 'wpa_ssid', 'accept_ra'
+  'wpa_roam', 'wpa_ssid', 'accept_ra', 'up_cmds', 'down_cmds', 'pre_up_cmds', 'post_up_cmds',
+  'pre_down_cmds', 'post_down_cmds'
   ] -%}
 {% if data.enabled %}auto {{ name }}
 {% endif %}{% if data.hotplug %}allow-hotplug {{ name }}

--- a/tests/pytests/unit/modules/test_debian_ip.py
+++ b/tests/pytests/unit/modules/test_debian_ip.py
@@ -845,6 +845,61 @@ def test_interfaces():
                 '    gateway 2001:db8:dead:beef::1\n',
                 '    accept_ra 2\n',
                 '\n']},
+
+        # Command hooks
+        {'iface_name': 'eth_optmap_test', 'iface_type': 'eth', 'enabled': True,
+            'build_interface': {
+                'proto': 'manual',
+                'up_cmds': ['echo "interface up"'],
+                'down_cmds': ['echo "interface down"'],
+                'pre_up_cmds': ['echo "pre-up"'],
+                'post_up_cmds': ['echo "post-up"'],
+                'pre_down_cmds': ['echo "pre-down"'],
+                'post_down_cmds': ['echo "post-down"'],
+                },
+            'get_interface': odict([('eth_optmap_test', odict([('enabled', True), ('data', odict([
+                ('inet', odict([
+                    ('addrfam', 'inet'),
+                    ('proto', 'manual'),
+                    ('filename', None),
+                    ('up_cmds', ['echo "interface up"']),
+                    ('down_cmds', ['echo "interface down"']),
+                    ('pre_up_cmds', ['echo "pre-up"']),
+                    ('post_up_cmds', ['echo "post-up"']),
+                    ('pre_down_cmds', ['echo "pre-down"']),
+                    ('post_down_cmds', ['echo "post-down"']),
+                    ])),
+                ]))]))]),
+            'return': [
+                'auto eth_optmap_test\n',
+                'iface eth_optmap_test inet manual\n',
+                '    up echo "interface up"\n',
+                '    down echo "interface down"\n',
+                '    pre-up echo "pre-up"\n',
+                '    post-up echo "post-up"\n',
+                '    pre-down echo "pre-down"\n',
+                '    post-down echo "post-down"\n',
+                '\n']},
+
+        # hwaddr should map to hwaddress
+        {'iface_name': 'eth_hwaddr_test', 'iface_type': 'eth', 'enabled': True,
+            'build_interface': {
+                'proto': 'manual',
+                'hwaddr': '00:11:22:33:44:55',
+                },
+            'get_interface': odict([('eth_hwaddr_test', odict([('enabled', True), ('data', odict([
+                ('inet', odict([
+                    ('addrfam', 'inet'),
+                    ('proto', 'manual'),
+                    ('filename', None),
+                    ('hwaddress', '00:11:22:33:44:55'),
+                    ])),
+                ]))]))]),
+            'return': [
+                'auto eth_hwaddr_test\n',
+                'iface eth_hwaddr_test inet manual\n',
+                '    hwaddress 00:11:22:33:44:55\n',
+                '\n']},
         ]
 # fmt: on
 


### PR DESCRIPTION
### What does this PR do?

For debian-ip, not all options get rendered in the final `interfaces` file.

The valid_opts list must be a superset of the keys of the optmap map for the mappted options to get rendered.

This commit adds the missing options to the valid_opts list.

### What issues does this PR fix or reference?
Fixes #58210 and #57820.

### Previous Behavior
Given
```
    enp0sbeef:
        ----------
        network:
            |_
              ----------
              enabled:
                  True
            |_
              ----------
              type:
                  eth
            |_
              ----------
              proto:
                  static
            |_
              ----------
              ipaddr:
                  10.0.0.25/24
            |_
              ----------
              post_up_cmds:
                  - echo "hi"
```

`/etc/network/interfaces`
```
    auto enp0sbeef
    iface enp0sbeef inet static
        address 10.0.0.25/24
```

### New Behavior
Given
```
    enp0sbeef:
        ----------
        network:
            |_
              ----------
              enabled:
                  True
            |_
              ----------
              type:
                  eth
            |_
              ----------
              proto:
                  static
            |_
              ----------
              ipaddr:
                  10.0.0.25/24
            |_
              ----------
              post_up_cmds:
                  - echo "hi"
```

`/etc/network/interfaces`
```
    auto enp0sbeef
    iface enp0sbeef inet static
        address 10.0.0.25/24
        post-up echo "hi"
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
