### PR TITLE
Fix minion-user

### DIFF
--- a/changelog/68684.fixed.md
+++ b/changelog/68684.fixed.md
@@ -1,0 +1,2 @@
+Fix salt-call and salt-pip to honor the configured minion user.
+

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -3,6 +3,7 @@ import os
 import salt.cli.caller
 import salt.defaults.exitcodes
 import salt.utils.parsers
+import salt.utils.verify
 from salt.config import _expand_glob_path, prepend_root_dir
 
 
@@ -10,6 +11,15 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
     """
     Used to locally execute a salt command
     """
+
+    def _ensure_minion_user(self):
+        """
+        Ensure salt-call runs with the configured minion user.
+        """
+        if not salt.utils.verify.check_user_from_opts(
+            self.config, context="salt-call"
+        ):
+            self.exit(salt.defaults.exitcodes.EX_NOPERM)
 
     def run(self):
         """
@@ -45,6 +55,8 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
             self.config["cachedir"] = cache_dir
             self.config["extension_modules"] = os.path.join(cache_dir, "extmods")
             prepend_root_dir(self.config, ["cachedir", "extension_modules"])
+
+        self._ensure_minion_user()
 
         caller = salt.cli.caller.Caller.factory(self.config)
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -14,8 +14,10 @@ import time
 import traceback
 from random import randint
 
+import salt.config
 import salt.defaults.exitcodes
 from salt.exceptions import SaltClientError, SaltReqTimeoutError, SaltSystemExit
+import salt.utils.verify
 
 log = logging.getLogger(__name__)
 
@@ -626,6 +628,17 @@ def salt_pip():
         sys.exit(salt.defaults.exitcodes.EX_GENERIC)
     else:
         extras = str(relenv_path / "extras-{}.{}".format(*sys.version_info))
+
+    config_dir = os.environ.get("SALT_CONFIG_DIR")
+    if not config_dir:
+        relenv_config_dir = relenv_path / "etc" / "salt"
+        if relenv_config_dir.is_dir():
+            config_dir = str(relenv_config_dir)
+    minion_config_path = os.path.join(config_dir, "minion") if config_dir else None
+    minion_opts = salt.config.minion_config(minion_config_path)
+    if not salt.utils.verify.check_user_from_opts(minion_opts, context="salt-pip"):
+        sys.exit(salt.defaults.exitcodes.EX_NOPERM)
+
     env = _pip_environment(os.environ.copy(), extras)
     args = _pip_args(sys.argv[1:], extras)
     command = [

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -368,6 +368,22 @@ def check_user(user):
     return True
 
 
+def check_user_from_opts(opts, user_key="user", context=None):
+    """
+    Check the configured user from opts and switch if needed.
+    """
+    if not isinstance(opts, dict):
+        return True
+    user = opts.get(user_key)
+    if not user:
+        return True
+    if context:
+        log.debug("Ensuring process user is '%s' for %s", user, context)
+    else:
+        log.debug("Ensuring process user is '%s'", user)
+    return check_user(user)
+
+
 def list_path_traversal(path):
     """
     Returns a full list of directories leading up to, and including, a path.

--- a/tests/pytests/functional/cli/test_salt_pip.py
+++ b/tests/pytests/functional/cli/test_salt_pip.py
@@ -29,3 +29,27 @@ def test_outside_onedir_env(capsys):
             salt.scripts.salt_pip()
     captured = capsys.readouterr()
     assert "'salt-pip' is only meant to be used from a Salt onedir." in captured.err
+
+
+def test_salt_pip_checks_minion_user(tmp_path):
+    relenv_path = tmp_path / "relenv"
+    config_dir = relenv_path / "etc" / "salt"
+    config_dir.mkdir(parents=True)
+    minion_config_path = config_dir / "minion"
+    with patch(
+        "salt.scripts._get_onedir_env_path", return_value=relenv_path
+    ), patch(
+        "salt.config.minion_config", return_value={"user": "salt"}
+    ) as minion_config_mock, patch(
+        "salt.utils.verify.check_user_from_opts", return_value=True
+    ) as check_user_mock, patch(
+        "subprocess.run"
+    ) as run_mock, patch(
+        "sys.argv", ["salt-pip", "list"]
+    ):
+        run_mock.return_value.returncode = 0
+        with pytest.raises(SystemExit) as exc:
+            salt.scripts.salt_pip()
+        assert exc.value.code == 0
+        minion_config_mock.assert_called_once_with(str(minion_config_path))
+        check_user_mock.assert_called_once()

--- a/tests/pytests/unit/cli/test_salt_call.py
+++ b/tests/pytests/unit/cli/test_salt_call.py
@@ -30,3 +30,32 @@ def test_passing_cachedir_to_extension_modules(temp_salt_minion):
             assert salt_call.config["extension_modules"] == os.path.join(
                 test_cache_dir, "extmods"
             )
+
+
+def test_salt_call_checks_minion_user(temp_salt_minion):
+    """
+    Ensure salt-call checks the configured minion user before execution.
+    """
+    test_cache_dir = os.path.join(temp_salt_minion.config["root_dir"], "call_cache")
+    with patch(
+        "sys.argv",
+        [
+            "salt-call",
+            "--local",
+            "--config-dir",
+            temp_salt_minion.config["root_dir"],
+            "--cachedir",
+            test_cache_dir,
+            "test.true",
+        ],
+    ), patch("salt.utils.verify.verify_files", MagicMock()), patch(
+        "salt._logging.impl.setup_logfile_handler", MagicMock()
+    ):
+        salt_call = SaltCall()
+        with patch(
+            "salt.utils.verify.check_user_from_opts", return_value=True
+        ) as check_user_mock, patch("salt.cli.caller.Caller.factory", MagicMock()):
+            salt_call.run()
+            check_user_mock.assert_called_once_with(
+                salt_call.config, context="salt-call"
+            )


### PR DESCRIPTION
### What does this PR do?
Ensures salt-call and salt-pip honor the configured minion user by checking the minion opts and switching users before execution, with tests and a changelog entry.

### What issues does this PR fix or reference?
Fixes #68684 

### Previous Behavior
salt-call and salt-pip could run as root even when the minion was configured to run as a non-root user, leading to root-owned files.

### New Behavior
Both CLIs enforce the configured minion user before running, preventing unintended root-owned artifacts.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
