### PR TITLE
Do not insert local paths before standard library paths

### DIFF
--- a/changelog/68755.fixed.md
+++ b/changelog/68755.fixed.md
@@ -1,0 +1,1 @@
+Don't insert local paths before standard library paths in LazyLoader, preventing sys.path reordering when loader modules are already importable.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -778,9 +778,12 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         self.loaded_files.add(name)
         fpath_dirname = os.path.dirname(fpath)
+        fpath_appended = False
         try:
             self.__populate_sys_path()
-            sys.path.append(fpath_dirname)
+            if fpath_dirname not in sys.path:
+                sys.path.append(fpath_dirname)
+                fpath_appended = True
             if suffix == ".pyx":
                 mod = pyximport.load_module(name, fpath, tempfile.gettempdir())
             elif suffix == ".o":
@@ -917,7 +920,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self.missing_modules[name] = error
             return False
         finally:
-            sys.path.remove(fpath_dirname)
+            if fpath_appended:
+                sys.path.remove(fpath_dirname)
             self.__clean_sys_path()
 
         loader_context = salt.loader.context.LoaderContext()

--- a/tests/pytests/integration/ssh/state/test_state.py
+++ b/tests/pytests/integration/ssh/state/test_state.py
@@ -113,3 +113,10 @@ def test_state_test(salt_ssh_cli, state_tree):
         ret.data["test_|-Ok with def_|-Ok with def_|-succeed_with_changes"]["result"]
         is None
     )
+
+
+def test_state_pkg(salt_ssh_cli):
+    ret = salt_ssh_cli.run("state.single", "pkg.installed", "coreutils", "test=True")
+    assert ret.returncode == 0
+    assert ret.data
+    assert ret.data["pkg_|-coreutils_|-coreutils_|-installed"]["result"] is not False


### PR DESCRIPTION
### What does this PR do?

Inserting local paths like `salt/utils` before standard library makes many modules in utils conflict with standard library. This is especially relevant for salt-ssh. For example salt.utils.configparser - it tries to import configparser from stdlib, but due to salt/utils path being prepended to sys.path, it imports itself:

    [ERROR   ] Failed to import fileserver gitfs, this is due most likely to a syntax error:
    Traceback (most recent call last):
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/loader/lazy.py", line 902, in _load_module
        self.run(spec.loader.exec_module, mod)
        ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/loader/lazy.py", line 1365, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
               ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/loader/lazy.py", line 1380, in _run_as
        ret = _func_or_method(*args, **kwargs)
      File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
      File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/fileserver/gitfs.py", line 52, in <module>
        import salt.utils.gitfs
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/utils/gitfs.py", line 31, in <module>
        import salt.utils.configparser
      File "/var/tmp/.root_dd8a91_salt/pyall/salt/utils/configparser.py", line 7, in <module>
        from configparser import *  # pylint: disable=no-name-in-module,wildcard-import,unused-wildcard-import
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/var/tmp/.root_dd8a91_salt/running_data/var/cache/salt/minion/extmods/utils/configparser.py", line 12, in <module>
        class GitConfigParser(RawConfigParser):
                              ^^^^^^^^^^^^^^^
    NameError: name 'RawConfigParser' is not defined

On the other hand, places that try to use such duplicated modules from utils, import them via full name (as seen above: `import salt.utils.configparser`).

Change the insert_system_path() function to not insert paths before standard library.

### What issues does this PR fix or reference?

Fixes #68755

### Previous Behavior
Several state modules (including `pkg.installed` on RedHat-based distro) are unavailable via salt-ssh

### New Behavior
No import conflict, `pkg.installed` works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
