### PR TITLE
Remove uses of spwd

### DIFF
--- a/changelog/67119.fixed.md
+++ b/changelog/67119.fixed.md
@@ -1,0 +1,1 @@
+Remove usage of spwd

--- a/salt/modules/linux_shadow.py
+++ b/salt/modules/linux_shadow.py
@@ -8,6 +8,7 @@ Manage the shadow file on Linux systems
     <module-provider-override>`.
 """
 
+import collections
 import datetime
 import functools
 import logging
@@ -16,12 +17,6 @@ import os
 import salt.utils.data
 import salt.utils.files
 from salt.exceptions import CommandExecutionError
-
-try:
-    import spwd
-except ImportError:
-    pass
-
 
 try:
     import salt.utils.pycrypto
@@ -33,6 +28,21 @@ except ImportError:
 __virtualname__ = "shadow"
 
 log = logging.getLogger(__name__)
+
+struct_spwd = collections.namedtuple(
+    "struct_spwd",
+    [
+        "sp_namp",
+        "sp_pwdp",
+        "sp_lstchg",
+        "sp_min",
+        "sp_max",
+        "sp_warn",
+        "sp_inact",
+        "sp_expire",
+        "sp_flag",
+    ],
+)
 
 
 def __virtual__():
@@ -71,7 +81,7 @@ def info(name, root=None):
     if root is not None:
         getspnam = functools.partial(_getspnam, root=root)
     else:
-        getspnam = functools.partial(spwd.getspnam)
+        getspnam = functools.partial(_getspnam, root="/")
 
     try:
         data = getspnam(name)
@@ -509,7 +519,7 @@ def list_users(root=None):
     if root is not None:
         getspall = functools.partial(_getspall, root=root)
     else:
-        getspall = functools.partial(spwd.getspall)
+        getspall = functools.partial(_getspall, root="/")
 
     return sorted(
         user.sp_namp if hasattr(user, "sp_namp") else user.sp_nam for user in getspall()
@@ -529,7 +539,7 @@ def _getspnam(name, root=None):
                 # Generate a getspnam compatible output
                 for i in range(2, 9):
                     comps[i] = int(comps[i]) if comps[i] else -1
-                return spwd.struct_spwd(comps)
+                return struct_spwd(*comps)
     raise KeyError
 
 
@@ -545,4 +555,4 @@ def _getspall(root=None):
             # Generate a getspall compatible output
             for i in range(2, 9):
                 comps[i] = int(comps[i]) if comps[i] else -1
-            yield spwd.struct_spwd(comps)
+            yield struct_spwd(*comps)


### PR DESCRIPTION
### What does this PR do?

Complete https://github.com/saltstack/salt/pull/67788 to remove spwd on Linux. Solaris parts are not touched as they already have compatibility for systems without spwd.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/67119

### Previous Behavior

`user` module would fail with `NameError: name 'spwd' is not defined` on Python 3.13.

### New Behavior

`user` module works again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
