### PR TITLE
ssh_auth and ssh fixes for 3006.x and 3007.x

### DIFF
--- a/changelog/60769.fixed.md
+++ b/changelog/60769.fixed.md
@@ -1,0 +1,1 @@
+Fixed ssh_auth.present to respect provided `options` when read keys from source file

--- a/changelog/61299.fixed.md
+++ b/changelog/61299.fixed.md
@@ -1,0 +1,1 @@
+Fixed ssh_auth regexp to handle key types with @ or .

--- a/changelog/68403.fixed.md
+++ b/changelog/68403.fixed.md
@@ -1,0 +1,1 @@
+Fixed ssh_auth.present and ssh.absent to report changes if some key was added or removed when reading keys from a source file

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -625,6 +625,7 @@ def set_auth_key_from_file(
     config=".ssh/authorized_keys",
     saltenv="base",
     fingerprint_hash_type=None,
+    **kwargs,
 ):
     """
     Add a key to the authorized_keys file, using a file as the source.
@@ -648,13 +649,14 @@ def set_auth_key_from_file(
         return "fail"
     else:
         rval = ""
+        options = kwargs.get("options", None)
         for key in s_keys:
             rval += set_auth_key(
                 user,
                 key,
                 enc=s_keys[key]["enc"],
                 comment=s_keys[key]["comment"],
-                options=s_keys[key]["options"],
+                options=options or s_keys[key]["options"],
                 config=config,
                 cache_keys=list(s_keys.keys()),
                 fingerprint_hash_type=fingerprint_hash_type,

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -98,7 +98,7 @@ def _present_test(
             )
     else:
         # check if this is of form {options} {enc} {key} {comment}
-        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w-]+\s.+)$")
+        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
@@ -171,7 +171,7 @@ def _absent_test(
             return (True, f"All host keys in file {source} are already absent")
     else:
         # check if this is of form {options} {enc} {key} {comment}
-        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w-]+\s.+)$")
+        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
@@ -268,7 +268,7 @@ def present(
 
     if source == "":
         # check if this is of form {options} {enc} {key} {comment}
-        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w-]+\s.+)$")
+        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
@@ -482,7 +482,7 @@ def absent(
                 )
     else:
         # Get just the key
-        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w-]+\s.+)$")
+        sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -253,7 +253,8 @@ def present(
         3. Paste it into a new file.
 
     options
-        The options passed to the key, pass a list object
+        The options passed to the key, pass a list object.
+        If set, this will overwrite the ``options`` to all keys in source file
 
     config
         The location of the authorized keys file relative to the user's home
@@ -307,36 +308,16 @@ def present(
     if source != "" and not source_path:
         data = "no key"
     elif source != "" and source_path:
-        key = __salt__["cp.get_file_str"](source, saltenv=__env__)
-        filehasoptions = False
-        # check if this is of form {options} {enc} {key} {comment}
-        sshre = re.compile(r"^(sk-)?(ssh\-|ecds).*")
-        key = key.rstrip().split("\n")
-        for keyline in key:
-            filehasoptions = sshre.match(keyline)
-            if not filehasoptions:
-                data = __salt__["ssh.set_auth_key_from_file"](
-                    user,
-                    source,
-                    config=config,
-                    saltenv=__env__,
-                    fingerprint_hash_type=fingerprint_hash_type,
-                )
-            else:
-                # Split keyline to get key and comment
-                keyline = keyline.split(" ")
-                key_type = keyline[0]
-                key_value = keyline[1]
-                key_comment = keyline[2] if len(keyline) > 2 else ""
-                data = __salt__["ssh.set_auth_key"](
-                    user,
-                    key_value,
-                    enc=key_type,
-                    comment=key_comment,
-                    options=options or [],
-                    config=config,
-                    fingerprint_hash_type=fingerprint_hash_type,
-                )
+        # ssh.set_auth_key_from_file already reads and add/replace all keys
+        # from source file.
+        data = __salt__["ssh.set_auth_key_from_file"](
+            user,
+            source,
+            config=config,
+            saltenv=__env__,
+            fingerprint_hash_type=fingerprint_hash_type,
+            options=options,
+        )
     else:
         data = __salt__["ssh.set_auth_key"](
             user,
@@ -454,32 +435,23 @@ def absent(
         )
         return ret
 
-    # Extract Key from file if source is present
+    # Get only the path to the file without env referrences to check if exists
     if source != "":
-        key = __salt__["cp.get_file_str"](source, saltenv=__env__)
-        filehasoptions = False
-        # check if this is of form {options} {enc} {key} {comment}
-        sshre = re.compile(r"^(sk-)?(ssh\-|ecds).*")
-        key = key.rstrip().split("\n")
-        for keyline in key:
-            filehasoptions = sshre.match(keyline)
-            if not filehasoptions:
-                ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
-                    user,
-                    source,
-                    config,
-                    saltenv=__env__,
-                    fingerprint_hash_type=fingerprint_hash_type,
-                )
-            else:
-                # Split keyline to get key
-                keyline = keyline.split(" ")
-                ret["comment"] = __salt__["ssh.rm_auth_key"](
-                    user,
-                    keyline[1],
-                    config=config,
-                    fingerprint_hash_type=fingerprint_hash_type,
-                )
+        source_path = __salt__["cp.get_url"](source, None, saltenv=__env__)
+
+    # Extract Key from file if source is present
+    if source != "" and not source_path:
+        data = "no key"
+    elif source != "" and source_path:
+        # ssh.rm_auth_key_from_file already reads and delete all keys
+        # from source file.
+        ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
+            user,
+            source,
+            config,
+            saltenv=__env__,
+            fingerprint_hash_type=fingerprint_hash_type,
+        )
     else:
         # Get just the key
         sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -301,23 +301,24 @@ def present(
         )
         return ret
 
-    # Get only the path to the file without env referrences to check if exists
     if source != "":
+        # Get only the path to the file without env references to check if exists
         source_path = __salt__["cp.get_url"](source, None, saltenv=__env__)
 
-    if source != "" and not source_path:
-        data = "no key"
-    elif source != "" and source_path:
-        # ssh.set_auth_key_from_file already reads and add/replace all keys
-        # from source file.
-        data = __salt__["ssh.set_auth_key_from_file"](
-            user,
-            source,
-            config=config,
-            saltenv=__env__,
-            fingerprint_hash_type=fingerprint_hash_type,
-            options=options,
-        )
+        # Extract Key from file if source is present
+        if not source_path:
+            data = "no key"
+        else:
+            # ssh.set_auth_key_from_file already reads and add/replace all keys
+            # from source file.
+            data = __salt__["ssh.set_auth_key_from_file"](
+                user,
+                source,
+                config=config,
+                saltenv=__env__,
+                fingerprint_hash_type=fingerprint_hash_type,
+                options=options,
+            )
     else:
         data = __salt__["ssh.set_auth_key"](
             user,
@@ -435,23 +436,23 @@ def absent(
         )
         return ret
 
-    # Get only the path to the file without env referrences to check if exists
     if source != "":
+        # Get only the path to the file without env references to check if exists
         source_path = __salt__["cp.get_url"](source, None, saltenv=__env__)
 
-    # Extract Key from file if source is present
-    if source != "" and not source_path:
-        data = "no key"
-    elif source != "" and source_path:
-        # ssh.rm_auth_key_from_file already reads and delete all keys
-        # from source file.
-        ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
-            user,
-            source,
-            config,
-            saltenv=__env__,
-            fingerprint_hash_type=fingerprint_hash_type,
-        )
+        # Extract Key from file if source is present
+        if not source_path:
+            data = "no key"
+        else:
+            # ssh.rm_auth_key_from_file already reads and delete all keys
+            # from source file.
+            ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
+                user,
+                source,
+                config,
+                saltenv=__env__,
+                fingerprint_hash_type=fingerprint_hash_type,
+            )
     else:
         # Get just the key
         sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")

--- a/tests/pytests/unit/states/test_ssh_auth.py
+++ b/tests/pytests/unit/states/test_ssh_auth.py
@@ -5,12 +5,103 @@
 import pytest
 
 import salt.states.ssh_auth as ssh_auth
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import MagicMock, call, patch
 
 
 @pytest.fixture
 def configure_loader_modules():
-    return {ssh_auth: {}}
+    return {ssh_auth: {"__env__": "base"}}
+
+
+@pytest.fixture()
+def enc_types():
+    # This list is from sshd manual page of openssh 8.7
+    return [
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "sk-ssh-ed25519@openssh.com",
+        "ssh-ed25519",
+        "ssh-dss",
+        "ssh-rsa",
+    ]
+
+
+def test__present_test(enc_types):
+    """
+    Test to verify if many encryption key types are accepted by ssh_auth._present_test
+    """
+    user = "user"
+    key = "1ABCDXXXXXXXXXXXXXXXXXXXXXXXXXXXX="
+    comment = "user@example.internal"
+    name_list = []
+    expected_calls = []
+    for enc in enc_types:
+        name_list.append(f"{enc} {key} {comment}")
+        expected_calls.append(
+            call(
+                user,
+                key,
+                enc,
+                comment,
+                [],
+                config=".ssh/authorized_keys",
+                fingerprint_hash_type=None,
+            )
+        )
+
+    mock_check_key = MagicMock(return_value="update")
+
+    with patch.dict(ssh_auth.__salt__, {"ssh.check_key": mock_check_key}):
+        with patch.dict(ssh_auth.__opts__, {"test": True}):
+            for name in name_list:
+                ret = None, f"Key {key} for user {user} is set to be updated"
+                assert (
+                    ssh_auth._present_test(
+                        user, name, enc, comment, [], "", ".ssh/authorized_keys", None
+                    )
+                    == ret
+                )
+            mock_check_key.assert_has_calls(expected_calls)
+
+
+def test__absent_test(enc_types):
+    """
+    Test to verify if many encryption key types are accepted by ssh_auth._absent_test
+    """
+    user = "user"
+    key = "1ABCDXXXXXXXXXXXXXXXXXXXXXXXXXXXX="
+    comment = "user@example.internal"
+    name_list = []
+    expected_calls = []
+    for enc in enc_types:
+        name_list.append(f"{enc} {key} {comment}")
+        expected_calls.append(
+            call(
+                user,
+                key,
+                enc,
+                comment,
+                [],
+                config=".ssh/authorized_keys",
+                fingerprint_hash_type=None,
+            )
+        )
+
+    mock_check_key = MagicMock(return_value="update")
+
+    with patch.dict(ssh_auth.__salt__, {"ssh.check_key": mock_check_key}):
+        with patch.dict(ssh_auth.__opts__, {"test": True}):
+            for name in name_list:
+                ret = None, f"Key {key} for user {user} is set for removal"
+                assert (
+                    ssh_auth._absent_test(
+                        user, name, enc, comment, [], "", ".ssh/authorized_keys", None
+                    )
+                    == ret
+                )
+            mock_check_key.assert_has_calls(expected_calls)
 
 
 def test_present():
@@ -42,6 +133,101 @@ def test_present():
             comt = "The authorized host key sshkeys for user root was added"
             ret.update({"comment": comt, "changes": {name: "New"}})
             assert ssh_auth.present(name, user, source) == ret
+
+
+def test_present_with_source():
+    """
+    Test to check if ssh.set_auth_key_from_file is called with the correct parameters
+    """
+    user = "user"
+    source = "salt://fakefile"
+    config = ".ssh/authorized_keys"
+
+    mock_cp_get_url = MagicMock(return_value=True)
+    mock_auth_key_from_file = MagicMock(return_value="new")
+
+    with patch.dict(
+        ssh_auth.__salt__,
+        {
+            "cp.get_url": mock_cp_get_url,
+            "ssh.set_auth_key_from_file": mock_auth_key_from_file,
+        },
+    ):
+        with patch.dict(ssh_auth.__opts__, {"test": False}):
+            name = "Call Without Options"
+            ret = {
+                "name": name,
+                "changes": {name: "New"},
+                "result": True,
+                "comment": f"The authorized host key {name} for user {user} was added",
+            }
+            assert ssh_auth.present(name, user, source=source) == ret
+            mock_auth_key_from_file.assert_called_with(
+                "user",
+                "salt://fakefile",
+                config=".ssh/authorized_keys",
+                saltenv="base",
+                fingerprint_hash_type=None,
+                options=None,
+            )
+            name = "Call With Options"
+            ret = {
+                "name": name,
+                "changes": {name: "New"},
+                "result": True,
+                "comment": f"The authorized host key {name} for user {user} was added",
+            }
+            assert (
+                ssh_auth.present(name, user, source=source, options=["no-pty"]) == ret
+            )
+            mock_auth_key_from_file.assert_called_with(
+                "user",
+                "salt://fakefile",
+                config=".ssh/authorized_keys",
+                saltenv="base",
+                fingerprint_hash_type=None,
+                options=["no-pty"],
+            )
+
+
+def test_present_different_key_types_are_accepted(enc_types):
+    """
+    Test to verify if many encryption key types are accepted by ssh_auth.present
+    """
+    user = "user"
+    key = "1ABCDXXXXXXXXXXXXXXXXXXXXXXXXXXXX="
+    comment = "user@example.internal"
+    name_list = []
+    expected_calls = []
+    for enc in enc_types:
+        name_list.append(f"{enc} {key} {comment}")
+        expected_calls.append(
+            call(
+                user,
+                key,
+                enc,
+                comment,
+                [],
+                "",
+                ".ssh/authorized_keys",
+                None,
+            )
+        )
+
+    with patch.object(
+        ssh_auth, "_present_test", return_value=[None, "Key is to be added"]
+    ) as mock__present_test:
+        # it's tested with `test: True` because this already tests the fullkey regexp
+        with patch.dict(ssh_auth.__opts__, {"test": True}):
+            for name in name_list:
+                ret = {
+                    "name": name,
+                    "changes": {},
+                    "result": None,
+                    "comment": "Key is to be added",
+                }
+                assert ssh_auth.present(name, user) == ret
+            mock__present_test.assert_has_calls(expected_calls)
 
 
 def test_absent():
@@ -78,6 +264,78 @@ def test_absent():
             comt = "Key removed"
             ret.update({"comment": comt, "result": True, "changes": {name: "Removed"}})
             assert ssh_auth.absent(name, user, source) == ret
+
+
+def test_absent_with_source():
+    """
+    Test to check if ssh.rm_auth_key_from_file is called with the correct parameters
+    """
+    user = "user"
+    source = "salt://fakefile"
+    config = ".ssh/authorized_keys"
+
+    mock_cp_get_url = MagicMock(return_value=True)
+    mock_auth_key_from_file = MagicMock(return_value="Key removed")
+
+    with patch.dict(
+        ssh_auth.__salt__,
+        {
+            "cp.get_url": mock_cp_get_url,
+            "ssh.rm_auth_key_from_file": mock_auth_key_from_file,
+        },
+    ):
+        with patch.dict(ssh_auth.__opts__, {"test": False}):
+            name = "Call Absent With Source"
+            ret = {
+                "name": name,
+                "changes": {name: "Removed"},
+                "result": True,
+                "comment": "Key removed",
+            }
+            assert ssh_auth.absent(name, user, source=source) == ret
+            mock_auth_key_from_file.assert_called_with(
+                "user",
+                "salt://fakefile",
+                ".ssh/authorized_keys",
+                saltenv="base",
+                fingerprint_hash_type=None,
+            )
+
+
+def test_absent_with_different_key_types_are_accepted(enc_types):
+    """
+    Test to verify if many encription key types are accepted
+    """
+    user = "user"
+    key = "1ABCDXXXXXXXXXXXXXXXXXXXXXXXXXXXX="
+    comment = "user@example.internal"
+    name_list = []
+    expected_calls = []
+    for enc in enc_types:
+        name_list.append(f"{enc} {key} {comment}")
+        expected_calls.append(
+            call(
+                user,
+                key,
+                config=".ssh/authorized_keys",
+                fingerprint_hash_type=None,
+            )
+        )
+
+    mock_rm_test = MagicMock(return_value="Key removed")
+
+    with patch.dict(ssh_auth.__salt__, {"ssh.rm_auth_key": mock_rm_test}):
+        # it's tested with `test: False` because the fullkey regexp is only in the actual execution
+        with patch.dict(ssh_auth.__opts__, {"test": False}):
+            for name in name_list:
+                ret = {
+                    "name": name,
+                    "changes": {key: "Removed"},
+                    "result": True,
+                    "comment": "Key removed",
+                }
+                assert ssh_auth.absent(name, user) == ret
+            mock_rm_test.assert_has_calls(expected_calls)
 
 
 def test_manage():

--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -5,7 +5,7 @@ import salt.utils.files
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import MagicMock, call, mock_open, patch
 from tests.support.unit import TestCase
 
 
@@ -86,6 +86,206 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
             ),
             "fail",
         )
+
+    def test_set_auth_key_from_file(self):
+        """
+        Test if set_auth_key_from_file pass the correct options to set_auth_key and
+        if multiple keys are supported.
+        """
+        s_keys_dict = {
+            "S1KeyWithSpecialCharactersAndMultipleWordCommentaryXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ssh-ed25519@openssh.com",
+                "comment": "user@internal.example Multiple Words Commentary",
+                "options": [],
+                "fingerprint": "c5:6c:6d:47:6e:d6:16:56:60:7b:f6:ab:59:c6:33:03:87:b8:3b:d7:67:7e:37:8a:db:83:8b:b5:48:de:91:c1",
+            },
+            "S4KeyWithSpecialCharactersAndMultipleWordCommentaryAndOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ssh-ed25519@openssh.com",
+                "comment": "user@internal.example Multiple Words Commentary",
+                "options": ["no-port-forwarding", "no-pty"],
+                "fingerprint": "3a:14:23:b6:db:0a:d7:07:30:30:3b:b4:9a:31:0c:29:9b:c5:fa:5f:5e:5a:7d:fb:4b:44:da:70:02:79:ca:04",
+            },
+        }
+        user = "user"
+        config = "authorized_keys_somewhere"
+        options = ["no-pty"]
+        fingerprint_hash_type = None
+
+        expected_calls_without_options = []
+        expected_calls_with_options = []
+        for key in s_keys_dict:
+            expected_calls_without_options.append(
+                call(
+                    user,
+                    key,
+                    enc=s_keys_dict[key]["enc"],
+                    comment=s_keys_dict[key]["comment"],
+                    options=s_keys_dict[key]["options"],
+                    config=config,
+                    cache_keys=list(s_keys_dict.keys()),
+                    fingerprint_hash_type=fingerprint_hash_type,
+                )
+            )
+            expected_calls_with_options.append(
+                call(
+                    user,
+                    key,
+                    enc=s_keys_dict[key]["enc"],
+                    comment=s_keys_dict[key]["comment"],
+                    options=options,
+                    config=config,
+                    cache_keys=list(s_keys_dict.keys()),
+                    fingerprint_hash_type=fingerprint_hash_type,
+                )
+            )
+
+        with patch.object(ssh, "set_auth_key", return_value="new") as mock_set_auth_key:
+            with patch("os.path.isfile", return_value=True):
+                with patch.dict(
+                    ssh.__salt__,
+                    {"cp.cache_file": MagicMock(return_value="/fakecache/fakefile")},
+                ):
+                    with patch(
+                        "salt.modules.ssh._validate_keys",
+                        MagicMock(return_value=s_keys_dict),
+                    ):
+                        self.assertEqual(
+                            ssh.set_auth_key_from_file(
+                                "user", source="salt://fakefile", config=config
+                            ),
+                            "new",
+                        )
+                        mock_set_auth_key.assert_has_calls(
+                            expected_calls_without_options
+                        )
+
+                        self.assertEqual(
+                            ssh.set_auth_key_from_file(
+                                "user",
+                                source="salt://fakefile",
+                                config=config,
+                                options=options,
+                            ),
+                            "new",
+                        )
+                        mock_set_auth_key.assert_has_calls(expected_calls_with_options)
+
+    def test_rm_auth_key_from_file(self):
+        """
+        Test if multiple keys are supported by rm_auth_key_from_file
+        """
+        s_keys_dict = {
+            "S1KeyWithSpecialCharactersAndMultipleWordCommentaryXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ssh-ed25519@openssh.com",
+                "comment": "user@internal.example Multiple Words Commentary",
+                "options": [],
+                "fingerprint": "c5:6c:6d:47:6e:d6:16:56:60:7b:f6:ab:59:c6:33:03:87:b8:3b:d7:67:7e:37:8a:db:83:8b:b5:48:de:91:c1",
+            },
+            "S4KeyWithSpecialCharactersAndMultipleWordCommentaryAndOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ssh-ed25519@openssh.com",
+                "comment": "user@internal.example Multiple Words Commentary",
+                "options": ["no-port-forwarding", "no-pty"],
+                "fingerprint": "3a:14:23:b6:db:0a:d7:07:30:30:3b:b4:9a:31:0c:29:9b:c5:fa:5f:5e:5a:7d:fb:4b:44:da:70:02:79:ca:04",
+            },
+        }
+        user = "user"
+        config = "authorized_keys_somewhere"
+        fingerprint_hash_type = None
+
+        expected_calls = []
+        for key in s_keys_dict:
+            expected_calls.append(
+                call(
+                    user,
+                    key,
+                    config=config,
+                    fingerprint_hash_type=fingerprint_hash_type,
+                )
+            )
+
+        with patch.object(
+            ssh, "rm_auth_key", return_value="Key removed"
+        ) as mock_rm_auth_key:
+            with patch("os.path.isfile", return_value=True):
+                with patch.dict(
+                    ssh.__salt__,
+                    {"cp.cache_file": MagicMock(return_value="/fakecache/fakefile")},
+                ):
+                    with patch(
+                        "salt.modules.ssh._validate_keys",
+                        MagicMock(return_value=s_keys_dict),
+                    ):
+                        self.assertEqual(
+                            ssh.rm_auth_key_from_file(
+                                "user", source="salt://fakefile", config=config
+                            ),
+                            "Key removed",
+                        )
+                        mock_rm_auth_key.assert_has_calls(expected_calls)
+
+    def test__validate_keys(self):
+        """
+        Test if keys read from file are correctly validated
+        """
+        s_keys_dict = {
+            "KeyWithSpecialCharactersAndOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ecdsa-sha2-nistp256@openssh.com",
+                "comment": "user@internal.example",
+                "options": ["no-port-forwarding", "no-pty"],
+                "fingerprint": "b4:98:a7:02:bf:0d:1f:0a:c2:96:19:4c:10:7e:7b:51:ad:d7:ee:2c:3e:96:37:58:4d:ab:73:98:db:ee:36:f1",
+            },
+            "KeyWithoutOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "ecdsa-sha2-nistp256",
+                "comment": "user@internal.example",
+                "options": [],
+                "fingerprint": "4e:1f:ba:e6:16:31:56:67:f6:c1:ea:34:0c:b4:83:43:28:2c:5f:e7:c1:95:5c:07:90:6f:70:d5:4d:1b:3e:af",
+            },
+            "KeyWithoutOptionsAndWithoutCommentsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "ecdsa-sha2-nistp384",
+                "comment": "",
+                "options": [],
+                "fingerprint": "3d:55:90:4b:d5:7d:22:03:37:c7:8c:4f:32:8b:5e:a9:77:f8:fd:f7:e4:24:52:87:14:90:b3:d6:c3:d8:57:f0",
+            },
+            "KeyWithOptionsAndWithoutCommentsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "ecdsa-sha2-nistp521",
+                "comment": "",
+                "options": ["no-port-forwarding", "no-pty"],
+                "fingerprint": "a9:7d:6d:00:30:df:28:75:1b:1f:f1:b5:b6:36:3c:82:e4:bf:70:97:bf:6c:a6:e0:9a:b6:37:6b:0d:30:57:e8",
+            },
+            "KeyWithSpecialCharactersWithoutOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "sk-ssh-ed25519@openssh.com",
+                "comment": "user@internal.example",
+                "options": [],
+                "fingerprint": "3e:8b:af:7c:16:12:c6:e2:df:2d:03:16:b7:19:28:b8:3e:65:de:b0:7d:fc:74:06:a9:d6:b1:0f:92:df:7c:cf",
+            },
+            "KeyWithMultipleWordCommentaryAndNoOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "ssh-ed25519",
+                "comment": "user@internal.example Multiple Word Commentary",
+                "options": [],
+                "fingerprint": "29:e8:ef:0d:f4:93:09:13:19:af:66:bf:d0:ca:45:0a:ed:ac:30:e6:3b:41:22:3a:d6:ea:e6:a3:5f:8b:af:07",
+            },
+            "KeyWithMultipleWordCommentaryAndWithOptionsXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=": {
+                "enc": "ssh-rsa",
+                "comment": "user@internal.example Multiple Word Commentary",
+                "options": ["no-port-forwarding", "no-pty"],
+                "fingerprint": "c7:e2:fb:76:03:ab:f0:11:2d:62:11:33:25:57:1a:1f:88:2d:cc:4f:95:44:bd:2c:79:11:8f:84:d9:75:b5:bf",
+            },
+        }
+
+        read_file_contents = ""
+        for key in s_keys_dict:
+            line = f"{s_keys_dict[key]['enc']} {key}"
+            if s_keys_dict[key]["options"]:
+                options = ",".join(s_keys_dict[key]["options"])
+                line = " ".join([options, line])
+            if s_keys_dict[key]["comment"]:
+                line = " ".join([line, s_keys_dict[key]["comment"]])
+            line += "\n"
+            read_file_contents += line
+
+        fopen_mock = mock_open(read_data=read_file_contents)
+        with patch("salt.utils.files.fopen", fopen_mock):
+            assert ssh._validate_keys("keyfile", None) == s_keys_dict
 
     def test_replace_auth_key(self):
         """


### PR DESCRIPTION
### What does this PR do?
It changes the how `ssh_auth.present` and `ssh_auth.absent` handles when the keys to be added or removed comes from a source file. This fixes:

1. The state reporting no changes even when keys are added or removed;
2. The wrongly `options` handling when using source file;

Added in this patch is a fix to handle keys with @ and . in their encryption types and many tests to execution module `ssh.py` and state module `ssh_auth.py`:

1. Tests all occurrences of the encryption types validation regexp in `ssh_auth.py` against all supported OpenSSH 8.7 key types;
3. Tests if `ssh.set_auth_key_from_file` is correctly called from `ssh_auth.present` sending the `options` if specified;
4. Tests if `ssh.rm_auth_key_from_file` is correctly called from `ssh_auth.absent`
5. Tests if `ssh.set_auth_key_from_file` and `ssh.rm_auth_key_from_file` correctly handles multiple keys
6. Tests if `ssh.set_auth_key_from_file` and `ssh.rm_auth_key_from_file` accept keys with @ and .
7. Tests if `ssh.set_auth_key_from_file` and `ssh.rm_auth_key_from_file` parses multiple words comments
8. Tests `ssh._validate_keys` against all encryption keys supported by OpenSSH 8.7, with options, without options, with simple comments, with multiple word comments and even without any comment.

I hope this set of tests are enough to prevent any regression and warranty that reading keys from source works flawlessly.

### What issues does this PR fix or reference?
Fixes #68403 
Fixes #61299 
Fixes #60769 
Fixes #57447
Fixes #40078
Tests #63434

### Previous Behavior
- Changes are not reported when reading keys from file
- State defined `options` weren't respected when reading keys from file
- Key types with @ and . weren't accepted

### New Behavior
- If the state changes something by adding or removing one or more keys, it reports as "changed". Individual changes are not reported.
- State defined `options` overwrites those in the key when reading keys from file
- Key types with @ and . are accepted

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No