### PR TITLE
Fix batch mode treating error payloads as minion IDs

### DIFF
--- a/changelog/68672.fixed.md
+++ b/changelog/68672.fixed.md
@@ -1,0 +1,1 @@
+Fix `salt` batch mode incorrectly treating transport-level error payloads as minion IDs, preventing spurious `Minion 'error' failed to respond` messages and hardening duplicate return handling.

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -86,13 +86,15 @@ class Batch:
         fret = set()
         nret = set()
         for ret in ping_gen:
-            if ("minions" and "jid") in ret:
+            if "minions" in ret and "jid" in ret:
                 for minion in ret["minions"]:
                     nret.add(minion)
                 continue
             else:
                 try:
                     m = next(iter(ret.keys()))
+                    if not isinstance(m, str) or m == "error":
+                        continue
                 except StopIteration:
                     if not self.quiet:
                         salt.utils.stringutils.print_cli(
@@ -376,7 +378,19 @@ class Batch:
                             break
                         continue
                     if raw_mode:
+                        if "data" not in part or part.get("error"):
+                            log.debug(
+                                "Skipping error payload in batch return (raw mode): %s",
+                                part,
+                            )
+                            continue
                         minion_id = part["data"]["id"]
+                        if not isinstance(minion_id, str) or minion_id == "error":
+                            log.debug(
+                                "Skipping error payload in batch return (raw mode): %s",
+                                part,
+                            )
+                            continue
                         raw_by_minion[minion_id] = part
                         new_returns[minion_id] = {
                             "ret": part["data"].get("return"),
@@ -392,7 +406,19 @@ class Batch:
                                     " probably a duplicate key".format(minion_id)
                                 )
                     else:
+                        if "error" in part:
+                            log.debug(
+                                "Skipping error payload in batch return: %s",
+                                part,
+                            )
+                            continue
                         for minion_id, mret in part.items():
+                            if not isinstance(minion_id, str):
+                                log.debug(
+                                    "Skipping non-string key in batch return: %s",
+                                    part,
+                                )
+                                continue
                             raw_by_minion[minion_id] = copy.copy(mret)
                             new_returns[minion_id] = mret
                             if minion_id in minion_tracker[queue]["minions"]:
@@ -424,6 +450,12 @@ class Batch:
                 minion_id = next(iter(ping_ret.keys()))
             except StopIteration:
                 break
+            if not isinstance(minion_id, str) or minion_id == "error":
+                log.debug(
+                    "Skipping error payload in late-minion discovery: %s",
+                    ping_ret,
+                )
+                continue
             if minion_id not in state["all_minions"]:
                 state["all_minions"].append(minion_id)
                 state["pending"].append(minion_id)

--- a/tests/pytests/unit/cli/test_batch.py
+++ b/tests/pytests/unit/cli/test_batch.py
@@ -746,3 +746,105 @@ def test_run_event_failures_are_swallowed(batch):
     results = list(Batch.run(batch))
     assert len(results) == 1
     assert next(iter(results[0][0].values())) is True
+
+
+def test_gather_minions_ignores_error_payload(batch):
+    """
+    Transport-level error payloads (e.g. ``{"error": "...", "jid": "..."}``
+    or ``{"error": "Authentication failure"}``) must not be treated as
+    minion IDs in gather_minions().
+
+    Regression for issues #46876, #48509, #50238, #60724.
+    """
+    ping_returns = [
+        # Transport-level error payload — must be ignored
+        {"error": "Authentication failure", "jid": "20260101000000"},
+        # Legit discovery payload — emitted before individual pings
+        {"minions": ["minion1"], "jid": "20260101000001"},
+        # Individual minion ping reply
+        {"minion1": {"ret": True}},
+    ]
+
+    batch.local.cmd_iter = MagicMock(return_value=iter(ping_returns))
+
+    batch.opts.update(
+        {
+            "tgt": "*",
+            "tgt_type": "glob",
+            "timeout": 5,
+            "gather_job_timeout": 5,
+        }
+    )
+
+    minions, _, _ = batch.gather_minions()
+
+    assert "error" not in minions
+    assert minions == ["minion1"]
+
+
+def test_gather_minions_fixes_minions_jid_check(batch):
+    """
+    The Python expression ``("minions" and "jid") in ret`` evaluates to
+    ``"jid" in ret`` — a bug that causes the discovery payload to be
+    processed as a minion return rather than skipped.
+
+    The fix replaces it with ``"minions" in ret and "jid" in ret`` so
+    the full-list discovery packet is handled correctly.
+    """
+    # A payload that has "jid" but NOT "minions" — the old buggy check
+    # would have treated it as a discovery payload; the fixed check must
+    # fall through to the else branch.
+    ping_returns = [
+        {"jid": "20260101000000"},  # has "jid", no "minions" — old code would skip
+        {"minion1": {"ret": True}},
+    ]
+
+    batch.local.cmd_iter = MagicMock(return_value=iter(ping_returns))
+
+    batch.opts.update(
+        {
+            "tgt": "*",
+            "tgt_type": "glob",
+            "timeout": 5,
+            "gather_job_timeout": 5,
+        }
+    )
+
+    minions, _, _ = batch.gather_minions()
+
+    # minion1 must be discovered; the jid-only dict must not be treated as a
+    # discovery packet that feeds "minion1" into nret (it has no "minions" key).
+    assert "minion1" in minions
+
+
+def test_run_ignores_error_payload_in_cmd_returns(batch):
+    """
+    When ``cmd_iter_no_block`` yields a transport-level error dict
+    (keyed by ``"error"`` instead of a real minion ID) the batch run
+    must silently skip it rather than treating ``"error"`` as a minion.
+
+    Regression for the ``KeyError: 'ret'`` crash described in #46876.
+    """
+    batch.opts = {
+        "batch": "1",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 5,
+    }
+    batch.gather_minions = MagicMock(return_value=[["minion1"], [], []])
+
+    def _make_iter(*args, **kwargs):
+        # First yield is a transport-level error payload
+        yield {"error": "Publish failed", "failed": True}
+        # Second yield is the real minion return
+        yield {"minion1": {"ret": True, "retcode": 0}}
+
+    batch.local.cmd_iter_no_block = MagicMock(side_effect=_make_iter)
+    batch.local.event.get_event = MagicMock(return_value=None)
+
+    results = list(Batch.run(batch))
+
+    returned_minions = [next(iter(d.keys())) for d, _rc in results]
+    assert "error" not in returned_minions
+    assert "minion1" in returned_minions


### PR DESCRIPTION
### What does this PR do?

Batch mode could incorrectly treat transport-level error payloads (e.g. `{"error": "...", "failed": True}`) as valid minion IDs, leading to spurious `"Minion 'error' failed to respond"` messages and incorrect batch tracking.

### What issues does this PR fix or reference?
Issues: https://github.com/saltstack/salt/issues/46876 https://github.com/saltstack/salt/issues/48509 https://github.com/saltstack/salt/issues/50238 https://github.com/saltstack/salt/issues/60724
PRs: https://github.com/saltstack/salt/pull/53159 https://github.com/saltstack/salt/pull/54725 https://github.com/saltstack/salt/pull/54923 

### Previous Behavior
Running batched commands like `salt -b4 *-minion*  test.ping` caused loads of extra errors that are not actual _errors_ and minion payloads misinterpreted:

```
Executing run on ['minion1xxx', 'error', 'minion2xxx, 'minion3xxx']

minion error was already deleted from tracker, probably a duplicate key
minion error was already deleted from tracker, probably a duplicate key
minion error was already deleted from tracker, probably a duplicate key
minion error was already deleted from tracker, probably a duplicate key
[ERROR   ] An un-handled exception was caught by Salt's global exception handler:
KeyError: 'ret'
Traceback (most recent call last):
  File "/usr/bin/salt", line 12, in <module>
    sys.exit(salt_main())
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/scripts.py", line 529, in salt_main
    client.run()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/salt.py", line 55, in run
    self._run_batch()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/salt.py", line 291, in _run_batch
    for res, job_retcode in batch.run():
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/batch.py", line 326, in run
    ret[minion] = data["ret"]
KeyError: 'ret'
Traceback (most recent call last):
  File "/usr/bin/salt", line 12, in <module>
    sys.exit(salt_main())
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/scripts.py", line 529, in salt_main
    client.run()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/salt.py", line 55, in run
    self._run_batch()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/salt.py", line 291, in _run_batch
    for res, job_retcode in batch.run():
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/batch.py", line 326, in run
    ret[minion] = data["ret"]
KeyError: 'ret'
```

### New Behavior
Receiving proper execution list without tons of errors and failing halfway through minion list:
```
Executing run on ['minion1xxx', 'minion4xxx', 'minion2xxx, 'minion3xxx']
...
jid:
    20260130100634363546
retcode:
    0
minion4xxx:
    True
jid:
    20260130100634363546
retcode:
   0
....
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://github.com/saltstack/salt/pull/68672/commits/fb66c40a9256b3e198b2434325b23a33bf8d8e91
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
