### PR TITLE
Fix salt-ssh tests with newer Python

### DIFF
--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -9,6 +9,8 @@ pr-testrun-slugs:
   - ubuntu-24.04
   - rockylinux-9
   - rockylinux-9-pkg
+  - fedora-42
+  - fedora-42-pkg
   - windows-2025
   - windows-2025-pkg
   - macos-15

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -7,13 +7,13 @@ release_branches:
 pr-testrun-slugs:
   - ubuntu-24.04-pkg
   - ubuntu-24.04
-  - rockylinux-9
-  - rockylinux-9-pkg
+#  - rockylinux-9
+#  - rockylinux-9-pkg
   - fedora-42
   - fedora-42-pkg
-  - windows-2025
-  - windows-2025-pkg
-  - macos-15
-  - macos-15-pkg
+#  - windows-2025
+#  - windows-2025-pkg
+#  - macos-15
+#  - macos-15-pkg
 full-testrun-slugs:
   - all

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -12,7 +12,7 @@ from tests.support.helpers import (
 from tests.support.mock import patch
 
 pytestmark = [
-    pytest.mark.slow_test,
+    # pytest.mark.slow_test,
     pytest.mark.requires_sshd_server,
     pytest.mark.skipif(
         'grains["osfinger"].startswith(("Arch Linux"))',

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -15,7 +15,7 @@ pytestmark = [
     pytest.mark.slow_test,
     pytest.mark.requires_sshd_server,
     pytest.mark.skipif(
-        'grains["osfinger"].startswith(("Fedora Linux-40", "Ubuntu-24.04", "Arch Linux"))',
+        'grains["osfinger"].startswith(("Arch Linux"))',
         reason="System ships with a version of python that is too recent for salt-ssh tests",
         # Actually, the problem is that the tornado we ship is not prepared for Python 3.12,
         # and it imports `ssl` and checks if the `match_hostname` function is defined, which

--- a/tests/pytests/integration/ssh/conftest.py
+++ b/tests/pytests/integration/ssh/conftest.py
@@ -6,10 +6,7 @@ from tests.support.pytest.helpers import reap_stray_processes
 
 @pytest.fixture(scope="package", autouse=True)
 def _auto_skip_on_system_python_too_recent(grains):
-    if (
-        grains["osfinger"] in ("Fedora Linux-40", "Ubuntu-24.04", "Debian-13")
-        or grains["os_family"] == "Arch"
-    ):
+    if grains["os_family"] == "Arch":
         pytest.skip(
             "System ships with a version of python that is too recent for salt-ssh tests",
             # Actually, the problem is that the tornado we ship is not prepared for Python 3.12,

--- a/tests/pytests/integration/ssh/state/test_pillar_override.py
+++ b/tests/pytests/integration/ssh/state/test_pillar_override.py
@@ -13,7 +13,7 @@ import salt.utils.dictupdate
 pytestmark = [
     pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
     pytest.mark.usefixtures("pillar_tree_nested"),
-    pytest.mark.slow_test,
+    # pytest.mark.slow_test,
 ]
 
 

--- a/tests/pytests/integration/ssh/state/test_state.py
+++ b/tests/pytests/integration/ssh/state/test_state.py
@@ -2,7 +2,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
-    pytest.mark.slow_test,
+    # pytest.mark.slow_test,
 ]
 
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -572,6 +572,7 @@ def _os_test_filter(osdef, transport, chunk, arm_runner, requested_slugs):
         "photonos-5-arm64",
         "ubuntu-22.04",
         "ubuntu-22.04-arm64",
+        "fedora-42",
     ):
         return False
     return True

--- a/tools/precommit/workflows.py
+++ b/tools/precommit/workflows.py
@@ -89,10 +89,10 @@ TEST_SALT_LISTING = PlatformDefinitions(
                 container="ghcr.io/saltstack/salt-ci-containers/testing:debian-13",
             ),
             Linux(
-                slug="fedora-40",
-                display_name="Fedora 40",
+                slug="fedora-42",
+                display_name="Fedora 42",
                 arch="x86_64",
-                container="ghcr.io/saltstack/salt-ci-containers/testing:fedora-40",
+                container="ghcr.io/saltstack/salt-ci-containers/testing:fedora-42",
             ),
             # Linux(slug="opensuse-15", display_name="Opensuse 15", arch="x86_64"),
             Linux(


### PR DESCRIPTION
### What does this PR do?

Enable tests for salt-ssh with newer system python version. This should prevent (or at least detect earlier) issues like #68755 , #66346 or #66898 - or many other issues related to python version compatibility.

This is not ready for review yet, I'm exploring what issues are affecting CI environment, compared to my local deployment. This PR will likely end up including few more fixes for compatibility with Python 3.12.

### What issues does this PR fix or reference?
Fixes

### Previous Behavior

salt-ssh tested in very limited capacity, excluding managing modern distributions.

### New Behavior

salt-ssh tested in broader set of environments, covering more of https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-supported-operating-systems.html#salt-supported-operating-systems

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
