### PR TITLE
Fix stacktrace when ip4/ip6 isn't configured

### DIFF
--- a/changelog/68355.fixed.md
+++ b/changelog/68355.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue with network grains in interfaces that don't support ip4 or ip6

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -180,7 +180,9 @@ def _get_ip_base_properties(i_face):
         "dynamic_dns_enabled": ip_properties.IsDynamicDnsEnabled,
     }
     # IPv4 Properties
-    if i_face.Supports(NetworkInterfaceComponent.IPv4):
+    if i_face.Supports(
+        NetworkInterfaceComponent.IPv4  # pylint: disable=used-before-assignment
+    ):
         ipv4_properties = ip_properties.GetIPv4Properties()
         if ipv4_properties:
             ip_base_properties.update(

--- a/tests/pytests/functional/utils/test_win_network.py
+++ b/tests/pytests/functional/utils/test_win_network.py
@@ -16,9 +16,9 @@ def test__get_ip_base_properties():
     interfaces = win_network._get_network_interfaces()
     for interface in interfaces:
         base_properties = win_network._get_ip_base_properties(interface)
-        assert "dhcp_enabled" in base_properties
-        assert "forwarding_enabled" in base_properties
-        assert "wins_enabled" in base_properties
+        assert "ipv4_dhcp_enabled" in base_properties
+        assert "ipv4_forwarding_enabled" in base_properties
+        assert "ipv4_wins_enabled" in base_properties
 
 
 def test_get_interface_info_dot_net_formatted():
@@ -27,4 +27,4 @@ def test_get_interface_info_dot_net_formatted():
         assert "description" in interfaces[interface]
         assert "hwaddr" in interfaces[interface]
         assert "up" in interfaces[interface]
-        assert "dhcp_enabled" in interfaces[interface]
+        assert "dhcp_enabled" in interfaces[interface]["inet"][0]

--- a/tests/pytests/unit/utils/test_win_network.py
+++ b/tests/pytests/unit/utils/test_win_network.py
@@ -48,9 +48,15 @@ def mock_ip_base():
             "dns_enabled": False,
             "dns_suffix": "",
             "dynamic_dns_enabled": False,
-            "dhcp_enabled": False,
-            "forwarding_enabled": False,
-            "wins_enabled": False,
+            "ipv4_apipa_active": False,
+            "ipv4_apipa_enabled": True,
+            "ipv4_dhcp_enabled": False,
+            "ipv4_forwarding_enabled": False,
+            "ipv4_index": 1,
+            "ipv4_mtu": 1500,
+            "ipv4_wins_enabled": False,
+            "ipv6_index": 1,
+            "ipv6_mtu": 1500,
         }
     )
 
@@ -151,11 +157,9 @@ def test_get_interface_info_dot_net(
         "Ethernet": {
             "alias": "Ethernet",
             "description": "Dell GigabitEthernet",
-            "dhcp_enabled": False,
             "dns_enabled": False,
             "dns_suffix": "",
             "dynamic_dns_enabled": False,
-            "forwarding_enabled": False,
             "id": "{C5F468C0-DD5F-4C2B-939F-A411DCB5DE16}",
             "ip_addresses": [
                 {
@@ -180,6 +184,13 @@ def test_get_interface_info_dot_net(
                 "239.255.255.250",
             ],
             "ip_wins": [],
+            "ipv4_apipa_active": False,
+            "ipv4_apipa_enabled": True,
+            "ipv4_dhcp_enabled": False,
+            "ipv4_forwarding_enabled": False,
+            "ipv4_index": 1,
+            "ipv4_mtu": 1500,
+            "ipv4_wins_enabled": False,
             "ipv6_addresses": [
                 {
                     "address": "fe80::e8a4:1224:5548:2b81",
@@ -192,6 +203,8 @@ def test_get_interface_info_dot_net(
             "ipv6_anycast": [],
             "ipv6_dns": ["2600:740a:1:304::1"],
             "ipv6_gateways": ["fe80::208:a2ff:fe0b:de70"],
+            "ipv6_index": 1,
+            "ipv6_mtu": 1500,
             "ipv6_multicast": [
                 "ff01::1",
                 "ff02::1",
@@ -205,7 +218,6 @@ def test_get_interface_info_dot_net(
             "receive_only": False,
             "status": "Up",
             "type": "Ethernet",
-            "wins_enabled": False,
         }
     }
 
@@ -241,21 +253,28 @@ def test_get_network_info(
     expected = {
         "Ethernet": {
             "description": "Dell GigabitEthernet",
-            "dhcp_enabled": False,
             "hwaddr": "02:D5:F1:DD:31:E0",
             "inet": [
                 {
                     "address": "172.18.87.49",
+                    "apipa_active": False,
+                    "apipa_enabled": True,
                     "broadcast": "172.18.87.63",
+                    "dhcp_enabled": False,
+                    "forwarding_enabled": False,
                     "gateway": "192.168.0.1",
-                    "label": "Ethernet",
+                    "index": 1,
+                    "mtu": 1500,
                     "netmask": "255.255.255.240",
+                    "wins_enabled": False,
                 }
             ],
             "inet6": [
                 {
                     "address": "fe80::e8a4:1224:5548:2b81",
                     "gateway": "fe80::208:a2ff:fe0b:de70",
+                    "index": 1,
+                    "mtu": 1500,
                     "prefixlen": 64,
                 }
             ],


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the win_network Salt util for network interfaces where IP4 or IP6 were not enabled/configured.

### What issues does this PR fix or reference?
Fixes #68355

### Previous Behavior
If IP4 or IP6 was not configured, it would throw a stacktrace.

### New Behavior
No stacktrace, unconfigured values are `None`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
