### PR TITLE
Upgrade pyopenssl to >= 26.0.0

### DIFF
--- a/changelog/68832.fixed.md
+++ b/changelog/68832.fixed.md
@@ -1,0 +1,3 @@
+Upgrade pyopenssl to >= 26.0.0
+ - CVE-2026-27459
+ - CVE-2026-27448

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,7 +33,7 @@ psutil<6.0.0; python_version <= '3.9'
 psutil>=5.0.0; python_version >= '3.10'
 pymssql==2.3.11; sys_platform == 'win32'
 pymysql>=1.0.2; sys_platform == 'win32'
-pyopenssl>=25.0.0
+pyopenssl>=26.0.0
 python-dateutil>=2.8.1
 python-gnupg>=0.4.7
 pythonnet>=3.0.1; sys_platform == 'win32'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -465,7 +465,7 @@ pynacl==1.5.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -337,7 +337,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -229,7 +229,7 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pygments==2.17.2
     # via sphinx
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -364,7 +364,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -503,7 +503,7 @@ pynacl==1.5.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -374,7 +374,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -341,7 +341,7 @@ pymysql==1.1.2
     #   -r requirements/base.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.in
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -457,7 +457,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -331,7 +331,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -225,7 +225,7 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pygments==2.19.2
     # via sphinx
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -358,7 +358,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -495,7 +495,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -366,7 +366,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -335,7 +335,7 @@ pymysql==1.1.2
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.in
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -452,7 +452,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -327,7 +327,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -221,7 +221,7 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pygments==2.19.2
     # via sphinx
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -354,7 +354,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -490,7 +490,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -362,7 +362,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -331,7 +331,7 @@ pymysql==1.1.2
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.in
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -457,7 +457,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -330,7 +330,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -223,7 +223,7 @@ pygments==2.19.2
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   sphinx
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -357,7 +357,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -490,7 +490,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -365,7 +365,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -333,7 +333,7 @@ pymysql==1.1.2
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.in
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -527,7 +527,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -380,7 +380,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -236,7 +236,7 @@ pygments==2.19.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   sphinx
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -419,7 +419,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -554,7 +554,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -410,7 +410,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.in
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -354,7 +354,7 @@ pymysql==1.1.2
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.in
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -127,7 +127,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -146,7 +146,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.1.2 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -137,7 +137,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -148,7 +148,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.1.2
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -125,7 +125,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -144,7 +144,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.1.2 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -135,7 +135,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -146,7 +146,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.1.2
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -142,7 +142,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.1.2 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -133,7 +133,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -144,7 +144,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.1.2
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -123,7 +123,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -142,7 +142,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.1.2 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -133,7 +133,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -144,7 +144,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.1.2
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -127,7 +127,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -150,7 +150,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.1.2 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -137,7 +137,7 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -150,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.1.2
     # via -r requirements/base.txt
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
Adresses the following CVEs:
 - CVE-2026-27459
 - CVE-2026-27448

fixes: #68832