### PR TITLE
Allow for toggling of LDAP attribute ordering

### DIFF
--- a/changelog/68628.added.md
+++ b/changelog/68628.added.md
@@ -1,0 +1,2 @@
+Add ``strict_order`` directive to ``ldap.managed`` to restore idempotency
+when LDAP servers return attribute values in a different order than declared.


### PR DESCRIPTION


### What does this PR do?

With some LDAP implementations attributes are not stored and returned in the order in which they were added, leading to the state repeatedly reporting changes. Introduce a toggle which enables internal sorting of old and new attributes and restores idempotency in such situations.

### What issues does this PR fix or reference?

Fixes https://github.com/saltstack/salt/issues/68626.

### Previous Behavior

Stray changes upon ordering differences.

### New Behavior

No changes if ordering is not deemed relevant.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
