### PR TITLE
Fix/improve syspaths warning message [3006.x]

### DIFF
--- a/changelog/68412.fixed.md
+++ b/changelog/68412.fixed.md
@@ -1,0 +1,3 @@
+Test loader now prevents .pyc files from being written during test run using
+sys.dont_write_bytecode = True. This results in 3x faster test execution and
+reduced IO operations

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -26,7 +26,7 @@ if salt.utils.platform.is_junos():
 else:
     __PLATFORM = sys.platform.lower()
 
-typo_warning = True
+missing_vars_warning = True
 log = logging.getLogger(__name__)
 EXPECTED_VARIABLES = (
     "ROOT_DIR",
@@ -64,12 +64,12 @@ else:
         if hasattr(__generated_syspaths, key):
             continue
         else:
-            if typo_warning:
-                log.warning("Possible Typo?")
+            if missing_vars_warning:
+                log.warning("Missing variable in _syspaths.py")
                 log.warning(
-                    "To dissolve this warning add `[variable] = None` to _syspaths.py"
+                    "To resolve this warning add `[variable] = None` to _syspaths.py"
                 )
-            typo_warning = False
+            missing_vars_warning = False
             log.warning("Variable %s is missing, value set to None", key)
             setattr(
                 __generated_syspaths, key, None

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -563,7 +563,7 @@ class LazyLoaderReloadingTest(TestCase):
         # when modules are reloaded quickly (see TODO comments below)
         self._original_dont_write_bytecode = sys.dont_write_bytecode
         sys.dont_write_bytecode = True
-        
+
         self.tmp_dir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
         self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
 
@@ -588,7 +588,7 @@ class LazyLoaderReloadingTest(TestCase):
     def tearDown(self):
         # Restore original dont_write_bytecode setting
         sys.dont_write_bytecode = self._original_dont_write_bytecode
-        
+
         for attrname in ("tmp_dir", "utils", "proxy", "loader", "minion_mods", "utils"):
             try:
                 delattr(self, attrname)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -559,6 +559,11 @@ class LazyLoaderReloadingTest(TestCase):
             os.makedirs(RUNTIME_VARS.TMP)
 
     def setUp(self):
+        # Prevent .pyc files from being written to avoid performance issues
+        # when modules are reloaded quickly (see TODO comments below)
+        self._original_dont_write_bytecode = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        
         self.tmp_dir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
         self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
 
@@ -581,6 +586,9 @@ class LazyLoaderReloadingTest(TestCase):
         )
 
     def tearDown(self):
+        # Restore original dont_write_bytecode setting
+        sys.dont_write_bytecode = self._original_dont_write_bytecode
+        
         for attrname in ("tmp_dir", "utils", "proxy", "loader", "minion_mods", "utils"):
             try:
                 delattr(self, attrname)
@@ -602,15 +610,11 @@ class LazyLoaderReloadingTest(TestCase):
             fh.flush()
             os.fsync(fh.fileno())  # flush to disk
 
-        # pyc files don't like it when we change the original quickly
-        # since the header bytes only contain the timestamp (granularity of seconds)
-        # TODO: don't write them? Is *much* slower on re-load (~3x)
-        # https://docs.python.org/2/library/sys.html#sys.dont_write_bytecode
-        remove_bytecode(self.module_path)
+        # .pyc files are prevented by sys.dont_write_bytecode = True in setUp()
 
     def rm_module(self):
         os.unlink(self.module_path)
-        remove_bytecode(self.module_path)
+        # .pyc files are prevented by sys.dont_write_bytecode = True in setUp()
 
     @property
     def module_path(self):


### PR DESCRIPTION
Backport of #68412 to 3006.x.

This PR cherry-picks the commits from the original PR and targets the oldest supported branch as requested.

Original PR: https://github.com/saltstack/salt/pull/68412