### PR TITLE
Support attrlist in ldap.managed

### DIFF
--- a/changelog/53364.fixed.md
+++ b/changelog/53364.fixed.md
@@ -1,0 +1,1 @@
+Support attrlist in ldap.managed


### PR DESCRIPTION
### What does this PR do?

This resolves not being able to manage operational attributes by introducing a way to pass the list to filter in the LDAP search through to the search function. Passing a customizable list was deemed most flexible, as one might not want to control all but only specific operational attributes. For example, one can set attrlist to ["*", "aci"] to manage all user attributes plus the "aci" operational attribute.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/53364.

### Previous Behavior

No way of enabling additional attributes in the search, causing repeated changes to be reported (an apply of which then fails due to the attribute already existing).

### New Behavior

Additional attributes can be selectively enabled.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
