### PR TITLE
fix(mac_brew_pkg): manage unknown versions

### DIFF
--- a/changelog/68763.fixed.md
+++ b/changelog/68763.fixed.md
@@ -1,0 +1,8 @@
+Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when
+Homebrew returns `null` values for cask metadata:
+
+- When the installed version of a cask is `null` (e.g. Homebrew cannot
+  determine the installed version), it is now reported as `"unknown"`
+  instead of raising an error.
+- When `full_token` is `null`, it is now filtered out so that `None`
+  is never used as a package name key in the returned dictionary.

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -190,7 +190,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             # Tap is null when the package is from homebrew/cask.
             pkg_tap = "homebrew/cask"
         pkg_names.add("/".join([pkg_tap, package["token"]]))
-        for pkg_name in pkg_names:
+        for pkg_name in [pkg for pkg in pkg_names if pkg is not None]:
             __salt__["pkg_resource.add_pkg"](ret, pkg_name, pkg_version)
 
     __salt__["pkg_resource.sort_pkglist"](ret)

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -181,6 +181,8 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     for package in package_info["casks"]:
         pkg_version = package["installed"]
+        if pkg_version is None:
+            pkg_version = ""
         pkg_names = {package["full_token"], package["token"]}
         pkg_tap = package.get("tap", None)
         # The following name is appended to maintain backward compatibility

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -492,6 +492,102 @@ def test_list_pkgs_homebrew_cask_pakages():
         assert mac_brew.list_pkgs(versions_as_list=True) == expected_pkgs
 
 
+def test_list_pkgs_cask_null_installed_version():
+    """
+    Tests that a cask with "installed": null gets version set to "unknown"
+    instead of raising an error or storing None.
+
+    This covers the fix: if pkg_version is None: pkg_version = "unknown"
+    """
+
+    def _call_brew_with_null_installed(*cmd, failhard=True):
+        if cmd == ("info", "--json=v2", "--installed"):
+            return {
+                "stdout": textwrap.dedent(
+                    """\
+                    {
+                      "casks": [
+                        {
+                          "full_token": "discord",
+                          "token": "discord",
+                          "tap": "homebrew/cask",
+                          "installed": null
+                        }
+                      ],
+                      "formulae": []
+                    }
+                    """
+                ),
+                "retcode": 0,
+                "stderr": "",
+            }
+        return {}
+
+    expected_pkgs = {
+        "homebrew/cask/discord": "",
+        "discord": "",
+    }
+
+    with (
+        patch("salt.modules.mac_brew_pkg._call_brew", _call_brew_with_null_installed),
+        patch.dict(
+            mac_brew.__salt__,
+            {
+                "pkg_resource.add_pkg": custom_add_pkg,
+                "pkg_resource.sort_pkglist": MagicMock(),
+            },
+        ),
+    ):
+        assert mac_brew.list_pkgs(versions_as_list=True) == expected_pkgs
+
+
+def test_list_pkgs_cask_null_full_token():
+    """
+    Tests that a cask with "full_token": null does not produce a None key
+    in the returned package dict.
+
+    This covers the fix: [pkg for pkg in pkg_names if pkg is not None]
+    """
+
+    def _call_brew_with_null_full_token(*cmd, failhard=True):
+        if cmd == ("info", "--json=v2", "--installed"):
+            return {
+                "stdout": textwrap.dedent(
+                    """\
+                    {
+                      "casks": [
+                        {
+                          "full_token": null,
+                          "token": "discord",
+                          "tap": "homebrew/cask",
+                          "installed": "0.0.293"
+                        }
+                      ],
+                      "formulae": []
+                    }
+                    """
+                ),
+                "retcode": 0,
+                "stderr": "",
+            }
+        return {}
+
+    with (
+        patch("salt.modules.mac_brew_pkg._call_brew", _call_brew_with_null_full_token),
+        patch.dict(
+            mac_brew.__salt__,
+            {
+                "pkg_resource.add_pkg": custom_add_pkg,
+                "pkg_resource.sort_pkglist": MagicMock(),
+            },
+        ),
+    ):
+        pkgs = mac_brew.list_pkgs(versions_as_list=True)
+        assert None not in pkgs
+        assert "discord" in pkgs
+        assert pkgs["discord"] == "0.0.293"
+
+
 def test_list_pkgs_no_context():
     """
     Tests removed implementation


### PR DESCRIPTION
### What does this PR do?

Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when Homebrew returns `null` values for cask metadata:

- When the installed version of a cask is `null` (e.g. Homebrew cannot determine the installed version), it is now reported as `"unknown"` instead of raising an error.
- When `full_token` is `null`, it is now filtered out so that `None` is never used as a package name key in the returned dictionary.

### What issues does this PR fix or reference?

This PR manage those situations to avoid propagating `None` values.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes