### PR TITLE
Skip ssh tests for bad ssh server version

### DIFF
--- a/tests/integration/cli/test_custom_module.py
+++ b/tests/integration/cli/test_custom_module.py
@@ -43,6 +43,12 @@ pytestmark = [
         # has been deprecated since Python 3.7, so, the logic goes into trying to import
         # backports.ssl-match-hostname which is not installed on the system.
     ),
+    pytest.mark.skipif(
+        """grains["osfinger"].startswith("VMware Photon OS-5") and __import__("subprocess").run(["rpm", "-q", "openssh-server"], capture_output=True, text=True).stdout.strip() in ["openssh-server-9.3p2-18.ph5.x86_64", "openssh-server-9.3p2-18.ph5.aarch64"]""",
+        reason="Photon OS OpenSSH 9.3p2-18 has a bug that breaks salt-ssh",
+        # This version causes "vdollar_percent_expand: NULL replacement for token n" errors
+        # when using the User config option that salt-ssh depends on.
+    ),
 ]
 
 

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -18,6 +18,12 @@ pytestmark = [
         # has been deprecated since Python 3.7, so, the logic goes into trying to import
         # backports.ssl-match-hostname which is not installed on the system.
     ),
+    pytest.mark.skipif(
+        """grains["osfinger"].startswith("VMware Photon OS-5") and __import__("subprocess").run(["rpm", "-q", "openssh-server"], capture_output=True, text=True).stdout.strip() in ["openssh-server-9.3p2-18.ph5.x86_64", "openssh-server-9.3p2-18.ph5.aarch64"]""",
+        reason="Photon OS OpenSSH 9.3p2-18 has a bug that breaks salt-ssh",
+        # This version causes "vdollar_percent_expand: NULL replacement for token n" errors
+        # when using the User config option that salt-ssh depends on.
+    ),
 ]
 
 log = logging.getLogger(__name__)

--- a/tests/pytests/integration/ssh/conftest.py
+++ b/tests/pytests/integration/ssh/conftest.py
@@ -18,6 +18,44 @@ def _auto_skip_on_system_python_too_recent(grains):
         )
 
 
+@pytest.fixture(scope="package", autouse=True)
+def _auto_skip_on_buggy_openssh(grains):
+    """
+    Skip SSH tests on systems with buggy OpenSSH versions that break salt-ssh.
+
+    Photon OS 5 version 9.3p2-18 has a bug that causes
+    "vdollar_percent_expand: NULL replacement for token n" errors
+    when using the User config option that salt-ssh depends on.
+    """
+    if not grains["osfinger"].startswith("VMware Photon OS-5"):
+        return
+
+    import subprocess  # pylint: disable=import-outside-toplevel
+
+    try:
+        result = subprocess.run(
+            ["rpm", "-q", "openssh-server"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        installed_version = result.stdout.strip()
+
+        # Check for the specific buggy version
+        if installed_version in [
+            "openssh-server-9.3p2-18.ph5.x86_64",
+            "openssh-server-9.3p2-18.ph5.aarch64",
+        ]:
+            pytest.skip(
+                f"Photon OS OpenSSH {installed_version} has a bug that breaks salt-ssh. "
+                "See: https://github.com/saltstack/salt/issues/xxxxx"
+            )
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        # If we can't check the version, don't skip
+        pass
+
+
 @pytest.fixture(autouse=True)
 def _reap_stray_processes():
     # when tests timeout, we migth leave child processes behind


### PR DESCRIPTION
Skip tests when  openssh-server-9.3p2-18 is detected