### PR TITLE
fix system-reboot-return

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta, tzinfo
 import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.process
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.utils.decorators import depends
 
@@ -90,12 +91,33 @@ def poweroff():
     return ret
 
 
-def reboot(at_time=None):
+def _schedule_shutdown(cmd, delay):
+    """
+    Schedule a shutdown command to run after a delay in seconds.
+    """
+    if delay is None or delay <= 0:
+        return __salt__["cmd.run"](cmd, python_shell=False)
+    salt.utils.process.run_delayed(
+        __salt__["cmd.run"],
+        delay,
+        args=(cmd,),
+        kwargs={"python_shell": False},
+        name="system.reboot",
+    )
+    return f"Reboot scheduled in {delay} seconds"
+
+
+def reboot(at_time=None, delay=None):
     """
     Reboot the system
 
     at_time
         The wait time in minutes before the system will be rebooted.
+
+    delay
+        Delay in seconds before rebooting when ``at_time`` is not specified.
+        If not passed, the value of ``system_reboot_delay`` from the minion
+        config is used.
 
     CLI Example:
 
@@ -104,8 +126,11 @@ def reboot(at_time=None):
         salt '*' system.reboot
     """
     cmd = ["shutdown", "-r", (f"{at_time}" if at_time else "now")]
-    ret = __salt__["cmd.run"](cmd, python_shell=False)
-    return ret
+    if at_time is None:
+        delay = salt.utils.platform.reboot_grace_delay(__opts__, delay)
+    else:
+        delay = 0
+    return _schedule_shutdown(cmd, delay)
 
 
 def shutdown(at_time=None):

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -3,6 +3,7 @@ Functions for identifying which platform a machine is
 """
 
 import contextlib
+import logging
 import multiprocessing
 import os
 import platform
@@ -12,6 +13,8 @@ import sys
 import distro
 
 from salt.utils.decorators import memoize as real_memoize
+
+log = logging.getLogger(__name__)
 
 
 def linux_distribution(full_distribution_name=True):
@@ -191,6 +194,29 @@ def is_openbsd():
     Simple function to return if host is OpenBSD or not
     """
     return sys.platform.startswith("openbsd")
+
+
+def _parse_delay(value, default):
+    try:
+        delay = int(value)
+    except (TypeError, ValueError):
+        log.debug("Invalid delay value %r, using default %s", value, default)
+        return default
+    if delay < 0:
+        log.debug("Negative delay value %s, using default %s", delay, default)
+        return default
+    return delay
+
+
+def reboot_grace_delay(opts=None, override=None, default=1):
+    """
+    Return a safe delay in seconds before issuing a reboot.
+    """
+    if override is not None:
+        return _parse_delay(override, default)
+    if opts and "system_reboot_delay" in opts:
+        return _parse_delay(opts.get("system_reboot_delay"), default)
+    return default
 
 
 @real_memoize

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -50,6 +50,30 @@ except ImportError:
 _INTERNAL_PROCESS_FINALIZE_FUNCTION_LIST = []
 
 
+def run_delayed(target, delay, args=None, kwargs=None, name="DelayedTarget"):
+    """
+    Run a target callable in a background thread after a delay.
+    """
+    if args is None:
+        args = ()
+    if kwargs is None:
+        kwargs = {}
+    delay = max(0, delay or 0)
+
+    def _runner():
+        if delay:
+            time.sleep(delay)
+        try:
+            target(*args, **kwargs)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Delayed call %s failed", name)
+
+    thread = threading.Thread(target=_runner, name=name)
+    thread.daemon = True
+    thread.start()
+    return thread
+
+
 def appendproctitle(name):
     """
     Append "name" to the current process title

--- a/tests/pytests/unit/modules/test_system.py
+++ b/tests/pytests/unit/modules/test_system.py
@@ -47,9 +47,19 @@ def test_reboot():
     Test to reboot the system with shutdown -r
     """
     cmd_mock = MagicMock(return_value="A")
-    with patch.dict(system.__salt__, {"cmd.run": cmd_mock}):
-        assert system.reboot() == "A"
-    cmd_mock.assert_called_with(["shutdown", "-r", "now"], python_shell=False)
+    delay_mock = MagicMock(return_value=1)
+    run_delayed = MagicMock()
+    with patch.dict(system.__salt__, {"cmd.run": cmd_mock}), patch(
+        "salt.utils.platform.reboot_grace_delay", delay_mock
+    ), patch("salt.utils.process.run_delayed", run_delayed):
+        assert system.reboot() == "Reboot scheduled in 1 seconds"
+    run_delayed.assert_called_with(
+        cmd_mock,
+        1,
+        args=(["shutdown", "-r", "now"],),
+        kwargs={"python_shell": False},
+        name="system.reboot",
+    )
 
 
 def test_reboot_with_delay():
@@ -60,6 +70,20 @@ def test_reboot_with_delay():
     with patch.dict(system.__salt__, {"cmd.run": cmd_mock}):
         assert system.reboot(at_time=5) == "A"
     cmd_mock.assert_called_with(["shutdown", "-r", "5"], python_shell=False)
+
+
+def test_reboot_immediate_with_override():
+    """
+    Test to reboot the system immediately when delay override is 0
+    """
+    cmd_mock = MagicMock(return_value="A")
+    run_delayed = MagicMock()
+    with patch.dict(system.__salt__, {"cmd.run": cmd_mock}), patch(
+        "salt.utils.process.run_delayed", run_delayed
+    ):
+        assert system.reboot(delay=0) == "A"
+    cmd_mock.assert_called_with(["shutdown", "-r", "now"], python_shell=False)
+    run_delayed.assert_not_called()
 
 
 def test_shutdown():


### PR DESCRIPTION
### What does this PR do?
Adds a delayed reboot path so system.reboot can return before the system restarts, with a configurable grace delay and supporting helpers, plus unit tests.

### What issues does this PR fix or reference?
issue #68687 

### Previous Behavior
system.reboot could reboot before the return was sent, causing orchestrations to hang waiting for a response.

### New Behavior
system.reboot schedules the reboot after a short delay (configurable), allowing the minion to return before rebooting.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
