### PR TITLE
Docs: note that service.masked may require service.disabled first (#61322)

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -832,6 +832,12 @@ def masked(name, runtime=False):
     Ensures that the named service is masked (i.e. prevented from being
     started).
 
+    .. note::
+        If the service is currently enabled, it should be disabled first
+        using :py:func:`service.disabled <salt.states.service.disabled>`
+        before masking. Attempting to mask an enabled service may result
+        in a systemd error.
+
     name
         Name of the service to mask
 


### PR DESCRIPTION
Fixes #61322

Add a note to the `service.masked` docstring advising users to
disable the service before masking it, as masking an enabled
service can result in a systemd error.