### PR TITLE
dictdiffer: deep diff of dicts in lists

### DIFF
--- a/changelog/68726.added.md
+++ b/changelog/68726.added.md
@@ -1,0 +1,1 @@
+utils.dictdiffer: support diffing of dicts in lists


### PR DESCRIPTION
### What does this PR do?

So far, lists would always be compared as a whole - in case of lists containing dicts as elements, this would cause lots of output even if only parts of the contained dicts changed. Allow matching of lists with consistently keyed dicts.
We do have listdiffer, but custom logic was implemented as importing listdiffer in dictdiffer would cause a circular import.

Let me know if you have a better idea for this.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/68726.

### Previous Behavior

No way to diff dicts in lists in dicts.

### New Behavior

Functionality is available.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
