### PR TITLE
Check if there are multiple version installed after upgrade

### DIFF
--- a/pkg/windows/msi/Product.wxs
+++ b/pkg/windows/msi/Product.wxs
@@ -30,7 +30,9 @@ IMCAC - Immediate Custom Action - It's immediate
     />
 
     <!-- Prevent downgrade -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MajorUpgrade
+      DowngradeErrorMessage="A newer version of [ProductName] is already installed."
+      AllowSameVersionUpgrades="yes" />
 
     <!-- Do not create cab files -->
     <MediaTemplate EmbedCab="yes" CompressionLevel="high" />

--- a/tests/pytests/pkg/upgrade/test_salt_upgrade.py
+++ b/tests/pytests/pkg/upgrade/test_salt_upgrade.py
@@ -132,6 +132,42 @@ def _get_running_named_salt_pid(process_name):
     return pids
 
 
+def _get_installed_salt_packages():
+    """
+    Get list of installed Salt packages on Windows via registry.
+    Returns list of tuples: (name, version)
+    """
+    if not platform.is_windows():
+        return []
+
+    import subprocess
+
+    cmd = [
+        "powershell",
+        "-Command",
+        (
+            "Get-ItemProperty HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | "
+            "Where-Object { $_.DisplayName -like '*Salt*' } | "
+            "Select-Object DisplayName, DisplayVersion | "
+            'ForEach-Object { "$($_.DisplayName)|$($_.DisplayVersion)" }'
+        ),
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        log.warning("Failed to query installed packages: %s", result.stderr)
+        return []
+
+    packages = []
+    for line in result.stdout.strip().split("\n"):
+        line = line.strip()
+        if line and "|" in line:
+            name, version = line.split("|", 1)
+            packages.append((name.strip(), version.strip()))
+
+    return packages
+
+
 def test_salt_upgrade(salt_call_cli, install_salt, debian_disable_policy_rcd):
     """
     Test an upgrade of Salt, Minion and Master
@@ -153,6 +189,19 @@ def test_salt_upgrade(salt_call_cli, install_salt, debian_disable_policy_rcd):
 
     # perform Salt package upgrade test
     salt_test_upgrade(salt_call_cli, install_salt)
+
+    # Verify only one Salt package is installed after upgrade (Windows)
+    if platform.is_windows():
+        installed_packages = _get_installed_salt_packages()
+        log.info("Installed Salt packages after upgrade: %s", installed_packages)
+        assert len(installed_packages) == 1, (
+            f"Expected 1 Salt package after upgrade, found {len(installed_packages)}: "
+            f"{installed_packages}"
+        )
+        package_name, package_version = installed_packages[0]
+        log.info(
+            "Verified single package: %s version %s", package_name, package_version
+        )
 
     new_py_version = install_salt.package_python_version()
     if new_py_version == original_py_version:


### PR DESCRIPTION
Pulling in a regression test and fix for MSI package upgrades. The commits were made on our merge forward to master where the issue started causing some pip test to fail. The issue we are addressing here is specific to our CI/CD pipelines because they generate packages for testing that do not have unique version from windows's perspective.