### PR TITLE
Mutating locals is unsupported in Py >=3.13

### DIFF
--- a/changelog/68445.fixed.md
+++ b/changelog/68445.fixed.md
@@ -1,0 +1,1 @@
+Stop mutating locals, which is unsupported in Py >=3.13

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -478,8 +478,7 @@ def get_tops(extra_mods="", so_mods=""):
     for mod in [m for m in extra_mods.split(",") if m]:
         if mod not in locals() and mod not in globals():
             try:
-                locals()[mod] = __import__(mod)
-                moddir, modname = os.path.split(locals()[mod].__file__)
+                moddir, modname = os.path.split(__import__(mod).__file__)
                 base, _ = os.path.splitext(modname)
                 if base == "__init__":
                     tops.append((moddir, None))
@@ -492,8 +491,7 @@ def get_tops(extra_mods="", so_mods=""):
 
     for mod in [m for m in so_mods.split(",") if m]:
         try:
-            locals()[mod] = __import__(mod)
-            tops.append((locals()[mod].__file__, None))
+            tops.append((__import__(mod).__file__, None))
         except ImportError:
             log.error('Unable to import so-module "%s"', mod, exc_info=True)
 


### PR DESCRIPTION
### What does this PR do?

In Python 3.13 and newer, mutating `__locals__` is no longer allowed [0]. 

This fixes the `test_thin` testsuite [1] when run with Python >=3.13. 

[0] https://docs.python.org/3/whatsnew/3.13.html#summary-release-highlights
[1] https://github.com/saltstack/salt/blob/master/tests/unit/utils/test_thin.py


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
