### PR TITLE
fix various bugs in list_present

### DIFF
--- a/changelog/31427.fixed.md
+++ b/changelog/31427.fixed.md
@@ -1,3 +1,3 @@
-Fixed an issue with how existing entries are tracked in grains.list\_present. Previous entries were only considered if
-the grain previously exited. If not then the state would not "see" the duplicates. Removed the dubious tracking via
+Fixed an issue with how existing entries are tracked in grains.list_present. Previous entries were only considered if
+the grain previously existed. If not then the state would not "see" the duplicates. Removed the dubious tracking via
 "context" and focused on using checking for existance in the live grains.

--- a/changelog/31427.fixed.md
+++ b/changelog/31427.fixed.md
@@ -1,0 +1,3 @@
+Fixed an issue with how existing entries are tracked in grains.list\_present. Previous entries were only considered if
+the grain previously exited. If not then the state would not "see" the duplicates. Removed the dubious tracking via
+"context" and focused on using checking for existance in the live grains.

--- a/changelog/39875.fixed.md
+++ b/changelog/39875.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue with complex objects in grains.list\_present. Original fix #52710 did not fully address the problem.

--- a/changelog/39875.fixed.md
+++ b/changelog/39875.fixed.md
@@ -1,1 +1,1 @@
-Fixed issue with complex objects in grains.list\_present. Original fix #52710 did not fully address the problem.
+Fixed issue with complex objects in grains.list_present. Original fix #52710 did not fully address the problem.


### PR DESCRIPTION
fixes #31427
fixes #39875 (previous solution was incomplete)

Trying to convert the list and sub-objects into a set caused various issues when checking for existance. Use a proper loop and `in` checks to provide a more correct behavior.

### What does this PR do?

Fixes some bugs in the grains.list_present state. Some potential performance is lost (no measurements or benchmarks made) in favor of correctness. Out of the newly added test the previous implementation only "passed" the "test_list_present_multiple_calls_present_as_list" test. New implementation passes all the new tests.


### What issues does this PR fix or reference?
fixes #31427
fixes #39875 (previous solution was incomplete)

### Previous Behavior
1. Duplicates could have been added when using the list_present state
2. Crashes could have occurred when complex objects were used

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs - I don't think any new docs are needed?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
