### PR TITLE
fix mongodb tops module for pymongo v4 compatibility

### DIFF
--- a/changelog/68659.fixed.md
+++ b/changelog/68659.fixed.md
@@ -1,0 +1,1 @@
+Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method

--- a/tests/pytests/unit/tops/test_mongo.py
+++ b/tests/pytests/unit/tops/test_mongo.py
@@ -30,3 +30,91 @@ def test_tops_should_correctly_pass_ssl_arg_to_MongoClient(expected_ssl, use_ssl
         fake_pymongo.MongoClient.assert_called_with(
             host="fnord", port="fnord", ssl=expected_ssl
         )
+
+
+def test_tops_should_pass_auth_to_MongoClient_for_pymongo_v4():
+    """
+    Test that authentication credentials are passed to MongoClient constructor
+    for pymongo v4 compatibility, not using deprecated mdb.authenticate()
+    """
+    salt.tops.mongo.HAS_PYMONGO = True
+    with patch("salt.tops.mongo.pymongo", create=True) as fake_pymongo, patch.dict(
+        "salt.tops.mongo.__opts__",
+        {
+            "master_tops": {"mongo": {}},
+            "mongo.host": "localhost",
+            "mongo.port": 27017,
+            "mongo.user": "testuser",
+            "mongo.password": "testpass",
+            "mongo.db": "salt",
+        },
+    ):
+        salt.tops.mongo.top(opts={"id": "test-minion"})
+
+        # Verify MongoClient is called with authentication parameters
+        fake_pymongo.MongoClient.assert_called_with(
+            host="localhost",
+            port=27017,
+            ssl=False,
+            username="testuser",
+            password="testpass",
+            authSource="admin",
+        )
+
+        # Verify that authenticate() is NOT called (pymongo v4 compatibility)
+        fake_db = fake_pymongo.MongoClient.return_value.__getitem__.return_value
+        assert not fake_db.authenticate.called
+
+
+def test_tops_should_use_custom_authdb():
+    """
+    Test that custom authdb is passed correctly to MongoClient
+    """
+    salt.tops.mongo.HAS_PYMONGO = True
+    with patch("salt.tops.mongo.pymongo", create=True) as fake_pymongo, patch.dict(
+        "salt.tops.mongo.__opts__",
+        {
+            "master_tops": {"mongo": {}},
+            "mongo.host": "localhost",
+            "mongo.port": 27017,
+            "mongo.user": "testuser",
+            "mongo.password": "testpass",
+            "mongo.authdb": "myauthdb",
+            "mongo.db": "salt",
+        },
+    ):
+        salt.tops.mongo.top(opts={"id": "test-minion"})
+
+        # Verify custom authSource is used
+        fake_pymongo.MongoClient.assert_called_with(
+            host="localhost",
+            port=27017,
+            ssl=False,
+            username="testuser",
+            password="testpass",
+            authSource="myauthdb",
+        )
+
+
+def test_tops_without_auth_should_not_pass_credentials():
+    """
+    Test that when no credentials are provided, MongoClient is called without auth params
+    """
+    salt.tops.mongo.HAS_PYMONGO = True
+    with patch("salt.tops.mongo.pymongo", create=True) as fake_pymongo, patch.dict(
+        "salt.tops.mongo.__opts__",
+        {
+            "master_tops": {"mongo": {}},
+            "mongo.host": "localhost",
+            "mongo.port": 27017,
+            "mongo.db": "salt",
+        },
+    ):
+        salt.tops.mongo.top(opts={"id": "test-minion"})
+
+        # Verify MongoClient is called without authentication parameters
+        fake_pymongo.MongoClient.assert_called_with(
+            host="localhost",
+            port=27017,
+            ssl=False,
+        )


### PR DESCRIPTION
Fixes: https://github.com/saltstack/salt/issues/68659

### What does this PR do?
Fixes the mongodb tops module to work with pymongo v4+ by replacing the deprecated mdb.authenticate() method with authentication credentials passed directly to the MongoClient constructor.

### What issues does this PR fix or reference?
Fixes #68659

### Previous Behavior
The mongodb tops module used the deprecated mdb.authenticate(user, password) method which was removed in pymongo v4. This caused authentication failures when using pymongo v4.9+ (required for MongoDB v8 compatibility).
```
conn = pymongo.MongoClient(host=host, port=port, ssl=ssl)
mdb = conn[database]
if user and password:
    mdb.authenticate(user, password)  # ❌ Removed in pymongo v4
```

### New Behavior
Authentication credentials are now passed directly to MongoClient constructor using username, password, and authSource parameters, making it compatible with both pymongo v3 and v4+.
```
conn_kwargs = {"host": host, "port": port, "ssl": ssl}
if user and password:
    conn_kwargs["username"] = user
    conn_kwargs["password"] = password
    conn_kwargs["authSource"] = authdb  # Defaults to "admin"
conn = pymongo.MongoClient(**conn_kwargs)
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130