### PR TITLE
Fix integer-to-string conversion limit for `test.fib` function

### DIFF
--- a/changelog/68770.fixed.md
+++ b/changelog/68770.fixed.md
@@ -1,0 +1,1 @@
+Remove the integer-to-string conversion limit for `test.fib` function.

--- a/changelog/68770.fixed.md
+++ b/changelog/68770.fixed.md
@@ -1,1 +1,0 @@
-Remove the integer-to-string conversion limit for `test.fib` function.

--- a/changelog/68775.fixed.md
+++ b/changelog/68775.fixed.md
@@ -1,0 +1,1 @@
+Remove the integer-to-string conversion limit for `test.fib` function.

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -346,6 +346,12 @@ def fib(num):
 
         salt '*' test.fib 3
     """
+    # Remove the limit on the number of digits in an int,
+    # as Fibonacci numbers grow very quickly.
+    # The default limit for integer string conversion is 4300 digits,
+    # which means that num > 20577 will fail with a ValueError.
+    sys.set_int_max_str_digits(0)
+
     num = int(num)
     if num < 0:
         raise ValueError("Negative number is not allowed!")

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -34,6 +34,11 @@ def test_fib(salt_call_cli):
     assert ret.data[0] == 2
 
 
+def test_fib_str_limit(salt_call_cli):
+    ret = salt_call_cli.run("test.fib", "20578")
+    assert ret.returncode == 0
+
+
 def test_fib_txt_output(salt_call_cli):
     ret = salt_call_cli.run("--output=txt", "test.fib", "3")
     assert ret.returncode == 0


### PR DESCRIPTION
### What does this PR do?

This PR will remove the integer-to-string conversion limit for `test.fib` function.

### What issues does this PR fix or reference?

Fixes https://github.com/saltstack/salt/issues/68775

### Previous Behavior

```
# salt '*' test.fib 20578

ValueError: Exceeds the limit (4300) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit
```

### New Behavior

```
# salt '*' test.fib 20578

local:
    - 1578250 ... 02670484839
    - 0.0033774375915527344
```

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes