### PR TITLE
Wean off tornado.gen.coroutine

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -189,12 +189,11 @@ class AsyncReqChannel:
             ret["sig_algo"] = self.opts["signing_algorithm"]
         return ret
 
-    @tornado.gen.coroutine
-    def _send_with_retry(self, load, tries, timeout):
+    async def _send_with_retry(self, load, tries, timeout):
         _try = 1
         while True:
             try:
-                ret = yield self.transport.send(
+                ret = await self.transport.send(
                     load,
                     timeout=timeout,
                 )
@@ -206,10 +205,9 @@ class AsyncReqChannel:
                 else:
                     _try += 1
                     continue
-        raise tornado.gen.Return(ret)
+        return ret
 
-    @tornado.gen.coroutine
-    def crypted_transfer_decode_dictentry(
+    async def crypted_transfer_decode_dictentry(
         self,
         load,
         dictkey=None,
@@ -221,10 +219,10 @@ class AsyncReqChannel:
         if tries is None:
             tries = self.tries
         if not self.auth.authenticated:
-            yield self.auth.authenticate()
+            await self.auth.authenticate()
 
         nonce = uuid.uuid4().hex
-        ret = yield self._send_with_retry(
+        ret = await self._send_with_retry(
             self._package_load(load, nonce),
             tries,
             timeout,
@@ -232,8 +230,8 @@ class AsyncReqChannel:
         key = self.auth.get_keys()
         if not isinstance(ret, dict) or "key" not in ret:
             # Reauth in the case our key is deleted on the master side.
-            yield self.auth.authenticate()
-            ret = yield self._send_with_retry(
+            await self.auth.authenticate()
+            ret = await self._send_with_retry(
                 self._package_load(load, nonce),
                 tries,
                 timeout,
@@ -247,7 +245,7 @@ class AsyncReqChannel:
         # Validate the master's signature.
         if not self.verify_signature(signed_msg["data"], signed_msg["sig"]):
             # Try to reauth on error
-            yield self.auth.authenticate()
+            await self.auth.authenticate()
             if not self.verify_signature(signed_msg["data"], signed_msg["sig"]):
                 raise salt.crypt.AuthenticationError(
                     "Pillar payload signature failed to validate."
@@ -261,15 +259,14 @@ class AsyncReqChannel:
         # Validate the nonce.
         if data["nonce"] != nonce:
             raise salt.crypt.AuthenticationError("Pillar nonce verification failed.")
-        raise tornado.gen.Return(data["pillar"])
+        return data["pillar"]
 
     def verify_signature(self, data, sig):
         return salt.crypt.PublicKey.from_file(self.master_pubkey_path).verify(
             data, sig, self.opts["signing_algorithm"]
         )
 
-    @tornado.gen.coroutine
-    def _crypted_transfer(self, load, timeout, raw=False):
+    async def _crypted_transfer(self, load, timeout, raw=False):
         """
         Send a load across the wire, with encryption
 
@@ -283,11 +280,10 @@ class AsyncReqChannel:
         :param int timeout: The number of seconds on a response before failing
         """
 
-        @tornado.gen.coroutine
-        def _do_transfer():
+        async def _do_transfer():
             # Yield control to the caller. When send() completes, resume by populating data with the Future.result
             nonce = uuid.uuid4().hex
-            data = yield self.transport.send(
+            data = await self.transport.send(
                 self._package_load(load, nonce),
                 timeout=timeout,
             )
@@ -299,37 +295,34 @@ class AsyncReqChannel:
                 data = self.auth.session_crypticle.loads(data, raw, nonce=nonce)
             if not raw or self.ttype == "tcp":  # XXX Why is this needed for tcp
                 data = salt.transport.frame.decode_embedded_strs(data)
-            raise tornado.gen.Return(data)
+            return data
 
         if not self.auth.authenticated:
             # Return control back to the caller, resume when authentication succeeds
-            yield self.auth.authenticate()
+            await self.auth.authenticate()
         try:
             # We did not get data back the first time. Retry.
-            ret = yield _do_transfer()
+            ret = await _do_transfer()
         except salt.crypt.AuthenticationError:
             # If auth error, return control back to the caller, continue when authentication succeeds
-            yield self.auth.authenticate()
-            ret = yield _do_transfer()
-        raise tornado.gen.Return(ret)
+            await self.auth.authenticate()
+            ret = await _do_transfer()
+        return ret
 
-    @tornado.gen.coroutine
-    def _uncrypted_transfer(self, load, timeout):
+    async def _uncrypted_transfer(self, load, timeout):
         """
         Send a load across the wire in cleartext
 
         :param dict load: A load to send across the wire
         :param int timeout: The number of seconds on a response before failing
         """
-        ret = yield self.transport.send(self._package_load(load), timeout=timeout)
-
-        raise tornado.gen.Return(ret)
+        ret = await self.transport.send(self._package_load(load), timeout=timeout)
+        return ret
 
     async def connect(self):
         await self.transport.connect()
 
-    @tornado.gen.coroutine
-    def send(self, load, tries=None, timeout=None, raw=False):
+    async def send(self, load, tries=None, timeout=None, raw=False):
         """
         Send a request, return a future which will complete when we send the message
 
@@ -346,10 +339,10 @@ class AsyncReqChannel:
             try:
                 if self.crypt == "clear":
                     log.trace("ReqChannel send clear load=%r", load)
-                    ret = yield self._uncrypted_transfer(load, timeout=timeout)
+                    ret = await self._uncrypted_transfer(load, timeout=timeout)
                 else:
                     log.trace("ReqChannel send crypt load=%r", load)
-                    ret = yield self._crypted_transfer(load, timeout=timeout, raw=raw)
+                    ret = await self._crypted_transfer(load, timeout=timeout, raw=raw)
                 break
             except Exception as exc:  # pylint: disable=broad-except
                 log.trace("Failed to send msg %r", exc)
@@ -358,7 +351,7 @@ class AsyncReqChannel:
                 else:
                     _try += 1
                     continue
-        raise tornado.gen.Return(ret)
+        return ret
 
     def close(self):
         """
@@ -446,14 +439,13 @@ class AsyncPubChannel:
     def crypt(self):
         return "aes" if self.auth else "clear"
 
-    @tornado.gen.coroutine
-    def connect(self):
+    async def connect(self):
         """
         Return a future which completes when connected to the remote publisher
         """
         try:
             if not self.auth.authenticated:
-                yield self.auth.authenticate()
+                await self.auth.authenticate()
             # if this is changed from the default, we assume it was intentional
             if int(self.opts.get("publish_port", 4506)) != 4506:
                 publish_port = self.opts.get("publish_port")
@@ -462,7 +454,7 @@ class AsyncPubChannel:
                 publish_port = self.auth.creds["publish_port"]
             # TODO: The zeromq transport does not use connect_callback and
             # disconnect_callback.
-            yield self.transport.connect(
+            await self.transport.connect(
                 publish_port, self.connect_callback, self.disconnect_callback
             )
         # TODO: better exception handling...
@@ -508,8 +500,7 @@ class AsyncPubChannel:
             "version": 3,
         }
 
-    @tornado.gen.coroutine
-    def send_id(self, tok, force_auth):
+    async def send_id(self, tok, force_auth):
         """
         Send the minion id to the master so that the master may better
         track the connection state of the minion.
@@ -518,13 +509,11 @@ class AsyncPubChannel:
         """
         load = {"id": self.opts["id"], "tok": tok}
 
-        @tornado.gen.coroutine
-        def _do_transfer():
+        async def _do_transfer():
             msg = self._package_load(self.auth.crypticle.dumps(load))
             package = salt.transport.frame.frame_msg(msg, header=None)
-            yield self.transport.send(package)
-
-            raise tornado.gen.Return(True)
+            await self.transport.send(package)
+            return True
 
         if force_auth or not self.auth.authenticated:
             count = 0
@@ -533,27 +522,24 @@ class AsyncPubChannel:
                 or self.opts["tcp_authentication_retries"] < 0
             ):
                 try:
-                    yield self.auth.authenticate()
+                    await self.auth.authenticate()
                     break
                 except salt.exceptions.SaltClientError as exc:
                     log.debug(exc)
                     count += 1
         try:
-            ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            return await _do_transfer()
         except salt.crypt.AuthenticationError:
-            yield self.auth.authenticate()
-            ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            await self.auth.authenticate()
+            return await _do_transfer()
 
-    @tornado.gen.coroutine
-    def connect_callback(self, result):
+    async def connect_callback(self, result):
         if self._closing:
             return
         try:
             # Force re-auth on reconnect since the master
             # may have been restarted
-            yield self.send_id(self.token, self._reconnected)
+            await self.send_id(self.token, self._reconnected)
             self.connected = True
             self.event.fire_event({"master": self.opts["master"]}, "__master_connected")
             if self._reconnected:
@@ -579,7 +565,7 @@ class AsyncPubChannel:
                 }
                 with AsyncReqChannel.factory(self.opts) as channel:
                     try:
-                        yield channel.send(load, timeout=60)
+                        await channel.send(load, timeout=60)
                     except salt.exceptions.SaltReqTimeoutError:
                         log.info(
                             "fire_master failed: master could not be contacted. Request timed"
@@ -618,8 +604,7 @@ class AsyncPubChannel:
                     "Message signature failed to validate."
                 )
 
-    @tornado.gen.coroutine
-    def _decode_payload(self, payload):
+    async def _decode_payload(self, payload):
         # we need to decrypt it
         log.trace("Decoding payload: %s", payload)
         reauth = False
@@ -631,14 +616,14 @@ class AsyncPubChannel:
                 reauth = True
             if reauth:
                 try:
-                    yield self.auth.authenticate()
+                    await self.auth.authenticate()
                     payload["load"] = self.auth.crypticle.loads(payload["load"])
                 except salt.crypt.AuthenticationError:
                     log.error(
                         "Payload decryption failed even after re-authenticating with master %s",
                         self.opts["master_ip"],
                     )
-        raise tornado.gen.Return(payload)
+        return payload
 
     def __enter__(self):
         return self

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -13,7 +13,7 @@ import os
 import pathlib
 import time
 
-import tornado.gen
+import tornado.ioloop
 
 import salt.cache
 import salt.crypt
@@ -135,15 +135,14 @@ class ReqServerChannel:
         if hasattr(self.transport, "post_fork"):
             self.transport.post_fork(self.handle_message, io_loop)
 
-    @tornado.gen.coroutine
-    def handle_message(self, payload):
+    async def handle_message(self, payload):
         if (
             not isinstance(payload, dict)
             or "enc" not in payload
             or "load" not in payload
         ):
             log.warn("bad load received on socket")
-            raise tornado.gen.Return("bad load")
+            return "bad load"
         version = payload.get("version", 0)
         try:
             payload = self._decode_payload(payload, version)
@@ -158,7 +157,7 @@ class ReqServerChannel:
                 )
             else:
                 log.error("Bad load from minion: %s: %s", exc_type, exc)
-            raise tornado.gen.Return("bad load")
+            return "bad load"
 
         # TODO helper functions to normalize payload?
         if not isinstance(payload, dict) or not isinstance(payload.get("load"), dict):
@@ -167,16 +166,16 @@ class ReqServerChannel:
                 payload,
                 payload.get("load"),
             )
-            raise tornado.gen.Return("payload and load must be a dict")
+            return "payload and load must be a dict"
 
         try:
             id_ = payload["load"].get("id", "")
             if "\0" in id_:
                 log.error("Payload contains an id with a null byte: %s", payload)
-                raise tornado.gen.Return("bad load: id contains a null byte")
+                return "bad load: id contains a null byte"
         except TypeError:
             log.error("Payload contains non-string id: %s", payload)
-            raise tornado.gen.Return(f"bad load: id {id_} is not a string")
+            return f"bad load: id {id_} is not a string"
 
         sign_messages = False
         if version > 1:
@@ -185,9 +184,7 @@ class ReqServerChannel:
         # intercept the "_auth" commands, since the main daemon shouldn't know
         # anything about our key auth
         if payload["enc"] == "clear" and payload.get("load", {}).get("cmd") == "_auth":
-            raise tornado.gen.Return(
-                self._auth(payload["load"], sign_messages, version)
-            )
+            return self._auth(payload["load"], sign_messages, version)
 
         if payload["enc"] == "aes":
             nonce = None
@@ -205,7 +202,7 @@ class ReqServerChannel:
                             ttl,
                             self.opts["request_server_ttl"],
                         )
-                        raise tornado.gen.Return("bad load")
+                        return "bad load"
 
                 if payload["id"] != payload["load"]["id"]:
                     log.warning(
@@ -213,56 +210,52 @@ class ReqServerChannel:
                         payload["load"]["id"],
                         payload["id"],
                     )
-                    raise tornado.gen.Return("bad load")
+                    return "bad load"
                 if not salt.utils.verify.valid_id(self.opts, payload["load"]["id"]):
                     log.warning(
                         "Request contains invalid minion id '%s'", payload["load"]["id"]
                     )
-                    raise tornado.gen.Return("bad load")
+                    return "bad load"
                 if not self.validate_token(payload, required=True):
-                    raise tornado.gen.Return("bad load")
+                    return "bad load"
             # The token won't always be present in the payload for v2 and
             # below, but if it is we always wanto validate it.
             elif not self.validate_token(payload, required=False):
-                raise tornado.gen.Return("bad load")
+                return "bad load"
 
         # TODO: test
         try:
             # Take the payload_handler function that was registered when we created the channel
             # and call it, returning control to the caller until it completes
-            ret, req_opts = yield self.payload_handler(payload)
+            ret, req_opts = await self.payload_handler(payload)
         except Exception as e:  # pylint: disable=broad-except
             # always attempt to return an error to the minion
             log.error("Some exception handling a payload from minion", exc_info=True)
-            raise tornado.gen.Return("Some exception handling minion payload")
+            return "Some exception handling minion payload"
 
         req_fun = req_opts.get("fun", "send")
         if req_fun == "send_clear":
-            raise tornado.gen.Return(ret)
+            return ret
         elif req_fun == "send":
             if version > 2:
-                raise tornado.gen.Return(
-                    salt.crypt.Crypticle(self.opts, self.session_key(id_)).dumps(
-                        ret, nonce
-                    )
+                return salt.crypt.Crypticle(self.opts, self.session_key(id_)).dumps(
+                    ret, nonce
                 )
             else:
-                raise tornado.gen.Return(self.crypticle.dumps(ret, nonce))
+                return self.crypticle.dumps(ret, nonce)
         elif req_fun == "send_private":
-            raise tornado.gen.Return(
-                self._encrypt_private(
-                    ret,
-                    req_opts["key"],
-                    req_opts["tgt"],
-                    nonce,
-                    sign_messages,
-                    payload.get("enc_algo", salt.crypt.OAEP_SHA1),
-                    payload.get("sig_algo", salt.crypt.PKCS1v15_SHA1),
-                ),
+            return self._encrypt_private(
+                ret,
+                req_opts["key"],
+                req_opts["tgt"],
+                nonce,
+                sign_messages,
+                payload.get("enc_algo", salt.crypt.OAEP_SHA1),
+                payload.get("sig_algo", salt.crypt.PKCS1v15_SHA1),
             )
         log.error("Unknown req_fun %s", req_fun)
         # always attempt to return an error to the minion
-        raise tornado.gen.Return("Server-side exception handling payload")
+        return "Server-side exception handling payload"
 
     def _encrypt_private(
         self,

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -12,9 +12,6 @@ import threading
 import traceback
 import types
 
-import tornado.gen
-import tornado.ioloop
-
 import salt
 import salt._logging
 import salt.beacons
@@ -61,8 +58,7 @@ from salt.utils.process import SignalHandlingProcess, default_signals
 log = logging.getLogger(__name__)
 
 
-@tornado.gen.coroutine
-def post_master_init(self, master):
+async def post_master_init(self, master):
     """
     Function to finish init after a deltaproxy proxy
     minion has finished connecting to a master.
@@ -72,7 +68,7 @@ def post_master_init(self, master):
     """
 
     if self.connected:
-        self.opts["pillar"] = yield salt.pillar.get_async_pillar(
+        self.opts["pillar"] = await salt.pillar.get_async_pillar(
             self.opts,
             self.opts["grains"],
             self.opts["id"],
@@ -86,7 +82,7 @@ def post_master_init(self, master):
         self.opts["master"] = master
 
         tag = "salt/deltaproxy/start"
-        self._fire_master(tag=tag)
+        await self._fire_master_main(tag=tag)
 
     if "proxy" not in self.opts["pillar"] and "proxy" not in self.opts:
         errmsg = (
@@ -356,9 +352,10 @@ def post_master_init(self, master):
             )
 
         try:
-            results = yield tornado.gen.multi(waitfor)
+            results = await asyncio.gather(*waitfor)
         except Exception as exc:  # pylint: disable=broad-except
             log.error("Errors loading sub proxies: %s", exc)
+            raise
 
         _failed = self.opts["proxy"].get("ids", [])[:]
         for sub_proxy_data in results:
@@ -380,7 +377,7 @@ def post_master_init(self, master):
         log.debug("Initiating non-parallel startup for proxies")
         for _id in self.opts["proxy"].get("ids", []):
             try:
-                sub_proxy_data = yield subproxy_post_master_init(
+                sub_proxy_data = await subproxy_post_master_init(
                     _id, uid, self.opts, self.proxy, self.utils
                 )
             except Exception as exc:  # pylint: disable=broad-except
@@ -409,8 +406,7 @@ def post_master_init(self, master):
     self.ready = True
 
 
-@tornado.gen.coroutine
-def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils):
+async def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils):
     """
     Function to finish init after a deltaproxy proxy
     minion has finished connecting to a master.
@@ -437,7 +433,7 @@ def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils):
     proxy_grains = salt.loader.grains(
         proxyopts, proxy=main_proxy, context=proxy_context
     )
-    proxy_pillar = yield salt.pillar.get_async_pillar(
+    proxy_pillar = await salt.pillar.get_async_pillar(
         proxyopts,
         proxy_grains,
         minion_id,
@@ -581,7 +577,7 @@ def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils):
             "__proxy_keepalive", persist=True, fire_event=False
         )
 
-    raise tornado.gen.Return({"proxy_minion": _proxy_minion, "proxy_opts": proxyopts})
+    return {"proxy_minion": _proxy_minion, "proxy_opts": proxyopts}
 
 
 def target(cls, minion_instance, opts, data, connected, creds_map):

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -11,9 +11,6 @@ import threading
 import traceback
 import types
 
-import tornado.gen
-import tornado.ioloop
-
 import salt
 import salt.beacons
 import salt.cli.daemons
@@ -58,8 +55,7 @@ from salt.utils.process import SignalHandlingProcess, default_signals
 log = logging.getLogger(__name__)
 
 
-@tornado.gen.coroutine
-def post_master_init(self, master):
+async def post_master_init(self, master):
     """
     Function to finish init after a proxy
     minion has finished connecting to a master.
@@ -72,7 +68,7 @@ def post_master_init(self, master):
     if self.connected:
         self.opts["master"] = master
 
-        self.opts["pillar"] = yield salt.pillar.get_async_pillar(
+        self.opts["pillar"] = await salt.pillar.get_async_pillar(
             self.opts,
             self.opts["grains"],
             self.opts["id"],

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -11,8 +11,6 @@ import sys
 import time
 import traceback
 
-import tornado.gen
-
 import salt.channel.client
 import salt.fileclient
 import salt.loader
@@ -250,8 +248,7 @@ class AsyncRemotePillar(RemotePillarMixin):
         self._closing = False
         self.clean_cache = clean_cache
 
-    @tornado.gen.coroutine
-    def compile_pillar(self):
+    async def compile_pillar(self):
         """
         Return a future which will contain the pillar data from the master
         """
@@ -271,7 +268,7 @@ class AsyncRemotePillar(RemotePillarMixin):
             load["ext"] = self.ext
         start = time.monotonic()
         try:
-            ret_pillar = yield self.channel.crypted_transfer_decode_dictentry(
+            ret_pillar = await self.channel.crypted_transfer_decode_dictentry(
                 load,
                 dictkey="pillar",
             )
@@ -286,7 +283,7 @@ class AsyncRemotePillar(RemotePillarMixin):
             log.exception("Exception getting pillar:")
             raise SaltClientError("Exception getting pillar.")
         self.validate_return(ret_pillar)
-        raise tornado.gen.Return(ret_pillar)
+        return ret_pillar
 
     def destroy(self):
         if self._closing:
@@ -1394,7 +1391,8 @@ class Pillar:
 # TODO: actually migrate from Pillar to AsyncPillar to allow for futures in
 # ext_pillar etc.
 class AsyncPillar(Pillar):
-    @tornado.gen.coroutine
-    def compile_pillar(self, ext=True):
+    async def compile_pillar(
+        self, ext=True
+    ):  # pylint: disable=invalid-overridden-method
         ret = super().compile_pillar(ext=ext)
-        raise tornado.gen.Return(ret)
+        return ret

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -53,7 +53,7 @@ class ClosingError(Exception):
     """ """
 
 
-def _null_callback(*args, **kwargs):
+async def _null_callback(*args, **kwargs):
     pass
 
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -706,7 +706,6 @@ class AsyncReqMessageClient:
         self.socket.connect(self.addr)
         self.io_loop.spawn_callback(self._send_recv, self.socket)
 
-    @tornado.gen.coroutine
     def send(self, message, timeout=None, callback=None):
         """
         Return a future which will be completed when the message has a response

--- a/tests/pytests/unit/test_proxy_minion.py
+++ b/tests/pytests/unit/test_proxy_minion.py
@@ -5,7 +5,7 @@ import pytest
 from saltfactories.utils import random_string
 
 import salt.config
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import patch
 
 
 @pytest.mark.slow_test

--- a/tests/pytests/unit/test_proxy_minion.py
+++ b/tests/pytests/unit/test_proxy_minion.py
@@ -9,33 +9,6 @@ from tests.support.mock import MagicMock, patch
 
 
 @pytest.mark.slow_test
-def test_post_master_init_metaproxy_called(io_loop):
-    """
-    Tests that when the _post_master_ini function is called, _metaproxy_call is also called.
-    """
-
-    mock_opts = salt.config.DEFAULT_MINION_OPTS.copy()
-    mock_opts.update(salt.config.DEFAULT_PROXY_MINION_OPTS)
-    mock_jid_queue = [123]
-    proxy_minion = salt.minion.ProxyMinion(
-        mock_opts,
-        jid_queue=copy.copy(mock_jid_queue),
-        io_loop=io_loop,
-    )
-    mock_metaproxy_call = MagicMock()
-    with patch(
-        "salt.minion._metaproxy_call",
-        return_value=mock_metaproxy_call,
-        autospec=True,
-    ):
-        try:
-            ret = proxy_minion._post_master_init("dummy_master")
-            salt.minion._metaproxy_call.assert_called_once()
-        finally:
-            proxy_minion.destroy()
-
-
-@pytest.mark.slow_test
 async def test_handle_decoded_payload_metaproxy_called(io_loop):
     """
     Tests that when the _handle_decoded_payload function is called, _metaproxy_call is also called.

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1699,11 +1699,9 @@ async def test_req_chan_bad_payload_to_decode(pki_dir, io_loop, caplog):
         server.close()
 
 
-async def test_client_timeout_msg(minion_opts):
-    client = salt.transport.zeromq.AsyncReqMessageClient(
-        minion_opts, "tcp://127.0.0.1:4506"
-    )
-    client.connect()
+async def test_client_timeout_msg(minion_opts, io_loop):
+    client = salt.transport.zeromq.RequestClient(minion_opts, io_loop)
+    await client.connect()
     try:
         with pytest.raises(salt.exceptions.SaltReqTimeoutError):
             await client.send({"meh": "bah"}, 1)
@@ -1711,10 +1709,8 @@ async def test_client_timeout_msg(minion_opts):
         client.close()
 
 
-async def test_client_send_recv_on_cancelled_error(minion_opts):
-    client = salt.transport.zeromq.AsyncReqMessageClient(
-        minion_opts, "tcp://127.0.0.1:4506"
-    )
+async def test_client_send_recv_on_cancelled_error(minion_opts, io_loop):
+    client = salt.transport.zeromq.RequestClient(minion_opts, io_loop)
 
     mock_future = MagicMock(**{"done.return_value": True})
 


### PR DESCRIPTION
Continue to slowly wean off tornado, specifically tornado.gen.coroutine

Removes all uses of tornado.gen.coroutine outside of the saltnado api.
