### PR TITLE
Move deprecation warning to __init__ for odict

### DIFF
--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -18,12 +18,6 @@ from collections.abc import Callable
 
 from salt.utils.versions import warn_until
 
-warn_until(
-    3009,
-    "This module is deprecated. Use the standard library's collections.OrderedDict "
-    "or salt.utils.datastructures instead.",
-)
-
 
 class DefaultOrderedDict(OrderedDict):
     """
@@ -31,6 +25,11 @@ class DefaultOrderedDict(OrderedDict):
     """
 
     def __init__(self, default_factory=None, *a, **kw):
+        warn_until(
+            3009,
+            "This module is deprecated. Use the standard library's collections.OrderedDict "
+            "or salt.utils.datastructures instead.",
+        )
         if default_factory is not None and not isinstance(default_factory, Callable):
             raise TypeError("first argument must be callable")
         super().__init__(*a, **kw)
@@ -73,5 +72,13 @@ class DefaultOrderedDict(OrderedDict):
 
 
 class HashableOrderedDict(OrderedDict):
+    def __init__(self):
+        warn_until(
+            3009,
+            "This module is deprecated. Use the standard library's collections.OrderedDict "
+            "or salt.utils.datastructures instead.",
+        )
+        super().__init__()
+
     def __hash__(self):
         return id(self)


### PR DESCRIPTION
### What does this PR do?
Moves the deprecation warning to the initialization of the DefaultOrderedDict and HashableOrderedDict classes so the warning only appears when those are instantiated. Otherwise the warning appears on every salt command, even when the odict util is not used.

### What issues does this PR fix or reference?
Fixes #68486 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
