### PR TITLE
Fix pip.installed state managed pre-release upgrades

### DIFF
--- a/changelog/68525.fixed.md
+++ b/changelog/68525.fixed.md
@@ -1,0 +1,1 @@
+Fix `pip.installed` state managed pre-release upgrades

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,4 +1,5 @@
 mock >= 5.2.0
+packaging
 # PyTest
 docker >= 7.1.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'

--- a/requirements/static/ci/py3.10/cloud.lock
+++ b/requirements/static/ci/py3.10/cloud.lock
@@ -420,6 +420,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.10/darwin.lock
+++ b/requirements/static/ci/py3.10/darwin.lock
@@ -301,6 +301,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==3.4.0
     # via

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -340,6 +340,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0 ; sys_platform != 'win32'
     # via

--- a/requirements/static/ci/py3.10/linux.lock
+++ b/requirements/static/ci/py3.10/linux.lock
@@ -335,6 +335,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   ansible-core
     #   pytest
 paramiko==5.0.0

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -288,6 +288,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 passlib==1.7.4
     # via -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.11/cloud.lock
+++ b/requirements/static/ci/py3.11/cloud.lock
@@ -405,6 +405,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.11/darwin.lock
+++ b/requirements/static/ci/py3.11/darwin.lock
@@ -296,6 +296,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==4.0.0
     # via

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -341,6 +341,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0 ; sys_platform != 'win32'
     # via

--- a/requirements/static/ci/py3.11/linux.lock
+++ b/requirements/static/ci/py3.11/linux.lock
@@ -326,6 +326,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   ansible-core
     #   pytest
 paramiko==5.0.0

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -282,6 +282,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 passlib==1.7.4
     # via -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.12/cloud.lock
+++ b/requirements/static/ci/py3.12/cloud.lock
@@ -401,6 +401,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.12/darwin.lock
+++ b/requirements/static/ci/py3.12/darwin.lock
@@ -289,6 +289,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==4.0.0
     # via

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -321,6 +321,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0 ; sys_platform != 'win32'
     # via

--- a/requirements/static/ci/py3.12/linux.lock
+++ b/requirements/static/ci/py3.12/linux.lock
@@ -319,6 +319,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   ansible-core
     #   pytest
 paramiko==5.0.0

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -276,6 +276,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 passlib==1.7.4
     # via -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.13/cloud.lock
+++ b/requirements/static/ci/py3.13/cloud.lock
@@ -402,6 +402,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.13/darwin.lock
+++ b/requirements/static/ci/py3.13/darwin.lock
@@ -290,6 +290,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==4.0.0
     # via

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -322,6 +322,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0 ; sys_platform != 'win32'
     # via

--- a/requirements/static/ci/py3.13/linux.lock
+++ b/requirements/static/ci/py3.13/linux.lock
@@ -320,6 +320,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   ansible-core
     #   pytest
 paramiko==5.0.0

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -277,6 +277,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 passlib==1.7.4
     # via -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.14/cloud.lock
+++ b/requirements/static/ci/py3.14/cloud.lock
@@ -402,6 +402,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.9/cloud.lock
+++ b/requirements/static/ci/py3.9/cloud.lock
@@ -456,6 +456,7 @@ packaging==24.0
     #   -c requirements/static/ci/py3.9/linux.lock
     #   -c requirements/static/pkg/py3.9/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.9/darwin.lock
+++ b/requirements/static/ci/py3.9/darwin.lock
@@ -328,6 +328,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.9/darwin.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==4.0.0
     # via

--- a/requirements/static/ci/py3.9/freebsd.lock
+++ b/requirements/static/ci/py3.9/freebsd.lock
@@ -449,6 +449,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0 ; sys_platform != 'win32'
     # via

--- a/requirements/static/ci/py3.9/linux.lock
+++ b/requirements/static/ci/py3.9/linux.lock
@@ -354,6 +354,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.9/linux.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 paramiko==5.0.0
     # via

--- a/requirements/static/ci/py3.9/windows.lock
+++ b/requirements/static/ci/py3.9/windows.lock
@@ -292,6 +292,7 @@ packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.9/windows.lock
     #   -r requirements/base.txt
+    #   -r requirements/pytest.txt
     #   pytest
 passlib==1.7.4
     # via -r requirements/static/ci/common.txt

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1711,7 +1711,11 @@ def list_all_versions(
     pip_version = version(bin_env=bin_env, cwd=cwd, user=user)
     if salt.utils.versions.compare(ver1=pip_version, oper=">=", ver2="21.2"):
         regex = re.compile(r"\s*Available versions: (.*)")
-        cmd.extend(["index", "versions", pkg])
+        # pre-release versions are not included by default
+        if any([include_alpha, include_beta, include_rc]):
+            cmd.extend(["index", "versions", "--pre", pkg])
+        else:
+            cmd.extend(["index", "versions", pkg])
     else:
         if salt.utils.versions.compare(ver1=pip_version, oper=">=", ver2="20.3"):
             cmd.append("--use-deprecated=legacy-resolver")

--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -6,6 +6,7 @@ import sys
 from contextlib import contextmanager
 
 import pytest
+from packaging.version import parse as parse_version
 
 import salt.utils.platform
 from salt.exceptions import CommandNotFoundError
@@ -111,6 +112,53 @@ def test_list_available_packages_with_index_url(pip, pip_version, tmp_path):
             index_url="https://pypi.python.org/simple",
         )
         assert available_versions
+
+
+@pytest.mark.parametrize(
+    "pip_version",
+    (
+        pytest.param(
+            "pip==9.0.3",
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 10),
+                reason="'pip==9.0.3' is not available on Py >= 3.10",
+            ),
+        ),
+        "pip<20.0",
+        "pip<21.0",
+        "pip>=21.0",
+    ),
+)
+@pytest.mark.parametrize(
+    "include_alpha,include_beta,include_rc",
+    (
+        (False, False, True),  # 001
+        (False, True, False),  # 010
+        (False, True, True),   # 011
+        (True, False, False),  # 100
+        (True, False, True),   # 101
+        (True, True, False),   # 110
+        (True, True, True),    # 111
+    )
+)
+def test_list_available_packages_returns_prerelease_versions_if_alpha_beta_or_rc_included(
+    venv, pip, pip_version, include_alpha, include_beta, include_rc
+):
+    """Tests that pre-release versions are returned when flags enable them.
+
+    Note: relies on PyPI hosting pre-release versions of `typing-extensions`.
+    """
+    venv.install("-U", pip_version)
+    package_name = "typing-extensions"
+    versions = pip.list_all_versions(
+        package_name,
+        bin_env=str(venv.venv_bin_dir),
+        include_alpha=include_alpha,
+        include_beta=include_beta,
+        include_rc=include_rc,
+    )
+    # parse each version and assert there's a pre-release version somewhere
+    assert any(map(lambda v: v.is_prerelease, map(parse_version, versions)))
 
 
 def test_issue_2087_missing_pip(venv, pip, modules):

--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -129,18 +129,9 @@ def test_list_available_packages_with_index_url(pip, pip_version, tmp_path):
         "pip>=21.0",
     ),
 )
-@pytest.mark.parametrize(
-    "include_alpha,include_beta,include_rc",
-    (
-        (False, False, True),  # 001
-        (False, True, False),  # 010
-        (False, True, True),   # 011
-        (True, False, False),  # 100
-        (True, False, True),   # 101
-        (True, True, False),   # 110
-        (True, True, True),    # 111
-    )
-)
+@pytest.mark.parametrize("include_alpha", (True, False))
+@pytest.mark.parametrize("include_beta", (True, False))
+@pytest.mark.parametrize("include_rc", (True, False))
 def test_list_available_packages_returns_prerelease_versions_if_alpha_beta_or_rc_included(
     venv, pip, pip_version, include_alpha, include_beta, include_rc
 ):
@@ -158,7 +149,7 @@ def test_list_available_packages_returns_prerelease_versions_if_alpha_beta_or_rc
         include_rc=include_rc,
     )
     # parse each version and assert there's a pre-release version somewhere
-    assert any(map(lambda v: v.is_prerelease, map(parse_version, versions)))
+    assert any(list(map(lambda v: v.is_prerelease, map(parse_version, versions))))
 
 
 def test_issue_2087_missing_pip(venv, pip, modules):

--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -10,8 +10,11 @@ from packaging.version import parse as parse_version
 
 import salt.utils.platform
 from salt.exceptions import CommandNotFoundError
+from salt.modules import cmdmod
+from salt.modules import pip as pipmod
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 from tests.support.helpers import VirtualEnv, patched_environ
+from tests.support.mock import MagicMock
 
 pytestmark = [
     pytest.mark.slow_test,
@@ -19,6 +22,55 @@ pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_if_binaries_missing(*KNOWN_BINARY_NAMES, check_all=False),
 ]
+
+
+def mock_pip_versions_cmds(*args, **kwargs):
+    """Function to mock cmd.run_all for pip commands that get package versions but pass-thru other invocations.
+
+    Used by `test_list_available_packages_with_pre_releases_flags` because otherwise we must rely on the presence of
+    pre-release versions of a package in an uncontrolled package index.
+
+    This can be removed if there were an index that we could guarantee had pre-release versions of a package for any
+    caller.
+    """
+
+    def _is_pip_versions_cmd(cmd):
+        pip_args = None
+        for i, arg in enumerate(cmd):
+            if arg == "pip" or arg.endswith("salt-pip"):
+                pip_args = cmd[i + 1 :]
+        if pip_args is None:
+            return False
+        if pip_args[0] == "--use-deprecated=legacy-resolver":
+            pip_args = pip_args[1:]
+        if (
+            pip_args[:2] == ["index", "versions"]
+            or pip_args[0] == "install"
+            and pip_args[1].endswith("==versions")
+        ):
+            return True
+        return False
+
+    if _is_pip_versions_cmd(args[0]):
+        versions = "1.0.0, 1.0.1rc1, 1.0.2b1, 1.0.3.a1"
+        return {
+            "stdout": "\n".join(
+                [
+                    f"Available versions: {versions}",
+                    f"Could not find a version (from versions: {versions})",
+                ]
+            )
+        }
+    return cmdmod.run_all(*args, **kwargs)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        pipmod: {
+            "__salt__": {"cmd.run_all": MagicMock(side_effect=mock_pip_versions_cmds)}
+        }
+    }
 
 
 @pytest.fixture
@@ -137,12 +189,11 @@ def test_list_available_packages_with_pre_releases_flags(
 ):
     """Tests that pre-release versions are returned when flags enable them.
 
-    Note: relies on PyPI hosting pre-release versions of `typing-extensions`.
+    Note: relies on the `configure_loader_modules` fixture to mock the versions we test with.
     """
     venv.install("-U", pip_version)
-    package_name = "typing-extensions"
-    versions = pip.list_all_versions(
-        package_name,
+    versions = pipmod.list_all_versions(
+        "foo",
         bin_env=str(venv.venv_bin_dir),
         include_alpha=include_alpha,
         include_beta=include_beta,

--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -150,7 +150,7 @@ def test_list_available_packages_with_pre_releases_flags(
     )
 
     has_prerelease = any(map(lambda v: v.is_prerelease, map(parse_version, versions)))
-    if any(include_alpha, include_beta, include_rc):
+    if any([include_alpha, include_beta, include_rc]):
         assert has_prerelease
     else:
         assert not has_prerelease

--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -132,7 +132,7 @@ def test_list_available_packages_with_index_url(pip, pip_version, tmp_path):
 @pytest.mark.parametrize("include_alpha", (True, False))
 @pytest.mark.parametrize("include_beta", (True, False))
 @pytest.mark.parametrize("include_rc", (True, False))
-def test_list_available_packages_returns_prerelease_versions_if_alpha_beta_or_rc_included(
+def test_list_available_packages_with_pre_releases_flags(
     venv, pip, pip_version, include_alpha, include_beta, include_rc
 ):
     """Tests that pre-release versions are returned when flags enable them.
@@ -148,8 +148,12 @@ def test_list_available_packages_returns_prerelease_versions_if_alpha_beta_or_rc
         include_beta=include_beta,
         include_rc=include_rc,
     )
-    # parse each version and assert there's a pre-release version somewhere
-    assert any(list(map(lambda v: v.is_prerelease, map(parse_version, versions))))
+
+    has_prerelease = any(map(lambda v: v.is_prerelease, map(parse_version, versions)))
+    if any(include_alpha, include_beta, include_rc):
+        assert has_prerelease
+    else:
+        assert not has_prerelease
 
 
 def test_issue_2087_missing_pip(venv, pip, modules):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #68525 

### Previous Behavior
Python packages installed in an environment would not upgrade to their pre-release version when any exist in the index.

### New Behavior
Pre-release versions of packages managed by `pip.installed` state are upgraded when using `upgrade=True` and `pre_releases=True`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
