### PR TITLE
Handle REG_BINARY data in registry.pol

### DIFF
--- a/changelog/68387.fixed.md
+++ b/changelog/68387.fixed.md
@@ -1,0 +1,2 @@
+Fixed the lgpo_reg error when reading REG_BINARY type data in the registry.pol
+file.

--- a/salt/utils/win_lgpo_reg.py
+++ b/salt/utils/win_lgpo_reg.py
@@ -8,13 +8,19 @@ import os
 import re
 import struct
 
-import win32con
-
 import salt.modules.win_file
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.win_reg
 from salt.exceptions import CommandExecutionError
+
+try:
+    import win32con
+
+    HAS_WINDOWS_MODULES = True
+except ImportError:
+    HAS_WINDOWS_MODULES = False
+
 
 CLASS_INFO = {
     "User": {
@@ -60,6 +66,8 @@ def __virtual__():
     """
     if not salt.utils.platform.is_windows():
         return False, "LGPO_REG Util: Only available on Windows"
+    if not HAS_WINDOWS_MODULES:
+        return False, "LGPO_REG Util: Missing win32 modules"
 
     return __virtualname__
 

--- a/tests/pytests/unit/utils/test_win_lgpo_reg.py
+++ b/tests/pytests/unit/utils/test_win_lgpo_reg.py
@@ -591,3 +591,53 @@ def test_issue_56769_mixed_line_endings():
             result = fp.read()
 
         assert result == expected
+
+
+def test_dict_to_reg_pol_reg_binary():
+    """
+    Test REG_QWORD
+    """
+    test_dict = {
+        "SOFTWARE\\MyKey": {
+            "MyValue": {
+                "data": "1552f6a579b77b61460df56cb4b2ce0a34fe96b6176829d7916275b806edc2bb",
+                "type": "REG_BINARY",
+            },
+        },
+    }
+    expected = (
+        b"PReg\x01\x00\x00\x00[\x00"
+        b"S\x00O\x00F\x00T\x00W\x00A\x00R\x00E\x00\\\x00M\x00y\x00K\x00e\x00y\x00\x00\x00;\x00"
+        b"M\x00y\x00V\x00a\x00l\x00u\x00e\x00\x00\x00;\x00"
+        b"\x03\x00\x00\x00;\x00"
+        b" \x00\x00\x00;\x00"
+        b"\x15R\xf6\xa5y\xb7{aF\r\xf5l\xb4\xb2\xce\n4\xfe\x96\xb6\x17h)\xd7\x91bu\xb8\x06\xed\xc2\xbb"
+        b"]\x00"
+    )
+    result = win_lgpo_reg.dict_to_reg_pol(test_dict)
+    assert result == expected
+
+
+def test_reg_pol_to_dict_reg_binary():
+    """
+    Test REG_QWORD
+    """
+    test_data = (
+        b"PReg\x01\x00\x00\x00[\x00"
+        b"S\x00O\x00F\x00T\x00W\x00A\x00R\x00E\x00\\\x00M\x00y\x00K\x00e\x00y\x00\x00\x00;\x00"
+        b"M\x00y\x00V\x00a\x00l\x00u\x00e\x00\x00\x00;\x00"
+        b"\x03\x00\x00\x00;\x00"
+        b" \x00\x00\x00;\x00"
+        b"\x15R\xf6\xa5y\xb7{aF\r\xf5l\xb4\xb2\xce\n4\xfe\x96\xb6\x17h)\xd7\x91bu\xb8\x06\xed\xc2\xbb"
+        b"]\x00"
+    )
+    expected = {
+        "SOFTWARE\\MyKey": {
+            "MyValue": {
+                "data": "1552f6a579b77b61460df56cb4b2ce0a34fe96b6176829d7916275b806edc2bb",
+                "type": "REG_BINARY",
+            },
+        },
+    }
+    result = win_lgpo_reg.reg_pol_to_dict(test_data)
+    assert result == expected


### PR DESCRIPTION
### What does this PR do?
Fixes an issue when reading the `registry.pol` file (`lgpo_reg.read_reg_pol`) when it contains `REG_BINARY` type data. REG_BINARY data is converted to hex and displayed properly. Going the other way, hex data is converted to binary data for writing to `registry.pol`.

### What issues does this PR fix or reference?
Fixes #68387

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
