### PR TITLE
Bump relenv to 0.22.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -458,7 +458,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -475,7 +475,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -491,7 +491,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -508,7 +508,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -529,7 +529,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -476,7 +476,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -493,7 +493,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -510,7 +510,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -468,7 +468,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -486,7 +486,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -508,7 +508,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.1"
+      relenv-version: "0.22.2"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/changelog/68607.fixed.md
+++ b/changelog/68607.fixed.md
@@ -1,0 +1,5 @@
+Upgrade relenv to 0.22.2:
+* Remove RPATH from shared libraries that do not link to any other libraries in
+  our environment.
+* Ensure we always return a proper and consistang default python version for
+  create, fetch, build commands.

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.19"
-relenv_version: "0.22.1"
+relenv_version: "0.22.2"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04


### PR DESCRIPTION
* Remove RPATH from shared libraries that do not link to any other libraries in our environment.
* Ensure we always return a proper and consistent default python version for create, fetch, build commands.

FIxes: #68607