### PR TITLE
Fix issue with disk.tune passing incorrect args

### DIFF
--- a/changelog/68490.fixed.md
+++ b/changelog/68490.fixed.md
@@ -1,0 +1,3 @@
+Fixes issue with disk.tune passing incorrect args for read-only and read-write
+to blockdev.
+Improves argument and error handling in blockdev.

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -13,7 +13,7 @@ import salt.utils.decorators
 import salt.utils.decorators.path
 import salt.utils.path
 import salt.utils.platform
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 __func_alias__ = {"format_": "format"}
 
@@ -324,6 +324,8 @@ def tune(device, **kwargs):
     Valid options are: ``read-ahead``, ``filesystem-read-ahead``,
     ``read-only``, ``read-write``.
 
+    For ``read-only`` and ``read-write``, the value must be set to ``True``.
+
     See the ``blockdev(8)`` manpage for a more complete description of these
     options.
     """
@@ -336,19 +338,45 @@ def tune(device, **kwargs):
     }
     opts = ""
     args = []
-    for key in kwargs:
+    invalid_kwargs = {}
+
+    for key, value in kwargs.items():
+        # Check for invalid kwargs but ignore dunder args
+        if key not in kwarg_map and not key.startswith("__"):
+            invalid_kwargs[key] = value
+            continue
+
+        # Check that read-only and read-write have a value of True
+        # they do not accept other values
+        if key in ("read-only", "read-write") and not (
+            value == "True" or value is True
+        ):
+            invalid_kwargs[key] = value
+            continue
+
         if key in kwarg_map:
             switch = kwarg_map[key]
             if key != "read-write":
                 args.append(switch.replace("set", "get"))
             else:
                 args.append("getro")
-            if kwargs[key] == "True" or kwargs[key] is True:
-                opts += f"--{key} "
+            if key in ("read-only", "read-write"):
+                opts += f"--{switch} "
             else:
-                opts += f"--{switch} {kwargs[key]} "
+                opts += f"--{switch} {value} "
+
+    # Raise error if any invalid kwargs were found
+    if invalid_kwargs:
+        invalid_kwargs_str = ", ".join(f"{k}={v}" for k, v in invalid_kwargs.items())
+        raise SaltInvocationError(f"Invalid keyword arguments: {invalid_kwargs_str}")
+
     cmd = f"blockdev {opts}{device}"
-    out = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
+
+    # Any other errors, including invalid values for valid kwargs, will be
+    # caught by blockdev
+    blockdev_result = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if blockdev_result["retcode"] != 0:
+        raise CommandExecutionError(f"{blockdev_result['stderr']}")
     return dump(device, args)
 
 
@@ -366,7 +394,7 @@ def wipe(device):
     cmd = f"wipefs -a {device}"
     try:
         out = __salt__["cmd.run_all"](cmd, python_shell=False)
-    except subprocess.CalledProcessError as err:
+    except subprocess.CalledProcessError:
         return False
     if out["retcode"] == 0:
         return True
@@ -422,7 +450,7 @@ def resize2fs(device):
     cmd = f"resize2fs {device}"
     try:
         out = __salt__["cmd.run_all"](cmd, python_shell=False)
-    except subprocess.CalledProcessError as err:
+    except subprocess.CalledProcessError:
         return False
     if out["retcode"] == 0:
         return True


### PR DESCRIPTION
### What does this PR do?
Fixes issue with disk.tune passing incorrect args of "read-only", "read-write" rather than "setro" and "setrw" to blockdev.

Also cleans up handling of args, so that "read-only" and "read-write" can only have a value of True - they can't be negated.

Adds checking of return status from blockdev - that was just being discarded.

### What issues does this PR fix or reference?
Fixes 68490

### Previous Behavior
Calling the function with `read-write=True` or `read-only=True` would show and error from `blockdev` and fail to make the change. Despite this it would not return a failure.

### New Behavior
Options work correctly and change state of blockdevice.

Other incorrect args such as `read-only=False` or `read-write=False` will now raise a `SaltInvocationError`. 

Failures in `blockdev` will raise a `CommandExecutionError`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with SSH key?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
