### PR TITLE
Allow ssh users with backslash

### DIFF
--- a/changelog/68790.fixed.md
+++ b/changelog/68790.fixed.md
@@ -1,0 +1,1 @@
+Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1103,7 +1103,10 @@ class Single:
             self.python_env = kwargs.get("ssh_python_env")
         else:
             if user:
-                thin_dir = DEFAULT_THIN_DIR.replace("%%USER%%", user)
+                thin_dir = DEFAULT_THIN_DIR.replace(
+                    "%%USER%%",
+                    re.sub(r"[^a-zA-Z0-9\._\-@]", "_", user),
+                )
             else:
                 thin_dir = DEFAULT_THIN_DIR.replace("%%USER%%", "root")
             self.thin_dir = thin_dir.replace(

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -156,7 +156,7 @@ class Shell:
         if self.priv and self.priv != "agent-forwarding":
             options.append(f"IdentityFile={self.priv}")
         if self.user:
-            options.append(f"User={self.user}")
+            options.append(f"User={shlex.quote(self.user)}")
         if self.identities_only:
             options.append("IdentitiesOnly=yes")
 
@@ -202,7 +202,7 @@ class Shell:
         if self.port:
             options.append(f"Port={self.port}")
         if self.user:
-            options.append(f"User={self.user}")
+            options.append(f"User={shlex.quote(self.user)}")
         if self.identities_only:
             options.append("IdentitiesOnly=yes")
 

--- a/tests/pytests/unit/client/ssh/test_shell.py
+++ b/tests/pytests/unit/client/ssh/test_shell.py
@@ -273,3 +273,18 @@ def test_scp_command_execution_uses_custom_path():
         args, _ = mock_run_cmd.call_args
         assert "/custom/scp" in args[0]
         assert "source_file.txt example.com:/path/dest_file.txt" in args[0]
+
+
+def test_ssh_using_user_with_backslash():
+    _shell = shell.Shell(
+        opts={"_ssh_version": (4, 9)},
+        host="host.example.org",
+        user="exampledomain\\user",
+        passwd="password",
+    )
+    with patch.object(
+        _shell, "_run_cmd", return_value=(None, None, None)
+    ) as mock_run_cmd:
+        cmd_string = _shell.exec_cmd("whoami")
+        args, _ = mock_run_cmd.call_args
+        assert " User='exampledomain\\user' " in args[0]

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -960,3 +960,21 @@ def test_run_integration_with_no_pre_hook(opts, target):
     with patch.object(single_instance, "cmd_block", mock_cmd_block):
         stdout, stderr, retcode = single_instance.run()
         assert retcode == 0
+
+
+def test_check_thin_dir_with_backslash_user(opts):
+    """
+    Test `thin_dir` path generation for the user with backslash in the name
+    """
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "host.example.org",
+        "host.example.org",
+        user="exampledomain\\user",
+        mods={},
+        fsclient=None,
+        mine=False,
+    )
+    assert single.thin_dir == single.opts["thin_dir"]
+    assert ".exampledomain_user_" in single.thin_dir


### PR DESCRIPTION
### What does this PR do?

In case of using AD authentication on the client for the users, it's possible to use `user@domain` with `salt-ssh`, but the other valid notation `domain\user` doesn't work as producing broken `thin_dir` path and user value is passing to `ssh` the wrong way with improper quoting.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29164

### Previous Behavior
salt-ssh was failing with imporper calculation of target directory or either improper passing the username to ssh/scp commands used internally requiring extra quoting for the username (with extra quoting it was working fine to connect to remote system but was failing with directory path calculation)

### New Behavior
salt-ssh is able to work properly with DOMAIN\USER notation of the username.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
