### PR TITLE
Fix ssh_known_hosts.present excpetion when specified user not present 

### DIFF
--- a/changelog/62049.fixed.md
+++ b/changelog/62049.fixed.md
@@ -1,0 +1,1 @@
+Fixed a TypeError exception thrown by ssh_known_hosts.present when the specified user account does not exist

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -972,6 +972,8 @@ def check_known_host(
         port=port,
         fingerprint_hash_type=fingerprint_hash_type,
     )
+    if known_host_entries and "error" in known_host_entries:
+        return known_host_entries
     known_keys = [h["key"] for h in known_host_entries] if known_host_entries else []
     known_fingerprints = (
         [h["fingerprint"] for h in known_host_entries] if known_host_entries else []
@@ -1117,6 +1119,9 @@ def set_known_host(
         port=port,
         fingerprint_hash_type=fingerprint_hash_type,
     )
+    if stored_host_entries and "error" in stored_host_entries:
+        return stored_host_entries
+
     stored_keys = (
         [h["key"] for h in stored_host_entries if enc is None or h["enc"] == enc]
         if stored_host_entries

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -151,6 +151,11 @@ def present(
             ret["comment"] = f"ssh.check_known_host error: {err}"
             return ret
 
+        if isinstance(result, dict) and "error" in result:
+            ret["result"] = False
+            if "error" in result:
+                ret["comment"] = result["error"]
+            return ret
         if result == "exists":
             comment = f"Host {name} is already in {config}"
             ret["result"] = True

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -153,8 +153,7 @@ def present(
 
         if isinstance(result, dict) and "error" in result:
             ret["result"] = False
-            if "error" in result:
-                ret["comment"] = result["error"]
+            ret["comment"] = result["error"]
             return ret
         if result == "exists":
             comment = f"Host {name} is already in {config}"

--- a/tests/integration/modules/test_ssh.py
+++ b/tests/integration/modules/test_ssh.py
@@ -204,6 +204,16 @@ class SSHModuleTest(ModuleCase):
         self.assertEqual(ret, "exists")
 
     @pytest.mark.slow_test
+    def test_check_known_host_get_known_host_entries_error(self):
+        """
+        Return the error from get_known_host_entries, if supplied
+        """
+        arg = ["baduser", "github.com"]
+        ret = self.run_function("ssh.check_known_host", arg)
+        assert "error" in ret
+        assert "User baduser does not exist" in ret["error"]
+
+    @pytest.mark.slow_test
     def test_rm_known_host(self):
         """
         ssh.rm_known_host

--- a/tests/integration/states/test_ssh_known_hosts.py
+++ b/tests/integration/states/test_ssh_known_hosts.py
@@ -98,12 +98,22 @@ class SSHKnownHostsStateTest(ModuleCase, SaltReturnAssertsMixin):
     @pytest.mark.slow_test
     def test_present_fail(self):
         # save something wrong
+        kwargs = {
+            "name": "github.com",
+            "user": "root",
+            "enc": "ssh-rsa",
+            "fingerprint": "aa:bb:cc:dd",
+            "config": self.known_hosts,
+        }
+        ret = self.run_state("ssh_known_hosts.present", **kwargs)
+        self.assertSaltFalseReturn(ret)
+        # Missing user.
+        kwargs["user"] = "baduser"
+        kwargs["fingerprint"] = GITHUB_FINGERPRINT
+        del kwargs["config"]
         ret = self.run_state(
             "ssh_known_hosts.present",
-            name="github.com",
-            user="root",
-            fingerprint="aa:bb:cc:dd",
-            config=self.known_hosts,
+            **kwargs,
         )
         self.assertSaltFalseReturn(ret)
 


### PR DESCRIPTION
### What does this PR do?
Fixes the exception described in issue https://github.com/saltstack/salt/issues/62049, triggered when the `ssh_known_hosts.present` state module is used with the `user` argument, but the user account specified is not present.

### What issues does this PR fix or reference?
Fixes #62049

### Previous Behavior
Here is an example state sls file:
```
Add github.com SSH host-key to baduser known_hosts:
  ssh_known_hosts.present:
    - name: github.com
    - user: baduser
    - enc: ecdsa
    - fingerprint: 'a7:64:00:31:73:48:0b:54:c9:61:67:88:3a:db:6b:55:cf:7c:fd:1d:41:50:55:ae:df:f2:e2:c8:a8:14:7d:03'
    - port: 22
    - fingerprint_hash_type: sha256
```

If the user _baduser_ does not exist, this will happen:

```
$ salt-call -c local/etc/salt state.sls ssh_known_hosts
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/home/abolte/salt/salt/state.py", line 2231, in call
    ret = self.states[cdata["full"]](
  File "/home/abolte/salt/salt/loader/lazy.py", line 162, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/home/abolte/salt/salt/loader/lazy.py", line 1291, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/home/abolte/salt/salt/loader/lazy.py", line 1306, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/home/abolte/salt/salt/loader/lazy.py", line 1342, in wrapper
    return f(*args, **kwargs)
  File "/home/abolte/salt/salt/states/ssh_known_hosts.py", line 165, in present
    result = __salt__["ssh.set_known_host"](
  File "/home/abolte/salt/salt/loader/lazy.py", line 162, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/home/abolte/salt/salt/loader/lazy.py", line 1291, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/home/abolte/salt/salt/loader/lazy.py", line 1306, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/home/abolte/salt/salt/modules/ssh.py", line 1119, in set_known_host
    [h["key"] for h in stored_host_entries if enc is None or h["enc"] == enc]
  File "/home/abolte/salt/salt/modules/ssh.py", line 1119, in <listcomp>
    [h["key"] for h in stored_host_entries if enc is None or h["enc"] == enc]
TypeError: string indices must be integers

local:
----------
          ID: Add github.com SSH host-key to baduser known_hosts
    Function: ssh_known_hosts.present
        Name: github.com
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/home/abolte/salt/salt/state.py", line 2231, in call
                  ret = self.states[cdata["full"]](
                File "/home/abolte/salt/salt/loader/lazy.py", line 162, in __call__
                  ret = self.loader.run(run_func, *args, **kwargs)
                File "/home/abolte/salt/salt/loader/lazy.py", line 1291, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/home/abolte/salt/salt/loader/lazy.py", line 1306, in _run_as
                  ret = _func_or_method(*args, **kwargs)
                File "/home/abolte/salt/salt/loader/lazy.py", line 1342, in wrapper
                  return f(*args, **kwargs)
                File "/home/abolte/salt/salt/states/ssh_known_hosts.py", line 165, in present
                  result = __salt__["ssh.set_known_host"](
                File "/home/abolte/salt/salt/loader/lazy.py", line 162, in __call__
                  ret = self.loader.run(run_func, *args, **kwargs)
                File "/home/abolte/salt/salt/loader/lazy.py", line 1291, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/home/abolte/salt/salt/loader/lazy.py", line 1306, in _run_as
                  ret = _func_or_method(*args, **kwargs)
                File "/home/abolte/salt/salt/modules/ssh.py", line 1119, in set_known_host
                  [h["key"] for h in stored_host_entries if enc is None or h["enc"] == enc]
                File "/home/abolte/salt/salt/modules/ssh.py", line 1119, in <listcomp>
                  [h["key"] for h in stored_host_entries if enc is None or h["enc"] == enc]
              TypeError: string indices must be integers
     Started: 14:41:16.140516
    Duration: 16.238 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:  16.238 ms
```

### New Behavior
```
$ salt-call -c local/etc/salt state.sls ssh_known_hosts
[ERROR   ] User baduser does not exist
local:
----------
          ID: Add github.com SSH host-key to baduser known_hosts
    Function: ssh_known_hosts.present
        Name: github.com
      Result: False
     Comment: User baduser does not exist
     Started: 14:38:13.350626
    Duration: 4.048 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   4.048 ms
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
