### PR TITLE
[3006.x] Upgrade relenv to 0.21.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -435,7 +435,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -452,7 +452,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -468,7 +468,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -506,7 +506,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -453,7 +453,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -470,7 +470,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -487,7 +487,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -445,7 +445,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -463,7 +463,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.21.1"
+      relenv-version: "0.21.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/changelog/68431.fixed.md
+++ b/changelog/68431.fixed.md
@@ -1,0 +1,6 @@
+* Upgrade relenv to 0.21.2:
+  * We refresh the ensurepip bundle during every build so new runtimes ship with pip 25.2 and setuptools 80.9.0.
+  * Windows builds now pull newer SQLite (3.50.4.0) and XZ (5.6.2) sources, copy in a missing XZ config file, and tweak SBOM metadata; the libexpat update is prepared but only runs on older maintenance releases.
+  * Our downloader helpers log more clearly, know about more archive formats, and retry cleanly on transient errors.
+  * pip’s changing install API is handled by runtime wrappers that adapt to all of the current signatures.
+  * Linux verification tests install pip 25.2/25.3 before building setuptools to make sure that flow keeps working.

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.19"
-relenv_version: "0.21.1"
+relenv_version: "0.21.2"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04


### PR DESCRIPTION

* Upgrade relenv to 0.21.2:
  * We refresh the ensurepip bundle during every build so new runtimes ship with pip 25.2 and setuptools 80.9.0.
  * Windows builds now pull newer SQLite (3.50.4.0) and XZ (5.6.2) sources, copy in a missing XZ config file, and tweak SBOM metadata; the libexpat update is prepared but only runs on older maintenance releases.
  * Our downloader helpers log more clearly, know about more archive formats, and retry cleanly on transient errors.
  * pip’s changing install API is handled by runtime wrappers that adapt to all of the current signatures.
  * Linux verification tests install pip 25.2/25.3 before building setuptools to make sure that flow keeps working.

Fixes: #68431