### PR TITLE
Adds support for domain users in user.info

### DIFF
--- a/changelog/68450.fixed.md
+++ b/changelog/68450.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue in cmd execution module that always return "Invalid user" for domain users.

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -802,8 +802,23 @@ def info(name):
     """
     ret = {}
     items = {}
+    username = str(name)
+    domainname = None
+    server = None
+
+    # Handles domain users with Down-Level Logon Name: DOMAIN\user
+    if "\\" in str(name):
+        domainname, username = str(name).split("\\", 1)
+    # And domain users with User Principal Name (UPN): user@DOMAIN
+    if "@" in str(name):
+        username, domainname = str(name).split("@", 1)
+        domainname = domainname.removesuffix(".local")
+
+    if domainname:
+        server = win32net.NetGetAnyDCName(None, domainname)
+
     try:
-        items = win32net.NetUserGetInfo(None, str(name), 4)
+        items = win32net.NetUserGetInfo(server, username, 4)
     except win32net.error:
         pass
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -815,7 +815,11 @@ def info(name):
         domainname = domainname.removesuffix(".local")
 
     if domainname:
-        server = win32net.NetGetAnyDCName(None, domainname)
+        try:
+            server = win32net.NetGetAnyDCName(None, domainname)
+        except win32net.error:
+            # Restore username to original
+            username = str(name)
 
     try:
         items = win32net.NetUserGetInfo(server, username, 4)

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -57,12 +57,15 @@ def split_username(username):
     Splits out the username from the domain name and returns both.
     """
     domain = "."
-    user_name = username
-    if "@" in username:
-        user_name, domain = username.split("@")
-    if "\\" in username:
-        domain, user_name = username.split("\\")
-    return user_name, domain
+    user_name = str(username)
+    # Domain users with User Principal Name (UPN): user@DOMAIN
+    if "@" in user_name:
+        user_name, domain = user_name.split("@", maxsplit=1)
+        domain = domain.removesuffix(".local")
+    # Domain users with Down-Level Logon Name: DOMAIN\user
+    if "\\" in user_name:
+        domain, user_name = user_name.split("\\", maxsplit=1)
+    return str(user_name), str(domain)
 
 
 def create_env(user_token, inherit, timeout=1):

--- a/tests/pytests/unit/utils/test_win_runas.py
+++ b/tests/pytests/unit/utils/test_win_runas.py
@@ -8,9 +8,10 @@ from salt.utils import win_runas
     [
         ("test_user", ("test_user", ".")),  # Simple system name
         ("domain\\test_user", ("test_user", "domain")),  # Sam name
-        ("domain.com\\test_user", ("test_user", "domain.com")),  # Sam name with com
+        ("domain.com\\test_user", ("test_user", "domain.com")),  # Sam name with .com
         ("test_user@domain", ("test_user", "domain")),  # UPN Name
-        ("test_user@domain.com", ("test_user", "domain.com")),  # UPN Name with com
+        ("test_user@domain.com", ("test_user", "domain.com")),  # UPN Name with .com
+        ("test_user@domain.local", ("test_user", "domain")),  # UPN Name with .local
     ],
 )
 def test_split_username(input_value, expected):


### PR DESCRIPTION
### What does this PR do?

Adds suport for domain users in `user.info` so the `runas` option in `cmd` execution module works for domain users.

### What issues does this PR fix or reference?
Fixes #68450 

### Previous Behavior
`user.info` returns no information for domain users

### New Behavior
`user.info` returns the information for existent domain users

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No