### PR TITLE
Fix tornado escape

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -232,6 +232,17 @@ if any of the watched states changes.
 In the example above, ``cmd.run`` will run only if there are changes in the
 ``file.managed`` state.
 
+.. note::
+
+    When multiple state declarations share the same ID, ``onchanges`` still
+    resolves by the referenced state type and name. If a requisite resolves
+    back to the same state (self-reference), Salt ignores it to avoid
+    recursive requisites and logs a warning. Use distinct IDs if you need to
+    make ordering explicit or if name-based matching is ambiguous. If you
+    prefer ID-based matching, use the ``id`` requisite key explicitly to
+    avoid ambiguity between IDs and names. Running ``state.show_lowstate``
+    can help verify how a requisite resolves during compilation.
+
 An easy mistake to make is using ``onchanges_in`` when ``onchanges`` is the
 correct choice, as seen in this next example.
 

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -21,21 +21,39 @@ set -e
 case "$1" in
   configure)
     . /usr/share/debconf/confmodule
+    # Honor debconf user, and fall back to configured user in /etc/salt/master.
     if db_get salt-master/user; then
-      if [ "$RET" != "root" ]; then
-        if [ ! -e "/var/log/salt/master" ]; then
-          touch /var/log/salt/master
-          chmod 640 /var/log/salt/master
-        fi
-        if [ ! -e "/var/log/salt/key" ]; then
-          touch /var/log/salt/key
-          chmod 640 /var/log/salt/key
-        fi
-        chown -R $RET:$RET /etc/salt/pki/master /etc/salt/master.d \
-                           /var/log/salt/master /var/log/salt/key \
-                           /var/cache/salt/master /var/run/salt/master \
-                           || true
+        DB_USER="$RET"
+    else
+        DB_USER=""
+    fi
+    CFG_USER=""
+    if [ -r /etc/salt/master ]; then
+        CFG_USER="$(sed -n -E 's/^[[:space:]]*user:[[:space:]]*([^#[:space:]]+).*/\1/p' /etc/salt/master | head -n 1)"
+    fi
+    if [ -n "$CFG_USER" ] && [ "$DB_USER" = "salt" ]; then
+        DB_USER="$CFG_USER"
+        db_set salt-master/user "$DB_USER" || true
+    fi
+    db_fset salt-master/user seen true || true
+
+    if [ -n "$DB_USER" ] && [ "$DB_USER" != "root" ]; then
+      DB_GROUP="$(id -gn "$DB_USER" 2>/dev/null || true)"
+      if [ -z "$DB_GROUP" ]; then
+          DB_GROUP="$DB_USER"
       fi
+      if [ ! -e "/var/log/salt/master" ]; then
+        touch /var/log/salt/master
+        chmod 640 /var/log/salt/master
+      fi
+      if [ ! -e "/var/log/salt/key" ]; then
+        touch /var/log/salt/key
+        chmod 640 /var/log/salt/key
+      fi
+      chown -R $DB_USER:$DB_GROUP /etc/salt/pki/master /etc/salt/master.d \
+                         /var/log/salt/master /var/log/salt/key \
+                         /var/cache/salt/master /var/run/salt/master \
+                         || true
     fi
   ;;
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/pkg/debian/salt-master.preinst
+++ b/pkg/debian/salt-master.preinst
@@ -24,16 +24,56 @@ case "$1" in
 
   upgrade)
     . /usr/share/debconf/confmodule
+    # Determine the service user/group to preserve across upgrades.
+    # Precedence:
+    #   1) Existing debconf selection (if any)
+    #   2) Configured user in /etc/salt/master (if any)
+    #   3) Owner of current pidfile (if available)
+    #   4) Package default ($SALT_USER/$SALT_GROUP)
+
+    if db_get salt-master/user; then
+        DB_USER="$RET"
+    else
+        DB_USER=""
+    fi
+
+    CFG_USER=""
+    if [ -r /etc/salt/master ]; then
+        CFG_USER="$(sed -n -E 's/^[[:space:]]*user:[[:space:]]*([^#[:space:]]+).*/\1/p' /etc/salt/master | head -n 1)"
+    fi
+
     if [ -f /run/salt-master.pid ]
     then
         CUR_USER=$(ls -dl /run/salt-master.pid | cut -d ' ' -f 3)
         CUR_GROUP=$(ls -dl /run/salt-master.pid | cut -d ' ' -f 4)
     else
-        CUR_USER=$SALT_USER
-        CUR_GROUP=$SALT_GROUP
+        CUR_USER=""
+        CUR_GROUP=""
     fi
-    db_set salt-master/user $CUR_USER
-    chown -R $CUR_USER:$CUR_GROUP /etc/salt/pki/master /etc/salt/master.d \
+
+    # Preserve explicitly configured user if present
+    if [ -n "$DB_USER" ] && [ "$DB_USER" != "salt" ]; then
+        CHOSEN_USER="$DB_USER"
+    elif [ -n "$CFG_USER" ]; then
+        CHOSEN_USER="$CFG_USER"
+    elif [ -n "$CUR_USER" ]; then
+        CHOSEN_USER="$CUR_USER"
+    else
+        CHOSEN_USER="$SALT_USER"
+    fi
+
+    # Default group to the user's primary group if possible
+    CHOSEN_GROUP="$(id -gn "$CHOSEN_USER" 2>/dev/null || true)"
+    if [ -z "$CHOSEN_GROUP" ]; then
+        CHOSEN_GROUP="$CUR_GROUP"
+    fi
+    if [ -z "$CHOSEN_GROUP" ]; then
+        CHOSEN_GROUP="$SALT_GROUP"
+    fi
+
+    db_set salt-master/user "$CHOSEN_USER" || true
+    db_fset salt-master/user seen true || true
+    chown -R $CHOSEN_USER:$CHOSEN_GROUP /etc/salt/pki/master /etc/salt/master.d \
                                   /var/log/salt/master /var/log/salt/key \
                                   /var/cache/salt/master /var/run/salt/master \
                                   || true

--- a/pkg/debian/salt-minion.postinst
+++ b/pkg/debian/salt-minion.postinst
@@ -21,22 +21,39 @@ set -e
 case "$1" in
   configure)
     . /usr/share/debconf/confmodule
-    if db_get salt-minion/user
-    then
-      if [ "$RET" != "root" ]; then
-        if [ ! -e "/var/log/salt/minion" ]; then
-          touch /var/log/salt/minion
-          chmod 640 /var/log/salt/minion
-        fi
-        if [ ! -e "/var/log/salt/key" ]; then
-          touch /var/log/salt/key
-          chmod 640 /var/log/salt/key
-        fi
-        chown -R $RET:$RET /etc/salt/pki/minion /etc/salt/minion.d \
-                           /var/log/salt/minion /var/cache/salt/minion \
-                           /var/run/salt/minion \
-                           || true
+    # Honor debconf user, and fall back to configured user in /etc/salt/minion.
+    if db_get salt-minion/user; then
+      DB_USER="$RET"
+    else
+      DB_USER=""
+    fi
+    CFG_USER=""
+    if [ -r /etc/salt/minion ]; then
+        CFG_USER="$(sed -n -E 's/^[[:space:]]*user:[[:space:]]*([^#[:space:]]+).*/\1/p' /etc/salt/minion | head -n 1)"
+    fi
+    if [ -n "$CFG_USER" ] && [ "$DB_USER" = "salt" ]; then
+        DB_USER="$CFG_USER"
+        db_set salt-minion/user "$DB_USER" || true
+    fi
+    db_fset salt-minion/user seen true || true
+
+    if [ -n "$DB_USER" ] && [ "$DB_USER" != "root" ]; then
+      DB_GROUP="$(id -gn "$DB_USER" 2>/dev/null || true)"
+      if [ -z "$DB_GROUP" ]; then
+          DB_GROUP="$DB_USER"
       fi
+      if [ ! -e "/var/log/salt/minion" ]; then
+        touch /var/log/salt/minion
+        chmod 640 /var/log/salt/minion
+      fi
+      if [ ! -e "/var/log/salt/key" ]; then
+        touch /var/log/salt/key
+        chmod 640 /var/log/salt/key
+      fi
+      chown -R $DB_USER:$DB_GROUP /etc/salt/pki/minion /etc/salt/minion.d \
+                         /var/log/salt/minion /var/cache/salt/minion \
+                         /var/run/salt/minion \
+                         || true
     fi
   ;;
 

--- a/pkg/debian/salt-minion.preinst
+++ b/pkg/debian/salt-minion.preinst
@@ -26,17 +26,57 @@ case "$1" in
     . /usr/share/debconf/confmodule
     PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush();")
 
+    # Determine the service user/group to preserve across upgrades.
+    # Precedence:
+    #   1) Existing debconf selection (if any)
+    #   2) Configured user in /etc/salt/minion (if any)
+    #   3) Owner of current pidfile (if available)
+    #   4) Package default ($SALT_USER/$SALT_GROUP)
+
+    if db_get salt-minion/user; then
+        DB_USER="$RET"
+    else
+        DB_USER=""
+    fi
+
+    CFG_USER=""
+    if [ -r /etc/salt/minion ]; then
+        CFG_USER="$(sed -n -E 's/^[[:space:]]*user:[[:space:]]*([^#[:space:]]+).*/\1/p' /etc/salt/minion | head -n 1)"
+    fi
+
     # Reset permissions to fix previous installs
     if [ -f /run/salt-minion.pid ]
     then
         CUR_USER=$(ls -dl /run/salt-minion.pid | cut -d ' ' -f 3)
         CUR_GROUP=$(ls -dl /run/salt-minion.pid | cut -d ' ' -f 4)
     else
-        CUR_USER=$SALT_USER
-        CUR_GROUP=$SALT_GROUP
+        CUR_USER=""
+        CUR_GROUP=""
     fi
-    db_set salt-minion/user $CUR_USER
-    chown -R $CUR_USER:$CUR_GROUP /etc/salt/pki/minion /etc/salt/minion.d \
+
+    # Preserve explicitly configured user if present
+    if [ -n "$DB_USER" ] && [ "$DB_USER" != "salt" ]; then
+        CHOSEN_USER="$DB_USER"
+    elif [ -n "$CFG_USER" ]; then
+        CHOSEN_USER="$CFG_USER"
+    elif [ -n "$CUR_USER" ]; then
+        CHOSEN_USER="$CUR_USER"
+    else
+        CHOSEN_USER="$SALT_USER"
+    fi
+
+    # Default group to the user's primary group if possible
+    CHOSEN_GROUP="$(id -gn "$CHOSEN_USER" 2>/dev/null || true)"
+    if [ -z "$CHOSEN_GROUP" ]; then
+        CHOSEN_GROUP="$CUR_GROUP"
+    fi
+    if [ -z "$CHOSEN_GROUP" ]; then
+        CHOSEN_GROUP="$SALT_GROUP"
+    fi
+
+    db_set salt-minion/user "$CHOSEN_USER" || true
+    db_fset salt-minion/user seen true || true
+    chown -R $CHOSEN_USER:$CHOSEN_GROUP /etc/salt/pki/minion /etc/salt/minion.d \
                                   /var/log/salt/minion /var/cache/salt/minion \
                                   /var/run/salt/minion \
                                   || true

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -255,7 +255,26 @@ class FunctionWrapper(MutableMapping):
                 **self.kwargs,
             )
             stdout, stderr, retcode = single.cmd_block()
-            return parse_ret(stdout, stderr, retcode, result_only=True)
+            try:
+                return parse_ret(stdout, stderr, retcode, result_only=True)
+            except SSHCommandExecutionError as exc:
+                # Provide a more actionable error message for a common salt-ssh
+                # failure mode in bundled (onedir) environments.
+                if cmd == "pkg.version" and "is not available" in (exc.stderr or ""):
+                    hint = (
+                        "\n\nHint: On salt-ssh with bundled (onedir) Python, "
+                        "OS package backends can fail to load if optional system "
+                        "bindings are missing. Salt provides a fallback for "
+                        "read-only package queries to keep `pkg.version` "
+                        "available during template rendering."
+                    )
+                    raise SSHCommandExecutionError(
+                        stdout=exc.stdout,
+                        stderr=(exc.stderr or "") + hint,
+                        retcode=exc.retcode,
+                        parsed=exc.parsed,
+                    ) from exc
+                raise
 
         return caller
 

--- a/salt/ext/tornado/util.py
+++ b/salt/ext/tornado/util.py
@@ -1,0 +1,21 @@
+"""
+Minimal Tornado util subset shipped with Salt.
+
+We keep a tiny ``re_unescape`` implementation here for bundled builds and to
+avoid SyntaxWarning on Python 3.12+ caused by invalid escape sequences in
+docstrings.
+"""
+
+import salt.utils.tornado as tornado_utils
+
+RE_UNESCAPE_PATTERN = tornado_utils.RE_UNESCAPE_PATTERN
+
+
+def re_unescape(value):
+    return tornado_utils.re_unescape(value)
+
+
+re_unescape.__doc__ = tornado_utils.RE_UNESCAPE_DOC
+
+__all__ = ["RE_UNESCAPE_PATTERN", "re_unescape"]
+

--- a/salt/master.py
+++ b/salt/master.py
@@ -1097,7 +1097,18 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
         if hasattr(self, "process_manager"):
             self.process_manager.stop_restarting()
             self.process_manager.send_signal_to_processes(signum)
-            self.process_manager.kill_children()
+            try:
+                # During shutdown, Process.join() can trigger imports inside
+                # multiprocessing which may fail if stdlib modules are partially
+                # initialized due to signal re-entrancy (see #68573).
+                self.process_manager.kill_children(safe_join=True)
+            except ImportError:
+                # Be conservative and avoid failing shutdown. The process manager
+                # will fall back to non-blocking exitcode polling where needed.
+                log.debug(
+                    "Ignoring ImportError while reaping ReqServer processes",
+                    exc_info=True,
+                )
 
     # pylint: disable=W1701
     def __del__(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1244,7 +1244,16 @@ class MinionManager(MinionBase):
             minion.process_manager.stop_restarting()
             minion.process_manager.send_signal_to_processes(signum)
             # kill any remaining processes
-            minion.process_manager.kill_children()
+            try:
+                # Avoid propagating rare shutdown ImportErrors coming from the
+                # multiprocessing join/wait path (see #68573).
+                minion.process_manager.kill_children(safe_join=True)
+            except ImportError:
+                # Do not block shutdown; best-effort cleanup is acceptable here.
+                log.debug(
+                    "Ignoring ImportError while reaping MinionManager processes",
+                    exc_info=True,
+                )
             minion.destroy()
         if self.event_publisher is not None:
             self.event_publisher.close()

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -57,7 +57,7 @@ if salt.utils.platform.is_windows():
 
     import salt.platform.win
     from salt.utils.win_functions import escape_argument as _cmd_quote
-    from salt.utils.win_runas import runas as win_runas
+    import salt.utils.win_runas as win_runas
 
     HAS_WIN_RUNAS = True
 else:
@@ -788,7 +788,7 @@ def _run(
                 if change_windows_codepage:
                     salt.utils.win_chcp.set_codepage_id(windows_codepage)
                 try:
-                    proc = win_runas(cmd, runas, password, **new_kwargs)
+                    proc = win_runas.runas(cmd, runas, password, **new_kwargs)
                 except (OSError, pywintypes.error) as exc:
                     msg = "Unable to run command '{}' with the context '{}', reason: {}".format(
                         cmd if output_loglevel is not None else "REDACTED",
@@ -3023,16 +3023,21 @@ def script(
 
     win_cwd = False
     if salt.utils.platform.is_windows() and runas:
-        # Let's make sure the user exists first
-        if not __salt__["user.info"](runas):
+        # Resolve the user for domain/UPN support before creating the temp dir
+        try:
+            resolved_runas = win_runas.resolve_logon_credentials(runas)
+        except CommandExecutionError as exc:
             msg = f"Invalid user: {runas}"
-            raise CommandExecutionError(msg)
+            raise CommandExecutionError(msg) from exc
+
         if cwd is None:
             # Create a temp working directory
             cwd = tempfile.mkdtemp(dir=__opts__["cachedir"])
             win_cwd = True
             salt.utils.win_dacl.set_permissions(
-                obj_name=cwd, principal=runas, permissions="full_control"
+                obj_name=cwd,
+                principal=resolved_runas.get("sam_name") or runas,
+                permissions="full_control",
             )
 
     (_, ext) = os.path.splitext(salt.utils.url.split_env(source)[0])

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -230,6 +230,39 @@ def _render_filenames(path, dest, saltenv, template, **kw):
     return (path, dest)
 
 
+def _normalize_template_context_overrides(context):
+    """
+    Normalize a user-supplied template context without adding missing keys.
+    """
+    normalized = dict(context)
+    for key in ("salt", "opts", "grains", "pillar"):
+        if key not in normalized:
+            continue
+        value = normalized.get(key)
+        if isinstance(value, NamedLoaderContext):
+            value = value.value()
+        if value is None:
+            value = {}
+        normalized[key] = value
+    return normalized
+
+
+def _prepare_template_kwargs(kwargs):
+    """
+    Ensure template rendering kwargs include the standard context keys.
+    """
+    prepared = {} if not kwargs else dict(kwargs)
+    prepared.setdefault("salt", __salt__)
+    prepared.setdefault("pillar", __pillar__)
+    prepared.setdefault("grains", __grains__)
+    prepared.setdefault("opts", __opts__)
+    prepared = salt.utils.templates.normalize_render_context(prepared)
+    context = prepared.get("context")
+    if isinstance(context, dict):
+        prepared["context"] = _normalize_template_context_overrides(context)
+    return prepared
+
+
 def get_file(
     path, dest, saltenv=None, makedirs=False, template=None, gzip=None, **kwargs
 ):
@@ -329,14 +362,7 @@ def get_template(path, dest, template="jinja", saltenv=None, makedirs=False, **k
     if not saltenv:
         saltenv = __opts__["saltenv"] or "base"
 
-    if "salt" not in kwargs:
-        kwargs["salt"] = __salt__
-    if "pillar" not in kwargs:
-        kwargs["pillar"] = __pillar__
-    if "grains" not in kwargs:
-        kwargs["grains"] = __grains__
-    if "opts" not in kwargs:
-        kwargs["opts"] = __opts__
+    kwargs = _prepare_template_kwargs(kwargs)
     with _client() as client:
         return client.get_template(path, dest, template, makedirs, saltenv, **kwargs)
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1616,6 +1616,7 @@ def list_all_versions(
     include_alpha=False,
     include_beta=False,
     include_rc=False,
+    pre_releases=False,
     user=None,
     cwd=None,
     index_url=None,
@@ -1644,6 +1645,12 @@ def list_all_versions(
     include_rc
         Include release candidates versions in the list
 
+    pre_releases
+        Include all pre-release versions (alpha, beta, and release candidates)
+        in the list. When set to True, this overrides individual
+        ``include_alpha``, ``include_beta``, and ``include_rc`` settings.
+        .. versionadded:: 3007.2
+
     user
         The user under which to run pip
 
@@ -1666,6 +1673,12 @@ def list_all_versions(
     """
     cwd = _pip_bin_env(cwd, bin_env)
     cmd = _get_pip_bin(bin_env)
+
+    # If pre_releases is True, include all pre-release types
+    if pre_releases:
+        include_alpha = True
+        include_beta = True
+        include_rc = True
 
     # Is the `pip index` command available
     pip_version = version(bin_env=bin_env, cwd=cwd, user=user)

--- a/salt/modules/pkg.py
+++ b/salt/modules/pkg.py
@@ -1,0 +1,147 @@
+"""
+Generic package functions for salt-ssh in bundled (onedir) environments.
+
+This module exists as a **fallback** for salt-ssh runs where the normal OS
+package provider (for example, ``yumpkg``) cannot be loaded because optional
+system bindings are missing from the bundled Python environment. A common
+symptom is:
+
+    ``'pkg.version' is not available.``
+
+The aim is not to fully replace native providers, but to ensure that simple
+read-only functions used during Jinja/state rendering (like ``pkg.version``)
+remain available under salt-ssh.
+"""
+
+import fnmatch
+import logging
+
+import salt.utils.data
+import salt.utils.path
+import salt.utils.pkg
+import salt.utils.stringutils
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = "pkg"
+
+
+def __virtual__():
+    """
+    Only load as a fallback for salt-ssh when running from a bundled (onedir)
+    Python where the normal provider cannot load.
+    """
+    # Be conservative: this module should not replace native providers on
+    # regular minions.
+    if __opts__.get("file_client", "remote") != "local":
+        return (False, "pkg fallback only loads for file_client=local (salt-ssh)")
+
+    if not salt.utils.pkg.check_bundled():
+        return (False, "pkg fallback only loads in bundled (onedir) environments")
+
+    # If system bindings are available, allow the native provider to load.
+    if not salt.utils.pkg.onedir_missing_pkg_bindings():
+        return (False, "native pkg provider bindings are available")
+
+    return __virtualname__
+
+
+def _parse_rpm_qa(output):
+    """
+    Parse ``rpm -qa`` output which is formatted as ``name<TAB>version``.
+    """
+    pkgs = {}
+    for line in salt.utils.stringutils.to_str(output).splitlines():
+        if not line.strip():
+            continue
+        try:
+            name, ver = line.split("\t", 1)
+        except ValueError:
+            continue
+        pkgs.setdefault(name, []).append(ver)
+    return pkgs
+
+
+def _parse_dpkg_query(output):
+    """
+    Parse ``dpkg-query`` output which is formatted as ``name<TAB>version``.
+    """
+    pkgs = {}
+    for line in salt.utils.stringutils.to_str(output).splitlines():
+        if not line.strip():
+            continue
+        try:
+            name, ver = line.split("\t", 1)
+        except ValueError:
+            continue
+        pkgs.setdefault(name, []).append(ver)
+    return pkgs
+
+
+def list_pkgs(versions_as_list=False, **kwargs):
+    """
+    List installed packages using system package manager CLI tools.
+
+    This is a limited implementation intended for salt-ssh Jinja/state rendering.
+    """
+    __salt__["cmd.retcode"]  # make sure cmd module is available
+    versions_as_list = salt.utils.data.is_true(versions_as_list)
+
+    if salt.utils.path.which("rpm"):
+        out = __salt__["cmd.run_stdout"](
+            ["rpm", "-qa", "--qf", r"%{NAME}\t%{VERSION}-%{RELEASE}\n"],
+            python_shell=False,
+            ignore_retcode=False,
+        )
+        pkgs = _parse_rpm_qa(out)
+    elif salt.utils.path.which("dpkg-query"):
+        out = __salt__["cmd.run_stdout"](
+            ["dpkg-query", "-W", "-f=${Package}\t${Version}\n"],
+            python_shell=False,
+            ignore_retcode=False,
+        )
+        pkgs = _parse_dpkg_query(out)
+    else:
+        raise CommandExecutionError(
+            "No supported package query command found (rpm or dpkg-query)"
+        )
+
+    if not versions_as_list:
+        # Reduce lists to the first version string, aligning with typical pkg providers
+        for name, vers in list(pkgs.items()):
+            pkgs[name] = vers[0] if vers else ""
+    return pkgs
+
+
+def version(*names, **kwargs):
+    """
+    Return installed version(s) for the named package(s).
+
+    Matches the common ``pkg.version`` behavior: for one name, returns a string;
+    for multiple names, returns a dict.
+    """
+    versions_as_list = salt.utils.data.is_true(kwargs.pop("versions_as_list", False))
+    pkgs = list_pkgs(versions_as_list=True, **kwargs)
+
+    ret = {}
+    pkg_glob = False
+    for name in names:
+        if "*" in name:
+            pkg_glob = True
+            for match in fnmatch.filter(pkgs, name):
+                ret[match] = pkgs.get(match, [])
+        else:
+            ret[name] = pkgs.get(name, [])
+
+    if not versions_as_list:
+        for k in list(ret):
+            v = ret[k]
+            ret[k] = v[0] if v else ""
+
+    if len(ret) == 1 and not pkg_glob:
+        return next(iter(ret.values()), "")
+    return ret
+
+

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -14,6 +14,20 @@ from salt.loader.context import NamedLoaderContext
 log = logging.getLogger(__name__)
 
 
+def _resolve_salt_context():
+    """
+    Resolve __salt__ to a dict for template rendering when loader context is missing.
+    """
+    funcs = __salt__
+    if isinstance(__salt__, NamedLoaderContext):
+        resolved = __salt__.value()
+        if isinstance(resolved, dict):
+            funcs = resolved
+        elif resolved is None:
+            funcs = {}
+    return funcs
+
+
 def _split_module_dicts():
     """
     Create a copy of __salt__ dictionary with module.function and module[function]
@@ -24,9 +38,7 @@ def _split_module_dicts():
 
         {{ salt.cmd.run('uptime') }}
     """
-    funcs = __salt__
-    if isinstance(__salt__, NamedLoaderContext) and isinstance(__salt__.value(), dict):
-        funcs = __salt__.value()
+    funcs = _resolve_salt_context()
     if not isinstance(funcs, dict):
         return funcs
     mod_dict = dict(funcs)

--- a/salt/state.py
+++ b/salt/state.py
@@ -2686,6 +2686,7 @@ class State:
         """
         reqs = {}
         pending = False
+        prereq_run_dict = self.pre
         for req_type, chunk in self.dependency_dag.get_dependencies(low):
             reqs.setdefault(req_type, []).append(chunk)
         fun_stats = set()
@@ -2701,6 +2702,14 @@ class State:
             for chunk in chunks:
                 tag = _gen_tag(chunk)
                 run_dict_chunk = run_dict.get(tag)
+                if (
+                    run_dict_chunk is None
+                    and r_type_base == RequisiteType.ONCHANGES.value
+                    and chunk.get("__prereq__")
+                ):
+                    # If the requisite only ran in prereq (test) mode, use that
+                    # result for onchanges to avoid recursive unmet requisites.
+                    run_dict_chunk = prereq_run_dict.get(tag)
                 if run_dict_chunk:
                     filtered_run_dict[tag] = run_dict_chunk
             run_dict = filtered_run_dict

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -238,6 +238,7 @@ def _check_if_installed(
     index_url,
     extra_index_url,
     pip_list=False,
+    pre_releases=False,
     **kwargs,
 ):
     """
@@ -281,23 +282,32 @@ def _check_if_installed(
                 return ret
         if force_reinstall is False and upgrade:
             # Check desired version (if any) against currently-installed
-            include_alpha = False
-            include_beta = False
-            include_rc = False
-            if any(version_spec):
-                for spec in version_spec:
-                    if "a" in spec[1]:
-                        include_alpha = True
-                    if "b" in spec[1]:
-                        include_beta = True
-                    if "rc" in spec[1]:
-                        include_rc = True
+            # If pre_releases is True, include all pre-release types
+            if pre_releases:
+                include_alpha = True
+                include_beta = True
+                include_rc = True
+            else:
+                include_alpha = False
+                include_beta = False
+                include_rc = False
+                # Only check version spec for pre-release indicators if pre_releases is False
+                if any(version_spec):
+                    for spec in version_spec:
+                        if "a" in spec[1]:
+                            include_alpha = True
+                        if "b" in spec[1]:
+                            include_beta = True
+                        if "rc" in spec[1]:
+                            include_rc = True
+            # Use pre_releases parameter for cleaner API when available
             available_versions = __salt__["pip.list_all_versions"](
                 prefix,
                 bin_env=bin_env,
-                include_alpha=include_alpha,
-                include_beta=include_beta,
-                include_rc=include_rc,
+                pre_releases=pre_releases,
+                include_alpha=include_alpha if not pre_releases else True,
+                include_beta=include_beta if not pre_releases else True,
+                include_rc=include_rc if not pre_releases else True,
                 user=user,
                 cwd=cwd,
                 index_url=index_url,
@@ -320,7 +330,19 @@ def _check_if_installed(
                     "requirements".format(prefix)
                 )
                 return ret
-            if _pep440_version_cmp(pip_list[prefix], desired_version) == 0:
+            # Compare installed version with desired version
+            # When pre_releases=True, desired_version may include pre-releases
+            version_cmp = _pep440_version_cmp(pip_list[prefix], desired_version)
+            if version_cmp == 0:
+                # Installed version matches desired version exactly
+                ret["result"] = True
+                ret["comment"] = "Python package {} was already installed".format(
+                    state_pkg_name
+                )
+                return ret
+            elif version_cmp == 1:
+                # Installed version is newer than desired version
+                # This can happen with pre-releases - keep the newer installed version
                 ret["result"] = True
                 ret["comment"] = "Python package {} was already installed".format(
                     state_pkg_name
@@ -554,7 +576,9 @@ def installed(
         Current working directory to run pip from
 
     pre_releases
-        Include pre-releases in the available versions
+        Include pre-releases in the available versions. When used with
+        ``upgrade=True``, this allows upgrading to pre-release versions even
+        if they are not explicitly specified in the version requirements.
 
     cert
         Provide a path to an alternate CA bundle
@@ -889,6 +913,7 @@ def installed(
                     index_url,
                     extra_index_url,
                     pip_list,
+                    pre_releases=pre_releases,
                     **kwargs,
                 )
                 # If _check_if_installed result is None, something went wrong with

--- a/salt/utils/pkg/__init__.py
+++ b/salt/utils/pkg/__init__.py
@@ -16,6 +16,35 @@ import salt.utils.versions
 log = logging.getLogger(__name__)
 
 
+def onedir_missing_pkg_bindings():
+    """
+    Return True when running from a bundled (onedir) Python which is missing
+    common OS package-manager Python bindings.
+
+    This is primarily used to decide when to enable salt-ssh fallbacks which can
+    query package versions via CLI tools (rpm/dpkg) instead of Python bindings.
+    """
+    if not check_bundled():
+        return False
+
+    # These imports are optional and may not exist in onedir builds.
+    try:
+        import rpm  # pylint: disable=import-error,unused-import
+
+        return False
+    except ImportError:
+        pass
+
+    try:
+        import apt_pkg  # pylint: disable=import-error,unused-import
+
+        return False
+    except ImportError:
+        pass
+
+    return True
+
+
 def rtag(opts):
     """
     Return the rtag file location. This file is used to ensure that we don't

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -672,6 +672,57 @@ class ProcessManager:
                     log.trace("Process restart of %s", pid)
                     self.restart_process(pid)
 
+    def _proc_is_alive(self, proc):
+        """
+        Best-effort, non-blocking liveness check for a multiprocessing Process.
+
+        During interpreter shutdown and/or signal handling, calling into
+        multiprocessing internals can raise unexpected exceptions. We prefer a
+        conservative approach here to keep shutdown paths robust.
+        """
+        try:
+            return proc.is_alive()
+        except Exception:  # pylint: disable=broad-except
+            # If we cannot determine liveness, assume it's still alive so we
+            # don't prematurely remove it from our internal map.
+            return True
+
+    def _safe_join(self, proc, timeout=0):
+        """
+        Attempt to join a multiprocessing Process without propagating teardown errors.
+
+        Python can import stdlib modules during Process.join(). In rare shutdown
+        re-entrancy scenarios this can raise ImportError (see #68573). Treat such
+        failures as non-fatal and fall back to exitcode-based reaping.
+        """
+        try:
+            proc.join(timeout)
+            return True
+        except ImportError as exc:
+            log.debug("Ignoring ImportError from Process.join(): %s", exc, exc_info=True)
+            return False
+        except Exception:  # pylint: disable=broad-except
+            log.debug("Ignoring unexpected exception from Process.join()", exc_info=True)
+            return False
+
+    def _reap_children_nonblocking(self):
+        """
+        Reap any dead children without calling Process.join().
+
+        Accessing ``exitcode`` will poll the underlying Popen object without
+        importing ``multiprocessing.connection.wait``.
+        """
+        for pid, p_map in self._process_map.copy().items():
+            proc = p_map.get("Process")
+            if proc is None:
+                continue
+            try:
+                if proc.exitcode is not None:
+                    del self._process_map[pid]
+            except Exception:  # pylint: disable=broad-except
+                # Keep process in map if we can't determine exit status.
+                continue
+
     def kill_children(self, *args, **kwargs):
         """
         Kill all of the children
@@ -716,15 +767,25 @@ class ProcessManager:
                         # Race condition
                         pass
 
+        safe_join = kwargs.pop("safe_join", True)
         end_time = time.time() + self.wait_for_kill  # when to die
 
         log.trace("Waiting to kill process manager children")
         while self._process_map and time.time() < end_time:
             for pid, p_map in self._process_map.copy().items():
                 log.trace("Joining pid %s: %s", pid, p_map["Process"])
-                p_map["Process"].join(0)
+                proc = p_map.get("Process")
+                if proc is None:
+                    continue
+                joined = False
+                if safe_join:
+                    joined = self._safe_join(proc, 0)
+                if not joined:
+                    # Fall back to non-blocking exitcode poll. This avoids
+                    # stdlib import side-effects during teardown.
+                    self._reap_children_nonblocking()
 
-                if not p_map["Process"].is_alive():
+                if not self._proc_is_alive(proc):
                     # The process is no longer alive, remove it from the process map dictionary
                     try:
                         del self._process_map[pid]

--- a/salt/utils/requisite.py
+++ b/salt/utils/requisite.py
@@ -237,6 +237,26 @@ class DependencyGraph:
             node_dict["NAME"] = chunk["name"]
         return str(node_dict)
 
+    def _filter_self_reqs(
+        self,
+        node_tag: str,
+        req_tags: Iterable[str],
+        req_type: RequisiteType,
+        low: LowChunk,
+        req_key: str,
+        req_val: str,
+    ) -> set[str]:
+        filtered = {tag for tag in req_tags if tag != node_tag}
+        if len(filtered) != len(req_tags):
+            log.warning(
+                "Ignoring %s requisite on %s that points to itself (%s: %s)",
+                req_type.value,
+                self._chunk_str(low),
+                req_key,
+                req_val,
+            )
+        return filtered
+
     def add_chunk(self, low: LowChunk, allow_aggregate: bool) -> None:
         node_id = _gen_tag(low)
         self.dag.add_node(
@@ -269,12 +289,22 @@ class DependencyGraph:
                 for sls, req_tags in self.sls_to_nodes.items():
                     if fnmatch.fnmatch(sls, req_val):
                         found = True
-                        self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
+                        req_tags = self._filter_self_reqs(
+                            node_tag, req_tags, req_type, low, req_key, req_val
+                        )
+                        if req_tags:
+                            self._add_reqs(
+                                node_tag, has_prereq_node, req_type, req_tags
+                            )
             else:
                 node_tag = _gen_tag(low)
                 if req_tags := self.sls_to_nodes.get(req_val, []):
                     found = True
-                    self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
+                    req_tags = self._filter_self_reqs(
+                        node_tag, req_tags, req_type, low, req_key, req_val
+                    )
+                    if req_tags:
+                        self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
         elif self._is_fnmatch_pattern(req_val):
             # This iterates over every chunk to check
             # if any match instead of doing a look up since
@@ -283,11 +313,21 @@ class DependencyGraph:
             for (state_type, name_or_id), req_tags in self.nodes_lookup_map.items():
                 if req_key == state_type and (fnmatch.fnmatch(name_or_id, req_val)):
                     found = True
-                    self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
+                    req_tags = self._filter_self_reqs(
+                        node_tag, req_tags, req_type, low, req_key, req_val
+                    )
+                    if req_tags:
+                        self._add_reqs(
+                            node_tag, has_prereq_node, req_type, req_tags
+                        )
         elif req_tags := self.nodes_lookup_map.get((req_key, req_val)):
             found = True
             node_tag = _gen_tag(low)
-            self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
+            req_tags = self._filter_self_reqs(
+                node_tag, req_tags, req_type, low, req_key, req_val
+            )
+            if req_tags:
+                self._add_reqs(node_tag, has_prereq_node, req_type, req_tags)
         return found
 
     def add_requisites(self, low: LowChunk, disabled_reqs: Sequence[str]) -> str | None:

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -6,6 +6,7 @@ import base64
 import difflib
 import errno
 import fnmatch
+import inspect
 import logging
 import os
 import re
@@ -16,6 +17,21 @@ import unicodedata
 from salt.utils.decorators.jinja import jinja_filter
 
 log = logging.getLogger(__name__)
+
+
+def build_docstring(text):
+    """
+    Normalize a docstring payload for runtime assignment.
+
+    This helper lets callers avoid invalid escape sequence warnings on Python
+    3.12+ by assigning ``__doc__`` from a raw string instead of using a literal
+    function docstring with backslashes.
+    """
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        raise TypeError(f"expected str for docstring, got {type(text)}")
+    return inspect.cleandoc(text).strip("\n")
 
 
 @jinja_filter("to_bytes")

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -68,6 +68,14 @@ class AliasedLoader:
     def __contains__(self, name):
         return name in self.wrapped
 
+    def get(self, name, default=None):
+        """
+        Provide dict-like access for templates which call salt.get(...).
+        """
+        if self.wrapped is None:
+            return default
+        return self.wrapped.get(name, default)
+
 
 class AliasedModule:
     """
@@ -84,6 +92,27 @@ class AliasedModule:
 
     def __getattr__(self, name):
         return getattr(self.wrapped, name)
+
+
+def normalize_render_context(context, defaults=True):
+    """
+    Ensure common template context keys are present and dict-like.
+    """
+    if context is None:
+        return {}
+    if not isinstance(context, dict):
+        return context
+    normalized = dict(context)
+    for key in ("salt", "opts", "grains", "pillar"):
+        if not defaults and key not in normalized:
+            continue
+        value = normalized.get(key)
+        if isinstance(value, NamedLoaderContext):
+            value = value.value()
+        if value is None:
+            value = {}
+        normalized[key] = value
+    return normalized
 
 
 def generate_sls_context(tmplpath, sls):
@@ -169,14 +198,13 @@ def wrap_tmpl_func(render_str):
         if context is None:
             context = {}
 
-        # Alias cmd.run to cmd.shell to make python_shell=True the default for
-        # templated calls
-        if "salt" in kws:
-            kws["salt"] = AliasedLoader(kws["salt"])
-
         # We want explicit context to overwrite the **kws
         kws.update(context)
-        context = kws
+        context = normalize_render_context(kws)
+        # Alias cmd.run to cmd.shell to make python_shell=True the default for
+        # templated calls
+        if "salt" in context and not isinstance(context["salt"], AliasedLoader):
+            context["salt"] = AliasedLoader(context["salt"])
         assert "opts" in context
         assert "saltenv" in context
 
@@ -340,6 +368,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     :returns str: The string rendered by the template.
     """
+    context = normalize_render_context(context)
     opts = context["opts"]
     saltenv = context["saltenv"]
     loader = None
@@ -464,6 +493,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
                 )
                 decoded_context[key] = salt.utils.data.decode(value)
 
+        decoded_context = normalize_render_context(decoded_context)
         jinja_env.globals.update(decoded_context)
         try:
             template = jinja_env.from_string(tmplstr)

--- a/salt/utils/tornado.py
+++ b/salt/utils/tornado.py
@@ -1,0 +1,37 @@
+"""
+Helpers for Tornado compatibility in Salt.
+
+This module centralizes patterns and docstrings that would otherwise include
+backslashes (for example ``\d``), which can trigger SyntaxWarning in Python
+3.12+ if they appear in non-raw string literals.
+"""
+
+import re
+
+import salt.utils.stringutils
+
+RE_UNESCAPE_DOC = salt.utils.stringutils.build_docstring(
+    r"""
+    Unescape a string escaped by ``re.escape``.
+
+    May raise ``ValueError`` for regular expressions which could not have been
+    produced by ``re.escape`` (for example, strings containing ``\d`` cannot be
+    unescaped).
+    """
+)
+
+RE_UNESCAPE_PATTERN = re.compile(r"\\(.)")
+
+
+def _re_unescape_replacement(match):
+    return match.group(1)
+
+
+def re_unescape(value):
+    return RE_UNESCAPE_PATTERN.sub(_re_unescape_replacement, value)
+
+
+re_unescape.__doc__ = RE_UNESCAPE_DOC
+
+__all__ = ["RE_UNESCAPE_DOC", "RE_UNESCAPE_PATTERN", "re_unescape"]
+

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -210,6 +210,75 @@ def get_sam_name(username):
     return "\\".join([domain, username])
 
 
+def _candidate_account_names(username):
+    """
+    Build candidate account names to resolve, including UPN and DOMAIN/user forms.
+    """
+    if username is None:
+        return []
+
+    candidate_names = [str(username)]
+    name = candidate_names[0]
+
+    if "/" in name and "\\" not in name:
+        candidate_names.append(name.replace("/", "\\"))
+
+    if (
+        "@" in name
+        and hasattr(win32security, "TranslateName")
+        and hasattr(win32security, "NameUserPrincipal")
+        and hasattr(win32security, "NameSamCompatible")
+    ):
+        try:
+            candidate_names.append(
+                win32security.TranslateName(
+                    name,
+                    win32security.NameUserPrincipal,
+                    win32security.NameSamCompatible,
+                )
+            )
+        except pywintypes.error:
+            pass
+
+    # Preserve order but remove duplicates
+    return list(dict.fromkeys(candidate_names))
+
+
+def resolve_username(username):
+    """
+    Resolve a username into account details usable for validation and logon.
+
+    Returns a dict with account_name, domain, sid, sam_name, and lookup_name.
+    """
+    if not username:
+        raise CommandExecutionError("Username is required")
+
+    last_error = None
+    for candidate in _candidate_account_names(username):
+        try:
+            sid, domain, _ = win32security.LookupAccountName(None, candidate)
+            account_name, lookup_domain, _ = win32security.LookupAccountSid(None, sid)
+            resolved_domain = lookup_domain or domain
+            sam_name = (
+                f"{resolved_domain}\\{account_name}"
+                if resolved_domain
+                else account_name
+            )
+            return {
+                "account_name": account_name,
+                "domain": resolved_domain,
+                "sid": sid,
+                "sam_name": sam_name,
+                "lookup_name": candidate,
+            }
+        except pywintypes.error as exc:
+            last_error = exc
+            continue
+
+    detail = f": {last_error}" if last_error else ""
+    raise CommandExecutionError(f"User {username} not found{detail}")
+
+
 def enable_ctrl_logoff_handler():
     """
     Set the control handler on the console

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -32,6 +32,7 @@ try:
     import winerror
 
     import salt.platform.win
+    import salt.utils.win_functions
 
     HAS_WIN32 = True
 except ImportError:
@@ -78,7 +79,49 @@ def split_username(username):
     # Domain users with Down-Level Logon Name: DOMAIN\user
     if "\\" in user_name:
         domain, user_name = user_name.split("\\", maxsplit=1)
+    elif "/" in user_name:
+        domain, user_name = user_name.split("/", maxsplit=1)
     return str(user_name), str(domain)
+
+
+def resolve_logon_credentials(username):
+    """
+    Resolve a username into values suitable for Windows logon APIs.
+    """
+    if not isinstance(username, str):
+        username = str(username)
+
+    if not HAS_WIN32:
+        raise CommandExecutionError("win_runas requires pywin32 to resolve users")
+
+    resolved = salt.utils.win_functions.resolve_username(username)
+    sam_name = resolved.get("sam_name") or username
+    logon_name, logon_domain = split_username(sam_name)
+
+    return {
+        "input_name": username,
+        "account_name": resolved["account_name"],
+        "domain_name": resolved["domain"],
+        "sid": resolved["sid"],
+        "sam_name": sam_name,
+        "lookup_name": resolved["lookup_name"],
+        "logon_name": logon_name,
+        "logon_domain": logon_domain,
+    }
+
+
+def validate_username(username, raise_on_error=False):
+    """
+    Validate that a username can be resolved on the system.
+    """
+    try:
+        resolve_logon_credentials(username)
+    except CommandExecutionError as exc:
+        if raise_on_error:
+            raise
+        log.error("Invalid user '%s': %s", username, exc)
+        return False
+    return True
 
 
 def create_env(user_token, inherit, timeout=1):
@@ -169,17 +212,10 @@ def runas(cmd, username, password=None, **kwargs):
     Commands are run in with the highest level privileges possible for the
     account provided.
     """
-    # Sometimes this comes in as an int. LookupAccountName can't handle an int
-    # Let's make it a string if it's anything other than a string
-    if not isinstance(username, str):
-        username = str(username)
-    # Validate the domain and sid exist for the username
-    try:
-        _, domain, _ = win32security.LookupAccountName(None, username)
-        username, _ = split_username(username)
-    except pywintypes.error as exc:
-        message = win32api.FormatMessage(exc.winerror).rstrip("\n")
-        raise CommandExecutionError(message)
+    resolved = resolve_logon_credentials(username)
+    username = resolved["account_name"]
+    logon_name = resolved["logon_name"]
+    logon_domain = resolved["logon_domain"]
 
     # Elevate the token from the current process
     access = win32security.TOKEN_QUERY | win32security.TOKEN_ADJUST_PRIVILEGES
@@ -212,12 +248,12 @@ def runas(cmd, username, password=None, **kwargs):
         log.debug("No impersonation token, using unprivileged runas")
         return runas_unpriv(cmd, username, password, **kwargs)
 
-    if domain == "NT AUTHORITY":
+    if logon_domain == "NT AUTHORITY":
         # Logon as a system level account, SYSTEM, LOCAL SERVICE, or NETWORK
         # SERVICE.
         user_token = win32security.LogonUser(
-            username,
-            domain,
+            logon_name,
+            logon_domain,
             "",
             win32con.LOGON32_LOGON_SERVICE,
             win32con.LOGON32_PROVIDER_DEFAULT,
@@ -225,15 +261,15 @@ def runas(cmd, username, password=None, **kwargs):
     elif password:
         # Login with a password.
         user_token = win32security.LogonUser(
-            username,
-            domain,
+            logon_name,
+            logon_domain,
             password,
             win32con.LOGON32_LOGON_INTERACTIVE,
             win32con.LOGON32_PROVIDER_DEFAULT,
         )
     else:
         # Login without a password. This always returns an elevated token.
-        user_token = salt.platform.win.logon_msv1_s4u(username).Token
+        user_token = salt.platform.win.logon_msv1_s4u(logon_name).Token
 
     # Get a linked user token to elevate if needed
     elevation_type = win32security.GetTokenInformation(
@@ -370,17 +406,10 @@ def runas_unpriv(cmd, username, password, **kwargs):
     """
     Runas that works for non-privileged users
     """
-    # Sometimes this comes in as an int. LookupAccountName can't handle an int
-    # Let's make it a string if it's anything other than a string
-    if not isinstance(username, str):
-        username = str(username)
-    # Validate the domain and sid exist for the username
-    try:
-        _, domain, _ = win32security.LookupAccountName(None, username)
-        username, _ = split_username(username)
-    except pywintypes.error as exc:
-        message = win32api.FormatMessage(exc.winerror).rstrip("\n")
-        raise CommandExecutionError(message)
+    resolved = resolve_logon_credentials(username)
+    username = resolved["account_name"]
+    logon_name = resolved["logon_name"]
+    logon_domain = resolved["logon_domain"]
 
     # Create inheritable copy of the stdin
     stdin = salt.platform.win.kernel32.GetStdHandle(
@@ -445,8 +474,8 @@ def runas_unpriv(cmd, username, password, **kwargs):
     try:
         # Run command and return process info structure
         process_info = salt.platform.win.CreateProcessWithLogonW(
-            username=username,
-            domain=domain,
+            username=logon_name,
+            domain=logon_domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
             applicationname=None,

--- a/tests/pytests/functional/modules/state/requisites/test_onchanges.py
+++ b/tests/pytests/functional/modules/state/requisites/test_onchanges.py
@@ -1,6 +1,7 @@
 import pytest
 
 from . import normalize_ret
+from salt.state import _gen_tag
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
@@ -127,6 +128,49 @@ def test_onchanges_requisite(state, state_tree):
             ret['cmd_|-test_non_changing_state_|-echo "Should not run"_|-run'].comment
             == "State was not run because none of the onchanges reqs changed"
         )
+
+
+def test_onchanges_same_id_no_recursive_requisite(state, state_tree, tmp_path):
+    """
+    Ensure onchanges works when multiple states share the same ID.
+    """
+    target = tmp_path / "myservice.conf"
+    target_str = target.as_posix()
+    sls_contents = f"""
+    myservice:
+      file.managed:
+        - name: {target_str}
+        - source: salt://myservice.conf
+      test.succeed_with_changes:
+        - name: onchanges-run
+        - onchanges:
+          - file: {target_str}
+    """
+    with pytest.helpers.temp_file(
+        "requisite.sls", sls_contents, state_tree
+    ), pytest.helpers.temp_file("myservice.conf", "config\n", state_tree):
+        ret = state.sls("requisite")
+        assert not ret.failed
+
+        file_tag = _gen_tag(
+            {
+                "state": "file",
+                "__id__": "myservice",
+                "name": target_str,
+                "fun": "managed",
+            }
+        )
+        onchanges_tag = _gen_tag(
+            {
+                "state": "test",
+                "__id__": "myservice",
+                "name": "onchanges-run",
+                "fun": "succeed_with_changes",
+            }
+        )
+        assert ret[file_tag].changes
+        assert ret[onchanges_tag].changes
+        assert "Recursive requisite found" not in ret[onchanges_tag].comment
 
 
 def test_onchanges_requisite_multiple(state, state_tree):

--- a/tests/pytests/unit/modules/test_pkg_fallback.py
+++ b/tests/pytests/unit/modules/test_pkg_fallback.py
@@ -1,0 +1,54 @@
+import pytest
+
+import salt.modules.pkg as pkg
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {pkg: {"__opts__": {"file_client": "local"}, "__salt__": {}}}
+
+
+def test_virtual_only_loads_for_onedir_when_bindings_missing():
+    with patch("salt.utils.pkg.check_bundled", MagicMock(return_value=True)), patch(
+        "salt.utils.pkg.onedir_missing_pkg_bindings", MagicMock(return_value=True)
+    ):
+        ret = pkg.__virtual__()
+        assert ret == "pkg"
+
+
+def test_list_pkgs_rpm_parsing():
+    with patch("salt.utils.pkg.check_bundled", MagicMock(return_value=True)), patch(
+        "salt.utils.pkg.onedir_missing_pkg_bindings", MagicMock(return_value=True)
+    ), patch("salt.utils.path.which", MagicMock(side_effect=lambda x: x == "rpm")):
+        with patch.dict(
+            pkg.__salt__,
+            {
+                "cmd.retcode": MagicMock(return_value=0),
+                "cmd.run_stdout": MagicMock(
+                    return_value="salt\t3007.10-1\nsalt-minion\t3007.10-1\n"
+                ),
+            },
+        ):
+            ret = pkg.list_pkgs()
+            assert ret["salt"] == "3007.10-1"
+            assert ret["salt-minion"] == "3007.10-1"
+
+
+def test_version_multiple_names():
+    with patch("salt.utils.pkg.check_bundled", MagicMock(return_value=True)), patch(
+        "salt.utils.pkg.onedir_missing_pkg_bindings", MagicMock(return_value=True)
+    ), patch("salt.utils.path.which", MagicMock(side_effect=lambda x: x == "rpm")):
+        with patch.dict(
+            pkg.__salt__,
+            {
+                "cmd.retcode": MagicMock(return_value=0),
+                "cmd.run_stdout": MagicMock(
+                    return_value="salt\t3007.10-1\nsalt-ssh\t3007.10-1\n"
+                ),
+            },
+        ):
+            ret = pkg.version("salt", "salt-ssh")
+            assert ret == {"salt": "3007.10-1", "salt-ssh": "3007.10-1"}
+
+

--- a/tests/pytests/unit/states/test_pip.py
+++ b/tests/pytests/unit/states/test_pip.py
@@ -71,3 +71,96 @@ def test_issue_64169(caplog):
         # Confirm that the state continued to install the package as expected.
         # Only check the 'pkgs' parameter of pip.install
         assert mock_pip_install.call_args.kwargs["pkgs"] == pkg_to_install
+
+
+def test_pre_releases_upgrade_with_prerelease_available():
+    """
+    Test that pip.installed with upgrade=True and pre_releases=True
+    will upgrade to pre-release versions when available.
+    This test verifies the fix for issue #68525.
+    """
+    pkg_name = "test-package"
+    installed_version = "1.0.0"
+    available_prerelease = "1.0.1rc1"
+
+    mock_pip_list = MagicMock(
+        side_effect=[
+            {pkg_name: installed_version},  # Pre-cache pip list
+            {pkg_name: installed_version},  # Check if installed
+        ]
+    )
+    mock_pip_version = MagicMock(return_value="21.0.0")
+    mock_pip_list_all_versions = MagicMock(
+        return_value=["1.0.0", "1.0.1rc1", "1.0.1"]
+    )
+    mock_pip_install = MagicMock(return_value={"retcode": 0, "stdout": ""})
+
+    with patch.dict(
+        pip_state.__salt__,
+        {
+            "pip.list": mock_pip_list,
+            "pip.version": mock_pip_version,
+            "pip.list_all_versions": mock_pip_list_all_versions,
+            "pip.install": mock_pip_install,
+            "pip.normalize": pip_module.normalize,
+        },
+    ):
+        result = pip_state.installed(
+            name=pkg_name,
+            upgrade=True,
+            pre_releases=True,
+        )
+
+        # Verify that list_all_versions was called with pre_releases=True
+        # This ensures pre-releases are included in available versions
+        call_kwargs = mock_pip_list_all_versions.call_args.kwargs
+        assert call_kwargs.get("pre_releases") is True
+        assert call_kwargs.get("include_alpha") is True
+        assert call_kwargs.get("include_beta") is True
+        assert call_kwargs.get("include_rc") is True
+
+        # Verify that pip.install was called to upgrade the package
+        assert mock_pip_install.called
+        assert mock_pip_install.call_args.kwargs["upgrade"] is True
+        assert mock_pip_install.call_args.kwargs["pre_releases"] is True
+
+
+def test_pre_releases_upgrade_without_prerelease_flag():
+    """
+    Test that pip.installed with upgrade=True but pre_releases=False
+    does not include pre-releases in version checking.
+    """
+    pkg_name = "test-package"
+    installed_version = "1.0.0"
+
+    mock_pip_list = MagicMock(
+        side_effect=[
+            {pkg_name: installed_version},  # Pre-cache pip list
+            {pkg_name: installed_version},  # Check if installed
+        ]
+    )
+    mock_pip_version = MagicMock(return_value="21.0.0")
+    mock_pip_list_all_versions = MagicMock(
+        return_value=["1.0.0", "1.0.1rc1", "1.0.1"]
+    )
+    mock_pip_install = MagicMock(return_value={"retcode": 0, "stdout": ""})
+
+    with patch.dict(
+        pip_state.__salt__,
+        {
+            "pip.list": mock_pip_list,
+            "pip.version": mock_pip_version,
+            "pip.list_all_versions": mock_pip_list_all_versions,
+            "pip.install": mock_pip_install,
+            "pip.normalize": pip_module.normalize,
+        },
+    ):
+        result = pip_state.installed(
+            name=pkg_name,
+            upgrade=True,
+            pre_releases=False,
+        )
+
+        # Verify that list_all_versions was called with pre_releases=False
+        call_kwargs = mock_pip_list_all_versions.call_args.kwargs
+        assert call_kwargs.get("pre_releases") is False

--- a/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
+++ b/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
@@ -7,6 +7,8 @@ from pathlib import PurePath, PurePosixPath
 
 import pytest
 
+import salt.loader.context
+import salt.utils.templates
 from salt.utils.templates import wrap_tmpl_func, generate_sls_context
 from tests.support.mock import patch
 
@@ -59,6 +61,30 @@ def test_sls_context_no_call(tmp_path):
         wrapped = wrap_tmpl_func(render)
         res = wrapped(str(slsfile), context=context, tmplpath=str(slsfile))
         generate_sls_context.assert_not_called()
+
+
+def test_jinja_import_with_context_handles_empty_salt(tmp_path):
+    map_file = tmp_path / "map.jinja"
+    map_file.write_text(
+        "{%- set defaults = {'foo': salt.get('missing', 'bar')} -%}"
+    )
+    template = (
+        "{%- from 'map.jinja' import defaults with context -%}"
+        "{{ defaults['foo'] }}"
+    )
+    loader_context = salt.loader.context.LoaderContext()
+    named_salt = loader_context.named_context("__salt__")
+    result = salt.utils.templates.JINJA(
+        template,
+        from_str=True,
+        to_str=True,
+        salt=named_salt,
+        opts={"cachedir": str(tmp_path)},
+        saltenv=None,
+        tmplpath=str(tmp_path / "file.j2"),
+    )
+    assert result["result"] is True
+    assert result["data"] == "bar"
 
 
 def test_generate_sls_context__top_level():

--- a/tests/pytests/unit/utils/test_tornado_utils.py
+++ b/tests/pytests/unit/utils/test_tornado_utils.py
@@ -1,0 +1,11 @@
+import salt.utils.tornado as tornado_utils
+
+
+def test_re_unescape_basic():
+    assert tornado_utils.re_unescape(r"\.") == "."
+    assert tornado_utils.re_unescape(r"\d") == "d"
+
+
+def test_re_unescape_docstring_includes_backslash():
+    assert "``\\d``" in tornado_utils.RE_UNESCAPE_DOC
+

--- a/tests/pytests/unit/utils/test_win_runas.py
+++ b/tests/pytests/unit/utils/test_win_runas.py
@@ -9,6 +9,7 @@ from salt.utils import win_runas
         ("test_user", ("test_user", ".")),  # Simple system name
         ("domain\\test_user", ("test_user", "domain")),  # Sam name
         ("domain.com\\test_user", ("test_user", "domain.com")),  # Sam name with .com
+        ("domain/test_user", ("test_user", "domain")),  # Domain/user variant
         ("test_user@domain", ("test_user", "domain")),  # UPN Name
         ("test_user@domain.com", ("test_user", "domain.com")),  # UPN Name with .com
         ("test_user@domain.local", ("test_user", "domain")),  # UPN Name with .local

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -13,6 +13,7 @@ import pytest
 import salt._logging
 import salt.utils.platform
 import salt.utils.process
+from tests.support.mock import MagicMock
 from tests.support.mock import patch
 from tests.support.unit import TestCase
 
@@ -138,6 +139,34 @@ class TestProcessManager(TestCase):
         time.sleep(2)
         process_manager.check_children()
         assert initial_pid != next(iter(process_manager._process_map.keys()))
+
+    def test_kill_children_importerror_from_join_is_ignored(self):
+        """
+        Regression test for #68573.
+
+        Under rare shutdown re-entrancy, ``multiprocessing`` may raise an ImportError
+        when ``Process.join()`` triggers imports (for example, importing
+        ``multiprocessing.connection.wait`` while the module is partially
+        initialized). ``ProcessManager.kill_children()`` should not crash in that
+        case and should continue best-effort cleanup.
+        """
+
+        process_manager = salt.utils.process.ProcessManager(wait_for_kill=0.01)
+        self.addCleanup(process_manager.terminate)
+
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.is_alive.return_value = False
+        proc.exitcode = 0
+        proc.join.side_effect = ImportError(
+            "cannot import name 'wait' from partially initialized module "
+            "'multiprocessing.connection'"
+        )
+
+        process_manager._process_map[proc.pid] = {"Process": proc, "tgt": None, "args": [], "kwargs": {}}
+        # Should not raise, and should clean up the internal process map
+        process_manager.kill_children(safe_join=True)
+        assert process_manager._process_map == {}
 
     @incr
     def test_counter(self):


### PR DESCRIPTION
### What does this PR do?
Avoids Python 3.12+ SyntaxWarning for invalid escape sequences by moving the Tornado re_unescape docstring into a raw-string payload and assigning it at runtime. This keeps \d/regex references intact without triggering warnings.

### What issues does this PR fix or reference?
Fixes #68568

### Previous Behavior
Importing the vendored Tornado util module could emit SyntaxWarning: invalid escape sequence '\d' under Python 3.12+.

### New Behavior
No syntax warnings; re_unescape uses a safe, runtime-assigned docstring while preserving content.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
