### PR TITLE
[3006.x] Fix leak in SaltMessageServer

### DIFF
--- a/changelog/68394.fixed.md
+++ b/changelog/68394.fixed.md
@@ -1,0 +1,1 @@
+Fix leak in SaltMessageServer where the unpacker was re-used on a stream disconnect.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -427,7 +427,6 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         """
         log.trace("Req client %s connected", address)
         self.clients.append((stream, address))
-        unpacker = salt.utils.msgpack.Unpacker()
         try:
             while True:
                 wire_bytes = yield stream.read_bytes(4096, partial=True)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -461,7 +461,7 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         if self._closing:
             return
         self._closing = True
-        for item in self.clients:
+        for item in list(self.clients):
             client, address = item
             client.close()
             self.remove_client(item)
@@ -853,8 +853,9 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
         if self._closing:
             return
         self._closing = True
-        for client in self.clients:
+        for client in list(self.clients):
             client.close()
+        self.clients.clear()
 
     # pylint: disable=W1701
     def __del__(self):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -414,6 +414,7 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         self.io_loop = io_loop
         self.clients = []
         self.message_handler = message_handler
+        self.unpacker = salt.utils.msgpack.Unpacker()
 
     @salt.ext.tornado.gen.coroutine
     def handle_stream(  # pylint: disable=arguments-differ
@@ -430,17 +431,19 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         try:
             while True:
                 wire_bytes = yield stream.read_bytes(4096, partial=True)
-                unpacker.feed(wire_bytes)
-                for framed_msg in unpacker:
+                self.unpacker.feed(wire_bytes)
+                for framed_msg in self.unpacker:
                     framed_msg = salt.transport.frame.decode_embedded_strs(framed_msg)
                     header = framed_msg["head"]
                     self.io_loop.spawn_callback(
                         self.message_handler, stream, framed_msg["body"], header
                     )
         except _StreamClosedError:
+            self.unpacker = salt.utils.msgpack.Unpacker()
             log.trace("req client disconnected %s", address)
             self.remove_client((stream, address))
         except Exception as e:  # pylint: disable=broad-except
+            self.unpacker = salt.utils.msgpack.Unpacker()
             log.trace("other master-side exception: %s", e, exc_info=True)
             self.remove_client((stream, address))
             stream.close()

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -414,7 +414,6 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         self.io_loop = io_loop
         self.clients = []
         self.message_handler = message_handler
-        self.unpacker = salt.utils.msgpack.Unpacker()
 
     @salt.ext.tornado.gen.coroutine
     def handle_stream(  # pylint: disable=arguments-differ
@@ -428,23 +427,24 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         """
         log.trace("Req client %s connected", address)
         self.clients.append((stream, address))
+        unpacker = salt.utils.msgpack.Unpacker()
         try:
             while True:
                 wire_bytes = yield stream.read_bytes(4096, partial=True)
-                self.unpacker.feed(wire_bytes)
-                for framed_msg in self.unpacker:
+                unpacker.feed(wire_bytes)
+                for framed_msg in unpacker:
                     framed_msg = salt.transport.frame.decode_embedded_strs(framed_msg)
                     header = framed_msg["head"]
                     self.io_loop.spawn_callback(
                         self.message_handler, stream, framed_msg["body"], header
                     )
         except _StreamClosedError:
-            self.unpacker = salt.utils.msgpack.Unpacker()
             log.trace("req client disconnected %s", address)
+            unpacker = salt.utils.msgpack.Unpacker()
             self.remove_client((stream, address))
         except Exception as e:  # pylint: disable=broad-except
-            self.unpacker = salt.utils.msgpack.Unpacker()
             log.trace("other master-side exception: %s", e, exc_info=True)
+            unpacker = salt.utils.msgpack.Unpacker()
             self.remove_client((stream, address))
             stream.close()
 


### PR DESCRIPTION
- Address leak where unpacker hung around after a client disconnect.
- Regression test for unpacker leak
- Ensure there are no lingering clients and add regression tests for potentially leaky logic.
- changelog

Fixes #68394
This is a re-work of #68399