### PR TITLE
Fix winrepo-version

### DIFF
--- a/salt/modules/winrepo.py
+++ b/salt/modules/winrepo.py
@@ -17,6 +17,7 @@ import salt.utils.functools
 import salt.utils.gitfs
 import salt.utils.path
 import salt.utils.platform
+import salt.utils.data
 from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt.runners.winrepo import genrepo as _genrepo
 from salt.runners.winrepo import update_git_repos as _update_git_repos
@@ -43,6 +44,16 @@ def __virtual__():
     return (False, "This module only works on Windows.")
 
 
+def _normalize_versions_arg(value):
+    """
+    Normalize the normalize_versions argument for winrepo functions.
+    """
+    normalized = salt.utils.data.is_true(value)
+    if value not in (True, False) and str(value).lower() not in ("0", "false", "no", "off"):
+        log.debug("normalize_versions set to %s; coerced to %s", value, normalized)
+    return normalized
+
+
 def _get_local_repo_dir(saltenv="base"):
     winrepo_source_dir = __opts__["winrepo_source_dir"]
     dirs = []
@@ -53,9 +64,13 @@ def _get_local_repo_dir(saltenv="base"):
     return os.sep.join(dirs)
 
 
-def genrepo():
+def genrepo(normalize_versions=True):
     r"""
     Generate winrepo_cachefile based on sls files in the winrepo_dir
+
+    Args:
+        normalize_versions (bool):
+            Normalize numeric version keys to preserve trailing zeros when possible.
 
     CLI Example:
 
@@ -63,7 +78,10 @@ def genrepo():
 
         salt-call winrepo.genrepo
     """
-    return _genrepo(opts=__opts__, fire_event=False)
+    normalize_versions = _normalize_versions_arg(normalize_versions)
+    return _genrepo(
+        opts=__opts__, fire_event=False, normalize_versions=normalize_versions
+    )
 
 
 def update_git_repos(clean=False):

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -8,6 +8,7 @@ Runner to manage Windows software repo
 
 import logging
 import os
+import re
 
 import salt.loader
 import salt.minion
@@ -29,6 +30,45 @@ PER_REMOTE_OVERRIDES = ("ssl_verify", "refspecs", "fallback", "proxy")
 # runners and other modules that import salt.runners.winrepo.
 PER_REMOTE_ONLY = salt.utils.gitfs.PER_REMOTE_ONLY
 GLOBAL_ONLY = ("branch",)
+_VERSION_FIELDS = (
+    "full_name",
+    "installer",
+    "installer64",
+    "uninstaller",
+    "uninstaller64",
+    "msiexec",
+)
+_VERSION_PATTERN = re.compile(r"\d+(?:\.\d+)+")
+
+
+def _normalize_version_key(version, repodata):
+    """
+    Normalize a version key, preserving trailing zeros when possible.
+    """
+    if isinstance(version, str):
+        return version
+    if not isinstance(repodata, dict):
+        return str(version)
+    if isinstance(version, float):
+        candidates = []
+        for field in _VERSION_FIELDS:
+            value = repodata.get(field)
+            if not value:
+                continue
+            for match in _VERSION_PATTERN.findall(str(value)):
+                try:
+                    if float(match) == float(version):
+                        candidates.append(match)
+                except ValueError:
+                    continue
+        if candidates:
+            candidates = sorted(
+                set(candidates),
+                key=lambda item: (item.count("."), len(item)),
+                reverse=True,
+            )
+            return candidates[0]
+    return str(version)
 
 
 def _legacy_git():
@@ -37,7 +77,7 @@ def _legacy_git():
     )
 
 
-def genrepo(opts=None, fire_event=True):
+def genrepo(opts=None, fire_event=True, normalize_versions=True):
     """
     Generate winrepo_cachefile based on sls files in the winrepo_dir
 
@@ -83,16 +123,12 @@ def genrepo(opts=None, fire_event=True):
                     revmap = {}
                     for pkgname, versions in config.items():
                         log.debug("Compiling winrepo data for package '%s'", pkgname)
-                        for version, repodata in versions.items():
+                        for version, repodata in list(versions.items()):
                             log.debug(
                                 "Compiling winrepo data for %s version %s",
                                 pkgname,
                                 version,
                             )
-                            if not isinstance(version, str):
-                                config[pkgname][str(version)] = config[pkgname].pop(
-                                    version
-                                )
                             if not isinstance(repodata, dict):
                                 msg = "Failed to compile {}.".format(
                                     os.path.join(root, name)
@@ -111,6 +147,25 @@ def genrepo(opts=None, fire_event=True):
                                             msg,
                                         )
                                 continue
+                            if not isinstance(version, str) and normalize_versions:
+                                normalized = _normalize_version_key(version, repodata)
+                                if normalized != version:
+                                    if normalized in config[pkgname]:
+                                        log.warning(
+                                            "Duplicate winrepo version key '%s' for %s",
+                                            normalized,
+                                            pkgname,
+                                        )
+                                        config[pkgname].pop(version)
+                                    else:
+                                        config[pkgname][normalized] = config[pkgname].pop(
+                                            version
+                                        )
+                                    version = normalized
+                            elif not isinstance(version, str):
+                                config[pkgname][str(version)] = config[pkgname].pop(
+                                    version
+                                )
                             revmap[repodata["full_name"]] = pkgname
                     ret.setdefault("repo", {}).update(config)
                     ret.setdefault("name_map", {}).update(revmap)

--- a/salt/states/winrepo.py
+++ b/salt/states/winrepo.py
@@ -3,6 +3,7 @@ Manage Windows Package Repository
 """
 
 import itertools
+import logging
 
 # Python Libs
 import os
@@ -13,20 +14,25 @@ import salt.config
 # Salt Modules
 import salt.runner
 import salt.syspaths
+import salt.utils.data
 import salt.utils.path
 
 
+log = logging.getLogger(__name__)
 def __virtual__():
     return "winrepo"
 
 
-def genrepo(name, force=False, allow_empty=False):
+def genrepo(name, force=False, allow_empty=False, normalize_versions=True):
     """
     Refresh the winrepo.p file of the repository (salt-run winrepo.genrepo)
 
     If ``force`` is ``True`` no checks will be made and the repository will be
     generated if ``allow_empty`` is ``True`` then the state will not return an
     error if there are 0 packages,
+
+    normalize_versions
+        Normalize numeric version keys to preserve trailing zeros when possible.
 
     .. note::
 
@@ -85,7 +91,12 @@ def genrepo(name, force=False, allow_empty=False):
         return ret
 
     runner = salt.runner.RunnerClient(master_config)
-    runner_ret = runner.cmd("winrepo.genrepo", [])
+    normalize_versions = salt.utils.data.is_true(normalize_versions)
+    if not normalize_versions:
+        log.debug("winrepo.genrepo called with normalize_versions disabled")
+    runner_ret = runner.cmd(
+        "winrepo.genrepo", [], kwarg={"normalize_versions": normalize_versions}
+    )
     ret["changes"] = {"winrepo": runner_ret}
     if isinstance(runner_ret, dict) and runner_ret == {} and not allow_empty:
         os.remove(winrepo_cachefile)

--- a/tests/pytests/unit/runners/test_winrepo.py
+++ b/tests/pytests/unit/runners/test_winrepo.py
@@ -38,6 +38,16 @@ def winrepo_sls():
           msiexec: False
           locale: en_US
           reboot: False
+    salt_minion_py3:
+      3007.10:
+          full_name: 'Salt Minion 3007.10 (Py3)'
+          installer: 'https://packages.example.invalid/windows/3007.10/Salt-Minion-3007.10-Py3-AMD64-Setup.exe'
+          install_flags: '/S'
+          uninstaller: '%PROGRAMFILES%\\Salt Project\\Salt Minion\\uninst.exe'
+          uninstall_flags: '/S'
+          msiexec: False
+          locale: en_US
+          reboot: False
     """
     )
     return _winrepo_sls
@@ -46,7 +56,11 @@ def winrepo_sls():
 @pytest.fixture
 def winrepo_genrepo_data():
     _winrepo_genrepo_data = {
-        "name_map": {"WinSCP 5.7.4": "winscp_x86", "WinSCP 5.7.5": "winscp_x86"},
+        "name_map": {
+            "WinSCP 5.7.4": "winscp_x86",
+            "WinSCP 5.7.5": "winscp_x86",
+            "Salt Minion 3007.10 (Py3)": "salt_minion_py3",
+        },
         "repo": {
             "winscp_x86": {
                 "5.7.5": {
@@ -69,7 +83,19 @@ def winrepo_genrepo_data():
                     "locale": "en_US",
                     "reboot": False,
                 },
-            }
+            },
+            "salt_minion_py3": {
+                "3007.10": {
+                    "full_name": "Salt Minion 3007.10 (Py3)",
+                    "installer": "https://packages.example.invalid/windows/3007.10/Salt-Minion-3007.10-Py3-AMD64-Setup.exe",
+                    "install_flags": "/S",
+                    "uninstaller": "%PROGRAMFILES%\\Salt Project\\Salt Minion\\uninst.exe",
+                    "uninstall_flags": "/S",
+                    "msiexec": False,
+                    "locale": "en_US",
+                    "reboot": False,
+                },
+            },
         },
     }
     return _winrepo_genrepo_data


### PR DESCRIPTION
### What does this PR do?
Normalize winrepo version keys during winrepo.genrepo so trailing‑zero versions like 3007.10 are preserved and propagated through module/state calls; adds a unit test covering this case.

### What issues does this PR fix or reference?
Fixes #68620 

### Previous Behavior
Numeric YAML version keys like 3007.10 could be loaded as floats and normalized to 3007.1, leading to incorrect package selection/downloads.

### New Behavior
Version keys are normalized using repo metadata to preserve the intended string form (e.g., 3007.10), preventing unintended downgrades.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
