### PR TITLE
Fix issue with checking for non-blockdev devices

### DIFF
--- a/changelog/68541.fixed.md
+++ b/changelog/68541.fixed.md
@@ -1,0 +1,2 @@
+Fix check for non-blockdev devices in blockdev.tuned. Check always returned True
+previously, now actually checks with file.is_blkdev.

--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -77,10 +77,9 @@ def tuned(name, **kwargs):
         "read-write": "getro",
     }
 
-    if not __salt__["file.is_blkdev"]:
-        ret["comment"] = "Changes to {} cannot be applied. Not a block device. ".format(
-            name
-        )
+    if not __salt__["file.is_blkdev"](name):
+        ret["comment"] = f"Changes to {name} cannot be applied. Not a block device."
+        ret["result"] = False
     elif __opts__["test"]:
         ret["comment"] = f"Changes to {name} will be applied "
         ret["result"] = None

--- a/tests/pytests/functional/states/test_blockdev.py
+++ b/tests/pytests/functional/states/test_blockdev.py
@@ -1,0 +1,26 @@
+import logging
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def non_blockdev_file():
+    with pytest.helpers.temp_file() as tmp_file:
+        assert tmp_file.is_file()
+        yield tmp_file
+
+
+def test_tuned_not_block_device(states, non_blockdev_file):
+    """
+    Test to ensure that when the target is not a block device,
+    the state returns False and a comment indicating the issue.
+    """
+    name = str(non_blockdev_file)
+
+    ret = states.blockdev.tuned(
+        name=name,
+    )
+    assert ret["result"] is False
+    assert ret["comment"] == f"Changes to {name} cannot be applied. Not a block device."

--- a/tests/pytests/unit/states/test_blockdev.py
+++ b/tests/pytests/unit/states/test_blockdev.py
@@ -1,5 +1,5 @@
 """
-    :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
+:codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
 import os
@@ -24,13 +24,17 @@ def test_tuned():
 
     ret = {"name": name, "result": True, "changes": {}, "comment": ""}
 
-    comt = ("Changes to {} cannot be applied. Not a block device. ").format(name)
-    with patch.dict(blockdev.__salt__, {"file.is_blkdev": False}):
-        ret.update({"comment": comt})
+    comt = ("Changes to {} cannot be applied. Not a block device.").format(name)
+    with patch.dict(
+        blockdev.__salt__, {"file.is_blkdev": MagicMock(return_value=False)}
+    ):
+        ret.update({"comment": comt, "result": False})
         assert blockdev.tuned(name) == ret
 
     comt = f"Changes to {name} will be applied "
-    with patch.dict(blockdev.__salt__, {"file.is_blkdev": True}):
+    with patch.dict(
+        blockdev.__salt__, {"file.is_blkdev": MagicMock(return_value=True)}
+    ):
         ret.update({"comment": comt, "result": None})
         with patch.dict(blockdev.__opts__, {"test": True}):
             assert blockdev.tuned(name) == ret


### PR DESCRIPTION
### What does this PR do?

Fixes the check for non-blockdev devices, the "file.is_blkdev" function wasn't being called correctly so would always be True. Added test to cover functionality.

### What issues does this PR fix or reference?
Ports fix from #68465

### Previous Behavior
Running blockdev.tuned against a non-block device file would not throw the intended error

### New Behavior
Running blockdev.tuned against a non-block device file will return "Changes to <file> cannot be applied. Not a block device."

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
