### PR TITLE
accept either ["site"] or ["scope"] for duplicate site entry detection due to netbox API change

### DIFF
--- a/changelog/68375.fixed.md
+++ b/changelog/68375.fixed.md
@@ -1,0 +1,1 @@
+Fix issue with upstream Netbox API which changed api/ipam/prefixes output to use "scope" FK instead of "site"

--- a/salt/pillar/netbox.py
+++ b/salt/pillar/netbox.py
@@ -1015,7 +1015,8 @@ def _get_site_prefixes(
     # Clean up duplicate data in the dictionary
     prefix_count = 0
     for prefix in site_prefixes_results:
-        del site_prefixes_results[prefix_count]["site"]
+        site_prefixes_results[prefix_count].pop("site", None)
+        site_prefixes_results[prefix_count].pop("scope", None)
         prefix_count += 1
 
     # Return the results

--- a/tests/pytests/unit/pillar/test_netbox.py
+++ b/tests/pytests/unit/pillar/test_netbox.py
@@ -1238,6 +1238,150 @@ def site_prefixes():
         },
     ]
 
+@pytest.fixture
+def site_prefixes_results_nb_420():
+    return {
+        "dict": {
+            "count": 2,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "id": 50,
+                    "url": "https://netbox.example.com/api/ipam/prefixes/50/",
+                    "display_url": "https://netbox.example.com/ipam/prefixes/50/",
+                    "display": "198.51.100.0/24",
+                    "family": {
+                        "value": 4,
+                        "label": "IPv4"
+                    },
+                    "prefix": "198.51.100.0/24",
+                    "vrf": None,
+                    "scope_type": "dcim.site",
+                    "scope_id": 1,
+                    "scope": {
+                        "id": 1,
+                        "url": "https://netbox.example.com/api/dcim/sites/1/",
+                        "display": "Site 1",
+                        "name": "Site 1",
+                        "slug": "site1",
+                        "description": ""
+                    },
+                    "tenant": None,
+                    "vlan": None,
+                    "status": {
+                        "value": "active",
+                        "label": "Active"
+                    },
+                    "role": None,
+                    "is_pool": False,
+                    "mark_utilized": False,
+                    "description": "",
+                    "comments": "",
+                    "tags": [],
+                    "custom_fields": {},
+                    "created": "2025-12-13T15:01:28.282368Z",
+                    "last_updated": "2025-12-22T21:44:22.907412Z",
+                    "children": 0,
+                    "_depth": 1
+                },
+                {
+                    "id": 43,
+                    "url": "https://netbox.example.com/api/ipam/prefixes/43/",
+                    "display_url": "https://netbox.example.com/ipam/prefixes/43/",
+                    "display": "2001:db8::/48",
+                    "family": {
+                        "value": 6,
+                        "label": "IPv6"
+                    },
+                    "prefix": "2001:db8::/48",
+                    "vrf": None,
+                    "scope_type": "dcim.site",
+                    "scope_id": 1,
+                    "scope": {
+                        "id": 1,
+                        "url": "https://netbox.example.com/api/dcim/sites/1/",
+                        "display": "Site 1",
+                        "name": "Site 1",
+                        "slug": "site1",
+                        "description": ""
+                    },
+                    "tenant": None,
+                    "vlan": None,
+                    "status": {
+                        "value": "active",
+                        "label": "Active"
+                    },
+                    "role": None,
+                    "is_pool": False,
+                    "mark_utilized": False,
+                    "description": "IPv6 addresses for Site 1",
+                    "comments": "",
+                    "tags": [],
+                    "custom_fields": {},
+                    "created": "2025-12-12T20:42:27.011531Z",
+                    "last_updated": "2025-12-12T20:42:27.011555Z",
+                    "children": 3,
+                    "_depth": 1
+                },
+            ],
+        }
+    }
+
+@pytest.fixture
+def site_prefixes_nb_420():
+    return [
+        {
+            '_depth': 1,
+            'children': 0,
+            'comments': '',
+            'created': '2025-12-13T15:01:28.282368Z',
+            'custom_fields': {},
+            'description': '',
+            'display': '198.51.100.0/24',
+            'display_url': 'https://netbox.example.com/ipam/prefixes/50/',
+            'family': {'label': 'IPv4', 'value': 4},
+            'id': 50,
+            'is_pool': False,
+            'last_updated': '2025-12-22T21:44:22.907412Z',
+            'mark_utilized': False,
+            'prefix': '198.51.100.0/24',
+            'role': None,
+            'scope_id': 1,
+            'scope_type': 'dcim.site',
+            'status': {'label': 'Active', 'value': 'active'},
+            'tags': [],
+            'tenant': None,
+            'url': 'https://netbox.example.com/api/ipam/prefixes/50/',
+            'vlan': None,
+            'vrf': None
+        },
+        {
+            '_depth': 1,
+            'children': 3,
+            'comments': '',
+            'created': '2025-12-12T20:42:27.011531Z',
+            'custom_fields': {},
+            'description': 'IPv6 addresses for Site 1',
+            'display': '2001:db8::/48',
+            'display_url': 'https://netbox.example.com/ipam/prefixes/43/',
+            'family': {'label': 'IPv6', 'value': 6},
+            'id': 43,
+            'is_pool': False,
+            'last_updated': '2025-12-12T20:42:27.011555Z',
+            'mark_utilized': False,
+            'prefix': '2001:db8::/48',
+            'role': None,
+            'scope_id': 1,
+            'scope_type': 'dcim.site',
+            'status': {'label': 'Active', 'value': 'active'},
+            'tags': [],
+            'tenant': None,
+            'url': 'https://netbox.example.com/api/ipam/prefixes/43/',
+            'vlan': None,
+            'vrf': None
+        }
+    ]
 
 @pytest.fixture
 def proxy_details_results():
@@ -2096,6 +2240,25 @@ def test_when_we_retrieve_site_prefixes_then_return_list(
             default_kwargs["api_query_result_limit"],
         )
 
+        assert actual_result == expected_result
+
+def test_when_we_retrieve_site_prefixes_nb_420_then_return_list(
+    default_kwargs, headers, site_prefixes_results_nb_420, site_prefixes_nb_420
+):
+
+    expected_result = site_prefixes_nb_420
+
+    with patch("salt.utils.http.query", autospec=True) as query:
+        query.return_value = site_prefixes_results_nb_420
+
+        actual_result = netbox._get_site_prefixes(
+            default_kwargs["api_url"],
+            default_kwargs["minion_id"],
+            "Site 1",
+            1,
+            headers,
+            default_kwargs["api_query_result_limit"],
+        )
         assert actual_result == expected_result
 
 

--- a/tests/pytests/unit/pillar/test_netbox.py
+++ b/tests/pytests/unit/pillar/test_netbox.py
@@ -1238,6 +1238,7 @@ def site_prefixes():
         },
     ]
 
+
 @pytest.fixture
 def site_prefixes_results_nb_420():
     return {
@@ -1251,10 +1252,7 @@ def site_prefixes_results_nb_420():
                     "url": "https://netbox.example.com/api/ipam/prefixes/50/",
                     "display_url": "https://netbox.example.com/ipam/prefixes/50/",
                     "display": "198.51.100.0/24",
-                    "family": {
-                        "value": 4,
-                        "label": "IPv4"
-                    },
+                    "family": {"value": 4, "label": "IPv4"},
                     "prefix": "198.51.100.0/24",
                     "vrf": None,
                     "scope_type": "dcim.site",
@@ -1265,14 +1263,11 @@ def site_prefixes_results_nb_420():
                         "display": "Site 1",
                         "name": "Site 1",
                         "slug": "site1",
-                        "description": ""
+                        "description": "",
                     },
                     "tenant": None,
                     "vlan": None,
-                    "status": {
-                        "value": "active",
-                        "label": "Active"
-                    },
+                    "status": {"value": "active", "label": "Active"},
                     "role": None,
                     "is_pool": False,
                     "mark_utilized": False,
@@ -1283,17 +1278,14 @@ def site_prefixes_results_nb_420():
                     "created": "2025-12-13T15:01:28.282368Z",
                     "last_updated": "2025-12-22T21:44:22.907412Z",
                     "children": 0,
-                    "_depth": 1
+                    "_depth": 1,
                 },
                 {
                     "id": 43,
                     "url": "https://netbox.example.com/api/ipam/prefixes/43/",
                     "display_url": "https://netbox.example.com/ipam/prefixes/43/",
                     "display": "2001:db8::/48",
-                    "family": {
-                        "value": 6,
-                        "label": "IPv6"
-                    },
+                    "family": {"value": 6, "label": "IPv6"},
                     "prefix": "2001:db8::/48",
                     "vrf": None,
                     "scope_type": "dcim.site",
@@ -1304,14 +1296,11 @@ def site_prefixes_results_nb_420():
                         "display": "Site 1",
                         "name": "Site 1",
                         "slug": "site1",
-                        "description": ""
+                        "description": "",
                     },
                     "tenant": None,
                     "vlan": None,
-                    "status": {
-                        "value": "active",
-                        "label": "Active"
-                    },
+                    "status": {"value": "active", "label": "Active"},
                     "role": None,
                     "is_pool": False,
                     "mark_utilized": False,
@@ -1322,66 +1311,68 @@ def site_prefixes_results_nb_420():
                     "created": "2025-12-12T20:42:27.011531Z",
                     "last_updated": "2025-12-12T20:42:27.011555Z",
                     "children": 3,
-                    "_depth": 1
+                    "_depth": 1,
                 },
             ],
         }
     }
 
+
 @pytest.fixture
 def site_prefixes_nb_420():
     return [
         {
-            '_depth': 1,
-            'children': 0,
-            'comments': '',
-            'created': '2025-12-13T15:01:28.282368Z',
-            'custom_fields': {},
-            'description': '',
-            'display': '198.51.100.0/24',
-            'display_url': 'https://netbox.example.com/ipam/prefixes/50/',
-            'family': {'label': 'IPv4', 'value': 4},
-            'id': 50,
-            'is_pool': False,
-            'last_updated': '2025-12-22T21:44:22.907412Z',
-            'mark_utilized': False,
-            'prefix': '198.51.100.0/24',
-            'role': None,
-            'scope_id': 1,
-            'scope_type': 'dcim.site',
-            'status': {'label': 'Active', 'value': 'active'},
-            'tags': [],
-            'tenant': None,
-            'url': 'https://netbox.example.com/api/ipam/prefixes/50/',
-            'vlan': None,
-            'vrf': None
+            "_depth": 1,
+            "children": 0,
+            "comments": "",
+            "created": "2025-12-13T15:01:28.282368Z",
+            "custom_fields": {},
+            "description": "",
+            "display": "198.51.100.0/24",
+            "display_url": "https://netbox.example.com/ipam/prefixes/50/",
+            "family": {"label": "IPv4", "value": 4},
+            "id": 50,
+            "is_pool": False,
+            "last_updated": "2025-12-22T21:44:22.907412Z",
+            "mark_utilized": False,
+            "prefix": "198.51.100.0/24",
+            "role": None,
+            "scope_id": 1,
+            "scope_type": "dcim.site",
+            "status": {"label": "Active", "value": "active"},
+            "tags": [],
+            "tenant": None,
+            "url": "https://netbox.example.com/api/ipam/prefixes/50/",
+            "vlan": None,
+            "vrf": None,
         },
         {
-            '_depth': 1,
-            'children': 3,
-            'comments': '',
-            'created': '2025-12-12T20:42:27.011531Z',
-            'custom_fields': {},
-            'description': 'IPv6 addresses for Site 1',
-            'display': '2001:db8::/48',
-            'display_url': 'https://netbox.example.com/ipam/prefixes/43/',
-            'family': {'label': 'IPv6', 'value': 6},
-            'id': 43,
-            'is_pool': False,
-            'last_updated': '2025-12-12T20:42:27.011555Z',
-            'mark_utilized': False,
-            'prefix': '2001:db8::/48',
-            'role': None,
-            'scope_id': 1,
-            'scope_type': 'dcim.site',
-            'status': {'label': 'Active', 'value': 'active'},
-            'tags': [],
-            'tenant': None,
-            'url': 'https://netbox.example.com/api/ipam/prefixes/43/',
-            'vlan': None,
-            'vrf': None
-        }
+            "_depth": 1,
+            "children": 3,
+            "comments": "",
+            "created": "2025-12-12T20:42:27.011531Z",
+            "custom_fields": {},
+            "description": "IPv6 addresses for Site 1",
+            "display": "2001:db8::/48",
+            "display_url": "https://netbox.example.com/ipam/prefixes/43/",
+            "family": {"label": "IPv6", "value": 6},
+            "id": 43,
+            "is_pool": False,
+            "last_updated": "2025-12-12T20:42:27.011555Z",
+            "mark_utilized": False,
+            "prefix": "2001:db8::/48",
+            "role": None,
+            "scope_id": 1,
+            "scope_type": "dcim.site",
+            "status": {"label": "Active", "value": "active"},
+            "tags": [],
+            "tenant": None,
+            "url": "https://netbox.example.com/api/ipam/prefixes/43/",
+            "vlan": None,
+            "vrf": None,
+        },
     ]
+
 
 @pytest.fixture
 def proxy_details_results():
@@ -2241,6 +2232,7 @@ def test_when_we_retrieve_site_prefixes_then_return_list(
         )
 
         assert actual_result == expected_result
+
 
 def test_when_we_retrieve_site_prefixes_nb_420_then_return_list(
     default_kwargs, headers, site_prefixes_results_nb_420, site_prefixes_nb_420


### PR DESCRIPTION
### What does this PR do?

The netbox API changed format in netbox 4.2.0 to change to a generic foreign key format. This commit allows both old and new API formats.

### What issues does this PR fix or reference?
Fixes #68375

### Previous Behavior
the minion pillar data failed to load with:

```
2025-11-10 17:33:48,613 [salt.pillar      :1228][ERROR   ][3692613] Exception caught loading ext_pillar 'netbox':
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/__init__.py", line 1220, in ext_pillar
    ext = self._external_pillar_data(pillar, val, key)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/__init__.py", line 1140, in _external_pillar_data
    ext = self.ext_pillars[key](self.minion_id, pillar, **val)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 162, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1248, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1263, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/netbox.py", line 1157, in ext_pillar
    ret["netbox"]["site"]["prefixes"] = _get_site_prefixes(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/pillar/netbox.py", line 1023, in _get_site_prefixes
    del site_prefixes_results[prefix_count]["site"]
```

### New Behavior
minion pillar now loads

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
