### PR TITLE
Reduce test overhead

### DIFF
--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -46,12 +46,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
     {
         "linux": [
             Linux(
-                slug="rockylinux-8",
-                display_name="Rocky Linux 8",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8",
-            ),
-            Linux(
                 slug="rockylinux-8-arm64",
                 display_name="Rocky Linux 8 Arm64",
                 arch="arm64",
@@ -64,28 +58,10 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
             ),
             Linux(
-                slug="rockylinux-9-arm64",
-                display_name="Rocky Linux 9 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
-            ),
-            Linux(
                 slug="amazonlinux-2",
                 display_name="Amazon Linux 2",
                 arch="x86_64",
                 container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2",
-            ),
-            Linux(
-                slug="amazonlinux-2-arm64",
-                display_name="Amazon Linux 2 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2",
-            ),
-            Linux(
-                slug="amazonlinux-2023",
-                display_name="Amazon Linux 2023",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023",
             ),
             Linux(
                 slug="amazonlinux-2023-arm64",
@@ -98,18 +74,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 display_name="Debian 11",
                 arch="x86_64",
                 container="ghcr.io/saltstack/salt-ci-containers/testing:debian-11",
-            ),
-            Linux(
-                slug="debian-11-arm64",
-                display_name="Debian 11 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-11",
-            ),
-            Linux(
-                slug="debian-12",
-                display_name="Debian 12",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
             ),
             Linux(
                 slug="debian-12-arm64",
@@ -125,12 +89,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
             ),
             # Linux(slug="opensuse-15", display_name="Opensuse 15", arch="x86_64"),
             Linux(
-                slug="photonos-4",
-                display_name="Photon OS 4",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            Linux(
                 slug="photonos-4-arm64",
                 display_name="Photon OS 4 Arm64",
                 arch="arm64",
@@ -144,13 +102,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
             ),
             Linux(
-                slug="photonos-4-arm64",
-                display_name="Photon OS 4 Arm64",
-                arch="arm64",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            Linux(
                 slug="photonos-5",
                 display_name="Photon OS 5",
                 arch="x86_64",
@@ -160,27 +111,8 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 slug="photonos-5-arm64",
                 display_name="Photon OS 5 Arm64",
                 arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            Linux(
-                slug="photonos-5",
-                display_name="Photon OS 5",
-                arch="x86_64",
                 fips=True,
                 container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            Linux(
-                slug="photonos-5-arm64",
-                display_name="Photon OS 5 Arm64",
-                arch="arm64",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            Linux(
-                slug="ubuntu-22.04",
-                display_name="Ubuntu 22.04",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04",
             ),
             Linux(
                 slug="ubuntu-22.04-arm64",
@@ -192,12 +124,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 slug="ubuntu-24.04",
                 display_name="Ubuntu 24.04",
                 arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
-            ),
-            Linux(
-                slug="ubuntu-24.04-arm64",
-                display_name="Ubuntu 24.04 Arm64",
-                arch="arm64",
                 container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
             ),
         ],
@@ -216,13 +142,6 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
     {
         "linux": [
             LinuxPkg(
-                slug="rockylinux-8",
-                display_name="Rocky Linux 8",
-                arch="x86_64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8",
-            ),
-            LinuxPkg(
                 slug="rockylinux-8-arm64",
                 display_name="Rocky Linux 8 Arm64",
                 arch="arm64",
@@ -237,48 +156,11 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
             ),
             LinuxPkg(
-                slug="rockylinux-9-arm64",
-                display_name="Rocky Linux 9 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
-            ),
-            # Amazon linux 2 containers have degraded systemd so the package
-            # tests will not pass.
-            # LinuxPkg(
-            #     slug="amazonlinux-2",
-            #     display_name="Amazon Linux 2",
-            #     arch="x86_64",
-            #     pkg_type="rpm",
-            #     container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2",
-            # ),
-            # LinuxPkg(
-            #     slug="amazonlinux-2-arm64",
-            #     display_name="Amazon Linux 2 Arm64",
-            #     arch="arm64",
-            #     pkg_type="rpm",
-            #     container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2",
-            # ),
-            LinuxPkg(
                 slug="amazonlinux-2023",
                 display_name="Amazon Linux 2023",
                 arch="x86_64",
                 pkg_type="rpm",
                 container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023",
-            ),
-            LinuxPkg(
-                slug="amazonlinux-2023-arm64",
-                display_name="Amazon Linux 2023 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023",
-            ),
-            LinuxPkg(
-                slug="debian-11",
-                display_name="Debian 11",
-                arch="x86_64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-11",
             ),
             LinuxPkg(
                 slug="debian-11-arm64",
@@ -295,20 +177,6 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
             ),
             LinuxPkg(
-                slug="debian-12-arm64",
-                display_name="Debian 12 Arm64",
-                arch="arm64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
-            ),
-            LinuxPkg(
-                slug="photonos-4",
-                display_name="Photon OS 4",
-                arch="x86_64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            LinuxPkg(
                 slug="photonos-4-arm64",
                 display_name="Photon OS 4 Arm64",
                 arch="arm64",
@@ -319,14 +187,6 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
                 slug="photonos-4",
                 display_name="Photon OS 4",
                 arch="x86_64",
-                pkg_type="rpm",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            LinuxPkg(
-                slug="photonos-4-arm64",
-                display_name="Photon OS 4 Arm64",
-                arch="arm64",
                 pkg_type="rpm",
                 fips=True,
                 container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
@@ -343,30 +203,8 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
                 display_name="Photon OS 5 Arm64",
                 arch="arm64",
                 pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            LinuxPkg(
-                slug="photonos-5",
-                display_name="Photon OS 5",
-                arch="x86_64",
-                pkg_type="rpm",
                 fips=True,
                 container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            LinuxPkg(
-                slug="photonos-5-arm64",
-                display_name="Photon OS 5 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            LinuxPkg(
-                slug="ubuntu-22.04",
-                display_name="Ubuntu 22.04",
-                arch="x86_64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04",
             ),
             LinuxPkg(
                 slug="ubuntu-22.04-arm64",
@@ -379,13 +217,6 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
                 slug="ubuntu-24.04",
                 display_name="Ubuntu 24.04",
                 arch="x86_64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
-            ),
-            LinuxPkg(
-                slug="ubuntu-24.04-arm64",
-                display_name="Ubuntu 24.04 Arm64",
-                arch="arm64",
                 pkg_type="deb",
                 container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
             ),

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -129,7 +129,6 @@ TEST_SALT_LISTING = PlatformDefinitions(
         ],
         "macos": [
             MacOS(slug="macos-13", display_name="macOS 13", arch="x86_64"),
-            MacOS(slug="macos-14", display_name="macOS 14 (M1)", arch="arm64"),
             MacOS(slug="macos-15", display_name="macOS 15 (M1)", arch="arm64"),
         ],
         "windows": [
@@ -223,7 +222,6 @@ TEST_SALT_PKG_LISTING = PlatformDefinitions(
         ],
         "macos": [
             MacOSPkg(slug="macos-13", display_name="macOS 13", arch="x86_64"),
-            MacOSPkg(slug="macos-14", display_name="macOS 14 (M1)", arch="arm64"),
             MacOSPkg(slug="macos-15", display_name="macOS 15 (M1)", arch="arm64"),
         ],
         "windows": [


### PR DESCRIPTION
Reduce the amount of duplicate tests we are running by only testing one platform per linux OS.