### PR TITLE
Add win-gateway

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -351,6 +351,39 @@ def interfaces():
     return salt.utils.network.win_interfaces()
 
 
+def gateways(interface=None):
+    """
+    Return gateway addresses for one or more interfaces.
+
+    Args:
+
+        interface (:obj:`str`, optional):
+            Restrict results to a single interface name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.gateways
+        salt '*' network.gateways interface='Ethernet'
+    """
+    ifaces = salt.utils.network.win_interfaces()
+    ret = {}
+    for name, data in ifaces.items():
+        if interface and name != interface:
+            continue
+        gateways = set()
+        for entry in data.get("inet", []):
+            if entry.get("gateway"):
+                gateways.add(entry["gateway"])
+        for entry in data.get("inet6", []):
+            if entry.get("gateway"):
+                gateways.add(entry["gateway"])
+        if gateways:
+            ret[name] = sorted(gateways)
+    return ret
+
+
 def hw_addr(iface):
     """
     Return the hardware address (a.k.a. MAC address) for a given interface

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1169,7 +1169,42 @@ def win_interfaces():
     if WIN_NETWORK_LOADED is False:
         # Let's throw the ImportException again
         import salt.utils.win_network as _
-    return salt.utils.win_network.get_interface_info()
+    interfaces = salt.utils.win_network.get_interface_info()
+    return _normalize_windows_interfaces(interfaces)
+
+
+def _calc_ipv4_broadcast(address, netmask):
+    """
+    Calculate IPv4 broadcast address from address and netmask.
+    """
+    try:
+        network = ipaddress.ip_network(f"{address}/{netmask}", strict=False)
+    except ValueError:
+        return ""
+    return str(network.broadcast_address)
+
+
+def _normalize_windows_interfaces(interfaces):
+    """
+    Normalize Windows interface data for gateway/broadcast consistency.
+    """
+    for _, iface in interfaces.items():
+        for inet in iface.get("inet", []):
+            address = inet.get("address")
+            netmask = inet.get("netmask")
+            broadcast = inet.get("broadcast")
+            if address and netmask:
+                expected_broadcast = _calc_ipv4_broadcast(address, netmask)
+                if expected_broadcast:
+                    if not broadcast:
+                        inet["broadcast"] = expected_broadcast
+                    elif "gateway" not in inet and broadcast != expected_broadcast:
+                        inet["gateway"] = broadcast
+                        inet["broadcast"] = expected_broadcast
+        for inet6 in iface.get("inet6", []):
+            if "gateway" not in inet6 and "broadcast" in inet6:
+                inet6["gateway"] = inet6.pop("broadcast")
+    return interfaces
 
 
 def interfaces():

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -143,6 +143,26 @@ def __virtual__():
     return __virtualname__
 
 
+def _calc_ipv4_broadcast(address, netmask):
+    """
+    Calculate IPv4 broadcast address from address and netmask.
+    """
+    try:
+        network = ipaddress.IPv4Network(f"{address}/{netmask}", strict=False)
+    except (ValueError, ipaddress.AddressValueError):
+        return ""
+    return network.broadcast_address.compressed
+
+
+def _first_gateway(gateways, family_char):
+    """
+    Return the first gateway matching the address family.
+    """
+    if not gateways:
+        return ""
+    return next((gw for gw in gateways if family_char in gw), "")
+
+
 def _get_base_properties(i_face):
     raw_mac = i_face.GetPhysicalAddress().ToString()
     try:
@@ -486,26 +506,25 @@ def get_interface_info_wmi():
                             i_faces[i_face.Description]["inet"] = []
                         item = {"address": ip, "label": i_face.Description}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
-                                (i for i in i_face.DefaultIPGateway if "." in i), ""
-                            )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            gateway = _first_gateway(i_face.DefaultIPGateway, ".")
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             netmask = next((i for i in i_face.IPSubnet if "." in i), "")
                             if netmask:
                                 item["netmask"] = netmask
+                                broadcast = _calc_ipv4_broadcast(ip, netmask)
+                                if broadcast:
+                                    item["broadcast"] = broadcast
                         i_faces[i_face.Description]["inet"].append(item)
                     if ":" in ip:
                         if "inet6" not in i_faces[i_face.Description]:
                             i_faces[i_face.Description]["inet6"] = []
                         item = {"address": ip}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
-                                (i for i in i_face.DefaultIPGateway if ":" in i), ""
-                            )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            gateway = _first_gateway(i_face.DefaultIPGateway, ":")
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             prefixlen = next(
                                 (int(i) for i in i_face.IPSubnet if "." not in i), None

--- a/tests/pytests/unit/utils/test_win_network.py
+++ b/tests/pytests/unit/utils/test_win_network.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import pytest
 
 import salt.utils.win_network as win_network
@@ -299,6 +301,33 @@ def test_get_network_info(
         results = win_network.get_interface_info()
 
     assert expected == results
+
+
+def test_get_interface_info_wmi_gateway_and_broadcast():
+    iface = MagicMock()
+    iface.Description = "vmxnet3 Ethernet Adapter"
+    iface.MACAddress = "00-50-56-83-11-D5"
+    iface.IPEnabled = True
+    iface.IPAddress = ["10.153.30.240", "fe80::1"]
+    iface.DefaultIPGateway = ["10.153.31.240", "fe80::2"]
+    iface.IPSubnet = ["255.255.252.0", "64"]
+
+    fake_wmi = MagicMock()
+    fake_wmi.Win32_NetworkAdapterConfiguration.return_value = [iface]
+
+    with patch("salt.utils.win_network.wmi", create=True) as wmi_mod, patch(
+        "salt.utils.win_network.salt.utils.winapi.Com",
+        create=True,
+        return_value=contextlib.nullcontext(),
+    ):
+        wmi_mod.WMI.return_value = fake_wmi
+        results = win_network.get_interface_info_wmi()
+
+    inet = results[iface.Description]["inet"][0]
+    assert inet["gateway"] == "10.153.31.240"
+    assert inet["broadcast"] == "10.153.31.255"
+    inet6 = results[iface.Description]["inet6"][0]
+    assert inet6["gateway"] == "fe80::2"
 
 
 def test__get_base_properties_tap_adapter():


### PR DESCRIPTION
### What does this PR do?
Fixes Windows WMI interface parsing so gateway addresses are no longer reported as broadcast, normalizes legacy WMI data, and adds a helper to list gateways.

### What issues does this PR fix or reference?
issue #68692 

### Previous Behavior
On older Windows/.NET, network.interfaces reported the default gateway address as broadcast.

### New Behavior
network.interfaces reports gateway correctly and computes broadcast from IP/netmask; IPv6 gateway values are preserved.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
