### PR TITLE
Add `x86_64_v2` as a possible package architecture

### DIFF
--- a/changelog/68789.fixed.md
+++ b/changelog/68789.fixed.md
@@ -1,0 +1,1 @@
+Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -449,10 +449,9 @@ def normalize_name(name):
             return name
     except ValueError:
         return name
-    if arch in (__grains__["osarch"], "noarch") or salt.utils.pkg.rpm.check_32(
-        arch, osarch=__grains__["osarch"]
-    ):
-        return name[: -(len(arch) + 1)]
+    stripped_name = name[: -(len(arch) + 1)]
+    if salt.utils.pkg.rpm.resolve_name(stripped_name, arch) == stripped_name:
+        return stripped_name
     return name
 
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -14,7 +14,8 @@ import salt.utils.stringutils
 log = logging.getLogger(__name__)
 
 # These arches compiled from the rpmUtils.arch python module source
-ARCHES_64 = ("x86_64", "athlon", "amd64", "ia32e", "ia64", "geode")
+ARCHES_X86_64 = ("x86_64", "x86_64_v2")
+ARCHES_64 = ARCHES_X86_64 + ("athlon", "amd64", "ia32e", "ia64", "geode")
 ARCHES_32 = ("i386", "i486", "i586", "i686")
 ARCHES_PPC = ("ppc", "ppc64", "ppc64le", "ppc64iseries", "ppc64pseries")
 ARCHES_S390 = ("s390", "s390x")
@@ -105,7 +106,11 @@ def resolve_name(name, arch, osarch=None):
     if osarch is None:
         osarch = get_osarch()
 
-    if not check_32(arch, osarch) and arch not in (osarch, "noarch"):
+    if (
+        not check_32(arch, osarch)
+        and arch not in (osarch, "noarch")
+        and not (arch in ARCHES_X86_64 and osarch in ARCHES_X86_64)
+    ):
         name += f".{arch}"
     return name
 

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -3240,3 +3240,19 @@ def test_59705_version_as_accidental_float_should_become_text(
         yumpkg.install("fnord", version=new)
         call = cmd_mock.mock_calls[0][1][0]
         assert call == expected_cmd
+
+
+def test_normalize_name_with_arch_x86_64_v2():
+    """
+    Test if `salt.modules.yumpkg.normalize_name` is able to identify x86_64_v2
+    as a possible package architecture and remove it from name in case of
+    using it on x86_64 and not in any other cases.
+    """
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("chrony.x86_64_v2") == "chrony"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("chrony.x86_64") == "chrony"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="amd64")):
+        assert yumpkg.normalize_name("chrony.x86_64") == "chrony.x86_64"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("rootfiles.noarch") == "rootfiles"

--- a/tests/unit/modules/test_kernelpkg_linux_yum.py
+++ b/tests/unit/modules/test_kernelpkg_linux_yum.py
@@ -18,6 +18,7 @@ from tests.support.unit import TestCase
 try:
     import salt.modules.kernelpkg_linux_yum as kernelpkg
     import salt.modules.yumpkg as pkg
+    from salt.utils.pkg.rpm import get_osarch
 
     HAS_MODULES = True
 except ImportError:
@@ -33,7 +34,7 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
     _kernelpkg = kernelpkg
     KERNEL_LIST = ["3.10.0-327.el7", "3.11.0-327.el7", "4.9.1-100.el7"]
     LATEST = KERNEL_LIST[-1]
-    OS_ARCH = "x86_64"
+    OS_ARCH = get_osarch()
     OS_NAME = "RedHat"
     OS_MAJORRELEASE = "7"
 


### PR DESCRIPTION
### What does this PR do?

`x86_64_v2` is used by some Linux vendors as a package architecture compatible with `x86_64` and the repos could contain both `x86_64` and `x86_64_v2`.

`yumpkg` module should handle it properly.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29847

### Previous Behavior
On attempt to install the package, it could be installed, but wrongly reported as not installed.

### New Behavior
No issues with package name normalization.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
