### PR TITLE
Fix several x509_v2 issues

### DIFF
--- a/changelog/66929.fixed.md
+++ b/changelog/66929.fixed.md
@@ -1,0 +1,1 @@
+Fixed x509_v2.certificate_managed state fails if another state.apply is queued

--- a/changelog/66942.fixed.md
+++ b/changelog/66942.fixed.md
@@ -1,0 +1,1 @@
+Fixed x509_v2 private_key_managed failing on Windows due to default `mode` argument

--- a/changelog/68828.fixed.md
+++ b/changelog/68828.fixed.md
@@ -1,0 +1,1 @@
+Made x509_v2 certificate_managed respect `copypath` and `prepend_cn` parameters

--- a/salt/modules/x509_v2.py
+++ b/salt/modules/x509_v2.py
@@ -118,6 +118,14 @@ or compound matcher (for the latter, see the notes above).
 
 Breaking changes versus the previous ``x509`` modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* The ``public_key`` parameter to ``x509.certificate_managed`` (and corresponding
+  ``x509.create_certificate``) used to accept a private key.
+  The new modules require an actual public key if this parameter is specified.
+  You can pass a private key in the ``private_key`` parameter instead.
+
+  Failing to ensure it really is a public key you are passing as ``public_key`` fails
+  with ``Could not load PEM-encoded public key.``.
+
 * The output format has changed for all ``read_*`` functions as well as the state return dict.
 * The formatting of some extension definitions might have changed, but should
   be stable for most basic use cases.
@@ -267,33 +275,48 @@ def create_certificate(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     private_key
-        The private key corresponding to the public key the certificate should
-        be issued for. This is one way of specifying the public key that will
-        be included in the certificate, the other ones being ``public_key`` and ``csr``.
+        A **private key**, which is used to derive the public key the certificate
+        is issued for. If unset, checks ``public_key`` or ``csr`` to derive it.
+
+        Ignored when creating self-signed certificates (missing ``signing_cert``).
+
+        .. hint::
+            When ``encoding`` is ``pkcs12``, this private key is embedded into
+            the resulting container.
 
     private_key_passphrase
         If ``private_key`` is specified and encrypted, the passphrase to decrypt it.
 
     public_key
-        The public key the certificate should be issued for. Other ways of passing
-        the required information are ``private_key`` and ``csr``. If neither are set,
-        the public key of the ``signing_private_key`` will be included, i.e.
-        a self-signed certificate is generated.
+        A **public key**, which is used as the public key the certificate is issued for,
+        but only if ``private_key`` is **not** specified.
+
+        If this is unset, checks ``csr`` to derive it.
+
+        Ignored when creating self-signed certificates (missing ``signing_cert``).
 
     csr
-        A certificate signing request to use as a base for generating the certificate.
-        The following information will be respected, depending on configuration:
-        * public key
-        * extensions, if not otherwise specified (arguments, signing_policy)
+        A **certificate signing request** to use as a base for generating the certificate:
+
+        - Extensions not otherwise specified (arguments, signing_policy) are copied.
+        - If ``private_key`` and ``public_key`` are both unspecified, copies the embedded
+          public key into the certificate. This step is skipped when creating self-signed
+          certificates (missing ``signing_cert``).
 
     signing_cert
         The CA certificate to be used for signing the issued certificate.
 
+        Leave empty to create a self-signed certificate.
+
     signing_private_key
-        The private key corresponding to the public key in ``signing_cert``. Required.
+        The private key to be used for signing the new certificate. Required.
+
+        Usually, this is the private key corresponding to the public key in ``signing_cert``.
+        When creating self-signed certificates (missing ``signing_cert``), derives
+        the new certificate's embedded public key from this private key.
 
     signing_private_key_passphrase
         If ``signing_private_key`` is encrypted, the passphrase to decrypt it.
@@ -385,10 +408,9 @@ def create_certificate(
 
             .. code-block:: yaml
 
-                # mind this being a list, not a dict
                 - subjectAltName:
-                    - email:me@example.com
-                    - DNS:example.com
+                    - email:me@example.com  # list items can be strings
+                    - dns: example.com      # or single-key dicts
 
         issuerAltName
             The syntax is the same as for ``subjectAltName``, except that the additional
@@ -846,7 +868,7 @@ def create_crl(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     encoding
         Specify the encoding of the resulting certificate revocation list.
@@ -1059,7 +1081,7 @@ def create_csr(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     encoding
         Specify the encoding of the resulting certificate signing request.

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -227,8 +227,6 @@ def certificate_managed(
     signing_policy=None,
     encoding="pem",
     append_certs=None,
-    copypath=None,
-    prepend_cn=False,
     digest="sha256",
     signing_private_key=None,
     signing_private_key_passphrase=None,

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -1591,7 +1591,13 @@ def _file_managed(name, test=None, **kwargs):
         raise SaltInvocationError("test param can only be None or True")
     # work around https://github.com/saltstack/salt/issues/62590
     test = test or __opts__["test"]
-    res = __salt__["state.single"]("file.managed", name, test=test, **kwargs)
+    res = __salt__["state.single"](
+        "file.managed", name, test=test, concurrent=True, **kwargs
+    )
+    if not isinstance(res, dict):
+        raise CommandExecutionError(
+            f"Failed running file.managed in x509_v2 state: {res}"
+        )
     return res[next(iter(res))]
 
 

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -249,7 +249,7 @@ def certificate_managed(
     Ensure an X.509 certificate is present as specified.
 
     This function accepts the same arguments as :py:func:`x509.create_certificate <salt.modules.x509_v2.create_certificate>`,
-    as well as most ones for `:py:func:`file.managed <salt.states.file.managed>`.
+    as well as most ones for :py:func:`file.managed <salt.states.file.managed>`.
 
     name
         The path the certificate should be present at.
@@ -295,37 +295,49 @@ def certificate_managed(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
-
-    signing_private_key
-        The private key corresponding to the public key in ``signing_cert``. Required.
-
-    signing_private_key_passphrase
-        If ``signing_private_key`` is encrypted, the passphrase to decrypt it.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     signing_cert
         The CA certificate to be used for signing the issued certificate.
 
-    public_key
-        The public key the certificate should be issued for. Other ways of passing
-        the required information are ``private_key`` and ``csr``. If neither are set,
-        the public key of the ``signing_private_key`` will be included, i.e.
-        a self-signed certificate is generated.
+        Leave empty to create a self-signed certificate.
+
+    signing_private_key
+        The private key to be used for signing the new certificate. Required.
+
+        Usually, this is the private key corresponding to the public key in ``signing_cert``.
+        When creating self-signed certificates (missing ``signing_cert``), derives
+        the new certificate's embedded public key from this private key.
+
+    signing_private_key_passphrase
+        If ``signing_private_key`` is encrypted, the passphrase to decrypt it.
 
     private_key
-        The private key corresponding to the public key the certificate should
-        be issued for. This is one way of specifying the public key that will
-        be included in the certificate, the other ones being ``public_key`` and ``csr``.
+        A **private key**, which is used to derive the public key the certificate
+        is issued for. If this is unset, checks ``public_key`` or ``csr`` to derive it.
+
+        Ignored when creating self-signed certificates (missing ``signing_cert``).
+
+        .. hint::
+            When ``encoding`` is ``pkcs12``, this private key is embedded into
+            the resulting container.
 
     private_key_passphrase
         If ``private_key`` is specified and encrypted, the passphrase to decrypt it.
 
-    csr
-        A certificate signing request to use as a base for generating the certificate.
-        The following information will be respected, depending on configuration:
+    public_key
+        A **public key**, which is used as the public key the certificate is issued for,
+        but only if ``private_key`` is **not** specified. If this is unset, checks ``csr`` to derive it.
 
-        * public key
-        * extensions, if not otherwise specified (arguments, signing_policy)
+        Ignored when creating self-signed certificates (missing ``signing_cert``).
+
+    csr
+        A **certificate signing request** to use as a base for generating the certificate:
+
+        - Extensions not otherwise specified (arguments, signing_policy) are copied.
+        - If ``private_key`` and ``public_key`` are both unspecified, copies the embedded
+          public key into the certificate. This step is skipped when creating self-signed
+          certificates (missing ``signing_cert``).
 
     subject
         The subject's distinguished name embedded in the certificate. This is one way of
@@ -740,7 +752,7 @@ def crl_managed(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     encoding
         Specify the encoding of the resulting certificate revocation list.
@@ -1045,7 +1057,7 @@ def csr_managed(
         The hashing algorithm to use for the signature. Valid values are:
         sha1, sha224, sha256, sha384, sha512, sha512_224, sha512_256, sha3_224,
         sha3_256, sha3_384, sha3_512. Defaults to ``sha256``.
-        This will be ignored for ``ed25519`` and ``ed448`` key types.
+        Ignored for ``ed25519`` and ``ed448`` key types.
 
     encoding
         Specify the encoding of the resulting certificate revocation list.

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -188,6 +188,7 @@ import os.path
 from datetime import datetime, timedelta, timezone
 
 import salt.utils.files
+import salt.utils.platform
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 
@@ -1369,7 +1370,7 @@ def private_key_managed(
     if extra_args:
         raise SaltInvocationError(f"Unrecognized keyword arguments: {list(extra_args)}")
 
-    if not file_args.get("mode"):
+    if not file_args.get("mode") and not salt.utils.platform.is_windows():
         # ensure secure defaults
         file_args["mode"] = "0400"
 

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -1521,6 +1521,21 @@ def test_certificate_managed_pkcs12_embedded_pk_kept(
     assert new_pk.public_key().public_numbers() == cur_pk.public_key().public_numbers()
 
 
+@pytest.mark.parametrize("prepend_cn", [False, True])
+def test_certificate_managed_copypath(
+    x509, cert_args, rsa_privkey, ca_key, prepend_cn, tmp_path
+):
+    cert_args["private_key"] = rsa_privkey
+    cert_args["copypath"] = str(tmp_path)
+    cert_args["prepend_cn"] = prepend_cn
+    ret = x509.certificate_managed(**cert_args)
+    cert = _assert_cert_basic(ret, cert_args["name"], rsa_privkey, ca_key)
+    prefix = ""
+    if prepend_cn:
+        prefix = "success-"
+    assert (tmp_path / f"{prefix}{cert.serial_number:x}.crt").exists()
+
+
 def test_crl_managed_empty(x509, crl_args, ca_key):
     ret = x509.crl_managed(**crl_args)
     crl = _assert_crl_basic(ret, ca_key)

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -28,6 +28,7 @@ pytestmark = [
     pytest.mark.slow_test,
     pytest.mark.skipif(HAS_LIBS is False, reason="Needs cryptography library"),
     pytest.mark.skip_on_fips_enabled_platform,
+    pytest.mark.windows_whitelisted,
 ]
 
 
@@ -1362,6 +1363,7 @@ def test_certificate_managed_extension_removed(x509, cert_args, rsa_privkey, ca_
     }
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.parametrize("mode", ["0400", "0640", "0644"])
 def test_certificate_managed_mode(x509, cert_args, rsa_privkey, ca_key, mode, modules):
     """
@@ -1388,6 +1390,7 @@ def test_certificate_managed_file_managed_create_false(
     assert not pathlib.Path(cert_args["name"]).exists()
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_cert")
 @pytest.mark.parametrize("existing_cert", [{"mode": "0644"}], indirect=True)
 def test_certificate_managed_mode_change_only(
@@ -1409,6 +1412,7 @@ def test_certificate_managed_mode_change_only(
     assert cert_new.serial_number == cert.serial_number
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_cert")
 def test_certificate_managed_mode_test_true(x509, cert_args, modules):
     """
@@ -1765,6 +1769,7 @@ def test_crl_managed_existing_encoding_change_only(x509, crl_args, ca_key):
     assert new.extensions[0].value.crl_number == 1
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.parametrize("mode", ["0400", "0640", "0644"])
 def test_crl_managed_mode(x509, crl_args, ca_key, mode, modules):
     """
@@ -1787,6 +1792,7 @@ def test_crl_managed_file_managed_create_false(x509, crl_args):
     assert not pathlib.Path(crl_args["name"]).exists()
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_crl")
 @pytest.mark.parametrize(
     "existing_crl",
@@ -1812,6 +1818,7 @@ def test_crl_managed_mode_change_only(x509, crl_args, ca_key, modules):
     )
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_crl")
 def test_crl_managed_mode_test_true(x509, crl_args, modules):
     """
@@ -2059,6 +2066,7 @@ def test_csr_managed_extension_removed(x509, csr_args, csr_args_exts, rsa_privke
     }
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.parametrize("mode", ["0400", "0640", "0644"])
 def test_csr_managed_mode(x509, csr_args, rsa_privkey, mode, modules):
     """
@@ -2081,6 +2089,7 @@ def test_csr_managed_file_managed_create_false(x509, csr_args):
     assert not pathlib.Path(csr_args["name"]).exists()
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_csr")
 @pytest.mark.parametrize("existing_csr", [{"mode": "0644"}], indirect=True)
 def test_csr_managed_mode_change_only(x509, csr_args, ca_key, modules):
@@ -2097,6 +2106,7 @@ def test_csr_managed_mode_change_only(x509, csr_args, ca_key, modules):
     assert modules.file.get_mode(csr_args["name"]) == "0640"
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_csr")
 def test_csr_managed_mode_test_true(x509, csr_args, modules):
     """
@@ -2379,6 +2389,7 @@ def test_private_key_managed_passphrase_changed_overwrite(x509, pk_args):
     _assert_pk_basic(ret, "rsa", passphrase="hunter1")
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.parametrize("encoding", ["pem", "der"])
 @pytest.mark.parametrize("mode", [None, "0600", "0644"])
 def test_private_key_managed_mode(x509, pk_args, mode, encoding, modules):
@@ -2403,6 +2414,7 @@ def test_private_key_managed_file_managed_create_false(x509, pk_args):
     assert not pathlib.Path(pk_args["name"]).exists()
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_pk")
 def test_private_key_managed_mode_test_true(x509, pk_args, modules):
     """
@@ -2478,6 +2490,7 @@ def test_private_key_managed_follow_symlinks_changes(
     assert pathlib.Path(ret.name).is_symlink() == follow
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.usefixtures("existing_pk")
 @pytest.mark.parametrize("existing_pk", [{"mode": "0400"}], indirect=True)
 def test_private_key_managed_mode_change_only(x509, pk_args, modules):

--- a/tests/pytests/integration/states/test_x509_v2.py
+++ b/tests/pytests/integration/states/test_x509_v2.py
@@ -3,8 +3,10 @@ Tests for the x509_v2 module
 """
 
 import base64
+import json
 import logging
 import shutil
+import time
 from pathlib import Path
 
 import pytest
@@ -671,6 +673,71 @@ def test_certificate_managed_remote_renew(x509_salt_call_cli, cert_args):
     assert ret.returncode == 0
     cert_new = _get_cert(cert_args["name"])
     assert cert_new.serial_number != cert_cur.serial_number
+
+
+def test_certificate_managed_works_with_queued_state_application(
+    x509_salt_master, x509_salt_call_cli, x509_salt_minion, cert_args
+):
+    sleep_tpl = """
+    Sleep to allow queueing state run:
+      module.run:
+        - test.sleep:
+          - length: {}
+    """
+    cert_state = (
+        sleep_tpl.format("3")
+        + f"""
+    Some private key is present:
+      x509.certificate_managed:
+        - name: {json.dumps(cert_args['name'])}
+        - ca_server: {cert_args['ca_server']}
+        - signing_policy: {cert_args['signing_policy']}
+        - private_key: {json.dumps(cert_args['private_key'])}
+    """
+    )
+    tgt = Path(cert_args["name"])
+    salt_cli = x509_salt_master.salt_cli()
+
+    def jobwait(jid, exp):
+        cnt = 0
+        while (
+            bool(
+                x509_salt_call_cli.run(
+                    "saltutil.find_job", jid, minion_tgt=x509_salt_minion.id
+                ).data
+            )
+            is not exp
+        ):
+            cnt += 1
+            if cnt > 100:
+                raise AssertionError(
+                    f"Timeout waiting for jid {jid} to {exp and 'start' or 'finish'}"
+                )
+            time.sleep(0.1)
+
+    with x509_salt_master.state_tree.base.temp_file(
+        "queued_staterun_test.sls", cert_state
+    ), x509_salt_master.state_tree.base.temp_file("sleep.sls", sleep_tpl.format("0.1")):
+        res = salt_cli.run(
+            "state.apply",
+            "queued_staterun_test",
+            "--async",
+            minion_tgt=x509_salt_minion.id,
+        )
+        job_id = res.stdout.rsplit("ID: ", maxsplit=1)[-1].strip()
+        jobwait(job_id, True)  # ensure scheduling order
+        salt_cli.run(
+            "state.apply",
+            "sleep",
+            "queue=true",
+            "--async",
+            minion_tgt=x509_salt_minion.id,
+        )
+        assert not tgt.exists()
+        jobwait(job_id, False)
+
+    assert tgt.exists()
+    assert _get_cert(tgt)
 
 
 @pytest.mark.usefixtures("privkey_new")


### PR DESCRIPTION
### What does this PR do?
* Makes x509_v2 states use `concurrency=True` when calling `state.single` for `file.managed` runs [NOTE: This doesn't happen in 3008 because of changes to the `state.running` function, the new test is superfluous there]
* Makes `x509.certificate_managed` pass through `prepend_cn` and `copypath` params
* Documents a forgotten breaking change versus the previous modules regarding handling of the `public_key` parameter
* Tries to clear up documentation regarding what is expected in `private_key`, `public_key` and `csr` params
* Doesn't add default `mode` for private_key_managed on Windows

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/66929
Fixes: https://github.com/saltstack/salt/issues/68828
Fixes: https://github.com/saltstack/salt/issues/66889 (by updating docs)
Fixes: https://github.com/saltstack/salt/issues/66942

### Previous Behavior
* `x509.certificate_managed` (and probably other states) fail when a state run is queued
* `x509.certificate_managed` ignores `prepend_cn` and `copypath`
* Docs are missing a breaking change and reported to be confusing regarding public key input methods for certificate management
* private_key_managed fails on Windows

### New Behavior
* queued state runs don't interfere
* params are passed through
* An existing breaking change is documented properly, hopefully the docs are clearer
* private_key_managed works on Windows

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes