### PR TITLE
Fix SyntaxWarning for invalid escape sequence in tornado/util.py

### DIFF
--- a/changelog/68568.fixed.md
+++ b/changelog/68568.fixed.md
@@ -1,0 +1,2 @@
+Fixed SyntaxWarning for invalid escape sequence '\d' in salt/ext/tornado/util.py
+on Python 3.12+ by converting the re_unescape docstring to a raw string.

--- a/salt/ext/tornado/util.py
+++ b/salt/ext/tornado/util.py
@@ -243,7 +243,7 @@ _re_unescape_pattern = re.compile(r'\\(.)', re.DOTALL)
 
 def re_unescape(s):
     # type: (str) -> str
-    """Unescape a string escaped by `re.escape`.
+    r"""Unescape a string escaped by `re.escape`.
 
     May raise ``ValueError`` for regular expressions which could not
     have been produced by `re.escape` (for example, strings containing


### PR DESCRIPTION
### What does this PR do?

Fixes a `SyntaxWarning: invalid escape sequence '\d'` emitted by Python 3.12+ when importing `salt/ext/tornado/util.py`.

The `re_unescape` function's docstring contained a bare `\d` (as part of documenting that strings containing `\d` cannot be unescaped). Python 3.12+ treats unrecognized backslash sequences in regular strings as `SyntaxWarning`, which will become a `SyntaxError` in a future Python version.

The fix converts the docstring to a raw string (`r"""..."""`), which preserves the content while preventing the warning.

### What issues does this PR fix or reference?

Fixes #68568

### Previous Behavior

On Python 3.12+, importing `salt.ext.tornado.util` produces:
```
salt/ext/tornado/util.py:246: SyntaxWarning: invalid escape sequence '\d'
```

### New Behavior

No warning is emitted on any Python version.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?

No