### PR TITLE
Patch tornado for BDSA-2026-3867

### DIFF
--- a/changelog/68854.fixed.md
+++ b/changelog/68854.fixed.md
@@ -1,0 +1,1 @@
+Patch tornado for BDSA-2026-3867

--- a/salt/ext/tornado/httputil.py
+++ b/salt/ext/tornado/httputil.py
@@ -745,6 +745,28 @@ def _int_or_none(val):
     return int(val)
 
 
+class ParseMultipartConfig:
+    """Configures the parsing of multipart/form-data request bodies.
+
+    Its primary purpose is to place limits on the size and complexity of
+    request messages to avoid potential denial-of-service attacks.
+    """
+
+    def __init__(self, enabled=True, max_parts=100, max_part_header_size=10 * 1024):
+        self.enabled = enabled
+        self.max_parts = max_parts
+        self.max_part_header_size = max_part_header_size
+
+
+_DEFAULT_MULTIPART_CONFIG = ParseMultipartConfig()
+
+
+def set_parse_body_config(config):
+    """Sets the global default configuration for parsing request bodies."""
+    global _DEFAULT_MULTIPART_CONFIG
+    _DEFAULT_MULTIPART_CONFIG = config
+
+
 def parse_body_arguments(content_type, body, arguments, files, headers=None):
     """Parses a form request body.
 
@@ -768,10 +790,15 @@ def parse_body_arguments(content_type, body, arguments, files, headers=None):
     elif content_type.startswith("multipart/form-data"):
         try:
             fields = content_type.split(";")
+            if fields[0].strip() != "multipart/form-data":
+                raise HTTPInputError("Invalid content type")
             for field in fields:
                 k, sep, v = field.strip().partition("=")
                 if k == "boundary" and v:
-                    parse_multipart_form_data(utf8(v), body, arguments, files)
+                    parse_multipart_form_data(
+                        utf8(v), body, arguments, files,
+                        config=_DEFAULT_MULTIPART_CONFIG,
+                    )
                     break
             else:
                 raise HTTPInputError("multipart boundary not found")
@@ -779,13 +806,17 @@ def parse_body_arguments(content_type, body, arguments, files, headers=None):
             raise HTTPInputError("Invalid multipart/form-data: %s" % e) from e
 
 
-def parse_multipart_form_data(boundary, data, arguments, files):
+def parse_multipart_form_data(boundary, data, arguments, files, config=None):
     """Parses a ``multipart/form-data`` body.
 
     The ``boundary`` and ``data`` parameters are both byte strings.
     The dictionaries given in the arguments and files parameters
     will be updated with the contents of the body.
     """
+    if config is None:
+        config = _DEFAULT_MULTIPART_CONFIG
+    if not config.enabled:
+        raise HTTPInputError("multipart/form-data parsing is disabled")
     # The standard allows for the boundary to be quoted in the header,
     # although it's rare (it happens at least for google app engine
     # xmpp).  I think we're also supposed to handle backslash-escapes
@@ -797,12 +828,16 @@ def parse_multipart_form_data(boundary, data, arguments, files):
     if final_boundary_index == -1:
         raise HTTPInputError("Invalid multipart/form-data: no final boundary")
     parts = data[:final_boundary_index].split(b"--" + boundary + b"\r\n")
+    if len(parts) > config.max_parts:
+        raise HTTPInputError("multipart/form-data has too many parts")
     for part in parts:
         if not part:
             continue
         eoh = part.find(b"\r\n\r\n")
         if eoh == -1:
             raise HTTPInputError("multipart/form-data missing headers")
+        if eoh > config.max_part_header_size:
+            raise HTTPInputError("multipart/form-data part header too large")
         headers = HTTPHeaders.parse(part[:eoh].decode("utf-8"))
         disp_header = headers.get("Content-Disposition", "")
         disposition, disp_params = _parse_header(disp_header)


### PR DESCRIPTION
### What does this PR do?
Pulls in the changes from https://github.com/tornadoweb/tornado/commit/119a195e290c43ad2d63a2cf012c29d43d6ed839

### What issues does this PR fix or reference?
Fixes #68854 

### What was changed
**1. ParseMultipartConfig class**

A plain configuration class holds three settings:

- ``enabled (default True)`` — allows multipart parsing to be disabled entirely for applications that don't need it
- ``max_parts (default 100)`` — caps the number of MIME parts per request
- ``max_part_header_size (default 10240 bytes / 10 KB)`` — caps the size of the headers for each individual part
Design decision — plain class instead of dataclass

The upstream 6.5.5 fix uses ``@dataclasses.dataclass``. Dataclasses are available in Python 3.7+ and the branch supports Python 3.9+, so that wouldn't have been a technical problem. However, no other code in the 4.5.3 vendored file uses dataclasses, and the existing patches all follow the original coding style. A plain class with an ``__init__`` is functionally identical, requires no new import, and keeps the diff consistent with the style of the surrounding code.

**2. _DEFAULT_MULTIPART_CONFIG global and set_parse_body_config()**

A module-level default config instance is created once at import time. A ``set_parse_body_config()`` function is provided as a global escape hatch: if a Salt deployment has legitimate forms with more than 100 fields (each ``<input>`` element is a part), an operator can raise the limit at application startup without patching the library again. This mirrors the upstream API exactly.

**3. Limits in parse_multipart_form_data()**

The check if ``len(parts) > config.max_parts`` is placed immediately after the ``data.split()`` call, before any iteration. This means a request with 10,000 parts fails fast without processing any of them.

The check ``if eoh > config.max_part_header_size`` is placed inside the loop, right after ``part.find(b"\r\n\r\n")``, before the header bytes are handed to ``HTTPHeaders.parse()``. This prevents a large per-part header from reaching the more expensive header-parsing logic.

**4. Strict content-type check in parse_body_arguments()**

The function previously used ``content_type.startswith("multipart/form-data")`` to detect multipart bodies, then split on ``;`` to find the boundary. The upstream commit adds a check that ``fields[0].strip() == "multipart/form-data"`` exactly, which catches malformed content types like ``multipart/form-dataxyz`` that would have matched the startswith guard but aren't actually valid multipart bodies. This is defence-in-depth and also part of the same upstream commit.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
