### PR TITLE
add rest-cherrypy-timeout

### DIFF
--- a/salt/netapi/rest_cherrypy/__init__.py
+++ b/salt/netapi/rest_cherrypy/__init__.py
@@ -7,6 +7,8 @@ This is run by ``salt-api`` and started in a multiprocess.
 import logging
 import os
 
+import salt.utils.args
+
 from salt.utils.versions import Version
 
 # pylint: disable=C0103
@@ -25,6 +27,22 @@ __virtualname__ = os.path.abspath(__file__).rsplit(os.sep)[-2] or "rest_cherrypy
 
 logger = logging.getLogger(__virtualname__)
 cpy_min = "3.2.2"
+
+
+def parse_timeout(value, name="timeout"):
+    """
+    Parse a timeout value from config or request data.
+    """
+    if value in (None, ""):
+        return None
+    parsed = salt.utils.args.yamlify_arg(value)
+    if parsed is None:
+        return None
+    if isinstance(parsed, bool) or not isinstance(parsed, (int, float)):
+        raise ValueError(f"{name} must be a number")
+    if parsed < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return parsed
 
 
 def __virtual__():

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -608,6 +608,7 @@ import salt.utils.json
 import salt.utils.stringutils
 import salt.utils.versions
 import salt.utils.yaml
+from . import parse_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -1124,6 +1125,23 @@ def lowdata_fmt():
         cherrypy.request.lowstate = [data]
     else:
         cherrypy.serving.request.lowstate = data
+
+    _normalize_lowstate_timeouts(cherrypy.serving.request.lowstate)
+
+
+def _normalize_lowstate_timeouts(lowstate):
+    if not lowstate:
+        return
+    chunks = lowstate if isinstance(lowstate, list) else [lowstate]
+    for chunk in chunks:
+        if not isinstance(chunk, Mapping):
+            continue
+        if "timeout" not in chunk:
+            continue
+        try:
+            chunk["timeout"] = parse_timeout(chunk["timeout"])
+        except ValueError as exc:
+            raise cherrypy.HTTPError(400, str(exc))
 
 
 tools_config = {

--- a/salt/netapi/rest_cherrypy/event_processor.py
+++ b/salt/netapi/rest_cherrypy/event_processor.py
@@ -2,8 +2,19 @@ import logging
 
 import salt.netapi
 import salt.utils.json
+from . import parse_timeout
 
 logger = logging.getLogger(__name__)
+
+
+def _get_rest_timeout(opts):
+    try:
+        return parse_timeout(opts.get("rest_timeout"), name="rest_timeout")
+    except ValueError as exc:
+        logger.warning(
+            "Invalid rest_timeout value %r: %s", opts.get("rest_timeout"), exc
+        )
+        return None
 
 
 class SaltInfo:
@@ -166,17 +177,19 @@ class SaltInfo:
         if tgt:
             changed = True
             client = salt.netapi.NetapiClient(opts)
-            client.run(
-                {
-                    "fun": "grains.items",
-                    "tgt": tgt,
-                    "expr_type": "list",
-                    "mode": "client",
-                    "client": "local",
-                    "asynchronous": "local_async",
-                    "token": token,
-                }
-            )
+            low = {
+                "fun": "grains.items",
+                "tgt": tgt,
+                "expr_type": "list",
+                "mode": "client",
+                "client": "local",
+                "asynchronous": "local_async",
+                "token": token,
+            }
+            timeout = _get_rest_timeout(opts)
+            if timeout is not None:
+                low["timeout"] = timeout
+            client.run(low)
 
         if changed:
             self.publish_minions()

--- a/tests/pytests/unit/netapi/cherrypy/test_timeout.py
+++ b/tests/pytests/unit/netapi/cherrypy/test_timeout.py
@@ -1,0 +1,26 @@
+import pytest
+
+from salt.netapi.rest_cherrypy import parse_timeout
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("60", 60),
+        (60, 60),
+        ("2.5", 2.5),
+        ("0", 0),
+        ("None", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_timeout_valid(value, expected):
+    assert parse_timeout(value) == expected
+
+
+@pytest.mark.parametrize("value", ["nope", {}, [], True, -1, "-5"])
+def test_parse_timeout_invalid(value):
+    with pytest.raises(ValueError):
+        parse_timeout(value)
+


### PR DESCRIPTION
### What does this PR do?

Normalizes REST Cherrypy timeout values from requests/config, rejects invalid values with a 400, and adds unit coverage for timeout parsing.

### What issues does this PR fix or reference?
Fixes #68653 

### Previous Behavior
Passing -d timeout=... with non-numeric or string values could raise an exception when executed via the runner client.

### New Behavior
Timeouts are parsed into numbers or rejected early with a clear HTTP 400, preventing runner exceptions.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
