### PR TITLE
Add reactor cache cleanup

### DIFF
--- a/salt/engines/reactor.py
+++ b/salt/engines/reactor.py
@@ -20,12 +20,19 @@ Example Config in Master or Minion config
 import salt.utils.reactor
 
 
-def start(refresh_interval=None, worker_threads=None, worker_hwm=None):
+def start(
+    refresh_interval=None,
+    worker_threads=None,
+    worker_hwm=None,
+    cleanup_interval=None,
+):
     if refresh_interval is not None:
         __opts__["reactor_refresh_interval"] = refresh_interval
     if worker_threads is not None:
         __opts__["reactor_worker_threads"] = worker_threads
     if worker_hwm is not None:
         __opts__["reactor_worker_hwm"] = worker_hwm
+    if cleanup_interval is not None:
+        __opts__["reactor_cleanup_interval"] = cleanup_interval
 
     salt.utils.reactor.Reactor(__opts__).run()

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -192,3 +192,31 @@ def set_leader(value=True):
 
         res = sevent.get_event(wait=30, tag="salt/reactors/manage/leader/value")
         return res["result"]
+
+
+def cleanup():
+    """
+    Request cached reactor clients to be cleaned up.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run reactor.cleanup
+    """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
+    with salt.utils.event.get_event(
+        "master",
+        __opts__["sock_dir"],
+        opts=__opts__,
+        listen=True,
+    ) as sevent:
+
+        master_key = salt.utils.master.get_master_key("root", __opts__)
+
+        __jid_event__.fire_event({"key": master_key}, "salt/reactors/manage/cleanup")
+
+        res = sevent.get_event(wait=30, tag="salt/reactors/manage/cleanup-complete")
+        return res.get("result")

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -6,6 +6,7 @@ import fnmatch
 import glob
 import logging
 import os
+import time
 
 import salt.client
 import salt.defaults.exitcodes
@@ -273,6 +274,12 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
                         {"reactors": self.list_all()},
                         "salt/reactors/manage/list-results",
                     )
+                elif data["tag"].endswith("salt/reactors/manage/cleanup"):
+                    res = self.wrap.cleanup()
+                    event.fire_event(
+                        {"result": res},
+                        "salt/reactors/manage/cleanup-complete",
+                    )
                 else:
                     # do not handle any reactions if not leader in cluster
                     if not self.is_leader:
@@ -287,6 +294,7 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
                                 self.call_reactions(chunks)
                             except SystemExit:
                                 log.warning("Exit ignored by reactor")
+                self.wrap.maybe_cleanup()
 
 
 class ReactWrap:
@@ -316,6 +324,35 @@ class ReactWrap:
             self.opts["reactor_worker_threads"],  # number of workers for runner/wheel
             queue_size=self.opts["reactor_worker_hwm"],  # queue size for those workers
         )
+        self.cleanup_interval = self.opts.get(
+            "reactor_cleanup_interval", self.opts["reactor_refresh_interval"]
+        )
+        self._next_cleanup = None
+        if self.cleanup_interval:
+            self._next_cleanup = time.monotonic() + self.cleanup_interval
+
+    def maybe_cleanup(self):
+        """
+        Periodically release cached clients to avoid retaining stale references.
+        """
+        if not self.cleanup_interval:
+            return None
+        now = time.monotonic()
+        if self._next_cleanup is None or now < self._next_cleanup:
+            return None
+        self._next_cleanup = now + self.cleanup_interval
+        return self.cleanup()
+
+    def cleanup(self):
+        """
+        Force cache expiry checks and return cleanup details.
+        """
+        removed_clients = []
+        if isinstance(self.client_cache, salt.utils.cache.CacheDict):
+            for client_type in list(self.client_cache.keys()):
+                if client_type not in self.client_cache:
+                    removed_clients.append(client_type)
+        return {"removed_clients": removed_clients}
 
     def populate_client_cache(self, low):
         """


### PR DESCRIPTION
What does this PR do?
Adds periodic cleanup for reactor client caches and a manual reactor.cleanup runner to release retained objects in long-running reactor processes. Also allows configuring cleanup interval in the reactor engine.

What issues does this PR fix or reference?
Fixes #68660 

Previous Behavior
Reactor client cache could retain objects for long periods without explicit cleanup, contributing to memory growth under sustained event load.

New Behavior
Reactor periodically triggers cache cleanup and exposes a runner to request cleanup on demand.

Merge requirements satisfied?
[ ] Docs
[ ] Changelog
[ ] Tests written/updated

Commits signed with GPG?
No