### PR TITLE
Do not crash at start on NetBSD and OpenBSD

### DIFF
--- a/changelog/68773.fixed.md
+++ b/changelog/68773.fixed.md
@@ -1,0 +1,1 @@
+Fix salt-master startup crashes on NetBSD and OpenBSD: strip version suffix (e.g. `_STABLE`) before passing the OS release string to `packaging.version.Version` in `netbsd_interfaces()`, and ensure `osfullname` is initialised early in the OpenBSD/NetBSD branch of `os_data()`.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2850,7 +2850,7 @@ def os_data():
         grains["osfullname"] = "{} {}".format(grains["kernel"], grains["osrelease"])
         grains.update(_bsd_cpudata(grains))
     elif grains["kernel"] in ("OpenBSD", "NetBSD"):
-        grains["os_family"] = grains["os"] = grains["kernel"]
+        grains["os_family"] = grains["osfullname"] = grains["os"] = grains["kernel"]
         grains.update(_bsd_cpudata(grains))
         grains["osrelease"] = grains["kernelrelease"].split("-")[0]
         grains["osfullname"] = "{} {}".format(grains["kernel"], grains["osrelease"])

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1114,7 +1114,7 @@ def netbsd_interfaces():
     address)
     """
     # NetBSD versions prior to 8.0 can still use linux_interfaces()
-    if Version(os.uname()[2]) < Version("8.0"):
+    if Version(os.uname()[2].split("_")[0]) < Version("8.0"):
         return linux_interfaces()
 
     ifconfig_path = salt.utils.path.which("ifconfig")

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3487,6 +3487,74 @@ def test_bsd_osfullname():
     assert os_grains.get("osfullname") == "FreeBSD 10.3"
 
 
+@pytest.mark.skip_on_windows
+@pytest.mark.parametrize(
+    "kernel,kernelrelease,expected_osfullname",
+    [
+        # kernelrelease.split("-")[0] strips the -RELEASE suffix but not _STABLE
+        ("NetBSD", "10.1_STABLE", "NetBSD 10.1_STABLE"),
+        ("OpenBSD", "7.4-RELEASE", "OpenBSD 7.4"),
+    ],
+)
+def test_netbsd_openbsd_osfullname(kernel, kernelrelease, expected_osfullname):
+    """
+    Test that os_data() sets osfullname for NetBSD and OpenBSD without crashing.
+    The OpenBSD/NetBSD branch must set osfullname so that _osrelease_data() can
+    use it later.
+    """
+    nt_uname = namedtuple(
+        "nt_uname", ["system", "node", "release", "version", "machine", "processor"]
+    )
+    mock_uname = MagicMock(
+        return_value=nt_uname(
+            kernel,
+            "hostname",
+            kernelrelease,
+            f"{kernel} {kernelrelease}",
+            "amd64",
+            "amd64",
+        )
+    )
+    empty_mock = MagicMock(return_value={})
+
+    _cmd_run_map = {
+        "/sbin/sysctl -n hw.physmem": "2121781248",
+        "/sbin/sysctl -n vm.swap_total": "419430400",
+    }
+    cmd_run_mock = MagicMock(side_effect=lambda x: _cmd_run_map.get(x, ""))
+
+    with patch.object(platform, "uname", mock_uname), patch.object(
+        salt.utils.platform, "is_linux", MagicMock(return_value=False)
+    ), patch.object(
+        salt.utils.platform, "is_proxy", MagicMock(return_value=False)
+    ), patch.object(
+        salt.utils.platform, "is_windows", MagicMock(return_value=False)
+    ), patch.object(
+        salt.utils.platform, "is_freebsd", MagicMock(return_value=False)
+    ), patch(
+        "salt.utils.path.which", return_value="/sbin/sysctl"
+    ):
+        with patch.object(core, "_bsd_cpudata", empty_mock), patch.object(
+            core, "_hw_data", empty_mock
+        ), patch.object(core, "_virtual", empty_mock), patch.object(
+            core, "_virtual_hv", empty_mock
+        ), patch.object(
+            core, "_ps", empty_mock
+        ), patch.object(
+            core, "_memdata", empty_mock
+        ), patch.object(
+            core, "_netbsd_gpu_data", empty_mock
+        ), patch.dict(
+            core.__salt__, {"cmd.run": cmd_run_mock}
+        ):
+            os_grains = core.os_data()
+
+    assert "osfullname" in os_grains
+    assert os_grains.get("osfullname") == expected_osfullname
+    assert os_grains.get("os") == kernel
+    assert os_grains.get("os_family") == kernel
+
+
 def test_saltversioninfo():
     """
     test saltversioninfo core grain.

--- a/tests/pytests/unit/utils/test_network.py
+++ b/tests/pytests/unit/utils/test_network.py
@@ -1754,3 +1754,45 @@ def test_cidr_merge_span(value, expected):
 )
 def test_slaac(value, mac, expected):
     assert network.slaac(value, mac) == expected
+
+
+@pytest.mark.parametrize(
+    "uname_release",
+    [
+        "10.1_STABLE",
+        "10.1_BETA",
+        "9.3_STABLE",
+    ],
+)
+def test_netbsd_interfaces_version_with_suffix(uname_release):
+    """
+    netbsd_interfaces() must not raise InvalidVersion when os.uname()[2]
+    contains a suffix separated by underscore (e.g. '10.1_STABLE').
+    """
+    from packaging.version import Version
+
+    # Build a fake uname result where index 2 (release) has the given value.
+    # os.uname() is accessed as os.uname()[2] in netbsd_interfaces().
+    fake_uname = ("NetBSD", "hostname", uname_release, "", "amd64")
+    uname_mock = MagicMock(return_value=fake_uname)
+
+    version_part = uname_release.split("_")[0]
+    is_old = Version(version_part) < Version("8.0")
+
+    with patch("os.uname", uname_mock):
+        if is_old:
+            with patch.object(network, "linux_interfaces", MagicMock(return_value={})):
+                result = network.netbsd_interfaces()
+                assert result == {}
+        else:
+            with patch("salt.utils.path.which", return_value="/sbin/ifconfig"), patch(
+                "subprocess.Popen"
+            ) as mock_popen:
+                mock_popen.return_value.communicate.return_value = (b"", None)
+                with patch.object(
+                    network,
+                    "_netbsd_interfaces_ifconfig",
+                    MagicMock(return_value={}),
+                ):
+                    result = network.netbsd_interfaces()
+                    assert isinstance(result, dict)


### PR DESCRIPTION
### What does this PR do?
This PR fixes two crashes when starting salt_master on NetBSD; one of the crashes is expected to affect OpenBSD as well.

### What issues does this PR fix or reference?
The patch for salt/grains/core.py avoids accessing an undefined element
of the grains dictionary, on both NetBSD and OpenBSD. This matches the
corresponding code for FreeBSD.

The patch for salt/utils/network.py restricts the OS version test to the
part before "_" on NetBSD; this could raise an exception if py-packaging
wasn't aware of the suffix (e.g., "BETA" would work but "STABLE" not).

### Previous Behavior

```
  File "/usr/pkg/lib/python3.12/site-packages/salt/loader/lazy.py", line 1302, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/pkg/lib/python3.12/site-packages/salt/grains/core.py", line 2809, in os_data
    _osrelease_data(grains["os"], grains["osfullname"], grains["osrelease"])
                                  ~~~~~~^^^^^^^^^^^^^^
KeyError: 'osfullname'
```

And:

```
  File "/usr/pkg/lib/python3.12/site-packages/salt/utils/network.py", line 1102, in netbsd_interfaces
    if Version(os.uname()[2]) < Version("8.0"):
       ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/pkg/lib/python3.12/site-packages/packaging/version.py", line 202, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: '10.1_STABLE'
```

### New Behavior
Salt master starts as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes