### PR TITLE
Move testing container definitions

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -985,7 +985,7 @@ jobs:
     name: ${{ matrix.display_name }} ${{ matrix.tests-chunk }} ${{ matrix.transport }}${{ matrix.test-group && ' ' || '' }}${{ matrix.test-group && matrix.test-group || '' }}
 
     if: ${{ !cancelled() && toJSON(fromJSON(inputs.matrix)['windows']) != '[]' }}
-    runs-on: ${{ matrix.slug }}
+    runs-on: ${{ matrix.runner }}
     # Full test runs. Each chunk should never take more than 2 hours.
     # Partial test runs(no chunk parallelization), 6 Hours
     timeout-minutes: ${{ fromJSON(inputs.testrun)['type'] == 'full' && inputs.default-timeout || 360 }}

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -319,7 +319,7 @@ jobs:
 
   test-windows:
     name: ${{ matrix.display_name }} ${{ matrix.pkg_type }} ${{ matrix.tests-chunk }} ${{ matrix.version }}
-    runs-on: ${{ matrix.slug }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120  # 2 Hours - More than this and something is wrong
     if: ${{ !cancelled() && toJSON(fromJSON(inputs.matrix)['windows']) != '[]' }}
     strategy:

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,9 @@
 nox_version: "2022.8.7"
 python_version: "3.10.19"
 relenv_version: "0.22.4"
+release_branches:
+  - "3006.x"
+  - "3007.x"
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04
@@ -138,12 +141,14 @@ test-salt-listing:
       enabled: false
   macos:
     - slug: macos-15-intel
-      display_name: "macOS 15"
+      display_name: "macOS 15 (Intel)"
       arch: x86_64
+      runner: macos-15-intel
       enabled: true
     - slug: macos-15
       display_name: "macOS 15 (M1)"
       arch: arm64
+      runner: macos-15
       enabled: true
   windows:
     - slug: windows-2022
@@ -279,32 +284,38 @@ test-salt-pkg-listing:
       container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04"
       enabled: false
   macos:
-    - slug: macos-13-intel-pkg
-      display_name: "macOS 15"
+    - slug: macos-15-intel-pkg
+      display_name: "macOS 15 (Intel)"
       arch: x86_64
+      runner: macos-15-intel
       enabled: true
     - slug: macos-15-pkg
       display_name: "macOS 15 (M1)"
       arch: arm64
+      runner: macos-15
       enabled: true
   windows:
-    - slug: windows-2022-pkg
+    - slug: windows-2022-nsis-pkg
       display_name: "Windows 2022"
       arch: amd64
+      runner: windows-2022
       pkg_type: NSIS
       enabled: true
-    - slug: windows-2022-pkg
+    - slug: windows-2022-msi-pkg
       display_name: "Windows 2022"
       arch: amd64
+      runner: windows-2022
       pkg_type: MSI
       enabled: true
-    - slug: windows-2025-pkg
+    - slug: windows-2025-nsis-pkg
       display_name: "Windows 2025"
       arch: amd64
+      runner: windows-2025
       pkg_type: NSIS
       enabled: true
-    - slug: windows-2025-pkg
+    - slug: windows-2025-msi-pkg
       display_name: "Windows 2025"
       arch: amd64
+      runner: windows-2025
       pkg_type: MSI
       enabled: true

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -12,3 +12,299 @@ pr-testrun-slugs:
   - macos-15-pkg
 full-testrun-slugs:
   - all
+test-salt-listing:
+  linux:
+    - slug: rockylinux-8
+      display_name: "Rocky Linux 8"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8"
+      enabled: false
+    - slug: rockylinux-8-arm64
+      display_name: "Rocky Linux 8 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8"
+      enabled: true
+    - slug: rockylinux-9
+      display_name: "Rocky Linux 9"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9"
+      enabled: true
+    - slug: rockylinux-9-arm64
+      display_name: "Rocky Linux 9 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9"
+      enabled: false
+    - slug: amazonlinux-2
+      display_name: "Amazon Linux 2"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2"
+      enabled: true
+    - slug: amazonlinux-2-arm64
+      display_name: "Amazon Linux 2 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2"
+      enabled: false
+    - slug: amazonlinux-2023
+      display_name: "Amazon Linux 2023"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
+      enabled: false
+    - slug: amazonlinux-2023-arm64
+      display_name: "Amazon Linux 2023 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
+      enabled: true
+    - slug: debian-11
+      display_name: "Debian 11"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
+      enabled: true
+    - slug: debian-11-arm64
+      display_name: "Debian 11 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
+      enabled: false
+    - slug: debian-12
+      display_name: "Debian 12"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-12"
+      enabled: false
+    - slug: debian-12-arm64
+      display_name: "Debian 12 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-12"
+      enabled: true
+    - slug: debian-13
+      display_name: "Debian 13"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-13"
+      enabled: true
+    - slug: debian-13-arm64
+      display_name: "Debian 13 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-13"
+      enabled: false
+    - slug: fedora-40
+      display_name: "Fedora 40"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-40"
+      enabled: true
+    - slug: fedora-40-arm64
+      display_name: "Fedora 40 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-40"
+      enabled: false
+    - slug: photonos-4
+      display_name: "Photon OS 4"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-4"
+      enabled: true
+      fips: true
+    - slug: photonos-4-arm64
+      display_name: "Photon OS 4 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-4"
+      enabled: true
+    - slug: photonos-5
+      display_name: "Photon OS 5"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-5"
+      enabled: true
+    - slug: photonos-5-arm64
+      display_name: "Photon OS 5 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-5"
+      enabled: true
+      fips: true
+    - slug: ubuntu-22.04
+      display_name: "Ubuntu 22.04"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04"
+      enabled: false
+    - slug: ubuntu-22.04-arm64
+      display_name: "Ubuntu 22.04 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04"
+      enabled: true
+    - slug: ubuntu-24.04
+      display_name: "Ubuntu 24.04"
+      arch: x86_64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04"
+      enabled: true
+    - slug: ubuntu-24.04-arm64
+      display_name: "Ubuntu 24.04 Arm64"
+      arch: arm64
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04"
+      enabled: false
+  macos:
+    - slug: macos-15-intel
+      display_name: "macOS 15"
+      arch: x86_64
+      enabled: true
+    - slug: macos-15
+      display_name: "macOS 15 (M1)"
+      arch: arm64
+      enabled: true
+  windows:
+    - slug: windows-2022
+      display_name: "Windows 2022"
+      arch: amd64
+      enabled: true
+    - slug: windows-2025
+      display_name: "Windows 2025"
+      arch: amd64
+      enabled: true
+test-salt-pkg-listing:
+  linux:
+    - slug: rockylinux-8-pkg
+      display_name: "Rocky Linux 8"
+      arch: x86_64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8"
+      enabled: false
+    - slug: rockylinux-8-arm64-pkg
+      display_name: "Rocky Linux 8 Arm64"
+      arch: arm64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8"
+      enabled: true
+    - slug: rockylinux-9-pkg
+      display_name: "Rocky Linux 9"
+      arch: x86_64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9"
+      enabled: true
+    - slug: rockylinux-9-arm64-pkg
+      display_name: "Rocky Linux 9 Arm64"
+      arch: arm64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9"
+      enabled: false
+    - slug: amazonlinux-2023-pkg
+      display_name: "Amazon Linux 2023"
+      arch: x86_64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
+      enabled: true
+    - slug: amazonlinux-2023-arm64-pkg
+      display_name: "Amazon Linux 2023 Arm64"
+      arch: arm64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
+      enabled: false
+    - slug: debian-11-pkg
+      display_name: "Debian 11"
+      arch: x86_64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
+      enabled: false
+    - slug: debian-11-arm64-pkg
+      display_name: "Debian 11 Arm64"
+      arch: arm64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
+      enabled: true
+    - slug: debian-12-pkg
+      display_name: "Debian 12"
+      arch: x86_64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-12"
+      enabled: true
+    - slug: debian-12-arm64-pkg
+      display_name: "Debian 12 Arm64"
+      arch: arm64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-12"
+      enabled: false
+    - slug: debian-13-pkg
+      display_name: "Debian 13"
+      arch: x86_64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-13"
+      enabled: false
+    - slug: debian-13-arm64-pkg
+      display_name: "Debian 13 Arm64"
+      arch: arm64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-13"
+      enabled: true
+    - slug: photonos-4-pkg
+      display_name: "Photon OS 4"
+      arch: x86_64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-4"
+      enabled: true
+      fips: true
+    - slug: photonos-4-arm64-pkg
+      display_name: "Photon OS 4 Arm64"
+      arch: arm64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-4"
+      enabled: true
+    - slug: photonos-5-pkg
+      display_name: "Photon OS 5"
+      arch: x86_64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-5"
+      enabled: true
+    - slug: photonos-5-arm64-pkg
+      display_name: "Photon OS 5 Arm64"
+      arch: arm64
+      pkg_type: rpm
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:photon-5"
+      enabled: true
+      fips: true
+    - slug: ubuntu-22.04-pkg
+      display_name: "Ubuntu 22.04"
+      arch: x86_64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04"
+      enabled: false
+    - slug: ubuntu-22.04-arm64-pkg
+      display_name: "Ubuntu 22.04 Arm64"
+      arch: arm64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04"
+      enabled: true
+    - slug: ubuntu-24.04-pkg
+      display_name: "Ubuntu 24.04"
+      arch: x86_64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04"
+      enabled: true
+    - slug: ubuntu-24.04-arm64-pkg
+      display_name: "Ubuntu 24.04 Arm64"
+      arch: arm64
+      pkg_type: deb
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04"
+      enabled: false
+  macos:
+    - slug: macos-13-intel-pkg
+      display_name: "macOS 15"
+      arch: x86_64
+      enabled: true
+    - slug: macos-15-pkg
+      display_name: "macOS 15 (M1)"
+      arch: arm64
+      enabled: true
+  windows:
+    - slug: windows-2022-pkg
+      display_name: "Windows 2022"
+      arch: amd64
+      pkg_type: NSIS
+      enabled: true
+    - slug: windows-2022-pkg
+      display_name: "Windows 2022"
+      arch: amd64
+      pkg_type: MSI
+      enabled: true
+    - slug: windows-2025-pkg
+      display_name: "Windows 2025"
+      arch: amd64
+      pkg_type: NSIS
+      enabled: true
+    - slug: windows-2025-pkg
+      display_name: "Windows 2025"
+      arch: amd64
+      pkg_type: MSI
+      enabled: true

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -619,19 +619,25 @@ def _environment_slugs(ctx, slugdef, labels):
     label_requests = [
         _[0].rsplit(":", 1)[1] for _ in labels if _[0].startswith("test:os:")
     ]
-    all_slugs = []
+    all_slugs = set()
+    enabled_slugs = set()
     slugs = set()
     for platform in TEST_SALT_LISTING:
         for osdef in TEST_SALT_LISTING[platform]:
-            all_slugs.append(osdef.slug)
-    for platform in TEST_SALT_LISTING:
-        for osdef in TEST_SALT_LISTING[platform]:
-            all_slugs.append(osdef.slug)
+            all_slugs.add(osdef.slug)
+            if osdef.enabled:
+                enabled_slugs.add(osdef.slug)
+    for platform in TEST_SALT_PKG_LISTING:
+        for osdef in TEST_SALT_PKG_LISTING[platform]:
+            all_slugs.add(osdef.slug)
+            if osdef.enabled:
+                enabled_slugs.add(osdef.slug)
+
     if "all" in requests:
-        slugs = all_slugs[:]
+        slugs.update(enabled_slugs)
         requests.remove("all")
     if "all" in label_requests:
-        slugs = all_slugs[:]
+        slugs.update(enabled_slugs)
         label_requests.remove("all")
     for request in requests[:]:
         if request.startswith("+"):
@@ -640,7 +646,7 @@ def _environment_slugs(ctx, slugdef, labels):
                 ctx.warn(f"invalid slug name from environment {request}")
                 continue
             if request in slugs:
-                ctx.info("slug already requested from environment {request}")
+                ctx.info(f"slug already requested from environment {request}")
                 continue
             slugs.add(request)
         elif request.startswith("-"):
@@ -651,13 +657,13 @@ def _environment_slugs(ctx, slugdef, labels):
             if request in slugs:
                 slugs.remove(request)
             else:
-                ctx.info("slug from environment was never requested {request}")
+                ctx.info(f"slug from environment was never requested {request}")
         else:
             if request not in all_slugs:
                 ctx.warn(f"invalid slug name from environment {request}")
                 continue
             if request in slugs:
-                ctx.info("slug from environment already requested {request}")
+                ctx.info(f"slug from environment already requested {request}")
                 continue
             slugs.add(request)
 

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -42,229 +42,27 @@ cgroup = command_group(
 )
 
 # Testing platforms
-TEST_SALT_LISTING = PlatformDefinitions(
-    {
-        "linux": [
-            Linux(
-                slug="rockylinux-8-arm64",
-                display_name="Rocky Linux 8 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8",
-            ),
-            Linux(
-                slug="rockylinux-9",
-                display_name="Rocky Linux 9",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
-            ),
-            Linux(
-                slug="amazonlinux-2",
-                display_name="Amazon Linux 2",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2",
-            ),
-            Linux(
-                slug="amazonlinux-2023-arm64",
-                display_name="Amazon Linux 2023 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023",
-            ),
-            Linux(
-                slug="debian-11",
-                display_name="Debian 11",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-11",
-            ),
-            Linux(
-                slug="debian-12-arm64",
-                display_name="Debian 12 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
-            ),
-            Linux(
-                slug="debian-13",
-                display_name="Debian 13",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-13",
-            ),
-            Linux(
-                slug="fedora-40",
-                display_name="Fedora 40",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:fedora-40",
-            ),
-            # Linux(slug="opensuse-15", display_name="Opensuse 15", arch="x86_64"),
-            Linux(
-                slug="photonos-4-arm64",
-                display_name="Photon OS 4 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            Linux(
-                slug="photonos-4",
-                display_name="Photon OS 4",
-                arch="x86_64",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            Linux(
-                slug="photonos-5",
-                display_name="Photon OS 5",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            Linux(
-                slug="photonos-5-arm64",
-                display_name="Photon OS 5 Arm64",
-                arch="arm64",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            Linux(
-                slug="ubuntu-22.04-arm64",
-                display_name="Ubuntu 22.04 Arm64",
-                arch="arm64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04",
-            ),
-            Linux(
-                slug="ubuntu-24.04",
-                display_name="Ubuntu 24.04",
-                arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
-            ),
-        ],
-        "macos": [
-            MacOS(slug="macos-15-intel", display_name="macOS 15", arch="x86_64"),
-            MacOS(slug="macos-15", display_name="macOS 15 (M1)", arch="arm64"),
-        ],
-        "windows": [
-            Windows(slug="windows-2022", display_name="Windows 2022", arch="amd64"),
-            Windows(slug="windows-2025", display_name="Windows 2025", arch="amd64"),
-        ],
-    }
-)
-TEST_SALT_PKG_LISTING = PlatformDefinitions(
-    {
-        "linux": [
-            LinuxPkg(
-                slug="rockylinux-8-arm64",
-                display_name="Rocky Linux 8 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-8",
-            ),
-            LinuxPkg(
-                slug="rockylinux-9",
-                display_name="Rocky Linux 9",
-                arch="x86_64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:rockylinux-9",
-            ),
-            LinuxPkg(
-                slug="amazonlinux-2023",
-                display_name="Amazon Linux 2023",
-                arch="x86_64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023",
-            ),
-            LinuxPkg(
-                slug="debian-11-arm64",
-                display_name="Debian 11 Arm64",
-                arch="arm64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-11",
-            ),
-            LinuxPkg(
-                slug="debian-12",
-                display_name="Debian 12",
-                arch="x86_64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-12",
-            ),
-            LinuxPkg(
-                slug="debian-13-arm64",
-                display_name="Debian 13 Arm64",
-                arch="arm64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:debian-13",
-            ),
-            LinuxPkg(
-                slug="photonos-4-arm64",
-                display_name="Photon OS 4 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            LinuxPkg(
-                slug="photonos-4",
-                display_name="Photon OS 4",
-                arch="x86_64",
-                pkg_type="rpm",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-4",
-            ),
-            LinuxPkg(
-                slug="photonos-5",
-                display_name="Photon OS 5",
-                arch="x86_64",
-                pkg_type="rpm",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            LinuxPkg(
-                slug="photonos-5-arm64",
-                display_name="Photon OS 5 Arm64",
-                arch="arm64",
-                pkg_type="rpm",
-                fips=True,
-                container="ghcr.io/saltstack/salt-ci-containers/testing:photon-5",
-            ),
-            LinuxPkg(
-                slug="ubuntu-22.04-arm64",
-                display_name="Ubuntu 22.04 Arm64",
-                arch="arm64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-22.04",
-            ),
-            LinuxPkg(
-                slug="ubuntu-24.04",
-                display_name="Ubuntu 24.04",
-                arch="x86_64",
-                pkg_type="deb",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:ubuntu-24.04",
-            ),
-        ],
-        "macos": [
-            MacOSPkg(slug="macos-13-intel", display_name="macOS 15", arch="x86_64"),
-            MacOSPkg(slug="macos-15", display_name="macOS 15 (M1)", arch="arm64"),
-        ],
-        "windows": [
-            WindowsPkg(
-                slug="windows-2022",
-                display_name="Windows 2022",
-                arch="amd64",
-                pkg_type="NSIS",
-            ),
-            WindowsPkg(
-                slug="windows-2022",
-                display_name="Windows 2022",
-                arch="amd64",
-                pkg_type="MSI",
-            ),
-            WindowsPkg(
-                slug="windows-2025",
-                display_name="Windows 2025",
-                arch="amd64",
-                pkg_type="NSIS",
-            ),
-            WindowsPkg(
-                slug="windows-2025",
-                display_name="Windows 2025",
-                arch="amd64",
-                pkg_type="MSI",
-            ),
-        ],
-    }
-)
+_shared_context = tools.utils.get_cicd_shared_context()
+
+TEST_SALT_LISTING = PlatformDefinitions({"linux": [], "macos": [], "windows": []})
+for _platform, _defs in _shared_context["test-salt-listing"].items():
+    for _d in _defs:
+        if _platform == "linux":
+            TEST_SALT_LISTING["linux"].append(Linux(**_d))
+        elif _platform == "macos":
+            TEST_SALT_LISTING["macos"].append(MacOS(**_d))
+        elif _platform == "windows":
+            TEST_SALT_LISTING["windows"].append(Windows(**_d))
+
+TEST_SALT_PKG_LISTING = PlatformDefinitions({"linux": [], "macos": [], "windows": []})
+for _platform, _defs in _shared_context["test-salt-pkg-listing"].items():
+    for _d in _defs:
+        if _platform == "linux":
+            TEST_SALT_PKG_LISTING["linux"].append(LinuxPkg(**_d))
+        elif _platform == "macos":
+            TEST_SALT_PKG_LISTING["macos"].append(MacOSPkg(**_d))
+        elif _platform == "windows":
+            TEST_SALT_PKG_LISTING["windows"].append(WindowsPkg(**_d))
 
 
 def slugs():
@@ -274,7 +72,8 @@ def slugs():
     all_slugs = []
     for platform in TEST_SALT_LISTING:
         for osdef in TEST_SALT_LISTING[platform]:
-            all_slugs.append(osdef.slug)
+            if osdef.enabled:
+                all_slugs.append(osdef.slug)
     return all_slugs
 
 

--- a/tools/testsuite/download.py
+++ b/tools/testsuite/download.py
@@ -259,7 +259,7 @@ def download_artifact(
             "help": "The workflow run ID from where to download artifacts from",
         },
         "slug": {
-            "help": "Slug of the test run (examples: debian-11, macos-13, windows-2022)",
+            "help": "Slug of the test run (examples: debian-11, macos-15-intel, windows-2022)",
         },
         "repository": {
             "help": "The repository to query, e.g. saltstack/salt",

--- a/tools/utils/__init__.py
+++ b/tools/utils/__init__.py
@@ -60,6 +60,11 @@ class OS:
     display_name: str = attr.ib(default=None)
     pkg_type: str = attr.ib(default=None)
     enabled: bool = attr.ib(default=True)
+    runner: str = attr.ib()
+
+    @runner.default
+    def _default_runner(self):
+        return self.slug
 
     @arch.default
     def _default_arch(self):
@@ -90,6 +95,8 @@ class Linux(OS):
             "arch": self.arch,
             "display_name": self.display_name,
             "pkg_type": self.pkg_type,
+            "enabled": self.enabled,
+            "runner": self.runner,
             "fips": self.fips,
             "container": self.container,
             "job_name": self.job_name,
@@ -106,12 +113,7 @@ class LinuxPkg(Linux):
 
 @attr.s(frozen=True, slots=True)
 class MacOS(OS):
-    runner: str = attr.ib()
     platform: str = attr.ib(default="macos")
-
-    @runner.default
-    def _default_runner(self):
-        return self.slug
 
     @property
     def job_name(self):
@@ -124,6 +126,7 @@ class MacOS(OS):
             "arch": self.arch,
             "display_name": self.display_name,
             "pkg_type": self.pkg_type,
+            "enabled": self.enabled,
             "runner": self.runner,
             "job_name": self.job_name,
         }
@@ -155,6 +158,8 @@ class Windows(OS):
             "arch": self.arch,
             "display_name": self.display_name,
             "pkg_type": self.pkg_type,
+            "enabled": self.enabled,
+            "runner": self.runner,
             "job_name": self.job_name,
         }
 
@@ -406,10 +411,10 @@ def get_platform_and_arch_from_slug(slug: str) -> tuple[str, str]:
         arch = "amd64"
     elif "macos" in slug:
         platform = "macos"
-        if "macos-13" in slug and "xlarge" in slug:
-            arch = "arm64"
-        else:
+        if "intel" in slug:
             arch = "x86_64"
+        else:
+            arch = "arm64"
     else:
         platform = "linux"
         if "arm64" in slug:

--- a/tools/utils/__init__.py
+++ b/tools/utils/__init__.py
@@ -59,6 +59,7 @@ class OS:
     arch: str = attr.ib()
     display_name: str = attr.ib(default=None)
     pkg_type: str = attr.ib(default=None)
+    enabled: bool = attr.ib(default=True)
 
     @arch.default
     def _default_arch(self):


### PR DESCRIPTION
### What does this PR do?

Moves testing container and runner definitions to shared-gh-workflows-context.yml. This also adds the ability to turn off certain definitions. This allows local testing of ci runs to have the proper information to download the correct container on x86_64 when we're only testing arm64 of that container in ci/cd runs.