### PR TITLE
Fix import for WinRM version check

### DIFF
--- a/changelog/68768.fixed.md
+++ b/changelog/68768.fixed.md
@@ -1,0 +1,1 @@
+Fixed a winrm detection bug in salt-cloud.

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -82,7 +82,7 @@ try:
 
     # Verify WinRM 0.3.0 or greater
 
-    version = importlib.metadata.version("winrm")
+    version = importlib.metadata.version("pywinrm")
     if not salt.utils.versions.compare(version, ">=", WINRM_MIN_VER):
         HAS_WINRM = False
     else:

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -454,40 +454,26 @@ def test_deploy_windows_programdata_minion_conf():
             mock_smb.put_str.assert_called_with(config, expected, conn=mock_conn)
 
 
-@pytest.mark.skip_unless_on_windows(reason="Only applicable for Windows.")
 def test_winrm_pinnned_version():
     """
     Test that winrm is pinned to a version 0.3.0 or higher.
+
+    Also asserts that ``salt.utils.cloud.HAS_WINRM`` is True when the
+    pywinrm distribution is importable. This pins the production
+    detection path so a regression in the dist-name lookup (the bug
+    that motivated this test) is caught on every platform CI runs on,
+    not just Windows.
     """
-    mock_true = MagicMock(return_value=True)
-    mock_tuple = MagicMock(return_value=(0, 0, 0))
-    with patch("salt.utils.smb.get_conn", MagicMock()), patch(
-        "salt.utils.smb.mkdirs", MagicMock()
-    ), patch("salt.utils.smb.put_file", MagicMock()), patch(
-        "salt.utils.smb.delete_file", MagicMock()
-    ), patch(
-        "salt.utils.smb.delete_directory", MagicMock()
-    ), patch(
-        "time.sleep", MagicMock()
-    ), patch.object(
-        cloud, "wait_for_port", mock_true
-    ), patch.object(
-        cloud, "fire_event", MagicMock()
-    ), patch.object(
-        cloud, "wait_for_psexecsvc", mock_true
-    ), patch.object(
-        cloud, "run_psexec_command", mock_tuple
-    ):
+    try:
+        import winrm  # pylint: disable=unused-import
+    except ImportError:
+        raise pytest.skip('The "winrm" python module is not installed in this env.')
 
-        try:
-            import winrm  # pylint: disable=unused-import
-        except ImportError:
-            raise pytest.skip('The "winrm" python module is not installed in this env.')
-        else:
-            from importlib.metadata import version
+    from importlib.metadata import version
 
-            winrm_version = version("pywinrm")
-            assert winrm_version >= "0.3.0"
+    winrm_version = version("pywinrm")
+    assert winrm_version >= "0.3.0"
+    assert cloud.HAS_WINRM is True
 
 
 def test_ssh_gateway_arguments_default_alive_args():


### PR DESCRIPTION
PyPI's package is named pywinrm.

The importlib.metadata.version("winrm") call raises PackageNotFoundError which isn't caught by except ImportError, crashing the block and leaving winrm undefined despite being importable.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes salt-cloud with Windows minions using Winrm

### Previous Behavior
salt-cloud crashes when using winrm to deploy windows minion.

### New Behavior
salt-cloud deploys windows minion correctly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated: Kind of:
```
% cat test.py
import salt.utils.versions

# Set the minimum version of PyWinrm.
WINRM_MIN_VER = "0.3.0"

try:
    import importlib
    import importlib.metadata

    # Verify WinRM 0.3.0 or greater

    version = importlib.metadata.version("winrm")
    if not salt.utils.versions.compare(version, ">=", WINRM_MIN_VER):
        HAS_WINRM = False
    else:
        HAS_WINRM = True

    import winrm
    from winrm.exceptions import WinRMTransportError

except ImportError:
    HAS_WINRM = False

print(HAS_WINRM)
% /opt/saltstack/salt/bin/python3.10 test.py
False
% sed -i 's/importlib\.metadata\.version("winrm")/importlib.metadata.version("pywinrm")/' test.py
% /opt/saltstack/salt/bin/python3.10 test.py
True
```

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
