### PR TITLE
Add blockdev state module back

### DIFF
--- a/changelog/68465.fixed.md
+++ b/changelog/68465.fixed.md
@@ -1,0 +1,3 @@
+Add `blockdev` state module back in to core
+
+Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -18,6 +18,7 @@ state modules
     archive
     at
     beacon
+    blockdev
     chocolatey
     cloud
     cmd

--- a/doc/ref/states/all/salt.states.blockdev.rst
+++ b/doc/ref/states/all/salt.states.blockdev.rst
@@ -1,0 +1,5 @@
+salt.states.blockdev
+====================
+
+.. automodule:: salt.states.blockdev
+    :members:

--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -1,0 +1,198 @@
+"""
+Management of Block Devices
+
+A state module to manage blockdevices
+
+.. code-block:: yaml
+
+
+    /dev/sda:
+      blockdev.tuned:
+        - read-only: True
+
+    master-data:
+      blockdev.tuned:
+        - name: /dev/vg/master-data
+        - read-only: True
+        - read-ahead: 1024
+
+
+.. versionadded:: 2014.7.0
+"""
+
+import logging
+import os
+import os.path
+import time
+
+import salt.utils.path
+
+__virtualname__ = "blockdev"
+
+# Init logger
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    """
+    Only load this module if the disk execution module is available
+    """
+    if "disk.tune" in __salt__:
+        return __virtualname__
+    return (
+        False,
+        "Cannot load the {} state module: disk execution module not found".format(
+            __virtualname__
+        ),
+    )
+
+
+def tuned(name, **kwargs):
+    """
+    Manage options of block device
+
+    name
+        The name of the block device
+
+    opts:
+      - read-ahead
+          Read-ahead buffer size
+
+      - filesystem-read-ahead
+          Filesystem Read-ahead buffer size
+
+      - read-only
+          Set Read-Only
+
+      - read-write
+          Set Read-Write
+    """
+
+    ret = {"changes": {}, "comment": "", "name": name, "result": True}
+
+    kwarg_map = {
+        "read-ahead": "getra",
+        "filesystem-read-ahead": "getfra",
+        "read-only": "getro",
+        "read-write": "getro",
+    }
+
+    if not __salt__["file.is_blkdev"]:
+        ret["comment"] = "Changes to {} cannot be applied. Not a block device. ".format(
+            name
+        )
+    elif __opts__["test"]:
+        ret["comment"] = f"Changes to {name} will be applied "
+        ret["result"] = None
+        return ret
+    else:
+        current = __salt__["disk.dump"](name)
+        changes = __salt__["disk.tune"](name, **kwargs)
+        changeset = {}
+        for key in kwargs:
+            if key in kwarg_map:
+                switch = kwarg_map[key]
+                if current[switch] != changes[switch]:
+                    if isinstance(kwargs[key], bool):
+                        old = current[switch] == "1"
+                        new = changes[switch] == "1"
+                    else:
+                        old = current[switch]
+                        new = changes[switch]
+                    if key == "read-write":
+                        old = not old
+                        new = not new
+                    changeset[key] = f"Changed from {old} to {new}"
+        if changes:
+            if changeset:
+                ret["comment"] = f"Block device {name} successfully modified "
+                ret["changes"] = changeset
+            else:
+                ret["comment"] = f"Block device {name} already in correct state"
+        else:
+            ret["comment"] = f"Failed to modify block device {name}"
+            ret["result"] = False
+    return ret
+
+
+def formatted(name, fs_type="ext4", force=False, **kwargs):
+    """
+    Manage filesystems of partitions.
+
+    name
+        The name of the block device
+
+    fs_type
+        The filesystem it should be formatted as
+
+    force
+        Force mke2fs to create a filesystem, even if the specified device is
+        not a partition on a block special device. This option is only enabled
+        for ext and xfs filesystems
+
+        This option is dangerous, use it with caution.
+
+        .. versionadded:: 2016.11.0
+    """
+    ret = {
+        "changes": {},
+        "comment": f"{name} already formatted with {fs_type}",
+        "name": name,
+        "result": False,
+    }
+
+    if not os.path.exists(name):
+        ret["comment"] = f"{name} does not exist"
+        return ret
+
+    current_fs = _checkblk(name)
+
+    if current_fs == fs_type:
+        ret["result"] = True
+        return ret
+    elif not salt.utils.path.which(f"mkfs.{fs_type}"):
+        ret["comment"] = f"Invalid fs_type: {fs_type}"
+        ret["result"] = False
+        return ret
+    elif __opts__["test"]:
+        ret["comment"] = f"Changes to {name} will be applied "
+        ret["result"] = None
+        return ret
+
+    __salt__["disk.format"](name, fs_type, force=force, **kwargs)
+
+    # Repeat fstype check up to 10 times with 3s sleeping between each
+    # to avoid detection failing although mkfs has succeeded
+    # see https://github.com/saltstack/salt/issues/25775
+    # This retry maybe superfluous - switching to blkid
+    for i in range(10):
+
+        log.info("Check blk fstype attempt %d of 10", i + 1)
+        current_fs = _checkblk(name)
+
+        if current_fs == fs_type:
+            ret["comment"] = f"{name} has been formatted with {fs_type}"
+            ret["changes"] = {"new": fs_type, "old": current_fs}
+            ret["result"] = True
+            return ret
+
+        if current_fs == "":
+            log.info("Waiting 3s before next check")
+            time.sleep(3)
+        else:
+            break
+
+    ret["comment"] = f"Failed to format {name}"
+    ret["result"] = False
+    return ret
+
+
+def _checkblk(name):
+    """
+    Check if the blk exists and return its fstype if ok
+    """
+
+    blk = __salt__["cmd.run"](
+        ["blkid", "-o", "value", "-s", "TYPE", name], ignore_retcode=True
+    )
+    return "" if not blk else blk

--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -77,10 +77,9 @@ def tuned(name, **kwargs):
         "read-write": "getro",
     }
 
-    if not __salt__["file.is_blkdev"]:
-        ret["comment"] = "Changes to {} cannot be applied. Not a block device. ".format(
-            name
-        )
+    if not __salt__["file.is_blkdev"](name):
+        ret["comment"] = f"Changes to {name} cannot be applied. Not a block device."
+        ret["result"] = False
     elif __opts__["test"]:
         ret["comment"] = f"Changes to {name} will be applied "
         ret["result"] = None

--- a/tests/pytests/functional/states/test_blockdev.py
+++ b/tests/pytests/functional/states/test_blockdev.py
@@ -1,0 +1,26 @@
+import logging
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def non_blockdev_file():
+    with pytest.helpers.temp_file() as tmp_file:
+        assert tmp_file.is_file()
+        yield tmp_file
+
+
+def test_tuned_not_block_device(states, non_blockdev_file):
+    """
+    Test to ensure that when the target is not a block device,
+    the state returns False and a comment indicating the issue.
+    """
+    name = str(non_blockdev_file)
+
+    ret = states.blockdev.tuned(
+        name=name,
+    )
+    assert ret["result"] is False
+    assert ret["comment"] == f"Changes to {name} cannot be applied. Not a block device."

--- a/tests/pytests/unit/states/test_blockdev.py
+++ b/tests/pytests/unit/states/test_blockdev.py
@@ -1,0 +1,103 @@
+"""
+    :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
+"""
+
+import os
+
+import pytest
+
+import salt.states.blockdev as blockdev
+import salt.utils.path
+from tests.support.mock import MagicMock, Mock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {blockdev: {}}
+
+
+def test_tuned():
+    """
+    Test to manage options of block device
+    """
+    name = "/dev/vg/master-data"
+
+    ret = {"name": name, "result": True, "changes": {}, "comment": ""}
+
+    comt = ("Changes to {} cannot be applied. Not a block device. ").format(name)
+    with patch.dict(blockdev.__salt__, {"file.is_blkdev": False}):
+        ret.update({"comment": comt})
+        assert blockdev.tuned(name) == ret
+
+    comt = f"Changes to {name} will be applied "
+    with patch.dict(blockdev.__salt__, {"file.is_blkdev": True}):
+        ret.update({"comment": comt, "result": None})
+        with patch.dict(blockdev.__opts__, {"test": True}):
+            assert blockdev.tuned(name) == ret
+
+
+def test_formatted():
+    """
+    Test to manage filesystems of partitions.
+    """
+    name = "/dev/vg/master-data"
+
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+
+    with patch.object(
+        os.path, "exists", MagicMock(side_effect=[False, True, True, True, True])
+    ):
+        comt = f"{name} does not exist"
+        ret.update({"comment": comt})
+        assert blockdev.formatted(name) == ret
+
+        mock_ext4 = MagicMock(return_value="ext4")
+
+        # Test state return when block device is already in the correct state
+        with patch.dict(blockdev.__salt__, {"cmd.run": mock_ext4}):
+            comt = f"{name} already formatted with ext4"
+            ret.update({"comment": comt, "result": True})
+            assert blockdev.formatted(name) == ret
+
+        # Test state return when provided block device is an invalid fs_type
+        with patch.dict(blockdev.__salt__, {"cmd.run": MagicMock(return_value="")}):
+            ret.update({"comment": "Invalid fs_type: foo-bar", "result": False})
+            with patch.object(salt.utils.path, "which", MagicMock(return_value=False)):
+                assert blockdev.formatted(name, fs_type="foo-bar") == ret
+
+        # Test state return when provided block device state will change and test=True
+        with patch.dict(
+            blockdev.__salt__, {"cmd.run": MagicMock(return_value="new-thing")}
+        ):
+            comt = f"Changes to {name} will be applied "
+            ret.update({"comment": comt, "result": None})
+            with patch.object(salt.utils.path, "which", MagicMock(return_value=True)):
+                with patch.dict(blockdev.__opts__, {"test": True}):
+                    assert blockdev.formatted(name) == ret
+
+        # Test state return when block device format fails
+        with patch.dict(
+            blockdev.__salt__,
+            {
+                "cmd.run": MagicMock(return_value=mock_ext4),
+                "disk.format": MagicMock(return_value=True),
+            },
+        ):
+            comt = f"Failed to format {name}"
+            ret.update({"comment": comt, "result": False})
+            with patch.object(salt.utils.path, "which", MagicMock(return_value=True)):
+                with patch.dict(blockdev.__opts__, {"test": False}):
+                    assert blockdev.formatted(name) == ret
+
+
+def test__checkblk():
+    """
+    Confirm that we call cmd.run with ignore_retcode=True
+    """
+    cmd_mock = Mock()
+    with patch.dict(blockdev.__salt__, {"cmd.run": cmd_mock}):
+        blockdev._checkblk("/dev/foo")
+
+    cmd_mock.assert_called_once_with(
+        ["blkid", "-o", "value", "-s", "TYPE", "/dev/foo"], ignore_retcode=True
+    )

--- a/tests/pytests/unit/states/test_blockdev.py
+++ b/tests/pytests/unit/states/test_blockdev.py
@@ -1,5 +1,5 @@
 """
-    :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
+:codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
 import os
@@ -24,13 +24,17 @@ def test_tuned():
 
     ret = {"name": name, "result": True, "changes": {}, "comment": ""}
 
-    comt = ("Changes to {} cannot be applied. Not a block device. ").format(name)
-    with patch.dict(blockdev.__salt__, {"file.is_blkdev": False}):
-        ret.update({"comment": comt})
+    comt = ("Changes to {} cannot be applied. Not a block device.").format(name)
+    with patch.dict(
+        blockdev.__salt__, {"file.is_blkdev": MagicMock(return_value=False)}
+    ):
+        ret.update({"comment": comt, "result": False})
         assert blockdev.tuned(name) == ret
 
     comt = f"Changes to {name} will be applied "
-    with patch.dict(blockdev.__salt__, {"file.is_blkdev": True}):
+    with patch.dict(
+        blockdev.__salt__, {"file.is_blkdev": MagicMock(return_value=True)}
+    ):
         ret.update({"comment": comt, "result": None})
         with patch.dict(blockdev.__opts__, {"test": True}):
             assert blockdev.tuned(name) == ret


### PR DESCRIPTION
### What does this PR do?

Adds the `blockdev` state module back. It had been removed as part of the module migration in https://github.com/saltstack/salt/pull/65971 but this is likely to have been a mistake as it has fairly core functionality (formatting filesystems)  and the underlying `disk` execution module stayed in.

### Previous Behavior
`blockdev` state module had been removed

### New Behavior
`blockdev` state module is back in the core

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with SSH key?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
