### PR TITLE
Fixing ssh auth options

### DIFF
--- a/changelog/60769.fixed.md
+++ b/changelog/60769.fixed.md
@@ -1,0 +1,1 @@
+Add logic for options handling when using source with ssh_auth

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -71,21 +71,46 @@ def _present_test(
     """
     result = None
     if source:
-        keys = __salt__["ssh.check_key_file"](
-            user,
-            source,
-            config,
-            saltenv=__env__,
-            fingerprint_hash_type=fingerprint_hash_type,
-        )
-        if keys:
-            comment = ""
-            for key, status in keys.items():
+        if options:
+            key = __salt__["cp.get_file_str"](source, saltenv=__env__)
+            key = key.rstrip().split("\n")
+            for keyline in key:
+                comment = ""
+                keyline = keyline.split(" ")
+                key_type = keyline[0]
+                key_value = keyline[1]
+                key_comment = keyline[2] if len(keyline) > 2 else ""
+                status = __salt__["ssh.check_key"](
+                    user,
+                    key_value,
+                    enc=key_type,
+                    comment=key_comment,
+                    options=options,
+                    config=config,
+                    cache_keys=None,
+                    fingerprint_hash_type=fingerprint_hash_type,
+                )
                 if status == "exists":
                     continue
-                comment += f"Set to {status}: {key}\n"
-            if comment:
-                return result, comment
+                comment += f"Set to {status}: {','.join(options)} {key_value}\n"
+                if comment:
+                    return result, comment
+        else:
+            keys = __salt__["ssh.check_key_file"](
+                user,
+                source,
+                config,
+                saltenv=__env__,
+                fingerprint_hash_type=fingerprint_hash_type,
+            )
+            if keys:
+                comment = ""
+                for key, status in list(keys.items()):
+                    if status == "exists":
+                        continue
+                    comment += f"Set to {status}: {key}\n"
+                if comment:
+                    return result, comment
         err = sys.modules[__salt__["test.ping"].__module__].__context__.pop(
             "ssh_auth.error", None
         )
@@ -132,9 +157,7 @@ def _present_test(
         comment = f"Key {name} for user {user} is set to be added"
     elif check == "exists":
         result = True
-        comment = "The authorized host key {} is already present for user {}".format(
-            name, user
-        )
+        comment = f"The authorized host key {name} is already present for user {user}"
 
     return result, comment
 
@@ -147,21 +170,46 @@ def _absent_test(
     """
     result = None
     if source:
-        keys = __salt__["ssh.check_key_file"](
-            user,
-            source,
-            config,
-            saltenv=__env__,
-            fingerprint_hash_type=fingerprint_hash_type,
-        )
-        if keys:
-            comment = ""
-            for key, status in list(keys.items()):
+        if options:
+            key = __salt__["cp.get_file_str"](source, saltenv=__env__)
+            key = key.rstrip().split("\n")
+            for keyline in key:
+                comment = ""
+                keyline = keyline.split(" ")
+                key_type = keyline[0]
+                key_value = keyline[1]
+                key_comment = keyline[2] if len(keyline) > 2 else ""
+                status = __salt__["ssh.check_key"](
+                    user,
+                    key_value,
+                    enc=key_type,
+                    comment=key_comment,
+                    options=options,
+                    config=config,
+                    cache_keys=None,
+                    fingerprint_hash_type=fingerprint_hash_type,
+                )
                 if status == "add":
                     continue
-                comment += f"Set to remove: {key}\n"
-            if comment:
-                return result, comment
+                comment += f"Set to remove: {','.join(options)} {key_value}\n"
+                if comment:
+                    return result, comment
+        else:
+            keys = __salt__["ssh.check_key_file"](
+                user,
+                source,
+                config,
+                saltenv=__env__,
+                fingerprint_hash_type=fingerprint_hash_type,
+            )
+            if keys:
+                comment = ""
+                for key, status in list(keys.items()):
+                    if status == "add":
+                        continue
+                    comment += f"Set to remove: {key}\n"
+                if comment:
+                    return result, comment
         err = sys.modules[__salt__["test.ping"].__module__].__context__.pop(
             "ssh_auth.error", None
         )
@@ -305,20 +353,37 @@ def present(
         # Get only the path to the file without env references to check if exists
         source_path = __salt__["cp.get_url"](source, None, saltenv=__env__)
 
-        # Extract Key from file if source is present
         if not source_path:
             data = "no key"
         else:
-            # ssh.set_auth_key_from_file already reads and add/replace all keys
-            # from source file.
-            data = __salt__["ssh.set_auth_key_from_file"](
-                user,
-                source,
-                config=config,
-                saltenv=__env__,
-                fingerprint_hash_type=fingerprint_hash_type,
-                options=options,
-            )
+            key = __salt__["cp.get_file_str"](source, saltenv=__env__)
+            filewithoutoptions = False
+            sshre = re.compile(r"^(sk-)?(ssh\-|ecds).*")
+            key = key.rstrip().split("\n")
+            for keyline in key:
+                filewithoutoptions = sshre.match(keyline)
+                if filewithoutoptions and not options:
+                    data = __salt__["ssh.set_auth_key_from_file"](
+                        user,
+                        source,
+                        config=config,
+                        saltenv=__env__,
+                        fingerprint_hash_type=fingerprint_hash_type,
+                    )
+                else:
+                    keyline = keyline.split(" ")
+                    key_type = keyline[0]
+                    key_value = keyline[1]
+                    key_comment = keyline[2] if len(keyline) > 2 else ""
+                    data = __salt__["ssh.set_auth_key"](
+                        user,
+                        key_value,
+                        enc=key_type,
+                        comment=key_comment,
+                        options=options or [],
+                        config=config,
+                        fingerprint_hash_type=fingerprint_hash_type,
+                    )
     else:
         data = __salt__["ssh.set_auth_key"](
             user,
@@ -332,26 +397,18 @@ def present(
 
     if data == "replace":
         ret["changes"][name] = "Updated"
-        ret["comment"] = "The authorized host key {} for user {} was updated".format(
-            name, user
-        )
+        ret["comment"] = f"The authorized host key {name} for user {user} was updated"
         return ret
     elif data == "no change":
         ret["comment"] = (
-            "The authorized host key {} is already present for user {}".format(
-                name, user
-            )
+            f"The authorized host key {name} is already present for user {user}"
         )
     elif data == "new":
         ret["changes"][name] = "New"
-        ret["comment"] = "The authorized host key {} for user {} was added".format(
-            name, user
-        )
+        ret["comment"] = f"The authorized host key {name} for user {user} was added"
     elif data == "no key":
         ret["result"] = False
-        ret["comment"] = "Failed to add the ssh key. Source file {} is missing".format(
-            source
-        )
+        ret["comment"] = f"Failed to add the ssh key. Source file {source} is missing"
     elif data == "fail":
         ret["result"] = False
         err = sys.modules[__salt__["test.ping"].__module__].__context__.pop(
@@ -440,19 +497,31 @@ def absent(
         # Get only the path to the file without env references to check if exists
         source_path = __salt__["cp.get_url"](source, None, saltenv=__env__)
 
-        # Extract Key from file if source is present
         if not source_path:
             data = "no key"
         else:
-            # ssh.rm_auth_key_from_file already reads and delete all keys
-            # from source file.
-            ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
-                user,
-                source,
-                config,
-                saltenv=__env__,
-                fingerprint_hash_type=fingerprint_hash_type,
-            )
+            key = __salt__["cp.get_file_str"](source, saltenv=__env__)
+            filewithoutoptions = False
+            sshre = re.compile(r"^(sk-)?(ssh\-|ecds).*")
+            key = key.rstrip().split("\n")
+            for keyline in key:
+                filewithoutoptions = sshre.match(keyline)
+                if filewithoutoptions and not options:
+                    ret["comment"] = __salt__["ssh.rm_auth_key_from_file"](
+                        user,
+                        source,
+                        config,
+                        saltenv=__env__,
+                        fingerprint_hash_type=fingerprint_hash_type,
+                    )
+                else:
+                    keyline = keyline.split(" ")
+                    ret["comment"] = __salt__["ssh.rm_auth_key"](
+                        user,
+                        keyline[1],
+                        config=config,
+                        fingerprint_hash_type=fingerprint_hash_type,
+                    )
     else:
         # Get just the key
         sshre = re.compile(r"^(.*?)\s?((?:sk-)?(?:ssh\-|ecds)[\w@.-]+\s.+)$")


### PR DESCRIPTION
### What does this PR do?

This PR is an up-to-date version of #60770 which was closed for inactivity:
This should fix the behavior of ssh_auth when dealing with authorized_keys provided by files (source) and using the 'options' inside functions like 'ssh_auth.present'.

### What issues does this PR fix or reference?

This fixes issue #60769 

### Previous Behavior

Inside test functions, using options inside a SLS was not taken into account (ie. tests results always says that the key has to be changed).
Secondly, the filehasoptions variable was misleading: regular expression that is used is explicitly matching keys that has NO options.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [X] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
