### PR TITLE
Symlink#66939

### DIFF
--- a/changelog/66939.fixed.md
+++ b/changelog/66939.fixed.md
@@ -1,1 +1,1 @@
-When file.symlink is ran, and the cmd_check is used as an argument, the state fails. This fixes that
+Fixes file.symlink failure when passing cmd_check

--- a/changelog/66939.fixed.md
+++ b/changelog/66939.fixed.md
@@ -1,0 +1,1 @@
+When file.symlink is ran, and the cmd_check is used as an argument, the state fails. This fixes that

--- a/salt/state.py
+++ b/salt/state.py
@@ -1231,26 +1231,34 @@ class State:
         cmd_opts = {}
         if "shell" in self.opts["grains"]:
             cmd_opts["shell"] = self.opts["grains"].get("shell")
-        for entry in low_data["check_cmd"]:
+        if isinstance(low_data["check_cmd"], list):
+            for entry in low_data["check_cmd"]:
+                cmd = self.functions["cmd.retcode"](
+                    entry, ignore_retcode=True, python_shell=True, **cmd_opts
+                )
+        else:
             cmd = self.functions["cmd.retcode"](
-                entry, ignore_retcode=True, python_shell=True, **cmd_opts
+                low_data["check_cmd"],
+                ignore_retcode=True,
+                python_shell=True,
+                **cmd_opts,
             )
-            log.debug("Last command return code: %s", cmd)
-            if cmd == 0 and ret["result"] is False:
-                ret.update(
-                    {
-                        "comment": "check_cmd determined the state succeeded",
-                        "result": True,
-                    }
-                )
-            elif cmd != 0:
-                ret.update(
-                    {
-                        "comment": "check_cmd determined the state failed",
-                        "result": False,
-                    }
-                )
-                return ret
+        log.debug("Last command return code: %s", cmd)
+        if cmd == 0 and ret["result"] is False:
+            ret.update(
+                {
+                    "comment": "check_cmd determined the state succeeded",
+                    "result": True,
+                }
+            )
+        elif cmd != 0:
+            ret.update(
+                {
+                    "comment": "check_cmd determined the state failed",
+                    "result": False,
+                }
+            )
+            return ret
         return ret
 
     def _run_check_creates(self, low_data):

--- a/tests/pytests/integration/modules/test_file.py
+++ b/tests/pytests/integration/modules/test_file.py
@@ -275,7 +275,7 @@ def test_create_symlink_with_check_cmd_list(salt_call_cli, salt_master, tmp_path
         - makedirs: true
         - check_cmd: 
           - grep 'jaguar' {symlink_file}
-          - grep 'j' {synlink_file}
+          - grep 'j' {symlink_file}
     """
 
     sls_tempfile = salt_master.state_tree.base.temp_file(

--- a/tests/pytests/integration/modules/test_file.py
+++ b/tests/pytests/integration/modules/test_file.py
@@ -240,7 +240,7 @@ def test_create_symlink_with_check_cmd(salt_call_cli, salt_master, tmp_path):
         ret = salt_call_cli.run("state.apply", "test_symlink")
         symlink_path = Path(f"{name}/testing")
         assert symlink_path.exists()
-        assert symlink_path.read_text() == "jaguar"
+        assert symlink_path.read_text(encoding="utf-8") == "jaguar"
         assert symlink_path.is_symlink()
         expected_comment = "check_cmd determined the state succeeded"
         assert expected_comment in ret.stdout

--- a/tests/pytests/integration/modules/test_file.py
+++ b/tests/pytests/integration/modules/test_file.py
@@ -6,6 +6,8 @@ import os
 
 import pytest
 
+import salt.utils.win_dacl
+
 
 @pytest.mark.parametrize("verify_ssl", [True, False])
 @pytest.mark.slow_test
@@ -197,3 +199,50 @@ def test_check_file_meta_verify_ssl(
         )
     else:
         assert "SSL: CERTIFICATE_VERIFY_FAILED" in ret.stderr
+
+
+IS_WINDOWS = salt.utils.platform.is_windows()
+
+
+@pytest.mark.slow_test
+def test_create_symlink_with_check_cmd(salt_call_cli, salt_master, tmp_path):
+    """
+    file.symlink test to make sure chk_command runs before
+    creating the symlink
+    """
+    name = tmp_path / "test-symlink"
+    name.mkdir()
+    if IS_WINDOWS:
+        principal = salt.utils.win_functions.get_current_user()
+        salt.utils.win_dacl.set_owner(obj_name=str(name), principal=principal)
+        salt.utils.win_dacl.set_inheritance(obj_name=str(name), enabled=True)
+    symlink_file = name / "symlink"
+    symlink_file.write_text("jaguar")
+
+    assert symlink_file.exists()
+    assert symlink_file.is_file()
+
+    assert name.exists()
+    assert name.is_dir()
+
+    sls_contents = """
+    {name}/testing:
+      file.symlink:
+        - target: {symlink_file}
+        - user: cbert
+        - group: staff
+        - makedirs: true
+        - check_cmd: grep 'jaguar' {symlink_file}
+    """.format(
+        name=name, symlink_file=symlink_file
+    )
+    sls_tempfile = salt_master.state_tree.base.temp_file(
+        "test_symlink.sls", sls_contents
+    )
+
+    with sls_tempfile:
+        ret = salt_call_cli.run("state.apply", "test_symlink")
+        assert symlink_file.exists()
+        assert symlink_file.read_text() == "jaguar"
+        expected_comment = "check_cmd determined the state succeeded"
+        assert expected_comment in ret.stdout

--- a/tests/pytests/integration/modules/test_file.py
+++ b/tests/pytests/integration/modules/test_file.py
@@ -5,7 +5,6 @@ Tests for the file state
 import os
 
 import pytest
-
 import salt.utils.win_dacl
 from pathlib import Path
 

--- a/tests/pytests/integration/modules/test_file.py
+++ b/tests/pytests/integration/modules/test_file.py
@@ -273,7 +273,9 @@ def test_create_symlink_with_check_cmd_list(salt_call_cli, salt_master, tmp_path
         - user: cbert
         - group: staff
         - makedirs: true
-        - check_cmd: ["grep 'jaguar' {symlink_file}", grep "j" {symlink_file}]
+        - check_cmd: 
+          - grep 'jaguar' {symlink_file}
+          - grep 'j' {synlink_file}
     """
 
     sls_tempfile = salt_master.state_tree.base.temp_file(


### PR DESCRIPTION
### What does this PR do?
fixes cmd_check being used as an argument when running a state file with file.symlink in it.  before it would always fail

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/66939

### Previous Behavior
if cmd_check was added as an argument to file.symlink, it would always fail

### New Behavior
Now it doesn't fail

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
