### PR TITLE
Patch tornado for BDSA-2025-60810

### DIFF
--- a/changelog/68853.fixed.md
+++ b/changelog/68853.fixed.md
@@ -1,0 +1,1 @@
+Patch tornado for BDSA-2025-60810

--- a/salt/ext/tornado/web.py
+++ b/salt/ext/tornado/web.py
@@ -313,11 +313,21 @@ class RequestHandler(object):
         :arg int status_code: Response status code. If ``reason`` is ``None``,
             it must be present in `httplib.responses <http.client.responses>`.
         :arg string reason: Human-readable reason phrase describing the status
-            code. If ``None``, it will be filled in from
-            `httplib.responses <http.client.responses>`.
+            code (for example, the "Not Found" in ``HTTP/1.1 404 Not Found``).
+            Normally determined automatically from `http.client.responses`; this
+            argument should only be used if you need to use a non-standard
+            status code.
         """
         self._status_code = status_code
         if reason is not None:
+            if "<" in reason or not RequestHandler._REASON_PHRASE_RE.fullmatch(reason):
+                # Logically this would be better as an exception, but this method
+                # is called on error-handling paths that would need some refactoring
+                # to tolerate internal errors cleanly.
+                #
+                # The check for "<" is a defense-in-depth against XSS attacks (we also
+                # escape the reason when rendering error pages).
+                reason = "Unknown"
             self._reason = escape.native_str(reason)
         else:
             try:
@@ -358,6 +368,7 @@ class RequestHandler(object):
             del self._headers[name]
 
     _INVALID_HEADER_CHAR_RE = re.compile(r"[\x00-\x1f]")
+    _REASON_PHRASE_RE = re.compile(r"(?:[\t ]|[\x21-\x7E]|[\x80-\xFF])+")
 
     def _convert_header_value(self, value):
         # type: (_HeaderTypes) -> str
@@ -1035,7 +1046,8 @@ class RequestHandler(object):
                 reason = exception.reason
         self.set_status(status_code, reason=reason)
         try:
-            self.write_error(status_code, **kwargs)
+            if status_code != 304:
+                self.write_error(status_code, **kwargs)
         except Exception:
             app_log.error("Uncaught exception in write_error", exc_info=True)
         if not self._finished:
@@ -1063,7 +1075,7 @@ class RequestHandler(object):
             self.finish("<html><title>%(code)d: %(message)s</title>"
                         "<body>%(code)d: %(message)s</body></html>" % {
                             "code": status_code,
-                            "message": self._reason,
+                            "message": escape.xhtml_escape(self._reason),
                         })
 
     @property
@@ -2153,9 +2165,11 @@ class HTTPError(Exception):
         mode).  May contain ``%s``-style placeholders, which will be filled
         in with remaining positional parameters.
     :arg string reason: Keyword-only argument.  The HTTP "reason" phrase
-        to pass in the status line along with ``status_code``.  Normally
+        to pass in the status line along with ``status_code`` (for example,
+        the "Not Found" in ``HTTP/1.1 404 Not Found``).  Normally
         determined automatically from ``status_code``, but can be used
-        to use a non-standard numeric code.
+        to use a non-standard numeric code. This is not a general-purpose
+        error message.
     """
     def __init__(self, status_code=500, log_message=None, *args, **kwargs):
         self.status_code = status_code


### PR DESCRIPTION
### What does this PR do?
Pulls in changes from https://github.com/tornadoweb/tornado/commit/9c163aebeaad9e6e7d28bac1f33580eb00b0e421

### What issues does this PR fix or reference?
Fixes #68853 

### What was changed
**1. _REASON_PHRASE_RE class attribute on RequestHandler**

A compiled regex was added as a class-level constant, expressing the RFC 9112 ABNF grammar for a valid HTTP reason phrase:

```
reason-phrase = *( HTAB / SP / VCHAR / obs-text )
```

In regex terms: ``(?:[\t ]|[\x21-\x7E]|[\x80-\xFF])+`` — one or more characters that are tab, space, printable ASCII (0x21–0x7E), or extended ASCII (0x80–0xFF). Critically, this excludes control characters including CR (0x0D) and LF (0x0A), which are the characters needed for header injection.

**Design decision — why not add _ABNF to httputil.py?**

The upstream 6.x patch references ``httputil._ABNF.reason_phrase``, a class that centralises all RFC ABNF patterns. Adding the full _ABNF class to 4.5.3 would have been a larger, noisier change touching a file that has already had several patches applied, and the class is only needed in ``web.py`` for this specific fix. Inlining the single pattern as a class attribute keeps the change self-contained and minimises the diff.

**2. Validation in set_status()**

Before assigning ``self._reason``, the code now checks whether the reason phrase is valid. If it contains ``<`` or fails the regex, reason is silently replaced with "Unknown".

The ``<`` check is a fast defence-in-depth against XSS even before the regex runs (the regex would catch it anyway, but the explicit check mirrors the upstream comment about defence-in-depth). The silent replacement rather than raising an exception also matches upstream's reasoning: ``set_status()`` is frequently called on error-handling paths, and raising an exception there could mask the original error or produce confusing double-faults.

**3. escape.xhtml_escape() in write_error()**

The reason phrase is now HTML-escaped when rendered into the default error page. This is a second layer of defence — even if something slips through ``set_status()``'s validation, the output is still safe. ``escape.xhtml_escape`` was already imported in ``web.py``, so no new import was needed.

**4. if status_code != 304: guard in send_error()**

HTTP 304 Not Modified responses must not carry a message body per the HTTP specification. The upstream commit includes this fix in the same changeset. Previously, ``write_error()`` would be called unconditionally, potentially writing a body for 304 responses. This fix is included because it was part of the same upstream commit addressing the same security hardening work.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
