### PR TITLE
Fix beacons not sent when beacon_refresh called

### DIFF
--- a/changelog/68548.fixed.md
+++ b/changelog/68548.fixed.md
@@ -1,0 +1,1 @@
+Preserve interval_map on beacon refresh to ensure beacons are still fired when we refresh beacons.

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -18,13 +18,13 @@ class Beacon:
     This class is used to evaluate and execute on the beacon system
     """
 
-    def __init__(self, opts, functions):
+    def __init__(self, opts, functions, interval_map=None):
         import salt.loader
 
         self.opts = opts
         self.functions = functions
         self.beacons = salt.loader.beacons(opts, functions)
-        self.interval_map = dict()
+        self.interval_map = interval_map or dict()
 
     def process(self, config, grains):
         """

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2605,7 +2605,13 @@ class Minion(MinionBase):
         if not self.beacons_leader:
             return
         log.debug("Refreshing beacons.")
-        self.beacons = salt.beacons.Beacon(self.opts, self.functions)
+        # Preserve the interval_map so beacon intervals aren't reset on refresh
+        prev_interval_map = {}
+        if hasattr(self, "beacons") and hasattr(self.beacons, "interval_map"):
+            prev_interval_map = self.beacons.interval_map
+        self.beacons = salt.beacons.Beacon(
+            self.opts, self.functions, interval_map=prev_interval_map
+        )
 
     def matchers_refresh(self):
         """


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/68548

### Previous Behavior
The interval_map would get re-set to 0 whenever we called beacons_refresh. If beacons_refresh is continually getting called for example when running a state run then the beacons would never get sent.

### New Behavior
interval_map is preserved if set and the beacon still gets sent when running a state run (or any other situation that refreshes beacon)
