### PR TITLE
Fix 66096 hung mount

### DIFF
--- a/changelog/68678.fixed.md
+++ b/changelog/68678.fixed.md
@@ -1,0 +1,2 @@
+Handle corrupted grains cache msgpack data by refreshing the cache.
+

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -2068,6 +2068,29 @@ class LocalClient:
         self.destroy()
 
 
+class LoadedMod:
+    """
+    Proxy a module namespace on a FunctionWrapper instance.
+    """
+
+    __slots__ = ("mod", "wrapper")
+
+    def __init__(self, mod, wrapper):
+        self.mod = mod
+        self.wrapper = wrapper
+
+    def __getattr__(self, name):
+        try:
+            return self.wrapper[f"{self.mod}.{name}"]
+        except KeyError:
+            raise AttributeError(
+                f"No attribute by the name of {name} was found on {self.mod}"
+            )
+
+    def __repr__(self):
+        return f"<FunctionWrapper module='{self.mod}'>"
+
+
 class FunctionWrapper(dict):
     """
     Create a function wrapper that looks like the functions dict on the minion
@@ -2117,6 +2140,15 @@ class FunctionWrapper(dict):
             return self.local.cmd(self.minion, key, args)
 
         return func
+
+    def __getattr__(self, mod_or_func):
+        """
+        Support dotted module access (e.g. __salt__.cp.get_file_str()).
+        """
+        if mod_or_func.startswith("__") and mod_or_func.endswith("__"):
+            # Don't pretend dunders are set.
+            raise AttributeError(mod_or_func)
+        return LoadedMod(mod_or_func, self)
 
 
 class Caller:

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1043,6 +1043,20 @@ def _format_cached_grains(cached_grains):
     return cached_grains
 
 
+def _invalidate_grains_cache(cfn, reason=None):
+    """
+    Remove an invalid grains cache file to allow refresh.
+    """
+    if reason:
+        log.warning("Invalid grains cache (%s). Removing %s and refreshing.", reason, cfn)
+    else:
+        log.warning("Invalid grains cache. Removing %s and refreshing.", cfn)
+    try:
+        os.remove(cfn)
+    except OSError as exc:
+        log.debug("Failed to remove grains cache file %s: %s", cfn, exc)
+
+
 def _load_cached_grains(opts, cfn):
     """
     Returns the grains cached in cfn, or None if the cache is too old or is
@@ -1070,16 +1084,20 @@ def _load_cached_grains(opts, cfn):
     log.debug("Retrieving grains from cache")
     try:
         with salt.utils.files.fopen(cfn, "rb") as fp_:
-            cached_grains = salt.utils.data.decode(
-                salt.payload.load(fp_), preserve_tuples=True
-            )
-        if not cached_grains:
-            log.debug("Cached grains are empty, cache might be corrupted. Refreshing.")
-            return None
-
-        return _format_cached_grains(cached_grains)
-    except OSError:
+            cached_grains = salt.payload.load(fp_, raise_on_error=False)
+    except OSError as exc:
+        log.debug("Failed to read grains cache file %s: %s", cfn, exc)
         return None
+    if not cached_grains:
+        _invalidate_grains_cache(cfn, "empty or unreadable")
+        return None
+    try:
+        cached_grains = salt.utils.data.decode(cached_grains, preserve_tuples=True)
+    except Exception as exc:  # pylint: disable=broad-except
+        _invalidate_grains_cache(cfn, f"decode error: {exc}")
+        return None
+
+    return _format_cached_grains(cached_grains)
 
 
 def grains(opts, force_refresh=False, proxy=None, context=None, loaded_base_name=None):

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3815,7 +3815,7 @@ def is_hardlink(path):
     return res and res["st_nlink"] > 1
 
 
-def is_link(path, nostat=False):
+def is_link(path, nostat=False, stat_timeout=None):
     """
     Check if the path is a symbolic link
 
@@ -3832,6 +3832,12 @@ def is_link(path, nostat=False):
             with a lot of files, but will reduce the chances of hanging.
 
             .. versionadded:: 3008.0
+        stat_timeout (float):
+            Maximum time in seconds to wait for lstat, to avoid hangs on
+            unreachable mounts. If the timeout is exceeded, ``False`` is
+            returned.
+
+            .. versionadded:: 3009.0
 
     Returns:
         bool: ``True`` if a symbolic link, otherwise returns ``False``.
@@ -3846,6 +3852,7 @@ def is_link(path, nostat=False):
     # therefore a custom function will need to be called. This function
     # therefore helps API consistency by providing a single function to call for
     # both operating systems.
+    path = os.path.expanduser(path)
     if nostat:
         parent_directory = os.path.dirname(path)
 
@@ -3855,10 +3862,23 @@ def is_link(path, nostat=False):
                     return item.is_symlink()
         return False
 
-    return os.path.islink(os.path.expanduser(path))
+    timeout_value = None
+    if stat_timeout is not None:
+        try:
+            timeout_value = max(0.0, float(stat_timeout))
+        except (TypeError, ValueError):
+            raise SaltInvocationError("stat_timeout must be a number")
+
+    if timeout_value is not None:
+        lst = salt.utils.files.safe_lstat(path, timeout=timeout_value)
+        return bool(lst) and stat.S_ISLNK(lst.st_mode)
+
+    return os.path.islink(path)
 
 
-def symlink(src, path, force=False, atomic=False, follow_symlinks=True):
+def symlink(
+    src, path, force=False, atomic=False, follow_symlinks=True, nostat=False, stat_timeout=None
+):
     """
     Create a symbolic link (symlink, soft link) to a file
 
@@ -3876,10 +3896,16 @@ def symlink(src, path, force=False, atomic=False, follow_symlinks=True):
             Use atomic file operations to create the symlink
             .. versionadded:: 3006.0
 
-        follow_symlinks (bool):
+    follow_symlinks (bool):
             If set to ``False``, use ``os.path.lexists()`` for existence checks
             instead of ``os.path.exists()``.
             .. versionadded:: 3007.0
+    nostat (bool):
+        Use parent directory scanning instead of lstat for symlink checks.
+        .. versionadded:: 3009.0
+    stat_timeout (float):
+        Maximum time in seconds to wait for lstat when checking symlinks.
+        .. versionadded:: 3009.0
 
     Returns:
         bool: ``True`` if successful, otherwise raises ``CommandExecutionError``
@@ -3900,7 +3926,8 @@ def symlink(src, path, force=False, atomic=False, follow_symlinks=True):
     if not os.path.isabs(path):
         raise SaltInvocationError(f"Link path must be absolute: {path}")
 
-    if os.path.islink(path):
+    is_link_path = is_link(path, nostat=nostat, stat_timeout=stat_timeout)
+    if is_link_path:
         try:
             if os.path.normpath(salt.utils.path.readlink(path)) == os.path.normpath(
                 src
@@ -3918,7 +3945,7 @@ def symlink(src, path, force=False, atomic=False, follow_symlinks=True):
         msg = f"Existing path is not a symlink: {path}"
         raise CommandExecutionError(msg)
 
-    if (os.path.islink(path) or exists(path)) and force and not atomic:
+    if (is_link_path or exists(path)) and force and not atomic:
         os.unlink(path)
     elif atomic:
         link_dir = os.path.dirname(path)

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -54,7 +54,7 @@ def format_payload(enc, **kwargs):
     return package(payload)
 
 
-def loads(msg, encoding=None, raw=False):
+def loads(msg, encoding=None, raw=False, log_error=True):
     """
     Run the correct loads serialization format
 
@@ -70,6 +70,7 @@ def loads(msg, encoding=None, raw=False):
                      been lost in this case) to what the encoding is
                      set as. In this case, it will fail if any of
                      the contents cannot be converted.
+    :param log_error: Log deserialization failures when True.
     """
     try:
 
@@ -97,14 +98,15 @@ def loads(msg, encoding=None, raw=False):
         if encoding is None and not raw:
             ret = salt.transport.frame.decode_embedded_strs(ret)
     except Exception as exc:  # pylint: disable=broad-except
-        log.critical(
-            "Could not deserialize msgpack message. This often happens "
-            "when trying to read a file not in binary mode. "
-            "To see message payload, enable debug logging and retry. "
-            "Exception: %s",
-            exc,
-        )
-        log.debug("Msgpack deserialization failure on message: %s", msg)
+        if log_error:
+            log.critical(
+                "Could not deserialize msgpack message. This often happens "
+                "when trying to read a file not in binary mode. "
+                "To see message payload, enable debug logging and retry. "
+                "Exception: %s",
+                salt.utils.msgpack.format_exception(exc),
+            )
+            log.debug("Msgpack deserialization failure on message: %s", msg)
         exc_msg = "Could not deserialize msgpack message. See log for more info."
         raise SaltDeserializationError(exc_msg) from exc
     finally:
@@ -200,14 +202,20 @@ def dumps(msg, use_bin_type=False):
         )
 
 
-def load(fn_):
+def load(fn_, raise_on_error=True):
     """
     Run the correct serialization to load a file
     """
     data = fn_.read()
     fn_.close()
-    if data:
-        return loads(data, encoding="utf-8")
+    if not data:
+        return None
+    try:
+        return loads(data, encoding="utf-8", log_error=raise_on_error)
+    except SaltDeserializationError:
+        if raise_on_error:
+            raise
+        return None
 
 
 def dump(msg, fn_):

--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -142,11 +142,14 @@ def render(template, saltenv="base", sls="", tmplpath=None, **kws):
     if not os.path.isfile(template):
         raise SaltRenderError(f"Template {template} is not a file!")
 
+    # Ensure python templates get a __salt__ object that supports dot notation
+    # consistently (including under salt-ssh wrappers).
+    salt_funcs = salt.utils.templates.wrap_salt_funcs(__salt__)
     tmp_data = salt.utils.templates.py(
         template,
         True,
-        __salt__=__salt__,
-        salt=__salt__,
+        __salt__=salt_funcs,
+        salt=salt_funcs,
         __grains__=__grains__,
         grains=__grains__,
         __opts__=__opts__,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1197,21 +1197,37 @@ def _set_symlink_ownership(path, user, group, win_owner):
     return _check_symlink_ownership(path, user, group, win_owner)
 
 
-def _symlink_check(name, target, force, user, group, win_owner, follow_symlinks=False):
+def _is_link(path, nostat=False, stat_timeout=None):
+    return __salt__["file.is_link"](
+        path, nostat=nostat, stat_timeout=stat_timeout
+    )
+
+
+def _symlink_check(
+    name,
+    target,
+    force,
+    user,
+    group,
+    win_owner,
+    follow_symlinks=False,
+    nostat=False,
+    stat_timeout=None,
+):
     """
     Check the symlink function
     """
     changes = {}
     exists = os.path.exists if follow_symlinks else os.path.lexists
 
-    if not exists(name) and not __salt__["file.is_link"](name):
+    if not exists(name) and not _is_link(name, nostat=nostat, stat_timeout=stat_timeout):
         changes["new"] = name
         return (
             None,
             f"Symlink {name} to {target} is set for creation",
             changes,
         )
-    if __salt__["file.is_link"](name):
+    if _is_link(name, nostat=nostat, stat_timeout=stat_timeout):
         if __salt__["file.readlink"](name) != target:
             changes["change"] = name
             return (
@@ -1792,6 +1808,8 @@ def symlink(
     disallow_copy_and_unlink=False,
     inherit_user_and_group=False,
     follow_symlinks=True,
+    nostat=False,
+    stat_timeout=None,
     **kwargs,
 ):
     """
@@ -1904,6 +1922,10 @@ def symlink(
         existence checks instead of ``os.path.exists()``.
 
         .. versionadded:: 3007.0
+    nostat (bool):
+        Use parent directory scanning instead of lstat when checking symlinks.
+    stat_timeout (float):
+        Maximum time in seconds to wait for lstat when checking symlinks.
 
     .. code-block:: yaml
 
@@ -1931,7 +1953,7 @@ def symlink(
     if (
         inherit_user_and_group
         and (user is None or group is None)
-        and __salt__["file.is_link"](name)
+        and _is_link(name, nostat=nostat, stat_timeout=stat_timeout)
     ):
         cur_user, cur_group = _get_symlink_ownership(name)
         if user is None:
@@ -2018,7 +2040,15 @@ def symlink(
         return _error(ret, msg)
 
     tresult, tcomment, tchanges = _symlink_check(
-        name, target, force, user, group, win_owner, follow_symlinks
+        name,
+        target,
+        force,
+        user,
+        group,
+        win_owner,
+        follow_symlinks,
+        nostat=nostat,
+        stat_timeout=stat_timeout,
     )
 
     if not os.path.isdir(os.path.dirname(name)):
@@ -2058,7 +2088,7 @@ def symlink(
         ret["changes"] = tchanges
         return ret
 
-    if __salt__["file.is_link"](name):
+    if _is_link(name, nostat=nostat, stat_timeout=stat_timeout):
         # The link exists, verify that it matches the target
         if os.path.normpath(__salt__["file.readlink"](name)) != os.path.normpath(
             target
@@ -2160,7 +2190,13 @@ def symlink(
 
     try:
         __salt__["file.symlink"](
-            target, name, force=force, atomic=atomic, follow_symlinks=follow_symlinks
+            target,
+            name,
+            force=force,
+            atomic=atomic,
+            follow_symlinks=follow_symlinks,
+            nostat=nostat,
+            stat_timeout=stat_timeout,
         )
     except (CommandExecutionError, OSError) as exc:
         ret["result"] = False
@@ -4027,6 +4063,8 @@ def directory(
     force=False,
     backupname=None,
     allow_symlink=True,
+    nostat=False,
+    stat_timeout=None,
     children_only=False,
     win_owner=None,
     win_perms=None,
@@ -4171,6 +4209,12 @@ def directory(
         argument.
 
         .. versionadded:: 2014.7.0
+
+    nostat
+        Use parent directory scanning instead of lstat when checking symlinks.
+
+    stat_timeout
+        Maximum time in seconds to wait for lstat when checking symlinks.
 
     children_only
         If children_only is True the base of a path is excluded when performing
@@ -4426,11 +4470,10 @@ def directory(
     if not os.path.isabs(name):
         return _error(ret, f"Specified file {name} is not an absolute path")
 
+    link_present = _is_link(name, nostat=nostat, stat_timeout=stat_timeout)
     # Check for existing file or symlink
-    if (
-        os.path.isfile(name)
-        or (not allow_symlink and os.path.islink(name))
-        or (force and os.path.islink(name))
+    if os.path.isfile(name) or (not allow_symlink and link_present) or (
+        force and link_present
     ):
         # Was a backupname specified
         if backupname is not None:
@@ -4466,7 +4509,7 @@ def directory(
                 else:
                     os.remove(name)
                     ret["changes"]["forced"] = "File was forcibly replaced"
-            elif __salt__["file.is_link"](name):
+            elif _is_link(name, nostat=nostat, stat_timeout=stat_timeout):
                 if __opts__["test"]:
                     ret["changes"]["forced"] = "Symlink would be forcibly replaced"
                 else:
@@ -4481,7 +4524,7 @@ def directory(
         else:
             if os.path.isfile(name):
                 return _error(ret, f"Specified location {name} exists and is a file")
-            elif os.path.islink(name):
+            elif link_present:
                 return _error(ret, f"Specified location {name} exists and is a symlink")
 
     # Check directory?

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import stat
 import subprocess
+import threading
 import tempfile
 import time
 import urllib.parse
@@ -688,6 +689,47 @@ def remove(path):
     except OSError as exc:
         if exc.errno != errno.ENOENT:
             raise
+
+
+def safe_lstat(path, timeout=None, follow_symlinks=False):
+    """
+    Perform a stat/lstat with an optional timeout.
+
+    Returns the stat result on success, or ``None`` on error/timeout.
+    """
+    try:
+        timeout_value = float(timeout) if timeout is not None else None
+    except (TypeError, ValueError):
+        timeout_value = None
+
+    result = {}
+
+    def _stat_call():
+        try:
+            if follow_symlinks:
+                result["stat"] = os.stat(path)
+            else:
+                result["stat"] = os.lstat(path)
+        except OSError as exc:
+            result["error"] = exc
+
+    if timeout_value is None:
+        _stat_call()
+        return result.get("stat")
+
+    thread = threading.Thread(
+        target=_stat_call, name="salt.utils.files.safe_lstat", daemon=True
+    )
+    thread.start()
+    thread.join(timeout_value)
+
+    if thread.is_alive():
+        log.warning("Timed out waiting for stat on %s after %ss", path, timeout_value)
+        return None
+    if "error" in result:
+        log.debug("safe_lstat failed for %s: %s", path, result["error"])
+        return None
+    return result.get("stat")
 
 
 @jinja_filter("list_files")

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -45,6 +45,29 @@ else:
 
     exceptions = _exceptions()
 
+
+def is_extra_data_exception(exc):
+    """
+    Return True if the exception is a msgpack ExtraData error.
+    """
+    extra_data = getattr(exceptions, "ExtraData", None)
+    return extra_data is not None and isinstance(exc, extra_data)
+
+
+def format_exception(exc):
+    """
+    Return a helpful string for msgpack exceptions.
+    """
+    if is_extra_data_exception(exc):
+        extra = getattr(exc, "extra", None)
+        try:
+            extra_len = len(extra) if extra is not None else None
+        except TypeError:
+            extra_len = None
+        if extra_len is not None:
+            return f"{exc} (extra {extra_len} bytes)"
+    return str(exc)
+
 # One-to-one mappings
 Packer = msgpack.Packer
 ExtType = msgpack.ExtType

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -86,6 +86,69 @@ class AliasedModule:
         return getattr(self.wrapped, name)
 
 
+class SaltModuleProxy:
+    """
+    Resolve module.function access against a salt functions mapping.
+    """
+
+    __slots__ = ("mod", "funcs")
+
+    def __init__(self, mod, funcs):
+        self.mod = mod
+        self.funcs = funcs
+
+    def __getattr__(self, name):
+        try:
+            return self.funcs[f"{self.mod}.{name}"]
+        except KeyError:
+            raise AttributeError(
+                f"No attribute by the name of {name} was found on {self.mod}"
+            )
+
+    def __repr__(self):
+        return f"<SaltModuleProxy module='{self.mod}'>"
+
+
+class SaltFuncsProxy:
+    """
+    Provide dot-notation access to __salt__ for python templates.
+    """
+
+    __slots__ = ("funcs",)
+
+    def __init__(self, funcs):
+        self.funcs = funcs
+
+    def __getitem__(self, name):
+        return self.funcs[name]
+
+    def __contains__(self, name):
+        return name in self.funcs
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return SaltModuleProxy(name, self.funcs)
+
+    def __repr__(self):
+        return f"<SaltFuncsProxy funcs={self.funcs!r}>"
+
+
+def resolve_named_context(value):
+    if isinstance(value, NamedLoaderContext):
+        return value.value()
+    return value
+
+
+def wrap_salt_funcs(value):
+    value = resolve_named_context(value)
+    if value is None:
+        return value
+    if getattr(value.__class__, "__getattr__", None):
+        return value
+    return SaltFuncsProxy(value)
+
+
 def generate_sls_context(tmplpath, sls):
     """
     Generate SLS/Template Context Items
@@ -677,6 +740,16 @@ def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
     sys.modules[name] = mod
 
     # File templates need these set as __var__
+    for key in ("grains", "pillar", "opts", "__grains__", "__pillar__", "__opts__"):
+        if key in kwargs:
+            kwargs[key] = resolve_named_context(kwargs[key])
+
+    if "salt" in kwargs:
+        wrapped_salt = wrap_salt_funcs(kwargs["salt"])
+        kwargs["salt"] = wrapped_salt
+        if "__salt__" in kwargs:
+            kwargs["__salt__"] = wrapped_salt
+
     if "__env__" not in kwargs and "saltenv" in kwargs:
         setattr(mod, "__env__", kwargs["saltenv"])
         builtins = ["salt", "grains", "pillar", "opts"]

--- a/tests/pytests/unit/client/test_functionwrapper.py
+++ b/tests/pytests/unit/client/test_functionwrapper.py
@@ -1,0 +1,29 @@
+import salt.client
+from tests.support.mock import patch
+
+
+class DummyLocalClient:
+    def __init__(self):
+        self.calls = []
+
+    def cmd(self, minion, fun, args=None, **kwargs):
+        self.calls.append((minion, fun, args))
+        if fun == "sys.list_functions":
+            return {minion: ["cp.get_file_str"]}
+        if fun == "cp.get_file_str":
+            return {minion: "payload"}
+        return {minion: None}
+
+
+def test_functionwrapper_dot_notation_executes_module_call():
+    dummy = DummyLocalClient()
+    with patch("salt.client.LocalClient", return_value=dummy):
+        wrapper = salt.client.FunctionWrapper(
+            {"conf_file": "/etc/salt/master"}, "minion-id"
+        )
+
+    result = wrapper.cp.get_file_str("salt://foo")
+
+    assert result == {"minion-id": "payload"}
+    assert dummy.calls[-1][1] == "cp.get_file_str"
+

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -15,6 +15,7 @@ import salt.config
 import salt.exceptions
 import salt.loader
 import salt.loader.lazy
+import salt.utils.msgpack
 from tests.support.mock import MagicMock, patch
 
 
@@ -55,6 +56,18 @@ def test_custom_grain_with_annotations(minion_opts, grains_dir):
     minion_opts["grains_dirs"] = [grains_dir]
     grains = salt.loader.grains(minion_opts, force_refresh=True)
     assert grains.get("example") == "42"
+
+
+def test_load_cached_grains_invalid_msgpack(tmp_path):
+    cfn = tmp_path / "grains.cache.p"
+    payload = salt.utils.msgpack.dumps({"os": "Darwin"})
+    cfn.write_bytes(payload + payload)
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["grains_cache_expiration"] = 300
+    opts["refresh_grains_cache"] = False
+    ret = salt.loader._load_cached_grains(opts, str(cfn))
+    assert ret is None
+    assert not cfn.exists()
 
 
 def test_raw_mod_functions():

--- a/tests/pytests/unit/renderers/test_py.py
+++ b/tests/pytests/unit/renderers/test_py.py
@@ -1,0 +1,44 @@
+import textwrap
+
+import pytest
+
+import salt.renderers.py as py
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        py: {
+            "__salt__": {
+                "cp.get_file_str": lambda path, saltenv="base": f"contents:{path}"
+            },
+            "__grains__": {},
+            "__pillar__": {},
+            "__opts__": {"renderer": "py"},
+        }
+    }
+
+
+def test_py_renderer_supports_salt_dot_notation(tmp_path):
+    sls_path = tmp_path / "cp_fail.sls"
+    sls_path.write_text(
+        textwrap.dedent(
+            """\
+            #!py
+
+            def run():
+                return {"ret": __salt__.cp.get_file_str("salt://cp_fail.sls")}
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    rendered = py.render(
+        str(sls_path),
+        saltenv="base",
+        sls="cp_fail",
+        tmplpath=str(sls_path),
+    )
+
+    assert rendered == {"ret": "contents:salt://cp_fail.sls"}
+

--- a/tests/pytests/unit/test_payload.py
+++ b/tests/pytests/unit/test_payload.py
@@ -4,10 +4,12 @@
 """
 
 import copy
+import io
 import datetime
 import logging
 from collections import OrderedDict
 
+import pytest
 import zmq
 
 import salt.exceptions
@@ -234,6 +236,20 @@ def test_format_payload():
     kwargs = {"foo": "bar"}
     payload = salt.payload.format_payload(enc=enc, kwargs=kwargs)
     assert payload == expected
+
+
+def test_load_returns_none_on_deserialization_error():
+    bad = salt.utils.msgpack.dumps({"a": 1}) + salt.utils.msgpack.dumps({"b": 2})
+    fp_ = io.BytesIO(bad)
+    ret = salt.payload.load(fp_, raise_on_error=False)
+    assert ret is None
+
+
+def test_load_raises_on_deserialization_error():
+    bad = salt.utils.msgpack.dumps({"a": 1}) + salt.utils.msgpack.dumps({"b": 2})
+    fp_ = io.BytesIO(bad)
+    with pytest.raises(salt.exceptions.SaltDeserializationError):
+        salt.payload.load(fp_)
 
 
 def test_SREQ_init():


### PR DESCRIPTION
### What does this PR do?
Adds a hung-mount-safe safe_lstat() helper and updates file.is_link, file.symlink, and related file states to support nostat/stat_timeout so symlink checks don’t hang on stalled mounts.

### What issues does this PR fix or reference?
Fixes #66096

### Previous Behavior
file.is_link could hang indefinitely on unreachable/hung NFS mounts due to lstat, and the file states always used that path.

### New Behavior
Symlink checks can avoid lstat or time out safely; file states propagate nostat/stat_timeout to prevent hangs.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
