### PR TITLE
fix get_interface_info_wmi returning the default gateway as "broadcast" (#68692)

### DIFF
--- a/changelog/68692.fixed.md
+++ b/changelog/68692.fixed.md
@@ -1,0 +1,1 @@
+fix get_interface_info_wmi returning the default gateway as "broadcast"

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -486,11 +486,11 @@ def get_interface_info_wmi():
                             i_faces[i_face.Description]["inet"] = []
                         item = {"address": ip, "label": i_face.Description}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
+                            gateway = next(
                                 (i for i in i_face.DefaultIPGateway if "." in i), ""
                             )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             netmask = next((i for i in i_face.IPSubnet if "." in i), "")
                             if netmask:
@@ -501,11 +501,11 @@ def get_interface_info_wmi():
                             i_faces[i_face.Description]["inet6"] = []
                         item = {"address": ip}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
+                            gateway = next(
                                 (i for i in i_face.DefaultIPGateway if ":" in i), ""
                             )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             prefixlen = next(
                                 (int(i) for i in i_face.IPSubnet if "." not in i), None


### PR DESCRIPTION
### What does this PR do?
Trivial and obvious change/fix for salt.utils.win_network.get_interface_info_wmi().

### What issues does this PR fix or reference?
Fixes #68692