### PR TITLE
[3006.x] Allow libgit2 to guess sysdir homedir successfully

### DIFF
--- a/changelog/64121.fixed.md
+++ b/changelog/64121.fixed.md
@@ -1,0 +1,1 @@
+Prevent `_pygit2.GitError: error loading known_hosts` with certain pygit2/libgit2 versions.

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -119,6 +119,15 @@ try:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
+        if "HOME" not in os.environ:
+            # Make sure $HOME env variable is set before importing pygit2 to prevent
+            # _pygit2.GitError: error loading known_hosts in some libgit2 versions.
+            # The internal "git_sysdir__dirs" from libgit2, is initializated
+            # when importing pygit2. The $HOME env must be present to allow libgit2
+            # guessing function to successfully set the homedir in the initializated
+            # libgit2 stack.
+            # https://github.com/saltstack/salt/issues/64121
+            os.environ["HOME"] = os.path.expanduser("~")
         import pygit2
     PYGIT2_VERSION = Version(pygit2.__version__)
     LIBGIT2_VERSION = Version(pygit2.LIBGIT2_VERSION)
@@ -2012,13 +2021,9 @@ class Pygit2(GitProvider):
         """
         # https://github.com/libgit2/pygit2/issues/339
         # https://github.com/libgit2/libgit2/issues/2122
-        # https://github.com/saltstack/salt/issues/64121
-        home = os.path.expanduser("~")
-        if "HOME" not in os.environ:
-            # Make sure $HOME env variable is set to prevent
-            # _pygit2.GitError: error loading known_hosts in some libgit2 versions.
-            os.environ["HOME"] = home
-        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
+        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = (
+            os.path.expanduser("~")
+        )
         new = False
         if not os.listdir(self._cachedir):
             # Repo cachedir is empty, initialize a new repo there

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import time
 
@@ -264,8 +265,6 @@ def test_checkout_pygit2_with_home_env_unset(_prepare_provider):
     provider.credentials = None
     with patched_environ(__cleanup__=["HOME"]):
         assert "HOME" not in os.environ
-        import importlib
-
         importlib.reload(salt.utils.gitfs)
         assert "HOME" in os.environ
 

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -264,7 +264,9 @@ def test_checkout_pygit2_with_home_env_unset(_prepare_provider):
     provider.credentials = None
     with patched_environ(__cleanup__=["HOME"]):
         assert "HOME" not in os.environ
-        provider.init_remote()
+        import importlib
+
+        importlib.reload(salt.utils.gitfs)
         assert "HOME" in os.environ
 
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the generic error that is still seen around gitfs with certain `pygit2` and `libgit2` versions:

```
_pygit2.GitError: error loading known_hosts:
```

After debugging `libgit2` and `pygit2` I was able to understand what's going on here. The internal `git_sysdir__dirs` struct is populated during `libgit2` initialization, which is only triggered at the time of importing `pygit2` module.

If the `HOME` environment variable is not defined when importing `pygit2`, then the internal guess function from `libgit2` to determine the homedir (`git_sysdir_guess_home_dirs`) fails to define the HOME path for the initializated stack. Therefore the above error occurs.

Also once `pygit2/libgit2` is instantiated, there is no way until `pygit2` version 1.18.2 to explicitely redefine the internal home dir on the initializated stack, as `GIT_OPT_SET_HOMEDIR` wasn't implemented in `pygit2` until 1.18.2. See https://github.com/libgit2/pygit2/pull/1409

So, this PR makes sure the `HOME` env variable is present at the time of importing `pygit2` at `salt.utils.gitfs`.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/64121

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
