### PR TITLE
Wean off tornado.gen.coroutine

### DIFF
--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -21,7 +21,7 @@ import salt.utils.files
 import salt.utils.stringutils
 import salt.utils.verify
 import salt.utils.versions
-from salt.utils.asynchronous import SyncWrapper
+from salt.utils.asynchronous import SyncWrapper, aioloop
 
 log = logging.getLogger(__name__)
 
@@ -422,7 +422,7 @@ class AsyncPubChannel:
 
     def __init__(self, opts, transport, auth, io_loop=None):
         self.opts = opts
-        self.io_loop = io_loop
+        self.io_loop = aioloop(io_loop)
         self.auth = auth
         try:
             # This loads or generates the minion's public key.
@@ -636,7 +636,7 @@ class AsyncPubChannel:
         return self
 
     def __exit__(self, *args):
-        self.io_loop.spawn_callback(self.close)
+        self.io_loop.call_soon(self.close)
 
     async def __aenter__(self):
         return self

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1171,10 +1171,13 @@ class MasterPubServerChannel:
                 payload_handler=self.handle_pool_publish,
             )
             self.pool_puller.start()
-        self.io_loop.add_callback(
-            self.transport.publisher,
-            self.publish_payload,
-            io_loop=self.io_loop,
+        # Extract asyncio loop for create_task
+        aio_loop = salt.utils.asynchronous.aioloop(self.io_loop)
+        aio_loop.create_task(
+            self.transport.publisher(
+                self.publish_payload,
+                io_loop=self.io_loop,
+            )
         )
         # run forever
         try:

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,8 +18,6 @@ import threading
 import time
 from collections import OrderedDict
 
-import tornado.gen
-
 import salt.acl
 import salt.auth
 import salt.channel.server
@@ -1008,13 +1006,19 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
             log.trace("Ignore tag %s", tag)
 
     def run(self):
-        io_loop = tornado.ioloop.IOLoop()
+        io_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(io_loop)
         with salt.utils.event.get_master_event(
             self.opts, self.opts["sock_dir"], io_loop=io_loop, listen=True
         ) as event_bus:
             event_bus.subscribe("")
             event_bus.set_event_handler(self.handle_event)
-            io_loop.start()
+            try:
+                io_loop.run_forever()
+            except (KeyboardInterrupt, SystemExit):
+                pass
+            finally:
+                io_loop.close()
 
 
 class ReqServer(salt.utils.process.SignalHandlingProcess):
@@ -1175,20 +1179,18 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         """
         Bind to the local port
         """
-        asyncio_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(asyncio_loop)
-        self.io_loop = tornado.ioloop.IOLoop(
-            asyncio_loop=asyncio_loop, make_current=False
-        )
+        self.io_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.io_loop)
         for req_channel in self.req_channels:
             req_channel.post_fork(
-                self._handle_payload, io_loop=asyncio_loop
+                self._handle_payload, io_loop=self.io_loop
             )  # TODO: cleaner? Maybe lazily?
         try:
-            self.io_loop.start()
+            self.io_loop.run_forever()
         except (KeyboardInterrupt, SystemExit):
-            # Tornado knows what to do
             pass
+        finally:
+            self.io_loop.close()
 
     async def _handle_payload(self, payload):
         """

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -5,6 +5,7 @@
 import asyncio
 import concurrent.futures
 import copy
+import functools
 import logging
 import os
 import signal
@@ -164,8 +165,13 @@ async def post_master_init(self, master):
     # Start engines here instead of in the Minion superclass __init__
     # This is because we need to inject the __proxy__ variable but
     # it is not setup until now.
-    self.io_loop.spawn_callback(
-        salt.engines.start_engines, self.opts, self.process_manager, proxy=self.proxy
+    self.io_loop.call_soon(
+        functools.partial(
+            salt.engines.start_engines,
+            self.opts,
+            self.process_manager,
+            proxy=self.proxy,
+        )
     )
 
     proxy_init_func_name = f"{fq_proxyname}.init"

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import copy
+import functools
 import logging
 import os
 import signal
@@ -160,8 +161,13 @@ async def post_master_init(self, master):
     # Start engines here instead of in the Minion superclass __init__
     # This is because we need to inject the __proxy__ variable but
     # it is not setup until now.
-    self.io_loop.spawn_callback(
-        salt.engines.start_engines, self.opts, self.process_manager, proxy=self.proxy
+    self.io_loop.call_soon(
+        functools.partial(
+            salt.engines.start_engines,
+            self.opts,
+            self.process_manager,
+            proxy=self.proxy,
+        )
     )
 
     if (

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -242,7 +242,6 @@ class PublishClient(salt.transport.base.PublishClient):
     def __init__(self, opts, io_loop, **kwargs):  # pylint: disable=W0231
         super().__init__(opts, io_loop, **kwargs)
         self.opts = opts
-        # XXX self.io_loop is never used. :(
         self.io_loop = salt.utils.asynchronous.aioloop(io_loop)
         self.unpacker = salt.utils.msgpack.Unpacker()
         self.connected = False

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -1476,7 +1476,8 @@ class RequestClient(salt.transport.base.RequestClient):
                     break
 
             if future.done():
-                if isinstance(future.exception, SaltReqTimeoutError):
+                exc = future.exception()
+                if isinstance(exc, SaltReqTimeoutError):
                     log.trace(
                         "Request timed out while waiting for a response. reconnecting."
                     )

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -1300,7 +1300,9 @@ class RequestClient(salt.transport.base.RequestClient):
                         cancelled_task.exception()
                     except asyncio.CancelledError:  # pragma: no cover
                         pass
-                    except Exception:  # pragma: no cover
+                    except (
+                        Exception  # pylint: disable=broad-exception-caught
+                    ):  # pragma: no cover
                         log.trace(
                             "Exception while cancelling send/receive task.",
                             exc_info=True,

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -14,6 +14,19 @@ import tornado.ioloop
 log = logging.getLogger(__name__)
 
 
+def aioloop(io_loop, warn=False):
+    """
+    Ensure the ioloop is an asyncio loop not a tornado ioloop.
+    """
+    if isinstance(io_loop, tornado.ioloop.IOLoop):
+        if warn:
+            import traceback
+
+            log.warning("Passed tornado loop %s", "".join(traceback.format_stack()))
+        return io_loop.asyncio_loop
+    return io_loop
+
+
 @contextlib.contextmanager
 def current_ioloop(io_loop):
     """

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -18,13 +18,16 @@ def aioloop(io_loop, warn=False):
     """
     Ensure the ioloop is an asyncio loop not a tornado ioloop.
     """
-    if isinstance(io_loop, tornado.ioloop.IOLoop):
+    if isinstance(io_loop, asyncio.AbstractEventLoop):
+        return io_loop
+    elif isinstance(io_loop, tornado.ioloop.IOLoop):
         if warn:
             import traceback
 
             log.warning("Passed tornado loop %s", "".join(traceback.format_stack()))
         return io_loop.asyncio_loop
-    return io_loop
+    else:
+        raise RuntimeError("Loop must be AbstractEventLoop (prefered) or IOLoop")
 
 
 @contextlib.contextmanager

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -49,6 +49,7 @@ Namespaced tag
 
 """
 
+import asyncio
 import atexit
 import contextlib
 import datetime

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -2,6 +2,7 @@
 Functions for daemonizing and otherwise modifying running processes
 """
 
+import asyncio
 import contextlib
 import copy
 import errno
@@ -20,8 +21,6 @@ import subprocess
 import sys
 import threading
 import time
-
-from tornado import gen
 
 import salt._logging
 import salt.defaults.exitcodes
@@ -608,8 +607,7 @@ class ProcessManager:
                 # Otherwise, it's a dead process, remove it from the process map
                 del self._process_map[pid]
 
-    @gen.coroutine
-    def run(self, asynchronous=False):
+    async def run(self, asynchronous=False):
         """
         Load and start all available api modules
         """
@@ -634,7 +632,7 @@ class ProcessManager:
                 # because os.wait() conflicts with the subprocesses management logic
                 # implemented in `multiprocessing` package. See #35480 for details.
                 if asynchronous:
-                    yield gen.sleep(10)
+                    await asyncio.sleep(10)
                 else:
                     time.sleep(10)
                 if not self._process_map:

--- a/tests/pytests/functional/transport/zeromq/test_request_client.py
+++ b/tests/pytests/functional/transport/zeromq/test_request_client.py
@@ -131,7 +131,9 @@ async def test_request_client_send_recv_socket_closed(
     with caplog.at_level(logging.TRACE):
         request_client.close()
         await asyncio.sleep(0.5)
-        assert "Send socket closed while polling." in caplog.messages
+        # The tornado version would see this log.
+        # assert "Send socket closed while polling." in caplog.messages
+        assert "Received send/recv shutdown sentinal" in caplog.messages
         assert f"Send and receive coroutine ending {socket}" in caplog.messages
 
 

--- a/tests/pytests/functional/utils/test_process.py
+++ b/tests/pytests/functional/utils/test_process.py
@@ -5,6 +5,7 @@ tests.pytests.functional.utils.test_process
 Test salt's process utility module
 """
 
+import asyncio
 import os
 import pathlib
 import time
@@ -71,3 +72,87 @@ def test_subprocess_list_fds():
             break
     assert len(process_list.processes) == 0
     assert _get_num_fds(pid) == num - 2
+
+
+async def test_process_manager_run_async():
+    """
+    Test that ProcessManager.run() is now an async coroutine.
+    This tests the conversion from Tornado @gen.coroutine to async/await.
+    """
+    process_manager = salt.utils.process.ProcessManager(wait_for_kill=5)
+    try:
+        # Verify run() is an async coroutine
+        import inspect
+
+        assert inspect.iscoroutinefunction(process_manager.run)
+
+        # Create a task to run the process manager asynchronously
+        task = asyncio.create_task(process_manager.run(asynchronous=True))
+
+        # Let it run briefly
+        await asyncio.sleep(0.5)
+
+        # Verify the task is running
+        assert not task.done()
+
+        # Cancel the task
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    finally:
+        process_manager.terminate()
+
+
+async def test_process_manager_run_uses_asyncio_sleep():
+    """
+    Test that ProcessManager.run() uses asyncio.sleep() instead of gen.sleep().
+    """
+    process_manager = salt.utils.process.ProcessManager(wait_for_kill=5)
+    try:
+        # Start the async run
+        task = asyncio.create_task(process_manager.run(asynchronous=True))
+
+        # Wait a bit to ensure it's looping with asyncio.sleep
+        await asyncio.sleep(0.1)
+
+        # Verify it's still running (would hang if gen.sleep was used incorrectly)
+        assert not task.done()
+
+        # Clean up
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    finally:
+        process_manager.terminate()
+
+
+def test_process_manager_run_synchronous():
+    """
+    Test that ProcessManager.run() can still run synchronously.
+    """
+    process_manager = salt.utils.process.ProcessManager(wait_for_kill=5)
+    try:
+        # When asynchronous=False, it should use time.sleep and exit quickly
+        # since there are no processes
+        import threading
+
+        ran = []
+
+        def run_sync():
+            # This should complete quickly since there are no processes
+            asyncio.run(process_manager.run(asynchronous=False))
+            ran.append(True)
+
+        thread = threading.Thread(target=run_sync)
+        thread.start()
+        thread.join(timeout=2)
+
+        # Should have completed
+        assert not thread.is_alive()
+        assert ran == [True]
+    finally:
+        process_manager.terminate()

--- a/tests/pytests/unit/transport/test_publish_client.py
+++ b/tests/pytests/unit/transport/test_publish_client.py
@@ -304,7 +304,7 @@ async def test_recv_timeout_zero():
     """
     host = "127.0.0.1"
     port = 11122
-    ioloop = MagicMock()
+    ioloop = asyncio.get_running_loop()
     mock_stream = MagicMock()
     mock_unpacker = MagicMock()
     mock_unpacker.__iter__.return_value = []

--- a/tests/pytests/unit/transport/test_tcp.py
+++ b/tests/pytests/unit/transport/test_tcp.py
@@ -492,6 +492,8 @@ async def test_presence_removed_on_stream_closed():
     opts = {"presence_events": True}
 
     io_loop_mock = MagicMock(spec=tornado.ioloop.IOLoop)
+    # Add asyncio_loop attribute for aioloop() compatibility
+    io_loop_mock.asyncio_loop = MagicMock()
 
     with patch("salt.master.AESFuncs.__init__", return_value=None):
         server = salt.transport.tcp.PubServer(opts, io_loop=io_loop_mock)

--- a/tests/pytests/unit/transport/test_tcp.py
+++ b/tests/pytests/unit/transport/test_tcp.py
@@ -443,7 +443,7 @@ async def test_when_async_req_channel_with_syndic_role_should_use_syndic_master_
 
 @pytest.mark.usefixtures("_fake_authd", "_fake_crypticle", "_fake_keys")
 async def test_mixin_should_use_correct_path_when_syndic():
-    mockloop = MagicMock()
+    mockloop = asyncio.get_running_loop()
     expected_pubkey_path = os.path.join("/etc/salt/pki/minion", "syndic_master.pub")
     opts = {
         "master_uri": "tcp://127.0.0.1:4506",

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1718,7 +1718,7 @@ async def test_client_send_recv_on_cancelled_error(minion_opts, io_loop):
         client.socket = AsyncMock()
         client.socket.poll.side_effect = zmq.eventloop.future.CancelledError
         client._queue.put_nowait((mock_future, {"meh": "bah"}))
-        await client._send_recv(client.socket)
+        await client._send_recv(client.socket, client._queue)
         mock_future.set_exception.assert_not_called()
     finally:
         client.close()


### PR DESCRIPTION
 This work is a part of #61380
 
 1. Coroutine Syntax Migration:
    - Replaced @tornado.gen.coroutine decorators with async def
    - Replaced raise tornado.gen.Return(value) with return value
    - Replaced yield statements with await for async operations
  2. IOLoop Handling:
    - Standardized on tornado.ioloop.IOLoop.current() or Python's asyncio event loop
    - Removed custom tornado ioloop management in favor of asyncio
  3. Async Method Conversions:
    - _handle_payload() methods converted from generators to async
    - eval_master() converted to async/await pattern
    - Connection and authentication methods now use native async
