### PR TITLE
fix MySQLdb version in the versions report by using the proper attribute

### DIFF
--- a/changelog/68522.fixed.md
+++ b/changelog/68522.fixed.md
@@ -1,0 +1,1 @@
+fix MySQLdb version in the versions report by using the proper attribute

--- a/salt/version.py
+++ b/salt/version.py
@@ -713,7 +713,7 @@ def dependency_information(include_salt_cloud=False):
         ("gitdb", "gitdb", "__version__"),
         ("gitpython", "git", "__version__"),
         ("python-gnupg", "gnupg", "__version__"),
-        ("mysql-python", "MySQLdb", "__version__"),
+        ("mysql-python", "MySQLdb", "version_info"),
         ("cherrypy", "cherrypy", "__version__"),
         ("docker-py", "docker", "__version__"),
         ("packaging", "packaging", "__version__"),

--- a/tests/pytests/functional/test_version.py
+++ b/tests/pytests/functional/test_version.py
@@ -52,6 +52,30 @@ sys.stdout.flush()
     assert salt_extension.name in versions_information["Salt Extensions"]
 
 
+def test_mysql_extensions_in_versions_report(tmp_path):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        # These are required for the test to pass, why are they not already
+        # installed?
+        venv.install("pyyaml")
+        venv.install("looseversion")
+        venv.install("packaging")
+        # Install mysql extension into the virtualenv
+        venv.install("mysqlclient")
+        installed_packages = venv.get_installed_packages()
+        assert "mysqlclient" in installed_packages
+        ret = venv.run_code(
+            """
+            import json
+            import salt.version
+
+            print(json.dumps(salt.version.versions_information()))
+            """
+        )
+    versions_information = json.loads(ret.stdout)
+    assert "Dependency Versions" in versions_information
+    assert versions_information.get("Dependency Versions").get("mysql-python") is not None
+
+
 def test_salt_extensions_absent_in_versions_report(tmp_path, salt_extension):
     """
     Ensure that the 'Salt Extensions' header does not show up when no extension is installed

--- a/tests/pytests/functional/test_version.py
+++ b/tests/pytests/functional/test_version.py
@@ -52,32 +52,6 @@ sys.stdout.flush()
     assert salt_extension.name in versions_information["Salt Extensions"]
 
 
-def test_mysql_extensions_in_versions_report(tmp_path):
-    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
-        # These are required for the test to pass, why are they not already
-        # installed?
-        venv.install("pyyaml")
-        venv.install("looseversion")
-        venv.install("packaging")
-        # Install mysql extension into the virtualenv
-        venv.install("mysqlclient")
-        installed_packages = venv.get_installed_packages()
-        assert "mysqlclient" in installed_packages
-        ret = venv.run_code(
-            """
-            import json
-            import salt.version
-
-            print(json.dumps(salt.version.versions_information()))
-            """
-        )
-    versions_information = json.loads(ret.stdout)
-    assert "Dependency Versions" in versions_information
-    assert (
-        versions_information.get("Dependency Versions").get("mysql-python") is not None
-    )
-
-
 def test_salt_extensions_absent_in_versions_report(tmp_path, salt_extension):
     """
     Ensure that the 'Salt Extensions' header does not show up when no extension is installed

--- a/tests/pytests/functional/test_version.py
+++ b/tests/pytests/functional/test_version.py
@@ -73,7 +73,9 @@ def test_mysql_extensions_in_versions_report(tmp_path):
         )
     versions_information = json.loads(ret.stdout)
     assert "Dependency Versions" in versions_information
-    assert versions_information.get("Dependency Versions").get("mysql-python") is not None
+    assert (
+        versions_information.get("Dependency Versions").get("mysql-python") is not None
+    )
 
 
 def test_salt_extensions_absent_in_versions_report(tmp_path, salt_extension):

--- a/tests/pytests/unit/test_version.py
+++ b/tests/pytests/unit/test_version.py
@@ -6,6 +6,8 @@ Test salt's regex git describe version parsing
 """
 
 import re
+import sys
+import types
 
 import pytest
 
@@ -13,6 +15,7 @@ import salt.version
 from salt.version import (
     SaltStackVersion,
     SaltVersionsInfo,
+    dependency_information,
     system_information,
     versions_report,
 )
@@ -529,6 +532,48 @@ def test_versions_report_no_extensions_available():
     with patch("salt.utils.entrypoints.iter_entry_points", return_value=()):
         versions_information = salt.version.versions_information()
         assert "Salt Extensions" not in versions_information
+
+
+def test_dependency_information_mysql_python_uses_version_info():
+    """
+    Regression test for the versions report showing "Not Installed" for
+    mysql-python when mysqlclient is actually installed.
+
+    The mysqlclient package (imported as ``MySQLdb``) exposes ``version_info``
+    as a tuple (e.g. ``(2, 2, 8, "final", 0)``) but has never exposed
+    ``__version__``. ``dependency_information()`` must read ``version_info``
+    so the formatter can join the tuple into a dotted string.
+    """
+    fake_mysqldb = types.ModuleType("MySQLdb")
+    fake_mysqldb.version_info = (2, 2, 8, "final", 0)
+    # mysqlclient does not expose __version__; ensure the attribute is absent
+    # so the test pins the post-fix behavior and would fail if dependency_information
+    # ever reverts to reading __version__.
+    assert not hasattr(fake_mysqldb, "__version__")
+    with patch.dict(sys.modules, {"MySQLdb": fake_mysqldb}):
+        deps = dict(dependency_information())
+    assert deps.get("mysql-python") == "2.2.8.final.0"
+
+
+def test_dependency_information_mysql_python_missing_when_not_installed():
+    """
+    When ``MySQLdb`` cannot be imported, ``dependency_information()`` should
+    yield ``None`` for ``mysql-python`` (rendered as "Not Installed" by
+    ``versions_report``).
+    """
+    # Force a clean import attempt by removing any cached MySQLdb entry and
+    # making __import__ raise ImportError for it.
+    real_import = __import__
+
+    def _import(name, *args, **kwargs):
+        if name == "MySQLdb":
+            raise ImportError("No module named 'MySQLdb'")
+        return real_import(name, *args, **kwargs)
+
+    with patch.dict(sys.modules), patch("builtins.__import__", side_effect=_import):
+        sys.modules.pop("MySQLdb", None)
+        deps = dict(dependency_information())
+    assert deps.get("mysql-python") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Fixes the version report by using the proper attribute for MySQLdb.

### Previous Behavior
```
$ salt -V | grep mysql-pyt
  mysql-python: Not Installed
```

### New Behavior
```
$ salt -V | grep mysql-pyt
  mysql-python: 2.2.7.final.0
```
### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
