### PR TITLE
fix(systemd_service): raise exception when no systemd-run found

### DIFF
--- a/changelog/68720.fixed.md
+++ b/changelog/68720.fixed.md
@@ -1,0 +1,5 @@
+Raise exception if systemd-run is not found when scope is enabled
+
+Instead of returning None when the systemd-run command is not found
+— which causes the command to fail with an unclear error —
+an exception is now raised, helping to identify the real issue.

--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -320,7 +320,14 @@ def _systemctl_cmd(action, name=None, systemd_scope=False, no_block=False, root=
         and salt.utils.systemd.has_scope(__context__)
         and __salt__["config.get"]("systemd.scope", True)
     ):
-        ret.extend([salt.utils.path.which("systemd-run"), "--scope"])
+        if systemd_run_path := salt.utils.path.which("systemd-run"):
+            ret.extend([systemd_run_path, "--scope"])
+        else:
+            raise CommandExecutionError(
+                "systemd-run is required for running systemctl with --scope, but it was not found on the system. "
+                "Make sure systemd-run is installed and in the system's PATH "
+                "or disable it using the 'systemd.scope' config option."
+            )
     ret.append(salt.utils.path.which("systemctl"))
     if no_block:
         ret.append("--no-block")

--- a/tests/pytests/unit/modules/test_systemd_service.py
+++ b/tests/pytests/unit/modules/test_systemd_service.py
@@ -2,6 +2,7 @@ import pytest
 
 import salt.modules.systemd_service as systemd_service
 import salt.utils.systemd
+from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
 
 pytestmark = [
@@ -111,3 +112,52 @@ def test_operation_no_block_default(operation, expected_command, grains):
             ],
             python_shell=False,
         )
+
+
+def test_systemctl_cmd_with_scope_and_systemd_run_found():
+    """
+    Test _systemctl_cmd includes systemd-run --scope when systemd_scope is True
+    and systemd-run is available.
+    """
+    has_scope_mock = MagicMock(return_value=True)
+    config_mock = MagicMock(return_value=True)
+    which_mock = MagicMock(side_effect=lambda x: "/usr/bin/" + x)
+
+    with patch.object(salt.utils.systemd, "has_scope", has_scope_mock):
+        with patch.dict(systemd_service.__salt__, {"config.get": config_mock}):
+            with patch("salt.utils.path.which", which_mock):
+                ret = systemd_service._systemctl_cmd(
+                    "status", "sshd", systemd_scope=True
+                )
+                assert ret == [
+                    "/usr/bin/systemd-run",
+                    "--scope",
+                    "/usr/bin/systemctl",
+                    "status",
+                    "sshd.service",
+                    "-n",
+                    "0",
+                ]
+
+
+def test_systemctl_cmd_with_scope_and_systemd_run_not_found():
+    """
+    Test _systemctl_cmd raises CommandExecutionError when systemd_scope is True
+    but systemd-run is not found on the system.
+    """
+    has_scope_mock = MagicMock(return_value=True)
+    config_mock = MagicMock(return_value=True)
+
+    def which_side_effect(cmd):
+        if cmd == "systemd-run":
+            return None
+        return "/usr/bin/" + cmd
+
+    with patch.object(salt.utils.systemd, "has_scope", has_scope_mock):
+        with patch.dict(systemd_service.__salt__, {"config.get": config_mock}):
+            with patch("salt.utils.path.which", which_side_effect):
+                with pytest.raises(
+                    CommandExecutionError,
+                    match="systemd-run is required.*but it was not found.*",
+                ):
+                    systemd_service._systemctl_cmd("status", "sshd", systemd_scope=True)


### PR DESCRIPTION
If the command is marked to be run with `--scope` but no `systemd-run` is found, then through and exception instead of returning `None`.

### What does this PR do?

### What issues does this PR fix or reference?

Instead of returning `None` when the `systemd-run` command is not found — which causes the command to fail with an unclear error — an exception is now raised, helping to identify the real issue.

### Previous Behavior

The previous error message obscured the underlying error, making it difficult to identify the root cause of the failure.

```
An exception occurred in this state: 'NoneType' object has no attribute 'strip'
Traceback (most recent call last):
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/state.py", line 2471, in call
    ret = self.states[cdata["full"]](
        *cdata["args"], **cdata["kwargs"]
    )
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 175, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1365, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1380, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1416, in wrapper
    return f(*args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/states/service.py", line 1065, in mod_watch
    __salt__["service.stop"](name)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 175, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1365, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1380, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/modules/systemd_service.py", line 911, in stop
    __salt__["cmd.run_all"](
    ~~~~~~~~~~~~~~~~~~~~~~~^
        _systemctl_cmd("stop", name, systemd_scope=True, no_block=no_block),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        python_shell=False,
        ^^^^^^^^^^^^^^^^^^^
    )["retcode"]
    ^
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 175, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1365, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/bdksxcaaa0chnm3jhx5z7232qk4bnvmf-salt-3007.11/lib/python3.13/site-packages/salt/loader/lazy.py", line 1380, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/var/cache/salt/minion/extmods/modules/cmdmod.py", line 2470, in run_all
    ret = _run(
        cmd,
    ...<26 lines>...
        **kwargs,
    )
  File "/var/cache/salt/minion/extmods/modules/cmdmod.py", line 461, in _run
    _log_cmd(cmd),
    ~~~~~~~~^^^^^
  File "/var/cache/salt/minion/extmods/modules/cmdmod.py", line 87, in _log_cmd
    return cmd[0].strip()
           ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'strip'
```

### New Behavior

The exception now includes a more descriptive message to help identify the underlying issue:

```
systemd-run is required for running systemctl with --scope, but it was not found on the system. Make sure systemd-run is installed and in the system's PATH or disable it using the 'systemd.scope' config option.
```

### Merge requirements satisfied?

- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?

Yes
