### PR TITLE
Handle SaltDeserializationError in grains cache loading

### DIFF
--- a/changelog/68678.fixed.md
+++ b/changelog/68678.fixed.md
@@ -1,0 +1,4 @@
+This PR fixes a bug where corrupted grains cache files cause unhandled
+`SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+The fix adds proper exception handling to gracefully recover from corrupted
+cache by regenerating grains.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1068,7 +1068,9 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except (OSError, SaltDeserializationError):
+    except (OSError, SaltDeserializationError) as error:
+        log.debug("Exception deserializing grains cache: %s", error)
+        log.debug("Cache was not readable or did not deserialize and might be corrupted. Refreshing.")
         return None
 
 

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1071,7 +1071,7 @@ def _load_cached_grains(opts, cfn):
     except (OSError, SaltDeserializationError):
         log.debug(
             "Grains cache was not readable or did not deserialize and might be corrupted. Refreshing.",
-            exc_info=True
+            exc_info=True,
         )
         return None
 

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1068,10 +1068,10 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except (OSError, SaltDeserializationError) as error:
-        log.debug("Exception deserializing grains cache: %s", error)
+    except (OSError, SaltDeserializationError):
         log.debug(
-            "Cache was not readable or did not deserialize and might be corrupted. Refreshing."
+            "Grains cache was not readable or did not deserialize and might be corrupted. Refreshing.",
+            exc_info=True
         )
         return None
 

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -26,7 +26,7 @@ import salt.utils.lazy
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import LoaderError
+from salt.exceptions import LoaderError, SaltDeserializationError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -1068,7 +1068,7 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except OSError:
+    except (OSError, SaltDeserializationError):
         return None
 
 

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1070,7 +1070,9 @@ def _load_cached_grains(opts, cfn):
         return _format_cached_grains(cached_grains)
     except (OSError, SaltDeserializationError) as error:
         log.debug("Exception deserializing grains cache: %s", error)
-        log.debug("Cache was not readable or did not deserialize and might be corrupted. Refreshing.")
+        log.debug(
+            "Cache was not readable or did not deserialize and might be corrupted. Refreshing."
+        )
         return None
 
 

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1694,6 +1694,28 @@ class LoaderLoadCachedGrainsTest(TestCase):
         osrelease_info = grains["osrelease_info"]
         assert isinstance(osrelease_info, tuple), osrelease_info
 
+    def test_deserialization_error_caught(self):
+        """
+        Test that _load_cached_grains catches SaltDeserializationError.
+
+        When msgpack encounters corrupted cache data, it raises
+        SaltDeserializationError. This should be caught and return None
+        so grains can be regenerated.
+        """
+        import salt.exceptions
+        import time
+
+        with patch('os.path.isfile', return_value=True), \
+             patch('os.path.getmtime', return_value=time.time()), \
+             patch('salt.utils.files.fopen'), \
+             patch('salt.payload.load',
+                   side_effect=salt.exceptions.SaltDeserializationError(
+                       "Could not deserialize msgpack message"
+                   )):
+            result = salt.loader._load_cached_grains(self.opts, "/fake/path")
+            # Should return None, not raise exception
+            self.assertIsNone(result)
+
 
 class LazyLoaderRefreshFileMappingTest(TestCase):
     """

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1702,16 +1702,18 @@ class LoaderLoadCachedGrainsTest(TestCase):
         SaltDeserializationError. This should be caught and return None
         so grains can be regenerated.
         """
-        import salt.exceptions
         import time
 
-        with patch('os.path.isfile', return_value=True), \
-             patch('os.path.getmtime', return_value=time.time()), \
-             patch('salt.utils.files.fopen'), \
-             patch('salt.payload.load',
-                   side_effect=salt.exceptions.SaltDeserializationError(
-                       "Could not deserialize msgpack message"
-                   )):
+        import salt.exceptions
+
+        with patch("os.path.isfile", return_value=True), patch(
+            "os.path.getmtime", return_value=time.time()
+        ), patch("salt.utils.files.fopen"), patch(
+            "salt.payload.load",
+            side_effect=salt.exceptions.SaltDeserializationError(
+                "Could not deserialize msgpack message"
+            ),
+        ):
             result = salt.loader._load_cached_grains(self.opts, "/fake/path")
             # Should return None, not raise exception
             self.assertIsNone(result)


### PR DESCRIPTION
### What does this PR do?
Fix for #68678

### What issues does this PR fix or reference?
Fixes a bug where corrupted grains cache files cause unhandled
SaltDeserializationError exceptions.

When msgpack encounters corrupted cache data, it raises
msgpack.exceptions.ExtraData, which is wrapped in
SaltDeserializationError by salt.payload.load(). Previously,
_load_cached_grains() only caught OSError, allowing the
exception to propagate and cause CRITICAL errors.

This fix adds SaltDeserializationError to the exception handler,
treating corrupted cache the same as missing cache: return None,
regenerate grains, and overwrite the corrupted cache file.

### Previous Behavior
Only OSError was handled, so the SaltDeserializationError would cause a CRITICAL failure.

### New Behavior
If the grains cache is corrupt and won't deserialize, catch the exception and
return None, which is a signal to callers to refresh the grains.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
