### PR TITLE
Fix to ensure that asyncio uses SaltLoggingClass

### DIFF
--- a/changelog/68400.fixed.md
+++ b/changelog/68400.fixed.md
@@ -1,0 +1,1 @@
+Fixes issue with asyncio logger not using SaltLoggingClass and causing exceptions when "%(jid)s" is used in a log format.

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -559,6 +559,13 @@ if logging.getLoggerClass() is not SaltLoggingClass:
         logging.root.addHandler(get_temp_handler())
 
 
+# Override asyncio logger class if asyncio is already imported
+if "asyncio" in sys.modules:
+    asyncio_logger = logging.getLogger("asyncio")
+    if not isinstance(asyncio_logger, SaltLoggingClass):
+        asyncio_logger.__class__ = SaltLoggingClass
+
+
 # Now that we defined the default logging logger class, we can instantiate our logger
 # DO NOT MOVE THIS
 log = logging.getLogger(__name__)

--- a/tests/pytests/unit/_logging/test_asyncio_logger.py
+++ b/tests/pytests/unit/_logging/test_asyncio_logger.py
@@ -1,0 +1,19 @@
+"""
+Tests to ensure asyncio logger uses SaltLoggingClass
+"""
+
+import logging
+
+
+def test_asyncio_logger_saltloggingclass():
+    """
+    Test that the asyncio logger is an instance of SaltLoggingClass
+
+    It is imported before salt._logging so we need to ensure it is overridden
+    """
+
+    asyncio_logger = logging.getLogger("asyncio")
+
+    import salt._logging.impl
+
+    assert isinstance(asyncio_logger, salt._logging.impl.SaltLoggingClass)


### PR DESCRIPTION
### What does this PR do?

Adds a check in to `salt._logging.impl` to ensure that the logger for `asyncio` is using `SaltLoggingClass`. If `asyncio` has been imported before `salt._logging` then the class is already set to `logging.Logger`. That can't handle additional fields such as `%(jid)s` and will throw an exception if that is set in the fmt string.

I considered just changing the order of imports in `salt/__init__.py`, which works when running salt normally, however it was impossible to test as the test suite always imports `asyncio`  well before any `salt` modules are imported.

### What issues does this PR fix or reference?
Fixes #68400 

### Previous Behavior
When using a `log_fmt_console` with `%(jid)s` and a `log_level` of `debug`, there would be exceptions like this:

```python
--- Logging error ---
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/logging/__init__.py", line 440, in format
    return self._format(record)
  File "/opt/saltstack/salt/lib/python3.10/logging/__init__.py", line 436, in _format
    return self._fmt % values
KeyError: 'jid'

```

### New Behavior
No exceptions are thrown

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with SSH?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
