### PR TITLE
Reorganize requirements/base.txt alphabetically to reduce merge conflicts

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,36 +1,36 @@
 --constraint=constraints.txt
 
-Jinja2>=3.1.5
-jmespath
-msgpack>=1.0.0
-PyYAML
-MarkupSafe
-requests<2.32.0 ; python_version < '3.10'
-requests>=2.32.5 ; python_version >= '3.10'
+# Dependencies are listed alphabetically by package name.
+# Multiple entries for the same package (with different version constraints) are grouped together.
+
 certifi==2023.07.22; python_version < '3.10'
 certifi>=2024.7.4; python_version >= '3.10'
-distro>=1.0.1
 cffi>=2.0.0
-
-
-psutil<6.0.0; python_version <= '3.9'
-psutil>=5.0.0; python_version >= '3.10'
+# We need contextvars for salt-ssh
+contextvars
+croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
+cryptography>=42.0.0
+distro>=1.0.1
+frozenlist>=1.3.0; python_version < '3.11'
+frozenlist>=1.5.0; python_version >= '3.11'
+# immutables is a requirement of contextvars
+immutables>=0.21
+jaraco.functools>=4.1.0
+jaraco.text>=4.0.0
+Jinja2>=3.1.5
+jmespath
+looseversion
+MarkupSafe
+msgpack>=1.0.0
 # Packaging 24.1 imports annotations from __future__ which breaks salt ssh
 # tests on target hosts with older python versions.
 packaging==24.0
-looseversion
-croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
-# We need contextvars for salt-ssh
-contextvars
-# immutables is a requirement of contextvars
-immutables>=0.21
-cryptography>=42.0.0
-urllib3>=1.26.20,<2.0.0; python_version < '3.10'
-urllib3>=2.6.3; python_version >= '3.10'
-
-jaraco.text>=4.0.0
-jaraco.functools>=4.1.0
+psutil<6.0.0; python_version <= '3.9'
+psutil>=5.0.0; python_version >= '3.10'
+PyYAML
+requests<2.32.0 ; python_version < '3.10'
+requests>=2.32.5 ; python_version >= '3.10'
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-frozenlist>=1.3.0; python_version < '3.11'
-frozenlist>=1.5.0; python_version >= '3.11'
+urllib3>=1.26.20,<2.0.0; python_version < '3.10'
+urllib3>=2.6.3; python_version >= '3.10'


### PR DESCRIPTION
Ensure our requirements base is alphabetical to reduce merge conflicts on merge forwards