### PR TITLE
Remove ensure pip but keep virtualenv states working

### DIFF
--- a/changelog/68388.fixed.md
+++ b/changelog/68388.fixed.md
@@ -1,0 +1,1 @@
+Add virtualenv to package dependencies so venv module can work without ensurepip.

--- a/pkg/common/env-cleanup-rules.yml
+++ b/pkg/common/env-cleanup-rules.yml
@@ -5,6 +5,7 @@ common:
     - "**/site-packages/ansible/plugins/test/**"
   dir_patterns: &common_dir_patterns
     - "**/__pycache__"
+    - "**/lib/python3.*/ensurepip"
     - "**/lib/python3.*/idlelib"
     - "**/lib/python3.*/test"
     - "**/lib/python3.*/tkinter"
@@ -46,6 +47,7 @@ ci:
     dir_patterns: &ci_windows_dir_patterns
       - *common_dir_patterns
       - "**/artifacts/salt/configs"
+      - "**/lib/ensurepip"
       - "**/site-packages/adodbapi"
       - "**/site-packages/isapi"
       - "**/site-packages/pythonwin"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,4 +37,6 @@ timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
 urllib3>=1.26.20,<2.0.0; python_version < '3.10'
 urllib3>=2.6.3; python_version >= '3.10'
+# For venv module to work without ensurepip
+virtualenv
 wheel >= 0.46.3

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -152,6 +152,7 @@ cryptography==42.0.5
     #   vcert
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -179,6 +180,7 @@ exceptiongroup==1.0.4
     #   pytest
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -407,6 +409,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
 pluggy==1.4.0
@@ -716,6 +719,7 @@ trustme==1.1.0
     #   -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   pytest-system-statistics
     #   virtualenv
@@ -736,7 +740,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -112,7 +112,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
@@ -130,6 +132,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -299,7 +302,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -506,6 +511,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   pytest-system-statistics
     #   virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
@@ -522,6 +528,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -50,12 +50,20 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+filelock==3.20.3 ; python_version >= "3.10"
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -144,6 +152,10 @@ packaging==24.0
     #   -r requirements/base.txt
     #   sphinx
     #   wheel
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   virtualenv
 portend==2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -229,6 +241,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   myst-docutils
+    #   virtualenv
 uc-micro-py==1.0.1
     # via linkify-it-py
 urllib3==2.6.3 ; python_version >= "3.10"
@@ -236,6 +249,10 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -110,7 +110,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
@@ -129,6 +131,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -290,7 +293,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -495,6 +500,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   pytest-system-statistics
     #   virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
@@ -511,6 +517,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -163,6 +163,7 @@ dill==0.3.8
     # via pylint
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -185,6 +186,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -412,6 +414,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   pylint
     #   virtualenv
@@ -699,6 +702,7 @@ twilio==7.9.2
     #   -r requirements/static/ci/linux.in
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
     #   astroid
     #   virtualenv
@@ -723,7 +727,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
 watchdog==0.10.3
     # via

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -120,7 +120,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt
@@ -138,6 +140,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -302,7 +305,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -542,6 +547,7 @@ twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   pytest-system-statistics
     #   virtualenv
 tzlocal==3.0
@@ -560,6 +566,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -102,7 +102,9 @@ cryptography==42.0.5
     #   requests-ntlm
     #   trustme
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
@@ -122,6 +124,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -273,7 +276,9 @@ pathspec==0.10.2
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -483,6 +488,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   pytest-system-statistics
     #   virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
@@ -498,6 +504,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   responses
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -148,6 +148,7 @@ cryptography==42.0.5
     #   vcert
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -171,6 +172,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -379,6 +381,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
 pluggy==1.4.0
@@ -682,7 +685,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -107,7 +107,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
@@ -123,6 +125,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -276,7 +279,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -481,6 +486,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -50,12 +50,20 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+filelock==3.20.3 ; python_version >= "3.10"
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -144,6 +152,10 @@ packaging==24.0
     #   -r requirements/base.txt
     #   sphinx
     #   wheel
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   virtualenv
 portend==2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -236,6 +248,10 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -108,7 +108,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
@@ -125,6 +127,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -271,7 +274,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -475,6 +480,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -159,6 +159,7 @@ dill==0.3.8
     # via pylint
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -181,6 +182,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -387,6 +389,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
     #   pylint
     #   virtualenv
@@ -668,7 +671,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
 watchdog==0.10.3
     # via

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -118,7 +118,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt
@@ -134,6 +136,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -283,7 +286,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -524,6 +529,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -100,7 +100,9 @@ cryptography==42.0.5
     #   requests-ntlm
     #   trustme
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
@@ -118,6 +120,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -269,7 +272,9 @@ pathspec==0.10.2
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -490,6 +495,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   responses
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -143,6 +143,7 @@ cryptography==42.0.5
     #   vcert
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -166,6 +167,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -374,6 +376,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
 pluggy==1.4.0
@@ -677,7 +680,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -103,7 +103,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
@@ -119,6 +121,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -272,7 +275,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -477,6 +482,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -46,12 +46,20 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+filelock==3.20.3 ; python_version >= "3.10"
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -140,6 +148,10 @@ packaging==24.0
     #   -r requirements/base.txt
     #   sphinx
     #   wheel
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   virtualenv
 portend==2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -232,6 +244,10 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -104,7 +104,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
@@ -121,6 +123,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -267,7 +270,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -471,6 +476,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -154,6 +154,7 @@ dill==0.3.8
     # via pylint
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -176,6 +177,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -382,6 +384,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
     #   pylint
     #   virtualenv
@@ -663,7 +666,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
 watchdog==0.10.3
     # via

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -114,7 +114,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/linux.txt
@@ -130,6 +132,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -279,7 +282,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -520,6 +525,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -96,7 +96,9 @@ cryptography==42.0.5
     #   requests-ntlm
     #   trustme
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.12/windows.txt
@@ -114,6 +116,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -265,7 +268,9 @@ pathspec==0.10.2
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.5.1
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -486,6 +491,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   responses
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -143,8 +143,9 @@ cryptography==42.0.8
     #   smbprotocol
     #   trustme
     #   vcert
-distlib==0.3.9
+distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   virtualenv
 distro==1.9.0
@@ -168,6 +169,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -366,8 +368,9 @@ passlib==1.7.4
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
-platformdirs==4.3.6
+platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   virtualenv
 pluggy==1.5.0
@@ -670,7 +673,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==5.0.3

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -104,8 +104,10 @@ cryptography==42.0.8
     #   pyopenssl
     #   trustme
     #   vcert
-distlib==0.3.9
-    # via virtualenv
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
+    #   virtualenv
 distro==1.9.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
@@ -121,6 +123,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -268,8 +271,10 @@ passlib==1.7.4
     # via -r requirements/static/ci/common.in
 pathspec==0.12.1
     # via yamllint
-platformdirs==4.3.6
-    # via virtualenv
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
+    #   virtualenv
 pluggy==1.5.0
     # via pytest
 portend==3.2.1
@@ -474,6 +479,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -46,12 +46,20 @@ cryptography==42.0.8
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   virtualenv
 distro==1.9.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
 docutils==0.21.2
     # via sphinx
+filelock==3.20.3 ; python_version >= "3.10"
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   virtualenv
 frozenlist==1.8.0 ; python_version >= "3.11"
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -135,6 +143,10 @@ packaging==24.0
     #   -r requirements/base.txt
     #   sphinx
     #   wheel
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   virtualenv
 portend==3.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -221,6 +233,10 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -105,8 +105,10 @@ cryptography==42.0.8
     #   pyopenssl
     #   trustme
     #   vcert
-distlib==0.3.9
-    # via virtualenv
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
+    #   virtualenv
 distro==1.9.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
@@ -123,6 +125,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -263,8 +266,10 @@ passlib==1.7.4
     # via -r requirements/static/ci/common.in
 pathspec==0.12.1
     # via yamllint
-platformdirs==4.3.6
-    # via virtualenv
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
+    #   virtualenv
 pluggy==1.5.0
     # via pytest
 portend==3.2.1
@@ -466,6 +471,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==5.0.3

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -159,8 +159,9 @@ cryptography==42.0.8
     #   vcert
 dill==0.3.9
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   virtualenv
 distro==1.9.0
@@ -183,6 +184,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -395,8 +397,9 @@ pathspec==0.12.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   yamllint
-platformdirs==4.3.6
+platformdirs==4.5.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
     #   pylint
     #   virtualenv
@@ -671,7 +674,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
 watchdog==5.0.3
     # via

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -118,8 +118,10 @@ cryptography==42.0.8
     #   pyopenssl
     #   trustme
     #   vcert
-distlib==0.3.9
-    # via virtualenv
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
+    #   virtualenv
 distro==1.9.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/linux.txt
@@ -135,6 +137,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -286,8 +289,10 @@ passlib==1.7.4
     # via -r requirements/static/ci/common.in
 pathspec==0.12.1
     # via yamllint
-platformdirs==4.3.6
-    # via virtualenv
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
+    #   virtualenv
 pluggy==1.5.0
     # via pytest
 portend==3.2.1
@@ -523,6 +528,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==5.0.3

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -100,8 +100,10 @@ cryptography==42.0.8
     #   pyspnego
     #   requests-ntlm
     #   trustme
-distlib==0.3.9
-    # via virtualenv
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/windows.txt
+    #   virtualenv
 distro==1.9.0
     # via
     #   -c requirements/static/ci/../pkg/py3.13/windows.txt
@@ -119,6 +121,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
 filelock==3.20.3 ; python_version >= "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/windows.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -262,8 +265,10 @@ patch==1.16
     # via -r requirements/static/ci/windows.in
 pathspec==0.12.1
     # via yamllint
-platformdirs==4.3.6
-    # via virtualenv
+platformdirs==4.5.1
+    # via
+    #   -c requirements/static/ci/../pkg/py3.13/windows.txt
+    #   virtualenv
 pluggy==1.5.0
     # via pytest
 portend==3.2.1
@@ -484,6 +489,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   responses
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.13/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==5.0.3

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -161,6 +161,7 @@ cryptography==42.0.5
     #   vcert
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -189,6 +190,7 @@ exceptiongroup==1.0.4
     #   pytest
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -438,6 +440,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
 pluggy==1.4.0
@@ -763,6 +766,7 @@ trustme==1.1.0
     #   -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   pytest-shell-utilities
     #   pytest-system-statistics
@@ -784,7 +788,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -117,7 +117,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
@@ -136,6 +138,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -324,7 +327,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -546,6 +551,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   pytest-shell-utilities
     #   pytest-system-statistics
     #   virtualenv
@@ -563,6 +569,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -50,12 +50,20 @@ cryptography==42.0.5
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
+distlib==0.4.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
 docutils==0.19
     # via sphinx
+filelock==3.19.1 ; python_version < "3.10"
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -148,6 +156,10 @@ packaging==24.0
     #   -r requirements/base.txt
     #   sphinx
     #   wheel
+platformdirs==4.4.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   virtualenv
 portend==2.4
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -233,6 +245,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   myst-docutils
+    #   virtualenv
 uc-micro-py==1.0.1
     # via linkify-it-py
 urllib3==1.26.20 ; python_version < "3.10"
@@ -240,6 +253,10 @@ urllib3==1.26.20 ; python_version < "3.10"
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -115,7 +115,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
@@ -135,6 +137,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -315,7 +318,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -535,6 +540,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   pytest-shell-utilities
     #   pytest-system-statistics
     #   virtualenv
@@ -552,6 +558,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -163,6 +163,7 @@ dill==0.3.8
     # via pylint
 distlib==0.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   virtualenv
 distro==1.5.0
@@ -186,6 +187,7 @@ etcd3-py==0.1.6
     #   -r requirements/static/ci/common.in
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
@@ -432,6 +434,7 @@ pathtools==0.1.2
     #   watchdog
 platformdirs==4.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   pylint
     #   virtualenv
@@ -730,6 +733,7 @@ twilio==7.9.2
     #   -r requirements/static/ci/linux.in
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
     #   astroid
     #   pylint
@@ -755,7 +759,9 @@ vcert==0.7.4 ; sys_platform != "win32"
     #   -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
 watchdog==0.10.3
     # via

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -120,7 +120,9 @@ cryptography==42.0.5
     #   trustme
     #   vcert
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt
@@ -139,6 +141,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -320,7 +323,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.4
@@ -572,6 +577,7 @@ twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   pytest-shell-utilities
     #   pytest-system-statistics
     #   virtualenv
@@ -591,6 +597,8 @@ vcert==0.7.4 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -102,7 +102,9 @@ cryptography==42.0.5
     #   requests-ntlm
     #   trustme
 distlib==0.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   virtualenv
 distro==1.5.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
@@ -122,6 +124,7 @@ exceptiongroup==1.0.4
     # via pytest
 filelock==3.19.1 ; python_version < "3.10"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   virtualenv
 flaky==3.8.1
@@ -273,7 +276,9 @@ pathspec==0.9.0
 pathtools==0.1.2
     # via watchdog
 platformdirs==4.4.0
-    # via virtualenv
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   virtualenv
 pluggy==1.4.0
     # via pytest
 portend==2.6
@@ -484,6 +489,7 @@ trustme==1.1.0
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   pytest-shell-utilities
     #   pytest-system-statistics
     #   virtualenv
@@ -500,6 +506,8 @@ urllib3==1.26.20 ; python_version < "3.10"
     #   responses
 virtualenv==20.36.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 watchdog==0.10.3

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -94,6 +98,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -141,10 +147,14 @@ timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -r requirements/base.txt
     #   -r requirements/darwin.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 vultr==1.0.1
     # via -r requirements/darwin.txt
 wheel==0.46.3

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -31,10 +31,14 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -84,6 +88,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -123,10 +129,14 @@ tempora==4.1.1
     # via portend
 timelib==0.2.5 ; python_version < "3.11"
     # via -r requirements/base.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -31,8 +31,12 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -83,6 +87,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -123,10 +129,14 @@ tempora==4.1.1
     # via portend
 timelib==0.3.0 ; python_version < "3.11"
     # via -r requirements/base.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -93,6 +97,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -143,11 +149,15 @@ timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -94,6 +98,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -145,6 +151,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 vultr==1.0.1
     # via -r requirements/darwin.txt
 wheel==0.46.3

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -31,10 +31,14 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -84,6 +88,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -127,6 +133,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -31,8 +31,12 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -83,6 +87,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -127,6 +133,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -93,6 +97,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -148,6 +154,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -30,8 +30,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -92,6 +96,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -143,6 +149,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 vultr==1.0.1
     # via -r requirements/darwin.txt
 wheel==0.46.3

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -29,10 +29,14 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -82,6 +86,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -125,6 +131,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -29,8 +29,12 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -81,6 +85,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -125,6 +131,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -30,8 +30,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.7.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -91,6 +95,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version >= "3.10"
@@ -146,6 +152,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -30,8 +30,12 @@ cryptography==42.0.8
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.8.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.12
@@ -89,6 +93,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==3.2.1
     # via cherrypy
 psutil==7.2.1 ; python_version >= "3.10"
@@ -137,6 +143,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 vultr==1.0.1
     # via -r requirements/darwin.txt
 wheel==0.46.3

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -29,10 +29,14 @@ cryptography==42.0.8
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.8.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.11
@@ -79,6 +83,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==3.2.1
     # via cherrypy
 psutil==7.2.1 ; python_version >= "3.10"
@@ -118,6 +124,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -29,8 +29,12 @@ cryptography==42.0.8
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.8.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 idna==3.11
@@ -78,6 +82,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==3.2.1
     # via cherrypy
 psutil==7.2.1 ; python_version >= "3.10"
@@ -119,6 +125,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -30,8 +30,12 @@ cryptography==42.0.8
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
+filelock==3.20.3
+    # via virtualenv
 frozenlist==1.8.0 ; python_version >= "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.12
@@ -88,6 +92,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.5.1
+    # via virtualenv
 portend==3.2.1
     # via cherrypy
 psutil==7.2.1 ; python_version >= "3.10"
@@ -141,6 +147,8 @@ urllib3==2.6.3 ; python_version >= "3.10"
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.19.1
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -94,6 +98,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.4.0
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version <= "3.9"
@@ -141,10 +147,14 @@ timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -r requirements/base.txt
     #   -r requirements/darwin.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 vultr==1.0.1
     # via -r requirements/darwin.txt
 wheel==0.46.3

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -31,10 +31,14 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+filelock==3.19.1
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -84,6 +88,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.4.0
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version <= "3.9"
@@ -123,10 +129,14 @@ tempora==4.1.1
     # via portend
 timelib==0.3.0 ; python_version < "3.11"
     # via -r requirements/base.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -31,8 +31,12 @@ cryptography==42.0.5
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.19.1
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 idna==3.7
@@ -83,6 +87,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.4.0
+    # via virtualenv
 portend==2.4
     # via cherrypy
 psutil==5.8.0 ; python_version <= "3.9"
@@ -123,10 +129,14 @@ tempora==4.1.1
     # via portend
 timelib==0.3.0 ; python_version < "3.11"
     # via -r requirements/base.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -32,8 +32,12 @@ cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   pyopenssl
+distlib==0.4.0
+    # via virtualenv
 distro==1.5.0
     # via -r requirements/base.txt
+filelock==3.19.1
+    # via virtualenv
 frozenlist==1.7.0 ; python_version < "3.11"
     # via -r requirements/base.txt
 gitdb==4.0.7
@@ -93,6 +97,8 @@ packaging==24.0
     # via
     #   -r requirements/base.txt
     #   wheel
+platformdirs==4.4.0
+    # via virtualenv
 portend==2.6
     # via cherrypy
 psutil==5.8.0 ; python_version <= "3.9"
@@ -144,11 +150,15 @@ timelib==0.2.5 ; python_version < "3.11"
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
+typing-extensions==4.15.0
+    # via virtualenv
 urllib3==1.26.20 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
     #   requests
+virtualenv==20.36.1
+    # via -r requirements/base.txt
 wheel==0.46.3
     # via
     #   -c requirements/constraints.txt

--- a/tests/pytests/functional/states/test_pip_state.py
+++ b/tests/pytests/functional/states/test_pip_state.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import pprint
 import shutil
+import subprocess
 import sys
 
 import pytest
@@ -64,6 +65,18 @@ def create_virtualenv(modules):
         Also, one windows, we must also point to the virtualenv binary outside the existing
         virtualenv because it will fail otherwise
         """
+        if "venv_bin" not in kwargs:
+            # Try to find the onedir virtualenv first
+            onedir_venv = os.path.join(
+                os.environ.get("REPO_ROOT_DIR", "/salt"),
+                "artifacts",
+                "salt",
+                "bin",
+                "virtualenv",
+            )
+            if os.path.exists(onedir_venv):
+                kwargs["venv_bin"] = onedir_venv
+
         if "python" not in kwargs:
             try:
                 if salt.utils.platform.is_windows():
@@ -81,12 +94,9 @@ def create_virtualenv(modules):
                         if os.path.exists(python):
                             break
                     else:
-                        pytest.fail(
-                            "Couldn't find a python binary name under '{}' matching: {}".format(
-                                os.path.join(sys.real_prefix, "bin"),
-                                python_binary_names,
-                            )
-                        )
+                        # Fallback to system python if we can't find the real prefix one
+                        python = sys.executable
+
                 # We're running off a virtualenv, and we don't want to create a virtualenv off of
                 # a virtualenv, let's point to the actual python that created the virtualenv
                 kwargs["python"] = python
@@ -394,6 +404,7 @@ def test_issue_6912_wrong_owner_requirements_file(
 
 @pytest.mark.destructive_test
 @pytest.mark.slow_test
+@pytest.mark.requires_network
 def test_issue_6833_pip_upgrade_pip(tmp_path, create_virtualenv, modules, states):
     # Create the testing virtualenv
     if sys.platform == "win32":
@@ -420,33 +431,45 @@ def test_issue_6833_pip_upgrade_pip(tmp_path, create_virtualenv, modules, states
             pprint.pformat(ret)
         )
 
-    # Let's install a fixed version pip over whatever pip was
-    # previously installed
-    ret = modules.pip.install("pip==19.3.1", upgrade=True, bin_env=venv_dir)
+    # Download wheels to avoid PyPI slowness/timeouts during test
+    wheels_dir = tmp_path / "wheels"
+    wheels_dir.mkdir()
 
-    if not isinstance(ret, dict):
-        pytest.fail(
-            "The 'pip.install' command did not return the excepted dictionary."
-            " Output:\n{}".format(ret)
-        )
+    pip_22_0_4_url = "https://files.pythonhosted.org/packages/4d/16/0a14ca596f30316efd412a60bdfac02a7259bf8673d4d917dc60b9a21812/pip-22.0.4-py3-none-any.whl"
+    pip_22_1_2_url = "https://files.pythonhosted.org/packages/96/2f/caec18213f6a67852f6997fb0673ae08d2e93d1b81573edb93ba4ef06970/pip-22.1.2-py3-none-any.whl"
 
-    assert ret["retcode"] == 0
-    assert "Successfully installed pip" in ret["stdout"]
+    for url in (pip_22_0_4_url, pip_22_1_2_url):
+        subprocess.check_call(["curl", "-L", "-O", url], cwd=str(wheels_dir))
 
-    # Let's make sure we have pip 9.0.1 installed
-    assert modules.pip.list("pip", bin_env=venv_dir) == {"pip": "19.3.1"}
+    # Use local wheels
+    with patched_environ(PIP_NO_INDEX="1", PIP_FIND_LINKS=str(wheels_dir)):
+        # Let's install a fixed version pip over whatever pip was
+        # previously installed
+        ret = modules.pip.install("pip==22.0.4", upgrade=True, bin_env=venv_dir)
 
-    # Now the actual pip upgrade pip test
-    ret = states.pip.installed(name="pip==20.0.1", upgrade=True, bin_env=venv_dir)
+        if not isinstance(ret, dict):
+            pytest.fail(
+                "The 'pip.install' command did not return the excepted dictionary."
+                " Output:\n{}".format(ret)
+            )
 
-    if not isinstance(ret.raw, dict):
-        pytest.fail(
-            "The 'pip.install' command did not return the excepted dictionary."
-            " Output:\n{}".format(ret)
-        )
+        assert ret["retcode"] == 0
+        assert "Successfully installed pip" in ret["stdout"]
 
-    assert ret.result is True
-    assert ret.changes == {"pip==20.0.1": "Installed"}
+        # Let's make sure we have pip 22.0.4 installed
+        assert modules.pip.list("pip", bin_env=venv_dir) == {"pip": "22.0.4"}
+
+        # Now the actual pip upgrade pip test
+        ret = states.pip.installed(name="pip==22.1.2", upgrade=True, bin_env=venv_dir)
+
+        if not isinstance(ret.raw, dict):
+            pytest.fail(
+                "The 'pip.install' command did not return the excepted dictionary."
+                " Output:\n{}".format(ret)
+            )
+
+        assert ret.result is True
+        assert ret.changes == {"pip==22.1.2": "Installed"}
 
 
 @pytest.mark.slow_test

--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -2,6 +2,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import urllib.error
 import urllib.request
@@ -30,6 +31,8 @@ pytestmark = [
 ]
 
 KNOWN_VIRTUALENV_BINARY_NAMES = (
+    "artifacts/salt/bin/virtualenv",
+    os.path.join(os.path.dirname(sys.executable), "virtualenv"),
     "virtualenv",
     "virtualenv2",
     "virtualenv-2.6",


### PR DESCRIPTION
Removes ensurepip so we do not keep getting flagged on old versions of the dependencies it bundles. We can keep virtualenv states working by adding virtualenv to our pcakaged modules.
 