### PR TITLE
Add mdadm and lvm grains back in to core

### DIFF
--- a/changelog/68470.fixed.md
+++ b/changelog/68470.fixed.md
@@ -1,0 +1,5 @@
+Adds `mdadm` and `lvm` grains modules back in to core.
+
+Restores the modules that had been removed as part of the community module
+migration. They are core bits of functionality and the associated execution and
+states modules had not been removed.

--- a/doc/ref/grains/all/index.rst
+++ b/doc/ref/grains/all/index.rst
@@ -13,6 +13,8 @@ grains modules
     core
     disks
     extra
+    lvm
+    mdadm
     minion_process
     opts
     package

--- a/doc/ref/grains/all/salt.grains.lvm.rst
+++ b/doc/ref/grains/all/salt.grains.lvm.rst
@@ -1,0 +1,5 @@
+salt.grains.lvm
+===============
+
+.. automodule:: salt.grains.lvm
+    :members:

--- a/doc/ref/grains/all/salt.grains.mdadm.rst
+++ b/doc/ref/grains/all/salt.grains.mdadm.rst
@@ -1,0 +1,5 @@
+salt.grains.mdadm
+=================
+
+.. automodule:: salt.grains.mdadm
+    :members:

--- a/salt/grains/lvm.py
+++ b/salt/grains/lvm.py
@@ -1,0 +1,62 @@
+"""
+Detect LVM Volumes
+"""
+
+import logging
+
+import salt.modules.cmdmod
+import salt.utils.files
+import salt.utils.path
+import salt.utils.platform
+
+__salt__ = {
+    "cmd.run": salt.modules.cmdmod._run_quiet,
+    "cmd.run_all": salt.modules.cmdmod._run_all_quiet,
+}
+
+log = logging.getLogger(__name__)
+
+
+def lvm():
+    """
+    Return list of LVM devices
+    """
+    if salt.utils.platform.is_linux():
+        return _linux_lvm()
+    elif salt.utils.platform.is_aix():
+        return _aix_lvm()
+    else:
+        log.trace("LVM grain does not support this OS")
+
+
+def _linux_lvm():
+    ret = {}
+    cmd = salt.utils.path.which("lvm")
+    if cmd:
+        vgs = __salt__["cmd.run_all"](f"{cmd} vgs -o vg_name --noheadings")
+
+        for vg in vgs["stdout"].splitlines():
+            vg = vg.strip()
+            ret[vg] = []
+            lvs = __salt__["cmd.run_all"](f"{cmd} lvs -o lv_name --noheadings {vg}")
+            for lv in lvs["stdout"].splitlines():
+                ret[vg].append(lv.strip())
+
+        return {"lvm": ret}
+    else:
+        log.trace("No LVM installed")
+
+
+def _aix_lvm():
+    ret = {}
+    cmd = salt.utils.path.which("lsvg")
+    vgs = __salt__["cmd.run"](f"{cmd}")
+
+    for vg in vgs.splitlines():
+        ret[vg] = []
+        lvs = __salt__["cmd.run"](f"{cmd} -l {vg}")
+        for lvline in lvs.splitlines()[2:]:
+            lv = lvline.split(" ", 1)[0]
+            ret[vg].append(lv)
+
+    return {"lvm": ret}

--- a/salt/grains/mdadm.py
+++ b/salt/grains/mdadm.py
@@ -1,0 +1,34 @@
+"""
+Detect MDADM RAIDs
+"""
+
+import logging
+
+import salt.utils.files
+
+log = logging.getLogger(__name__)
+
+
+def mdadm():
+    """
+    Return list of mdadm devices
+    """
+    devices = set()
+    try:
+        with salt.utils.files.fopen("/proc/mdstat", "r") as mdstat:
+            for line in mdstat:
+                line = salt.utils.stringutils.to_unicode(line)
+                if line.startswith("Personalities : "):
+                    continue
+                if line.startswith("unused devices:"):
+                    continue
+                if " : " in line:
+                    devices.add(line.split(" : ")[0])
+    except OSError:
+        return {}
+
+    devices = sorted(devices)
+    if devices:
+        log.trace("mdadm devices detected: %s", ", ".join(devices))
+
+    return {"mdadm": devices}

--- a/tests/pytests/unit/grains/test_lvm.py
+++ b/tests/pytests/unit/grains/test_lvm.py
@@ -1,0 +1,241 @@
+"""
+    :codeauthor: :email:`Shane Lee <slee@saltstack.com>`
+"""
+
+import pytest
+
+import salt.grains.lvm as lvm
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        lvm: {"__salt__": {}},
+    }
+
+
+def test__linux_lvm():
+    """
+    Test grains._linux_lvm, normal return
+    Should return a populated dictionary
+    """
+
+    vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+    lvs_out_vg00 = {
+        "pid": 456,
+        "retcode": 0,
+        "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+        "stderr": "",
+    }
+    lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
+    cmd_out = MagicMock(
+        autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+    )
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret == {
+        "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+    }, ret
+
+
+def test__linux_lvm_with_WARNINGs():
+    """
+    Test grains._linux_lvm, with WARNINGs in lvm command output
+    Should return a populated dictionary
+    """
+
+    vgs_out = {
+        "pid": 123,
+        "retcode": 0,
+        "stdout": "  vg00\n  vg01",
+        "stderr": "WARNING: Something wrong is not right",
+    }
+    lvs_out_vg00 = {
+        "pid": 456,
+        "retcode": 0,
+        "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+        "stderr": "WARNING: Something wrong is not right",
+    }
+    lvs_out_vg01 = {
+        "pid": 789,
+        "retcode": 0,
+        "stdout": "  opt",
+        "stderr": "WARNING: Something wrong is not right",
+    }
+    cmd_out = MagicMock(
+        autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+    )
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret == {
+        "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+    }, ret
+
+
+def test__linux_lvm_with_non_zero_exit_codes():
+    """
+    Test grains._linux_lvm, with non-zero exit codes for lvm command
+    Should return a populated dictionary
+    """
+
+    vgs_out = {
+        "pid": 123,
+        "retcode": 5,
+        "stdout": "  vg00\n  vg01",
+        "stderr": "  Skipping clustered volume vgcluster\n  Skipping volume group vgcluster",
+    }
+    lvs_out_vg00 = {
+        "pid": 456,
+        "retcode": 0,
+        "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+        "stderr": "",
+    }
+    lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
+    cmd_out = MagicMock(
+        autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+    )
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret == {
+        "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+    }, ret
+
+
+def test__linux_lvm_no_lvm():
+    """
+    Test grains._linux_lvm, no lvm installed
+    Should return nothing
+    """
+
+    vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+    lvs_out_vg00 = {
+        "pid": 456,
+        "retcode": 0,
+        "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+        "stderr": "",
+    }
+    lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
+    cmd_out = MagicMock(
+        autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+    )
+
+    patch_which = patch("salt.utils.path.which", autospec=True, return_value="")
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret is None, ret
+
+
+def test__linux_lvm_no_volume_groups():
+    """
+    Test grains._linux_lvm, lvm is installed but no volume groups created.
+    Should return a dictionary only with the header
+    """
+
+    vgs_out = {"pid": 123, "retcode": 0, "stdout": "", "stderr": ""}
+    cmd_out = MagicMock(autospec=True, side_effect=[vgs_out])
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret == {"lvm": {}}, ret
+
+
+def test__linux_lvm_no_logical_volumes():
+    """
+    Test grains._linux_lvm, lvm is installed, volume groups created but
+    no logical volumes present.
+    Should return a dictionary only with the header
+    """
+
+    vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+    lvs_out = {"pid": 456, "retcode": 0, "stdout": "", "stderr": ""}
+    cmd_out = MagicMock(autospec=True, side_effect=[vgs_out, lvs_out, lvs_out])
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._linux_lvm()
+
+    assert ret == {"lvm": {"vg00": [], "vg01": []}}, ret
+
+
+def test__aix_lvm():
+    """
+    Test grains._aix_lvm, normal return
+    Should return a populated dictionary
+    """
+
+    lsvg_out = "rootvg\nothervg"
+    lsvg_out_rootvg = (
+        "rootvg:\nLV NAME             TYPE       LPs     PPs     PVs  LV STATE     "
+        " MOUNT POINT\nhd5                 boot       1       1       1   "
+        " closed/syncd  N/A\nhd6                 paging     32      32      1   "
+        " open/syncd    N/A\nhd8                 jfs2log    1       1       1   "
+        " open/syncd    N/A\nhd4                 jfs2       32      32      1   "
+        " open/syncd    /\nhd2                 jfs2       16      16      1   "
+        " open/syncd    /usr\nhd9var              jfs2       32      32      1   "
+        " open/syncd    /var\nhd3                 jfs2       32      32      1   "
+        " open/syncd    /tmp\nhd1                 jfs2       16      16      1   "
+        " open/syncd    /home\nhd10opt             jfs2       16      16      1   "
+        " open/syncd    /opt"
+    )
+    lsvg_out_othervg = (
+        "othervg:\nLV NAME             TYPE       LPs     PPs     PVs  LV STATE    "
+        "  MOUNT POINT\nloglv01             jfs2log    1       1       1   "
+        " open/syncd    N/A\ndatalv              jfs2       16      16      1   "
+        " open/syncd    /data"
+    )
+    cmd_out = MagicMock(
+        autospec=True, side_effect=[lsvg_out, lsvg_out_rootvg, lsvg_out_othervg]
+    )
+
+    patch_which = patch(
+        "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lsvg"
+    )
+    patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+    with patch_which, patch_cmd_lvm:
+        ret = lvm._aix_lvm()
+
+    assert ret == {
+        "lvm": {
+            "rootvg": [
+                "hd5",
+                "hd6",
+                "hd8",
+                "hd4",
+                "hd2",
+                "hd9var",
+                "hd3",
+                "hd1",
+                "hd10opt",
+            ],
+            "othervg": ["loglv01", "datalv"],
+        }
+    }, ret

--- a/tests/pytests/unit/grains/test_mdadm.py
+++ b/tests/pytests/unit/grains/test_mdadm.py
@@ -1,0 +1,61 @@
+import logging
+import textwrap
+
+import pytest
+
+import salt.grains.mdadm as mdadm
+from tests.support.mock import mock_open, patch
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def proc_mdstat_no_devices():
+    return textwrap.dedent(
+        """
+        Personalities : [raid0] [raid1] [raid6] [raid5] [raid4] [raid10]
+        unused devices: <none>
+    """
+    )
+
+
+@pytest.fixture
+def proc_mdstat_md_device():
+    return textwrap.dedent(
+        """
+        Personalities : [raid0] [raid1] [raid6] [raid5] [raid4] [raid10]
+        md0 : active raid1 loop2[1] loop1[0]
+              101376 blocks super 1.2 [2/2] [UU]
+
+        unused devices: <none>
+    """
+    )
+
+
+def test_mdadm_grain_no_devices(proc_mdstat_no_devices):
+    """
+    Test mdadm grain with no md devices present
+    """
+    mock = mock_open(read_data=proc_mdstat_no_devices)
+    with patch("salt.utils.files.fopen", mock):
+
+        assert mdadm.mdadm() == {"mdadm": []}
+
+
+def test_mdadm_grain_md_device(proc_mdstat_md_device):
+    """
+    Test mdadm grain with md0 device present
+    """
+    mock = mock_open(read_data=proc_mdstat_md_device)
+    with patch("salt.utils.files.fopen", mock):
+
+        assert mdadm.mdadm() == {"mdadm": ["md0"]}
+
+
+def test_mdadm_grain_no_proc_mdstat():
+    """
+    Test mdadm grain when /proc/mdstat is not present
+    """
+    with patch("salt.utils.files.fopen", side_effect=FileNotFoundError()):
+
+        assert mdadm.mdadm() == {}


### PR DESCRIPTION
### What does this PR do?

Adds the `mdadm` and `lvm` grains modules back in to core. The were removed as part of the community module migration in https://github.com/saltstack/salt/pull/65971, but they provide key functionality on linux systems.  The associated execution and state modules (`mdadm_raid`/`mdadm` and `linux_lvm`/`lvm`) were not removed so it doesn't seem to make sense that the grains should be in a separate extension.

### Previous Behavior
`mdadm` and `lvm` grains were not available

### New Behavior
`mdadm` and `lvm` grains are available again

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with SSH key?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
