### PR TITLE
addition to maintenance_interval docs

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -414,10 +414,11 @@ Defines how often to restart the master's Maintenance process.
 
 .. note::
 
-    The maintenance_interval can interfere with the master scheduler
-    if scheduled jobs run at intervals greater than that interval.
-    For example, a master with the default 3600-second interval will
-    never run a scheduled job set to run every 7200 seconds.
+    Scheduled jobs will fail to trigger if their interval is greater than the
+    ``maintenance_interval``. Because the master scheduler only evaluates jobs
+    during maintenance cycles, a default 3600-second (1-hour) maintenance
+    interval will effectively ignore any job set to run every 7200 seconds (2
+    hours).
 
 .. conf_master:: output
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -412,6 +412,12 @@ Defines how often to restart the master's Maintenance process.
 
     maintenance_interval: 9600
 
+.. note::
+
+    The maintenance_interval can interfere with the master scheduler
+    if scheduled jobs run at intervals greater than that interval.
+    For example, a master with the default 3600-second interval will
+    never run a scheduled job set to run every 7200 seconds.
 
 .. conf_master:: output
 


### PR DESCRIPTION
### What does this PR do?
This adds a note to the documentation about the maintenance_interval, that if the master scheduler has a greater interval than the maintenance interval, that job will not run

### What issues does this PR fix or reference?
Fixes [https://github.com/saltstack/salt/issues/65784]

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
