### PR TITLE
Document --disable-keepalive option for minion and proxy

### DIFF
--- a/changelog/68544.fixed.md
+++ b/changelog/68544.fixed.md
@@ -1,0 +1,3 @@
+Added documentation and CLI help text for the --disable-keepalive option for
+salt-minion and salt-proxy, which disables the automatic restart mechanism
+when external process managers like systemd handle daemon restarts.

--- a/doc/ref/cli/_includes/daemon-options.rst
+++ b/doc/ref/cli/_includes/daemon-options.rst
@@ -9,3 +9,12 @@
 .. option:: --pid-file PIDFILE
 
     Specify the location of the pidfile. Default: /var/run/|salt-daemon|.pid
+
+.. option:: --disable-keepalive
+
+    Disable the automatic restart mechanism for |salt-daemon|. By default, the
+    daemon runs in a subprocess with automatic restart capabilities if it exits
+    with a keepalive signal. This option disables that behavior and runs the
+    daemon directly without the keepalive wrapper. Useful when an external
+    process manager like systemd handles restarts, or in containerized
+    environments where the container runtime manages the process lifecycle

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -189,7 +189,6 @@ def salt_minion():
         return
 
     if "--disable-keepalive" in sys.argv:
-        sys.argv.remove("--disable-keepalive")
         minion = salt.cli.daemons.Minion()
         minion.start()
         return
@@ -344,7 +343,6 @@ def salt_proxy():
         return
 
     if "--disable-keepalive" in sys.argv:
-        sys.argv.remove("--disable-keepalive")
         proxyminion = salt.cli.daemons.ProxyMinion()
         proxyminion.start()
         return

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -940,6 +940,18 @@ class DaemonMixIn(metaclass=MixInMeta):
             default=os.path.join(syspaths.PIDFILE_DIR, f"{self.get_prog_name()}.pid"),
             help="Specify the location of the pidfile. Default: '%default'.",
         )
+        self.add_option(
+            "--disable-keepalive",
+            dest="disable_keepalive",
+            default=False,
+            action="store_true",
+            help=(
+                "Disable the automatic restart mechanism. By default, the daemon "
+                "runs in a subprocess with automatic restart capabilities. This "
+                "option disables that behavior and runs the daemon directly. "
+                "Useful when an external process manager like systemd handles restarts."
+            ),
+        )
 
     def _mixin_before_exit(self):
         if hasattr(self, "config") and self.config.get("pidfile"):


### PR DESCRIPTION
Add documentation and CLI help text for the --disable-keepalive option, which disables the automatic restart mechanism. This option is useful when external process managers like systemd handle daemon restarts, or in containerized environments.

Fixes: #68544 