### PR TITLE
Fix stacktrace when master not available

### DIFF
--- a/changelog/62780.fixed.md
+++ b/changelog/62780.fixed.md
@@ -1,0 +1,1 @@
+Fix a stacktrace that happens then the minion fails to connect to a master.

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -689,7 +689,9 @@ class AsyncReqMessageClient:
                     # Time is in milliseconds.
                     ready = yield socket.poll(300, zmq.POLLIN)
                 except zmq.eventloop.future.CancelledError as exc:
-                    log.trace("Loop closed while polling receive socket.", exc_info=True)
+                    log.trace(
+                        "Loop closed while polling receive socket.", exc_info=True
+                    )
                     log.error("Master is unavailable (Connection Cancelled).")
                     send_recv_running = False
                     if not future.done():

--- a/tests/pytests/functional/transport/zeromq/test_request_client.py
+++ b/tests/pytests/functional/transport/zeromq/test_request_client.py
@@ -17,6 +17,7 @@ pytestmark = [
     pytest.mark.windows_whitelisted,
 ]
 
+
 @pytest.fixture
 def port():
     return pytestshellutils.utils.ports.get_unused_localhost_port()


### PR DESCRIPTION
### What does this PR do?
Fixes stacktrace that appears when starting a minion when the master is unavailable.

### What issues does this PR fix or reference?
Fixes #62780 

### Previous Behavior
Stacktrace

### New Behavior
No stacktrace

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
