### PR TITLE
Fix virtualenv call in test helper to use proper python version

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1748,14 +1748,14 @@ class VirtualEnv:
         return data
 
     def _create_virtualenv(self):
-        pyexec = shutil.which("python3") or shutil.which("python")
+        pyexec = self.get_real_python()
         if not pyexec:
             pytest.fail("'python' or 'python3' binary not found for virtualenv")
         cmd = [
             pyexec,
             "-m",
             "virtualenv",
-            f"--python={self.get_real_python()}",
+            f"--python={pyexec}",
         ]
         if self.system_site_packages:
             cmd.append("--system-site-packages")


### PR DESCRIPTION
### What does this PR do?

In some cases when there are multiple python flavors installed on the system, the tests could fail as the wrong python executable could be selected in the helper.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/28972

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
