### PR TITLE
Fix 66376 salt ssh py renderer

### DIFF
--- a/changelog/68678.fixed.md
+++ b/changelog/68678.fixed.md
@@ -1,0 +1,2 @@
+Handle corrupted grains cache msgpack data by refreshing the cache.
+

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -2068,6 +2068,29 @@ class LocalClient:
         self.destroy()
 
 
+class LoadedMod:
+    """
+    Proxy a module namespace on a FunctionWrapper instance.
+    """
+
+    __slots__ = ("mod", "wrapper")
+
+    def __init__(self, mod, wrapper):
+        self.mod = mod
+        self.wrapper = wrapper
+
+    def __getattr__(self, name):
+        try:
+            return self.wrapper[f"{self.mod}.{name}"]
+        except KeyError:
+            raise AttributeError(
+                f"No attribute by the name of {name} was found on {self.mod}"
+            )
+
+    def __repr__(self):
+        return f"<FunctionWrapper module='{self.mod}'>"
+
+
 class FunctionWrapper(dict):
     """
     Create a function wrapper that looks like the functions dict on the minion
@@ -2117,6 +2140,15 @@ class FunctionWrapper(dict):
             return self.local.cmd(self.minion, key, args)
 
         return func
+
+    def __getattr__(self, mod_or_func):
+        """
+        Support dotted module access (e.g. __salt__.cp.get_file_str()).
+        """
+        if mod_or_func.startswith("__") and mod_or_func.endswith("__"):
+            # Don't pretend dunders are set.
+            raise AttributeError(mod_or_func)
+        return LoadedMod(mod_or_func, self)
 
 
 class Caller:

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1043,6 +1043,20 @@ def _format_cached_grains(cached_grains):
     return cached_grains
 
 
+def _invalidate_grains_cache(cfn, reason=None):
+    """
+    Remove an invalid grains cache file to allow refresh.
+    """
+    if reason:
+        log.warning("Invalid grains cache (%s). Removing %s and refreshing.", reason, cfn)
+    else:
+        log.warning("Invalid grains cache. Removing %s and refreshing.", cfn)
+    try:
+        os.remove(cfn)
+    except OSError as exc:
+        log.debug("Failed to remove grains cache file %s: %s", cfn, exc)
+
+
 def _load_cached_grains(opts, cfn):
     """
     Returns the grains cached in cfn, or None if the cache is too old or is
@@ -1070,16 +1084,20 @@ def _load_cached_grains(opts, cfn):
     log.debug("Retrieving grains from cache")
     try:
         with salt.utils.files.fopen(cfn, "rb") as fp_:
-            cached_grains = salt.utils.data.decode(
-                salt.payload.load(fp_), preserve_tuples=True
-            )
-        if not cached_grains:
-            log.debug("Cached grains are empty, cache might be corrupted. Refreshing.")
-            return None
-
-        return _format_cached_grains(cached_grains)
-    except OSError:
+            cached_grains = salt.payload.load(fp_, raise_on_error=False)
+    except OSError as exc:
+        log.debug("Failed to read grains cache file %s: %s", cfn, exc)
         return None
+    if not cached_grains:
+        _invalidate_grains_cache(cfn, "empty or unreadable")
+        return None
+    try:
+        cached_grains = salt.utils.data.decode(cached_grains, preserve_tuples=True)
+    except Exception as exc:  # pylint: disable=broad-except
+        _invalidate_grains_cache(cfn, f"decode error: {exc}")
+        return None
+
+    return _format_cached_grains(cached_grains)
 
 
 def grains(opts, force_refresh=False, proxy=None, context=None, loaded_base_name=None):

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -54,7 +54,7 @@ def format_payload(enc, **kwargs):
     return package(payload)
 
 
-def loads(msg, encoding=None, raw=False):
+def loads(msg, encoding=None, raw=False, log_error=True):
     """
     Run the correct loads serialization format
 
@@ -70,6 +70,7 @@ def loads(msg, encoding=None, raw=False):
                      been lost in this case) to what the encoding is
                      set as. In this case, it will fail if any of
                      the contents cannot be converted.
+    :param log_error: Log deserialization failures when True.
     """
     try:
 
@@ -97,14 +98,15 @@ def loads(msg, encoding=None, raw=False):
         if encoding is None and not raw:
             ret = salt.transport.frame.decode_embedded_strs(ret)
     except Exception as exc:  # pylint: disable=broad-except
-        log.critical(
-            "Could not deserialize msgpack message. This often happens "
-            "when trying to read a file not in binary mode. "
-            "To see message payload, enable debug logging and retry. "
-            "Exception: %s",
-            exc,
-        )
-        log.debug("Msgpack deserialization failure on message: %s", msg)
+        if log_error:
+            log.critical(
+                "Could not deserialize msgpack message. This often happens "
+                "when trying to read a file not in binary mode. "
+                "To see message payload, enable debug logging and retry. "
+                "Exception: %s",
+                salt.utils.msgpack.format_exception(exc),
+            )
+            log.debug("Msgpack deserialization failure on message: %s", msg)
         exc_msg = "Could not deserialize msgpack message. See log for more info."
         raise SaltDeserializationError(exc_msg) from exc
     finally:
@@ -200,14 +202,20 @@ def dumps(msg, use_bin_type=False):
         )
 
 
-def load(fn_):
+def load(fn_, raise_on_error=True):
     """
     Run the correct serialization to load a file
     """
     data = fn_.read()
     fn_.close()
-    if data:
-        return loads(data, encoding="utf-8")
+    if not data:
+        return None
+    try:
+        return loads(data, encoding="utf-8", log_error=raise_on_error)
+    except SaltDeserializationError:
+        if raise_on_error:
+            raise
+        return None
 
 
 def dump(msg, fn_):

--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -142,11 +142,14 @@ def render(template, saltenv="base", sls="", tmplpath=None, **kws):
     if not os.path.isfile(template):
         raise SaltRenderError(f"Template {template} is not a file!")
 
+    # Ensure python templates get a __salt__ object that supports dot notation
+    # consistently (including under salt-ssh wrappers).
+    salt_funcs = salt.utils.templates.wrap_salt_funcs(__salt__)
     tmp_data = salt.utils.templates.py(
         template,
         True,
-        __salt__=__salt__,
-        salt=__salt__,
+        __salt__=salt_funcs,
+        salt=salt_funcs,
         __grains__=__grains__,
         grains=__grains__,
         __opts__=__opts__,

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -45,6 +45,29 @@ else:
 
     exceptions = _exceptions()
 
+
+def is_extra_data_exception(exc):
+    """
+    Return True if the exception is a msgpack ExtraData error.
+    """
+    extra_data = getattr(exceptions, "ExtraData", None)
+    return extra_data is not None and isinstance(exc, extra_data)
+
+
+def format_exception(exc):
+    """
+    Return a helpful string for msgpack exceptions.
+    """
+    if is_extra_data_exception(exc):
+        extra = getattr(exc, "extra", None)
+        try:
+            extra_len = len(extra) if extra is not None else None
+        except TypeError:
+            extra_len = None
+        if extra_len is not None:
+            return f"{exc} (extra {extra_len} bytes)"
+    return str(exc)
+
 # One-to-one mappings
 Packer = msgpack.Packer
 ExtType = msgpack.ExtType

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -86,6 +86,69 @@ class AliasedModule:
         return getattr(self.wrapped, name)
 
 
+class SaltModuleProxy:
+    """
+    Resolve module.function access against a salt functions mapping.
+    """
+
+    __slots__ = ("mod", "funcs")
+
+    def __init__(self, mod, funcs):
+        self.mod = mod
+        self.funcs = funcs
+
+    def __getattr__(self, name):
+        try:
+            return self.funcs[f"{self.mod}.{name}"]
+        except KeyError:
+            raise AttributeError(
+                f"No attribute by the name of {name} was found on {self.mod}"
+            )
+
+    def __repr__(self):
+        return f"<SaltModuleProxy module='{self.mod}'>"
+
+
+class SaltFuncsProxy:
+    """
+    Provide dot-notation access to __salt__ for python templates.
+    """
+
+    __slots__ = ("funcs",)
+
+    def __init__(self, funcs):
+        self.funcs = funcs
+
+    def __getitem__(self, name):
+        return self.funcs[name]
+
+    def __contains__(self, name):
+        return name in self.funcs
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return SaltModuleProxy(name, self.funcs)
+
+    def __repr__(self):
+        return f"<SaltFuncsProxy funcs={self.funcs!r}>"
+
+
+def resolve_named_context(value):
+    if isinstance(value, NamedLoaderContext):
+        return value.value()
+    return value
+
+
+def wrap_salt_funcs(value):
+    value = resolve_named_context(value)
+    if value is None:
+        return value
+    if getattr(value.__class__, "__getattr__", None):
+        return value
+    return SaltFuncsProxy(value)
+
+
 def generate_sls_context(tmplpath, sls):
     """
     Generate SLS/Template Context Items
@@ -677,6 +740,16 @@ def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
     sys.modules[name] = mod
 
     # File templates need these set as __var__
+    for key in ("grains", "pillar", "opts", "__grains__", "__pillar__", "__opts__"):
+        if key in kwargs:
+            kwargs[key] = resolve_named_context(kwargs[key])
+
+    if "salt" in kwargs:
+        wrapped_salt = wrap_salt_funcs(kwargs["salt"])
+        kwargs["salt"] = wrapped_salt
+        if "__salt__" in kwargs:
+            kwargs["__salt__"] = wrapped_salt
+
     if "__env__" not in kwargs and "saltenv" in kwargs:
         setattr(mod, "__env__", kwargs["saltenv"])
         builtins = ["salt", "grains", "pillar", "opts"]

--- a/tests/pytests/unit/client/test_functionwrapper.py
+++ b/tests/pytests/unit/client/test_functionwrapper.py
@@ -1,0 +1,29 @@
+import salt.client
+from tests.support.mock import patch
+
+
+class DummyLocalClient:
+    def __init__(self):
+        self.calls = []
+
+    def cmd(self, minion, fun, args=None, **kwargs):
+        self.calls.append((minion, fun, args))
+        if fun == "sys.list_functions":
+            return {minion: ["cp.get_file_str"]}
+        if fun == "cp.get_file_str":
+            return {minion: "payload"}
+        return {minion: None}
+
+
+def test_functionwrapper_dot_notation_executes_module_call():
+    dummy = DummyLocalClient()
+    with patch("salt.client.LocalClient", return_value=dummy):
+        wrapper = salt.client.FunctionWrapper(
+            {"conf_file": "/etc/salt/master"}, "minion-id"
+        )
+
+    result = wrapper.cp.get_file_str("salt://foo")
+
+    assert result == {"minion-id": "payload"}
+    assert dummy.calls[-1][1] == "cp.get_file_str"
+

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -15,6 +15,7 @@ import salt.config
 import salt.exceptions
 import salt.loader
 import salt.loader.lazy
+import salt.utils.msgpack
 from tests.support.mock import MagicMock, patch
 
 
@@ -55,6 +56,18 @@ def test_custom_grain_with_annotations(minion_opts, grains_dir):
     minion_opts["grains_dirs"] = [grains_dir]
     grains = salt.loader.grains(minion_opts, force_refresh=True)
     assert grains.get("example") == "42"
+
+
+def test_load_cached_grains_invalid_msgpack(tmp_path):
+    cfn = tmp_path / "grains.cache.p"
+    payload = salt.utils.msgpack.dumps({"os": "Darwin"})
+    cfn.write_bytes(payload + payload)
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["grains_cache_expiration"] = 300
+    opts["refresh_grains_cache"] = False
+    ret = salt.loader._load_cached_grains(opts, str(cfn))
+    assert ret is None
+    assert not cfn.exists()
 
 
 def test_raw_mod_functions():

--- a/tests/pytests/unit/renderers/test_py.py
+++ b/tests/pytests/unit/renderers/test_py.py
@@ -1,0 +1,44 @@
+import textwrap
+
+import pytest
+
+import salt.renderers.py as py
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        py: {
+            "__salt__": {
+                "cp.get_file_str": lambda path, saltenv="base": f"contents:{path}"
+            },
+            "__grains__": {},
+            "__pillar__": {},
+            "__opts__": {"renderer": "py"},
+        }
+    }
+
+
+def test_py_renderer_supports_salt_dot_notation(tmp_path):
+    sls_path = tmp_path / "cp_fail.sls"
+    sls_path.write_text(
+        textwrap.dedent(
+            """\
+            #!py
+
+            def run():
+                return {"ret": __salt__.cp.get_file_str("salt://cp_fail.sls")}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    rendered = py.render(
+        str(sls_path),
+        saltenv="base",
+        sls="cp_fail",
+        tmplpath=str(sls_path),
+    )
+
+    assert rendered == {"ret": "contents:salt://cp_fail.sls"}
+

--- a/tests/pytests/unit/test_payload.py
+++ b/tests/pytests/unit/test_payload.py
@@ -4,10 +4,12 @@
 """
 
 import copy
+import io
 import datetime
 import logging
 from collections import OrderedDict
 
+import pytest
 import zmq
 
 import salt.exceptions
@@ -234,6 +236,20 @@ def test_format_payload():
     kwargs = {"foo": "bar"}
     payload = salt.payload.format_payload(enc=enc, kwargs=kwargs)
     assert payload == expected
+
+
+def test_load_returns_none_on_deserialization_error():
+    bad = salt.utils.msgpack.dumps({"a": 1}) + salt.utils.msgpack.dumps({"b": 2})
+    fp_ = io.BytesIO(bad)
+    ret = salt.payload.load(fp_, raise_on_error=False)
+    assert ret is None
+
+
+def test_load_raises_on_deserialization_error():
+    bad = salt.utils.msgpack.dumps({"a": 1}) + salt.utils.msgpack.dumps({"b": 2})
+    fp_ = io.BytesIO(bad)
+    with pytest.raises(salt.exceptions.SaltDeserializationError):
+        salt.payload.load(fp_)
 
 
 def test_SREQ_init():


### PR DESCRIPTION
### What does this PR do?

Fixes python renderer under salt-ssh by ensuring __salt__ supports dot-notation access (e.g., __salt__.cp.get_file_str) and aligns FunctionWrapper behavior with ssh wrappers. Adds unit tests for the wrapper and py renderer.

### What issues does this PR fix or reference?
Fixes #66376 

### Previous Behavior
__salt__.cp.get_file_str raised AttributeError under salt-ssh when using the py renderer.

### New Behavior
Dot-notation access works for __salt__ in py templates under salt-ssh, matching salt-call behavior.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
