### PR TITLE
fix(aptpkg): change glob to only match top-level .list files

### DIFF
--- a/changelog/68475.fixed.md
+++ b/changelog/68475.fixed.md
@@ -1,0 +1,2 @@
+Changed the glob pattern for APT sources from `**/*.list` to `*.list`, in line
+with APT's default pattern in sources.list.d

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -265,7 +265,7 @@ if not HAS_APT:
             ]
             for file in self.files:
                 if file.is_dir():
-                    for fp in file.glob("**/*.list"):
+                    for fp in file.glob("*.list"):
                         self.add_file(file=fp)
                 else:
                     self.add_file(file)

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -1575,6 +1575,16 @@ def test_sourceslist_multiple_comps():
             assert source.dist == "focal-updates"
 
 
+def test_sourceslist_subdirectory_no_exception(fs):
+    fs.create_dir("/etc/apt/sources.list.d/backup.list")
+    fs.create_file(
+        "/etc/apt/sources.list.d/backup/test.list",
+        contents="deb http://archive.ubuntu.com/ubuntu/ focal main",
+    )
+    sources = aptpkg.SourcesList()
+    assert list(sources) == []
+
+
 @pytest.fixture(
     params=(
         "deb [ arch=amd64 ] http://archive.ubuntu.com/ubuntu/ focal-updates main restricted",


### PR DESCRIPTION
### What does this PR do?
This changes the glob pattern for APT sources from `**/*.list` to `*.list`, in line APT's default pattern in sources.list.d

### What issues does this PR fix or reference?
Fixes #68475

### Previous Behavior
Exception is thrown if there is a .list file in a subdirectory (e.g: backups/private.list)

### New Behavior
No exception is thrown

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
