### PR TITLE
Include minion ID in rejected authentication warning

### DIFF
--- a/changelog/68671.fixed.md
+++ b/changelog/68671.fixed.md
@@ -1,0 +1,2 @@
+Improved the rejected authentication warning message to include the minion ID,
+making it easier for administrators to identify which minions need upgrading.

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -151,9 +151,15 @@ class ReqServerChannel:
         # Enforce minimum authentication protocol version to prevent downgrade attacks
         minimum_version = self.opts.get("minimum_auth_version", 0)
         if minimum_version > 0 and version < minimum_version:
+            load = payload.get("load")
+            if isinstance(load, dict):
+                minion_id = load.get("id", "unknown minion")
+            else:
+                minion_id = "unknown minion"
             log.warning(
-                "Rejected authentication attempt using protocol version %d "
-                "(minimum required: %d)",
+                "Rejected authentication attempt from minion '%s' using "
+                "protocol version %d (minimum required: %d)",
+                minion_id,
                 version,
                 minimum_version,
             )

--- a/tests/pytests/unit/channel/test_server.py
+++ b/tests/pytests/unit/channel/test_server.py
@@ -379,6 +379,64 @@ def test_handle_message_version_extraction(auth_master_opts):
     ), "Expected minimum auth version to be at least 3"
 
 
+async def test_auth_version_downgrade_warning_includes_minion_id(
+    pki_dir, auth_minion_opts, req_server, setup_accepted_minion, caplog
+):
+    """
+    Test that the rejected authentication warning includes the minion ID.
+
+    When minimum_auth_version rejects a connection, the warning message should
+    include the minion's ID so administrators can identify which minion needs
+    to be upgraded.
+    """
+    with salt.utils.files.fopen(str(pki_dir / "minion" / "minion.pub"), "r") as fp:
+        pub_key = fp.read()
+
+    load = {
+        "cmd": "_auth",
+        "id": "my-outdated-minion",
+        "pub": pub_key,
+        "enc_algo": auth_minion_opts["encryption_algorithm"],
+        "sig_algo": auth_minion_opts["signing_algorithm"],
+    }
+
+    payload = {"enc": "clear", "load": load, "version": 0}
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="salt.channel.server"):
+        ret = await req_server.handle_message(payload)
+
+    assert ret == "bad load"
+    assert any(
+        "my-outdated-minion" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ), "Expected minion ID 'my-outdated-minion' in the rejection warning message"
+
+
+async def test_auth_version_downgrade_warning_encrypted_load(
+    req_server, caplog
+):
+    """
+    Test that the rejected authentication warning shows 'unknown minion' when
+    the load is not a dict (e.g., encrypted payload).
+    """
+    payload = {"enc": "aes", "load": b"encrypted-blob", "version": 0}
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="salt.channel.server"):
+        ret = await req_server.handle_message(payload)
+
+    assert ret == "bad load"
+    assert any(
+        "unknown minion" in record.message
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ), "Expected 'unknown minion' in the rejection warning for encrypted payloads"
+
+
 # Note: The remaining security bypasses (token, TTL, ID mismatch, session keys)
 # are already tested via the parametrized downgrade tests above and the
 # functional tests. The key regression test is ensuring old versions are rejected.

--- a/tests/pytests/unit/channel/test_server.py
+++ b/tests/pytests/unit/channel/test_server.py
@@ -415,9 +415,7 @@ async def test_auth_version_downgrade_warning_includes_minion_id(
     ), "Expected minion ID 'my-outdated-minion' in the rejection warning message"
 
 
-async def test_auth_version_downgrade_warning_encrypted_load(
-    req_server, caplog
-):
+async def test_auth_version_downgrade_warning_encrypted_load(req_server, caplog):
     """
     Test that the rejected authentication warning shows 'unknown minion' when
     the load is not a dict (e.g., encrypted payload).


### PR DESCRIPTION
### What does this PR do?

Improves the `minimum_auth_version` rejection warning in `salt/channel/server.py` to include the minion ID. This helps administrators identify which minions are using outdated protocol versions and need to be upgraded.

Before this change, the warning only showed the protocol version numbers:
```
[WARNING] Rejected authentication attempt using protocol version 2 (minimum required: 3)
```

After this change, the warning includes the minion ID:
```
[WARNING] Rejected authentication attempt from minion 'my-minion-id' using protocol version 2 (minimum required: 3)
```

If the payload is encrypted (load is not a dict), the message falls back to `'unknown minion'`.

### What issues does this PR fix or reference?

Fixes #68671

### Previous Behavior

The rejected authentication warning did not include the minion ID, making it difficult for administrators to identify which minion needed upgrading, especially in environments with many minions.

### New Behavior

The warning now includes the minion ID extracted from the payload, allowing administrators to quickly identify and upgrade the affected minion.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

No