### PR TITLE
Fix commands in the Contributing to Salt guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -487,8 +487,8 @@ they don't appear to be reflected, this is one option:
 
 ::
 
-   kill -INT $(pgrep salt-master)
-   kill -INT $(pgrep salt-minion)
+   kill -INT $(pgrep -f salt-master)
+   kill -INT $(pgrep -f salt-minion)
 
 If you'd rather not use ``kill``, you can have a couple of terminals
 open with your salt virtualenv activated and omit the ``--daemon``
@@ -539,7 +539,7 @@ Now you can run your tests:
 
 ::
 
-   python -m nox -e "test-3(coverage=False)" -- tests/unit/cli/test_batch.py
+   python -m nox -e "test-3(coverage=False)" -- tests/pytests/unit/cli/test_batch.py
 
 It's a good idea to install
 `espeak <https://github.com/espeak-ng/espeak-ng>`__ or use ``say`` on
@@ -548,7 +548,7 @@ this:
 
 ::
 
-   python -m nox -e "test-3(coverage=False)" -- tests/unit/cli/test_batch.py; espeak "Tests done, woohoo!"
+   python -m nox -e "test-3(coverage=False)" -- tests/pytests/unit/cli/test_batch.py; espeak "Tests done, woohoo!"
 
 That way you don't have to keep monitoring the actual test run.
 

--- a/changelog/68538.fixed.md
+++ b/changelog/68538.fixed.md
@@ -1,0 +1,1 @@
+Fixed some of the commands in the Contributing guide.


### PR DESCRIPTION
### What does this PR do?
Fixes commands that are no longer accurate in the _Contributing to Salt: A Guide for Contributors_ page.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68538 and the page URL [here](https://docs.saltproject.io/en/latest/topics/contributing-guide.html).

### Previous Behavior
The commands to stop the _salt-master_ and _salt-minion_ processes do not work.
```
(salt) abolte@debian12-salt-dev:~/salt$ ps auxf
abolte     82534  0.0  0.6  83132 54036 ?        S    15:04   0:00 /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon MainProcess
abolte     82647  0.0  0.7 164036 57428 ?        Sl   15:04   0:00  \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon PubServerChannel._publish_daemon
abolte     82648  0.0  0.6  90332 56888 ?        S    15:04   0:00  \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon EventPublisher
abolte     82652  0.0  0.6  82108 50556 ?        S    15:04   0:00  \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer ReqServer_ProcessManager
abolte     82653  0.0  0.6 458964 52224 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorkerQueue
abolte     82654  0.0  0.8 242892 66120 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorker-0
abolte     82656  0.0  0.8 242892 65224 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorker-1
abolte     82657  0.0  0.7 250060 59964 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorker-2
abolte     82664  0.0  0.8 244172 65772 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorker-3
abolte     82665  0.0  0.8 244172 66388 ?        Sl   15:04   0:00  |   \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon ReqServer MWorker-4
abolte     95264  0.0  0.6 156864 51552 ?        Sl   18:05   0:00  \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon FileserverUpdate
abolte     95266  0.0  0.7  89796 61344 ?        S    18:05   0:01  \_ /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-master --config-dir=local/etc/salt/ --log-level=debug --daemon Maintenance
abolte     83349  0.0  0.9 405560 75184 ?        Sl   15:04   0:09 /home/abolte/.pyenv/versions/salt/bin/python /home/abolte/.pyenv/versions/salt/bin/salt-minion --config-dir=local/etc/salt/ --log-level=debug --daemon MultiMinionProcessManager MinionProcessManager
(salt) abolte@debian12-salt-dev:~/salt$ kill -INT $(pgrep salt-minion)
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
(salt) abolte@debian12-salt-dev:~/salt$ pgrep salt-minion
(salt) abolte@debian12-salt-dev:~/salt$ pgrep salt-master
(salt) abolte@debian12-salt-dev:~/salt$ 
```

Additionally, the example unit test commands do not work due to a path change.
```
(salt) abolte@debian12-salt-dev:~/salt$ ls -l tests/unit/cli/test_batch.py
ls: cannot access 'tests/unit/cli/test_batch.py': No such file or directory
(salt) abolte@debian12-salt-dev:~/salt$
```

### New Behavior
They work if we use `-f`.
```
(salt) abolte@debian12-salt-dev:~/salt$ pgrep -f salt-minion
83349
(salt) abolte@debian12-salt-dev:~/salt$ pgrep -f salt-master
82534
82647
82648
82652
82653
82654
82656
82657
82664
82665
95264
95266
(salt) abolte@debian12-salt-dev:~/salt$ ls -l tests/pytests/unit/cli/test_batch.py
-rw-r--r-- 1 abolte abolte 3474 Dec 11 20:24 tests/pytests/unit/cli/test_batch.py
(salt) abolte@debian12-salt-dev:~/salt$ 
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Tests are not applicable here since this is exclusively a change to the documentation.

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
