### PR TITLE
Bump LocalClient pub and pub_async timeouts

### DIFF
--- a/changelog/68597.fixed.md
+++ b/changelog/68597.fixed.md
@@ -1,0 +1,3 @@
+Increase pub and pub_async timeouts on LocalClient from 5 to 15 for better
+handling of network delays. This change only affects programatic usage of
+LocalClient.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1850,7 +1850,7 @@ class LocalClient:
         tgt_type="glob",
         ret="",
         jid="",
-        timeout=5,
+        timeout=15,
         listen=False,
         **kwargs,
     ):
@@ -1951,7 +1951,7 @@ class LocalClient:
         tgt_type="glob",
         ret="",
         jid="",
-        timeout=5,
+        timeout=15,
         io_loop=None,
         listen=True,
         **kwargs,


### PR DESCRIPTION
A 5 second timeout causes things to start failing when 2 second artificial network delay is introduced. Changeing the default here to 15 seconds to avoid causeing all programatic usages of LocalClient to adjust their timeouts.

Fixes: #68597
