### PR TITLE
Use debug instead of warning

### DIFF
--- a/changelog/68688.fixed.md
+++ b/changelog/68688.fixed.md
@@ -1,0 +1,2 @@
+Fix an issue with too many warnings about the maximum number of processes
+reached. Moved to debug.

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -802,7 +802,7 @@ def handle_decoded_payload(self, data):
     if process_count_max > 0:
         process_count = len(salt.utils.minion.running(self.opts))
         while process_count >= process_count_max:
-            log.warning(
+            log.debug(
                 "Maximum number of processes reached while executing jid %s, waiting...",
                 data["jid"],
             )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1865,7 +1865,7 @@ class Minion(MinionBase):
         if process_count_max > 0:
             process_count = len(salt.utils.minion.running(self.opts))
             while process_count >= process_count_max:
-                log.warning(
+                log.debug(
                     "Maximum number of processes reached while executing jid %s,"
                     " waiting...",
                     data["jid"],


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the minion log was being filled with warnings about maximum number of processes reached.

### What issues does this PR fix or reference?
Fixes #68688 and Jira Ticket

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
