### PR TITLE
Fixed Arista EOS Napalm driver to return json data

### DIFF
--- a/changelog/68550.fixed.md
+++ b/changelog/68550.fixed.md
@@ -1,0 +1,1 @@
+Fixed Arista EOS Napalm driver to return json data, by allowing to pass cli kwargs to driver.

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -509,12 +509,22 @@ def environment(**kwargs):  # pylint: disable=unused-argument
 
 
 @salt.utils.napalm.proxy_napalm_wrap
-def cli(*commands, **kwargs):  # pylint: disable=unused-argument
+def cli(*commands, cli_kwargs=None, **kwargs):  # pylint: disable=unused-argument
     """
     Returns a dictionary with the raw output of all commands passed as arguments.
 
     commands
         List of commands to be executed on the device.
+
+    cli_kwargs
+        Dictionary of keyword arguments to pass directly to the NAPALM driver's
+        ``cli`` method. Use this for driver-specific options like ``encoding``.
+
+        .. versionadded:: 3006.19
+
+        Example::
+
+            salt '*' net.cli "show version" cli_kwargs='{"encoding": "json"}'
 
     textfsm_parse: ``False``
         Try parsing the outputs using the TextFSM templates.
@@ -689,10 +699,13 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
           }
         }
     """
+    napalm_kwargs = {"commands": list(commands)}
+    if cli_kwargs:
+        napalm_kwargs.update(cli_kwargs)
     raw_cli_outputs = salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
         "cli",
-        **{"commands": list(commands)},
+        **napalm_kwargs,
     )
     # thus we can display the output as is
     # in case of errors, they'll be caught in the proxy

--- a/tests/pytests/unit/modules/test_napalm_network.py
+++ b/tests/pytests/unit/modules/test_napalm_network.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the napalm_network module cli_kwargs feature
+"""
+
+import pytest
+
+import salt.modules.napalm_network as napalm_network
+import salt.utils.napalm
+import tests.support.napalm as napalm
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    module_globals = {
+        "__salt__": {
+            "config.get": MagicMock(
+                return_value={"test": {"driver": "test", "key": "3j9jla,LJ3j9laj"}}
+            ),
+            "file.file_exists": napalm.true,
+            "file.join": napalm.join,
+            "file.get_managed": napalm.get_managed_file,
+            "random.hash": napalm.random_hash,
+        },
+        "__opts__": {},
+        "__pillar__": {},
+    }
+    return {napalm_network: module_globals}
+
+
+def test_cli_kwargs_not_provided():
+    """
+    Test that when cli_kwargs is not provided, only commands are passed to NAPALM.
+    """
+    with patch(
+        "salt.utils.napalm.get_device",
+        MagicMock(return_value=napalm.MockNapalmDevice()),
+    ):
+        with patch.object(
+            salt.utils.napalm,
+            "call",
+            MagicMock(
+                return_value={
+                    "result": True,
+                    "comment": "",
+                    "out": {"show version": "EOS version 4.28"},
+                }
+            ),
+        ) as mock_call:
+            napalm_network.cli("show version")
+
+            mock_call.assert_called_once()
+            call_kwargs = mock_call.call_args[1]
+            assert call_kwargs == {"commands": ["show version"]}
+
+
+def test_cli_kwargs_with_encoding():
+    """
+    Test that when cli_kwargs contains encoding, it's passed to NAPALM.
+    """
+    with patch(
+        "salt.utils.napalm.get_device",
+        MagicMock(return_value=napalm.MockNapalmDevice()),
+    ):
+        with patch.object(
+            salt.utils.napalm,
+            "call",
+            MagicMock(
+                return_value={
+                    "result": True,
+                    "comment": "",
+                    "out": {"show version": "EOS version 4.28"},
+                }
+            ),
+        ) as mock_call:
+            napalm_network.cli("show version", cli_kwargs={"encoding": "json"})
+
+            mock_call.assert_called_once()
+            call_kwargs = mock_call.call_args[1]
+            assert call_kwargs == {"commands": ["show version"], "encoding": "json"}


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/68550

### Previous Behavior
Some Arista EOS versions would not return json data using the pipe `(| json)`

### New Behavior
Now we can enforce the return of json by passing in the encoding parameter to the napalm cli method.