### PR TITLE
Add strict ini section removal

### DIFF
--- a/changelog/68673.fixed.md
+++ b/changelog/68673.fixed.md
@@ -1,0 +1,2 @@
+Remove ini sections not present when ``strict: True`` in ``ini.options_present``.
+

--- a/doc/ref/states/all/salt.states.ini_manage.rst
+++ b/doc/ref/states/all/salt.states.ini_manage.rst
@@ -1,5 +1,28 @@
 salt.states.ini_manage
 ======================
 
+Strict mode behavior
+--------------------
+
+When ``strict: True`` is used with ``ini.options_present``, the ini file is
+pruned to match the ``sections`` dictionary:
+
+- keys not listed at the top level are removed
+- keys not listed inside a section are removed
+- sections not listed are removed entirely
+
+Example:
+
+.. code-block:: yaml
+
+    /etc/app/config.ini:
+      ini.options_present:
+        - strict: True
+        - sections:
+            service:
+              enabled: true
+            network:
+              port: 1234
+
 .. automodule:: salt.states.ini_manage
     :members:

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -339,6 +339,33 @@ def remove_section(file_name, section, separator="=", encoding=None):
         return ret
 
 
+def remove_sections(file_name, sections, separator="=", encoding=None):
+    """
+    Remove multiple sections from an ini file. Returns a dictionary of
+    removed sections with their values.
+
+    Args:
+
+        file_name (str):
+            The full path to the ini file.
+
+        sections (list):
+            A list of section names to remove.
+
+    Returns:
+        dict: Mapping of section name to removed section values (or None).
+    """
+    removed = {}
+    for section in sections or []:
+        removed[section] = remove_section(
+            file_name=file_name,
+            section=section,
+            separator=separator,
+            encoding=encoding,
+        )
+    return removed
+
+
 def get_ini(file_name, separator="=", encoding=None):
     """
     Retrieve the whole structure from an ini file and return it as a dictionary.

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -156,6 +156,35 @@ def options_present(
                                 }
                             }
                         )
+                desired_sections = {
+                    sname
+                    for sname, sbody in sections.items()
+                    if isinstance(sbody, (dict, OrderedDict))
+                }
+                sections_to_remove = set(original_sections).difference(desired_sections)
+                if sections_to_remove:
+                    if __opts__["test"]:
+                        for section_name in sorted(sections_to_remove):
+                            ret["comment"] += (
+                                f"Removed section {section_name}.\n"
+                            )
+                            ret["result"] = None
+                    else:
+                        removed_sections = __salt__["ini.remove_sections"](
+                            file_name=name,
+                            sections=sorted(sections_to_remove),
+                            separator=separator,
+                            encoding=encoding,
+                        )
+                        for section_name in sections_to_remove:
+                            changes.update(
+                                {
+                                    section_name: {
+                                        "before": removed_sections.get(section_name),
+                                        "after": None,
+                                    }
+                                }
+                            )
             for section_name, section_body in [
                 (sname, sbody)
                 for sname, sbody in sections.items()

--- a/tests/pytests/unit/states/test_ini_manage.py
+++ b/tests/pytests/unit/states/test_ini_manage.py
@@ -20,6 +20,8 @@ def configure_loader_modules():
             "__salt__": {
                 "ini.get_ini": mod_ini_manage.get_ini,
                 "ini.set_option": mod_ini_manage.set_option,
+                "ini.remove_option": mod_ini_manage.remove_option,
+                "ini.remove_sections": mod_ini_manage.remove_sections,
             },
             "__opts__": {"test": False},
         },
@@ -107,6 +109,30 @@ def test_options_present_true_file(tmp_path, sections):
         assert ini_manage.options_present(name, new_section) == exp_ret
 
     assert os.path.exists(name)
+    assert mod_ini_manage.get_ini(name) == sections
+
+
+def test_options_present_strict_removes_sections(tmp_path, sections):
+    """
+    Test to verify strict options_present removes sections not in the input.
+    """
+    name = str(tmp_path / "test_strict_remove_section.ini")
+
+    initial = copy.deepcopy(sections)
+    initial["extra"] = OrderedDict()
+    initial["extra"]["enabled"] = "true"
+    initial["other"] = OrderedDict()
+    initial["other"]["value"] = "42"
+    ini_manage.options_present(name, initial)
+
+    ret = ini_manage.options_present(name, sections, strict=True)
+
+    assert ret["result"] is True
+    assert ret["comment"] == "Changes take effect"
+    assert ret["changes"] == {
+        "extra": {"before": {"enabled": "true"}, "after": None},
+        "other": {"before": {"value": "42"}, "after": None},
+    }
     assert mod_ini_manage.get_ini(name) == sections
 
 


### PR DESCRIPTION
### What does this PR do?

Ensures ini.options_present with strict: True removes sections not declared, adds a helper to remove multiple sections, updates documentation, and adds unit coverage.

### What issues does this PR fix or reference?
Fixes #68673 

### Previous Behavior
Strict mode removed extra keys but left extra sections intact.

### New Behavior
Strict mode now prunes entire sections not present in the sections mapping.
Merge require

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Links referenced:
https://github.com/saltstack/salt/issues/68673