### PR TITLE
fix(pip): normalize names in list_freeze_parse and detect modern pip …

### DIFF
--- a/changelog/68784.fixed.md
+++ b/changelog/68784.fixed.md
@@ -1,0 +1,11 @@
+Fix `pip.installed` state reinstalling packages on every run even when the
+correct version is already present:
+
+- `pip.list_freeze_parse` now normalizes package names (lowercase, hyphens)
+  consistent with `pip.list`, so that packages whose `pip freeze` name uses
+  underscores or mixed case (e.g. `requests_oauthlib`) are correctly detected
+  as already installed when looked up by their normalized name.
+- The post-install check in `pip.installed` now also recognizes
+  `"Requirement already satisfied:"` (modern pip ≥ 10.0) in addition to the
+  old `"Requirement already up-to-date:"` message, preventing packages
+  confirmed as already present from being falsely reported as changed.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1343,7 +1343,7 @@ def list_freeze_parse(
 
     normal_prefix = normalize(prefix) if prefix else None
 
-    if prefix is None or "pip".startswith(normal_prefix):
+    if normal_prefix is None or "pip".startswith(normal_prefix):
         packages["pip"] = version(bin_env, cwd)
 
     for line in freeze(
@@ -1378,7 +1378,7 @@ def list_freeze_parse(
             continue
 
         normal_name = normalize(name)
-        if prefix:
+        if normal_prefix:
             if normal_name.startswith(normal_prefix):
                 packages[normal_name] = version_
         else:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1341,7 +1341,9 @@ def list_freeze_parse(
     cwd = _pip_bin_env(cwd, bin_env)
     packages = {}
 
-    if prefix is None or "pip".startswith(prefix):
+    normal_prefix = normalize(prefix) if prefix else None
+
+    if prefix is None or "pip".startswith(normal_prefix):
         packages["pip"] = version(bin_env, cwd)
 
     for line in freeze(
@@ -1375,11 +1377,12 @@ def list_freeze_parse(
             logger.error("Can't parse line '%s'", line)
             continue
 
+        normal_name = normalize(name)
         if prefix:
-            if name.lower().startswith(prefix.lower()):
-                packages[name] = version_
+            if normal_name.startswith(normal_prefix):
+                packages[normal_name] = version_
         else:
-            packages[name] = version_
+            packages[normal_name] = version_
 
     return packages
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -19,6 +19,7 @@ requisite to a pkg.installed state for the package which provides pip
 """
 
 import logging
+import re
 import sys
 import types
 
@@ -256,13 +257,10 @@ def _check_pkg_version_format(pkg):
         ret["result"] = False
         if not from_vcs and "=" in pkg and "==" not in pkg:
             ret["comment"] = (
-                "Invalid version specification in package {}. '=' is "
-                "not supported, use '==' instead.".format(pkg)
+                f"Invalid version specification in package {pkg}. '=' is not supported, use '==' instead."
             )
             return ret
-        ret["comment"] = "pip raised an exception while parsing '{}': {}".format(
-            pkg, exc
-        )
+        ret["comment"] = f"pip raised an exception while parsing '{pkg}': {exc}"
         return ret
 
     if install_req is None or install_req.req is None:
@@ -339,8 +337,8 @@ def _check_if_installed(
                 and _fulfills_version_spec(pip_list[prefix], version_spec)
             ) or (not any(version_spec)):
                 ret["result"] = True
-                ret["comment"] = "Python package {} was already installed".format(
-                    state_pkg_name
+                ret["comment"] = (
+                    f"Python package {state_pkg_name} was already installed"
                 )
                 return ret
         if force_reinstall is False and upgrade:
@@ -386,8 +384,8 @@ def _check_if_installed(
                 return ret
             if _pep440_version_cmp(pip_list[prefix], desired_version) == 0:
                 ret["result"] = True
-                ret["comment"] = "Python package {} was already installed".format(
-                    state_pkg_name
+                ret["comment"] = (
+                    f"Python package {state_pkg_name} was already installed"
                 )
                 return ret
 
@@ -915,8 +913,9 @@ def installed(
                 )
             if editable:
                 comments.append(
-                    "Package will be installed in editable mode (i.e. "
-                    'setuptools "develop mode") from {}.'.format(editable)
+                    'Package will be installed in editable mode (i.e. setuptools "develop mode") from {}.'.format(
+                        editable
+                    )
                 )
             ret["comment"] = " ".join(comments)
             return ret
@@ -1085,18 +1084,14 @@ def installed(
                         ret["changes"]["requirements"] = True
                 if ret["changes"].get("requirements"):
                     comments.append(
-                        "Successfully processed requirements file {}.".format(
-                            requirements
-                        )
+                        f"Successfully processed requirements file {requirements}."
                     )
                 else:
                     comments.append("Requirements were already installed.")
 
             if editable:
                 comments.append(
-                    "Package successfully installed from VCS checkout {}.".format(
-                        editable
-                    )
+                    f"Package successfully installed from VCS checkout {editable}."
                 )
                 ret["changes"]["editable"] = True
             ret["comment"] = " ".join(comments)
@@ -1108,10 +1103,18 @@ def installed(
             already_installed_packages = set()
             for line in pip_install_call.get("stdout", "").split("\n"):
                 # Output for already installed packages:
-                # 'Requirement already up-to-date: jinja2 in /usr/local/lib/python2.7/dist-packages\nCleaning up...'
-                if line.startswith("Requirement already up-to-date: "):
-                    package = line.split(":", 1)[1].split()[0]
-                    already_installed_packages.add(package.lower())
+                # modern pip: 'Requirement already satisfied: jinja2 in /usr/local/lib/...'
+                # old pip: 'Requirement already up-to-date: jinja2 in /usr/local/lib/python2.7/...'
+                if line.startswith(
+                    (
+                        "Requirement already satisfied: ",
+                        "Requirement already up-to-date: ",
+                    )
+                ):
+                    pkg_str = line.split(":", 1)[1].split()[0]
+                    # Strip version specifier to get just the package name
+                    pkg_name = re.split(r"[=!<>~@]", pkg_str)[0]
+                    already_installed_packages.add(__salt__["pip.normalize"](pkg_name))
 
             for prefix, state_name in target_pkgs:
                 # Case for packages that are not an URL
@@ -1138,7 +1141,7 @@ def installed(
                     else:
                         if (
                             prefix in pipsearch
-                            and prefix.lower() not in already_installed_packages
+                            and prefix not in already_installed_packages
                         ):
                             ver = pipsearch[prefix]
                             ret["changes"][f"{prefix}=={ver}"] = "Installed"

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -913,9 +913,7 @@ def installed(
                 )
             if editable:
                 comments.append(
-                    'Package will be installed in editable mode (i.e. setuptools "develop mode") from {}.'.format(
-                        editable
-                    )
+                    f'Package will be installed in editable mode (i.e. setuptools "develop mode") from {editable}.'
                 )
             ret["comment"] = " ".join(comments)
             return ret

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -1509,8 +1509,8 @@ def test_list_freeze_parse_command(python_binary):
                 use_vt=False,
             )
             assert ret == {
-                "SaltTesting-dev": "git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8",
-                "M2Crypto": "0.21.1",
+                "salttesting-dev": "git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8",
+                "m2crypto": "0.21.1",
                 "bbfreeze-loader": "1.1.0",
                 "bbfreeze": "1.1.0",
                 "pip": mock_version,
@@ -1559,8 +1559,8 @@ def test_list_freeze_parse_command_with_all(python_binary):
                 use_vt=False,
             )
             assert ret == {
-                "SaltTesting-dev": "git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8",
-                "M2Crypto": "0.21.1",
+                "salttesting-dev": "git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8",
+                "m2crypto": "0.21.1",
                 "bbfreeze-loader": "1.1.0",
                 "bbfreeze": "1.1.0",
                 "pip": "9.0.1",
@@ -1599,6 +1599,48 @@ def test_list_freeze_parse_command_with_prefix(python_binary):
                 use_vt=False,
             )
             assert ret == {"bbfreeze-loader": "1.1.0", "bbfreeze": "1.1.0"}
+
+
+def test_list_freeze_parse_normalizes_package_names(python_binary):
+    """
+    list_freeze_parse must return normalized package names (lowercase, hyphens)
+    consistent with list_(), so that pip_list lookups work correctly regardless
+    of how the name appears in `pip freeze` output (underscores, mixed case, etc.).
+    """
+    eggs = [
+        "requests_oauthlib==1.3.0",
+        "My_Package==2.0.0",
+        "Pillow==10.0.0",
+    ]
+    mock = MagicMock(return_value={"retcode": 0, "stdout": "\n".join(eggs)})
+    with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
+        with patch("salt.modules.pip.version", MagicMock(return_value="6.1.1")):
+            ret = pip.list_freeze_parse()
+            assert ret == {
+                "requests-oauthlib": "1.3.0",
+                "my-package": "2.0.0",
+                "pillow": "10.0.0",
+                "pip": "6.1.1",
+            }
+
+
+def test_list_freeze_parse_prefix_matches_normalized_name(python_binary):
+    """
+    list_freeze_parse must match packages by normalized prefix even when the
+    freeze output uses underscores but the caller uses hyphens (or vice versa).
+    This ensures _check_if_installed does not produce false negatives.
+    """
+    eggs = [
+        "requests_oauthlib==1.3.0",
+        "requests==2.31.0",
+        "other_pkg==0.1.0",
+    ]
+    mock = MagicMock(return_value={"retcode": 0, "stdout": "\n".join(eggs)})
+    with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
+        with patch("salt.modules.pip.version", MagicMock(return_value="6.1.1")):
+            # A hyphenated prefix must match an underscore-named package
+            ret = pip.list_freeze_parse(prefix="requests-oauthlib")
+            assert ret == {"requests-oauthlib": "1.3.0"}
 
 
 def test_list_upgrades_legacy(python_binary):

--- a/tests/pytests/unit/states/test_pip.py
+++ b/tests/pytests/unit/states/test_pip.py
@@ -71,3 +71,89 @@ def test_issue_64169(caplog):
         # Confirm that the state continued to install the package as expected.
         # Only check the 'pkgs' parameter of pip.install
         assert mock_pip_install.call_args.kwargs["pkgs"] == pkg_to_install
+
+
+def test_already_satisfied_not_reported_as_change():
+    """
+    When pip outputs 'Requirement already satisfied' (modern pip >= 10) for a
+    package that ended up in target_pkgs, the state must NOT report it as a
+    change. Previously only the old 'Requirement already up-to-date' message
+    was checked, causing the state to always report the package as installed.
+    """
+    pkg_name = "my-package"
+    pkg_version = "1.0.0"
+
+    mock_pip_list = MagicMock(
+        side_effect=[
+            {},  # pre-cache: empty → package goes to target_pkgs
+            {},  # _check_if_installed fallback: package not found
+            {pkg_name: pkg_version},  # post-install verification
+        ]
+    )
+    mock_pip_version = MagicMock(return_value="24.0.0")
+    mock_pip_install = MagicMock(
+        return_value={
+            "retcode": 0,
+            "stdout": f"Requirement already satisfied: {pkg_name} in /path/to/site-packages",
+        }
+    )
+
+    with patch.dict(
+        pip_state.__salt__,
+        {
+            "pip.list": mock_pip_list,
+            "pip.version": mock_pip_version,
+            "pip.install": mock_pip_install,
+            "pip.normalize": pip_module.normalize,
+        },
+    ):
+        ret = pip_state.installed(name=pkg_name)
+
+    assert ret["result"] is True
+    # The package was already satisfied — no changes should be reported
+    assert (
+        ret["changes"] == {}
+    ), "Package reported as 'Requirement already satisfied' must not appear in changes"
+
+
+def test_already_satisfied_with_version_spec_not_reported_as_change():
+    """
+    When pip outputs 'Requirement already satisfied: pkg==x.y.z ...' (with a
+    version specifier in the message), the version suffix must be stripped when
+    checking against already_installed_packages so the package is still
+    correctly excluded from changes.
+    """
+    pkg_name = "my-package"
+    pkg_version = "1.0.0"
+
+    mock_pip_list = MagicMock(
+        side_effect=[
+            {},  # pre-cache: empty
+            {},  # _check_if_installed fallback
+            {pkg_name: pkg_version},  # post-install verification
+        ]
+    )
+    mock_pip_version = MagicMock(return_value="24.0.0")
+    mock_pip_install = MagicMock(
+        return_value={
+            "retcode": 0,
+            # pip includes the version spec in the satisfied message
+            "stdout": f"Requirement already satisfied: {pkg_name}=={pkg_version} in /path",
+        }
+    )
+
+    with patch.dict(
+        pip_state.__salt__,
+        {
+            "pip.list": mock_pip_list,
+            "pip.version": mock_pip_version,
+            "pip.install": mock_pip_install,
+            "pip.normalize": pip_module.normalize,
+        },
+    ):
+        ret = pip_state.installed(name=pkg_name)
+
+    assert ret["result"] is True
+    assert (
+        ret["changes"] == {}
+    ), "Package with version spec in satisfied message must not appear in changes"


### PR DESCRIPTION
### What does this PR do?

Two related bugs in the pip state and module cause a Python package to be "installed" (and reported as changed) on every Salt state run, even when the package is already at the correct version.

#### Bug 1 — `list_freeze_parse` does not normalize package names

Commit 68728e6 updated `list_()` to return normalized package names (lowercase, hyphens) via `normalize()`. However, `list_freeze_parse`, which is the fallback used for pip < 9.0, was not updated. It still returns names exactly as they appear in `pip freeze` output (e.g. `"requests_oauthlib"` with an underscore).

Because `_check_if_installed` now receives a normalized `prefix` (e.g. `"requests-oauthlib"`) and compares it against a `CaseInsensitiveDict` that only handles case — not underscore vs. hyphen — the lookup always fails. The package is added to `target_pkgs` and pip is called on every run.

#### Bug 2 — Post-install detection uses an outdated pip message

After calling `pip.install`, the state checks pip's stdout to determine whether a package was already present, to avoid reporting it as a change.

The check was:

```python
if line.startswith("Requirement already up-to-date: "):
```

Modern pip (≥ 10.0) outputs "Requirement already satisfied: ..." instead.

Because the message never matched, `already_installed_packages` stayed empty and every pip call resulted in the package being reported as "Installed" in the state changes dict.

### Fix

* **salt/modules/pip.py** — `list_freeze_parse` now computes a `normal_prefix` and stores each package under its normalized name (`normalize(name)`), consistent with `list_()`.
* **salt/states/pip_state.py** — The post-install check now also matches "Requirement already satisfied: ". The package name is extracted by stripping any version specifier with `re.split`, then normalized with `pip.normalize` before being stored in `already_installed_packages`. The comparison with `prefix` (already normalized) no longer calls `.lower()` unnecessarily.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes