### PR TITLE
[Fix]: Upgrade across 3006.15 (0r 3007.7) generates spurious ppbt toolchain

### DIFF
--- a/changelog/68781.fixed.md
+++ b/changelog/68781.fixed.md
@@ -1,0 +1,1 @@
+Prevented generation of spurious ppbt toolchain in /root/.local on RPM upgrade

--- a/changelog/68781.fixed.md
+++ b/changelog/68781.fixed.md
@@ -1,1 +1,2 @@
-Prevented generation of spurious ppbt toolchain in /root/.local on RPM upgrade
+- Prevented generation of spurious ppbt toolchain in /root/.local on RPM upgrade
+- Stale pycache files now get cleaned up on RPM upgrade

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -618,6 +618,8 @@ fi
 
 %posttrans
 # (Re)generate pycache in posttrans, so we're sure any old libraries have been uninstalled.
+find /opt/saltstack/salt/lib -type f -name '*.pyc' -delete
+find /opt/saltstack/salt/lib -type d -name __pycache__ -empty -delete
 /opt/saltstack/salt/bin/python3 -m compileall -qq /opt/saltstack/salt/lib
 
 
@@ -695,8 +697,8 @@ fi
 %preun
 if [ $1 -eq 0 ]; then
   # Uninstall
-  find /opt/saltstack/salt -type f -name \*\.pyc -print0 | xargs --null --no-run-if-empty rm
-  find /opt/saltstack/salt -type d -name __pycache__ -empty -print0 | xargs --null --no-run-if-empty rmdir
+  find /opt/saltstack/salt -type f -name '*.pyc' -delete
+  find /opt/saltstack/salt -type d -name __pycache__ -empty -delete
 fi
 
 %postun master

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -530,7 +530,6 @@ fi
 %post
 ln -s -f /opt/saltstack/salt/spm %{_bindir}/spm
 ln -s -f /opt/saltstack/salt/salt-pip %{_bindir}/salt-pip
-/opt/saltstack/salt/bin/python3 -m compileall -qq /opt/saltstack/salt/lib
 
 
 %post cloud
@@ -615,6 +614,11 @@ else
   # Initial installation
   /bin/systemctl preset salt-api.service >/dev/null 2>&1 || :
 fi
+
+
+%posttrans
+# (Re)generate pycache in posttrans, so we're sure any old libraries have been uninstalled.
+/opt/saltstack/salt/bin/python3 -m compileall -qq /opt/saltstack/salt/lib
 
 
 %posttrans cloud

--- a/tests/pytests/pkg/integration/test_pkg_meta.py
+++ b/tests/pytests/pkg/integration/test_pkg_meta.py
@@ -108,6 +108,7 @@ def test_requires(
         "pre,interp: /bin/sh",
         "post,interp: /bin/sh",
         "preun,interp: /bin/sh",
+        "interp,posttrans: /bin/sh",
         "manual: /usr/sbin/groupadd",
         "manual: /usr/sbin/useradd",
         "manual: /usr/sbin/usermod",


### PR DESCRIPTION
### What does this PR do?
```
Move compileall to %posttrans to avoid accidental ppbt toolchain extract

The RPM specfile runs compileall in %post to byte-compile Python modules
under /opt/saltstack/salt/lib. This worked fine until commit 48c7d58
(Bump relenv version to 0.20.0).

In relenv >=0.20.0, the interpreter bootstrap actively imports ppbt and
extracts toolchains if available, rather than just checking if they're
already there. This should not have been a problem, as commit 4bd2832
(Remove ppbt after building the salt onedir) removed ppbt from the final
package so it never gets installed at runtime.

However, the subtleties of RPM scriptlet ordering cause issues on
upgrade. The %post scriptlet executes after the new version has been
installed, but before the stale files of the old version have been
removed. This means that ppbt is still present when the compileall runs,
so the bootstrap hooks extract the ppbt toolchain into
/root/.local/relenv.

This is usually harmless, but silently eats about 215 MiB of disk space,
which can be anywhere from mildly annoying to severely damaging
depending on how tight the root filesystem is.

Since both 48c7d58 and 4bd2832 went into 3006.15, any in-place
upgrade of salt that crosses this version will generate this spurious
toolchain.

Move the compileall into %posttrans, at which point we guarantee the old
package has been completely removed and we are only acting on the
correct python libraries.
```

```
Remove stale pycache on upgrade

When we regenerate the pycache on upgrade, stale files from removed
libraries may persist. Clear everything out first to avoid this.

For consistency, change the existing pycache clear-on-uninstall to use
the simpler -delete pattern instead of invoking xargs.
```

### What issues does this PR fix or reference?
Fixes #68781

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
