### PR TITLE
fix: set_locale on debian 13

### DIFF
--- a/changelog/68425.fixed.md
+++ b/changelog/68425.fixed.md
@@ -1,0 +1,1 @@
+Fix `set_locale` on Debian 13/14 where systemd-localed is unavailable; fall back to /etc/default/locale update.

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -212,9 +212,11 @@ def set_locale(locale):
         salt '*' locale.set_locale 'en_US.UTF-8'
     """
     lc_ctl = salt.utils.systemd.booted(__context__)
-    # localectl on SLE12 is installed but the integration is broken -- config is rewritten by YaST2
     if lc_ctl and not (
+        # localectl on SLE12 is installed but the integration is broken -- config is rewritten by YaST2
         __grains__["os_family"] in ["Suse"] and __grains__["osmajorrelease"] in [12]
+        # starting from Debian 13, update-locale must be used instead of localectl set-locale
+        or __grains__["os_family"] in ["Debian"] and __grains__["osmajorrelease"] >= 13
     ):
         return _localectl_set(locale)
 

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -214,9 +214,11 @@ def set_locale(locale):
     lc_ctl = salt.utils.systemd.booted(__context__)
     if lc_ctl and not (
         # localectl on SLE12 is installed but the integration is broken -- config is rewritten by YaST2
-        __grains__["os_family"] in ["Suse"] and __grains__["osmajorrelease"] in [12]
+        __grains__["os_family"] in ["Suse"]
+        and __grains__["osmajorrelease"] in [12]
         # starting from Debian 13, update-locale must be used instead of localectl set-locale
-        or __grains__["os_family"] in ["Debian"] and __grains__["osmajorrelease"] >= 13
+        or __grains__["os_family"] in ["Debian"]
+        and __grains__["osmajorrelease"] >= 13
     ):
         return _localectl_set(locale)
 

--- a/tests/pytests/unit/modules/test_localemod_debian13.py
+++ b/tests/pytests/unit/modules/test_localemod_debian13.py
@@ -1,0 +1,70 @@
+"""
+Tests for set_locale on Debian 13+ (issue #68425).
+
+Debian trixie (13) removed support for ``localectl set-locale``; Salt must
+fall through to the existing ``update-locale`` + ``/etc/default/locale``
+path on Debian 13 and newer while preserving the prior behaviour on
+Debian 12.
+"""
+
+import pytest
+
+import salt.modules.localemod as localemod
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {localemod: {"__context__": {}, "__salt__": {}}}
+
+
+@patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/update-locale"))
+@patch(
+    "salt.modules.localemod.__grains__",
+    {"os_family": "Debian", "osmajorrelease": 13},
+)
+@patch("salt.modules.localemod._localectl_set", MagicMock())
+@patch("salt.utils.systemd.booted", MagicMock(return_value=True))
+def test_set_locale_debian13_skips_localectl():
+    """Debian 13 with systemd must use update-locale, not localectl."""
+    with patch.dict(
+        localemod.__salt__,
+        {"file.replace": MagicMock(), "cmd.run": MagicMock()},
+    ):
+        localemod.set_locale("de_DE.utf8")
+        assert not localemod._localectl_set.called
+        assert localemod.__salt__["file.replace"].called
+        assert (
+            localemod.__salt__["file.replace"].call_args[0][0] == "/etc/default/locale"
+        )
+
+
+@patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/update-locale"))
+@patch(
+    "salt.modules.localemod.__grains__",
+    {"os_family": "Debian", "osmajorrelease": 14},
+)
+@patch("salt.modules.localemod._localectl_set", MagicMock())
+@patch("salt.utils.systemd.booted", MagicMock(return_value=True))
+def test_set_locale_debian14_skips_localectl():
+    """Future Debian releases (>=13) also fall through to update-locale."""
+    with patch.dict(
+        localemod.__salt__,
+        {"file.replace": MagicMock(), "cmd.run": MagicMock()},
+    ):
+        localemod.set_locale("de_DE.utf8")
+        assert not localemod._localectl_set.called
+
+
+@patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/localectl"))
+@patch(
+    "salt.modules.localemod.__grains__",
+    {"os_family": "Debian", "osmajorrelease": 12},
+)
+@patch("salt.modules.localemod._localectl_set", MagicMock())
+@patch("salt.utils.systemd.booted", MagicMock(return_value=True))
+def test_set_locale_debian12_still_uses_localectl():
+    """Debian 12 path is unchanged (regression guard)."""
+    localemod.set_locale("de_DE.utf8")
+    assert localemod._localectl_set.called
+    assert localemod._localectl_set.call_args[0][0] == "de_DE.utf8"


### PR DESCRIPTION
Fixes #68425

### What does this PR do?

Add a special case for Debian >= 13 with systemd : localectl set-local is not supported anymore.
Fall back to update-locale

