### PR TITLE
Pr add viruscheck to chocolatey

### DIFF
--- a/changelog/68558.added.md
+++ b/changelog/68558.added.md
@@ -1,0 +1,1 @@
+Add an option in the chocolatey state and module so that the viruscheck flag can be controlled.

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -578,6 +578,7 @@ def install(
     package_args=None,
     allow_multiple=False,
     execution_timeout=None,
+    viruscheck=None,
 ):
     """
     Instructs Chocolatey to install a package.
@@ -642,6 +643,13 @@ def install(
 
             .. versionadded:: 2018.3.0
 
+        viruscheck (bool):
+            Enable or disable the chocolatey virus check extension (licensed
+            version only). If not provided then no arguments are added.
+            Default is ``None``.
+
+            .. versionadded:: 3006.20
+
     Returns:
         str: The output of the ``chocolatey`` command
 
@@ -683,6 +691,9 @@ def install(
         cmd.append("--allow-multiple")
     if execution_timeout:
         cmd.extend(["--execution-timeout", execution_timeout])
+    if viruscheck is not None:
+        virusarg = "--viruscheck" if viruscheck else "--skipviruscheck"
+        cmd.append(virusarg)
 
     # Salt doesn't need to see the progress
     cmd.extend(_no_progress())

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -578,7 +578,7 @@ def install(
     package_args=None,
     allow_multiple=False,
     execution_timeout=None,
-    viruscheck=None,
+    virus_check=None,
 ):
     """
     Instructs Chocolatey to install a package.
@@ -643,7 +643,7 @@ def install(
 
             .. versionadded:: 2018.3.0
 
-        viruscheck (bool):
+        virus_check (bool):
             Enable or disable the chocolatey virus check extension (licensed
             version only). If not provided then no arguments are added.
             Default is ``None``.
@@ -691,8 +691,8 @@ def install(
         cmd.append("--allow-multiple")
     if execution_timeout:
         cmd.extend(["--execution-timeout", execution_timeout])
-    if viruscheck is not None:
-        virusarg = "--viruscheck" if viruscheck else "--skipviruscheck"
+    if virus_check is not None:
+        virusarg = "--viruscheck" if virus_check else "--skipviruscheck"
         cmd.append(virusarg)
 
     # Salt doesn't need to see the progress

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -35,7 +35,7 @@ def installed(
     package_args=None,
     allow_multiple=False,
     execution_timeout=None,
-    viruscheck=None,
+    virus_check=None,
 ):
     """
     Installs a package if not already installed
@@ -90,7 +90,7 @@ def installed(
             Chocolatey execution timeout value you want to pass to the
             installation process. Default is ``None``.
 
-        viruscheck (bool):
+        virus_check (bool):
             Enable or disable the chocolatey virus check extension (licensed
             version only). If not provided then no arguments are added.
             Default is ``None``.
@@ -176,7 +176,7 @@ def installed(
         package_args=package_args,
         allow_multiple=allow_multiple,
         execution_timeout=execution_timeout,
-        viruscheck=viruscheck,
+        virus_check=virus_check,
     )
 
     if "Running chocolatey failed" not in result:

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -35,6 +35,7 @@ def installed(
     package_args=None,
     allow_multiple=False,
     execution_timeout=None,
+    viruscheck=None,
 ):
     """
     Installs a package if not already installed
@@ -88,6 +89,11 @@ def installed(
         execution_timeout (str):
             Chocolatey execution timeout value you want to pass to the
             installation process. Default is ``None``.
+
+        viruscheck (bool):
+            Enable or disable the chocolatey virus check extension (licensed
+            version only). If not provided then no arguments are added.
+            Default is ``None``.
 
     Example:
 
@@ -170,6 +176,7 @@ def installed(
         package_args=package_args,
         allow_multiple=allow_multiple,
         execution_timeout=execution_timeout,
+        viruscheck=viruscheck,
     )
 
     if "Running chocolatey failed" not in result:

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -277,14 +277,14 @@ def test_add_source(choco_path):
         cmd_run_all_mock.assert_called_with(expected_call, python_shell=False)
 
 
-def test_install_viruscheck_true():
+def test_install_virus_check_true():
     mock_version = MagicMock(return_value="2.0.1")
     mock_find = MagicMock(return_value=choco_path)
     mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
     with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
         chocolatey, "_find_chocolatey", mock_find
     ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
-        chocolatey.install("busybox", viruscheck=True)
+        chocolatey.install("busybox", virus_check=True)
         # --no-progress and --yes populated from separate functions within the module.
         expected_call = [
             choco_path,
@@ -297,14 +297,14 @@ def test_install_viruscheck_true():
         mock_run.assert_called_with(expected_call, python_shell=False)
 
 
-def test_install_viruscheck_false():
+def test_install_virus_check_false():
     mock_version = MagicMock(return_value="2.0.1")
     mock_find = MagicMock(return_value=choco_path)
     mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
     with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
         chocolatey, "_find_chocolatey", mock_find
     ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
-        chocolatey.install("busybox", viruscheck=False)
+        chocolatey.install("busybox", virus_check=False)
         # --no-progress and --yes populated from separate functions within the module.
         expected_call = [
             choco_path,

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -277,6 +277,46 @@ def test_add_source(choco_path):
         cmd_run_all_mock.assert_called_with(expected_call, python_shell=False)
 
 
+def test_install_viruscheck_true():
+    mock_version = MagicMock(return_value="2.0.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.install("busybox", viruscheck=True)
+        # --no-progress and --yes populated from separate functions within the module.
+        expected_call = [
+            choco_path,
+            "install",
+            "busybox",
+            "--viruscheck",
+            "--no-progress",
+            "--yes",
+        ]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_install_viruscheck_false():
+    mock_version = MagicMock(return_value="2.0.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.install("busybox", viruscheck=False)
+        # --no-progress and --yes populated from separate functions within the module.
+        expected_call = [
+            choco_path,
+            "install",
+            "busybox",
+            "--skipviruscheck",
+            "--no-progress",
+            "--yes",
+        ]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
 def test_list_pre_2_0_0():
     mock_version = MagicMock(return_value="1.2.1")
     mock_find = MagicMock(return_value=choco_path)


### PR DESCRIPTION
### What does this PR do?

Adds the viruscheck argument to the chocolatey cli for installing packages.

https://docs.chocolatey.org/en-us/features/virus-check/#options-and-switches

---

There are no tests. I'm not sure the best location. I'm thinking they should be added here:
```tests/pytests/unit/modules/test_chocolatey.py```

Though, I thought I saw somewhere that Salt was trying to move away from pytest stuffs?

### What issues does this PR fix or reference?
Fixes

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
