### PR TITLE
Expand Thorium documentation with concrete examples

### DIFF
--- a/changelog/68857.changed.md
+++ b/changelog/68857.changed.md
@@ -1,0 +1,1 @@
+Expanded Thorium documentation with concrete examples and added unit coverage for the documented Thorium workflows.

--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -282,16 +282,15 @@ Putting data in a register is useless if you don't do anything with it. The
 ``check`` module is designed to examine register data and determine whether it
 matches the given parameters. For instance, the ``check.contains`` function
 will return ``True`` if the given ``value`` is contained in the specified
-register:
+register. This works especially well with ``reg.set``, which stores scalar
+values in a ``set()``:
 
 .. code-block:: yaml
 
     foo:
-      reg.list:
+      reg.set:
         - add: bar
         - match: my/custom/event
-        - stamp: True
-        - prune: 50
       check.contains:
         - value: somedata
 
@@ -322,6 +321,16 @@ different means of comparing values:
 * ``eq``: Check whether the register entry is equal to the given value
 * ``ne``: Check whether the register entry is not equal to the given value
 
+When you are working with a ``list`` register, the ``len_*`` functions are
+often more useful than the scalar comparisons:
+
+* ``len_gt``: Check whether the register contains more than the given number of entries
+* ``len_gte``: Check whether the register contains at least the given number of entries
+* ``len_lt``: Check whether the register contains fewer than the given number of entries
+* ``len_lte``: Check whether the register contains at most the given number of entries
+* ``len_eq``: Check whether the register contains exactly the given number of entries
+* ``len_ne``: Check whether the register contains anything other than the given number of entries
+
 There is also a function called ``check.event`` which does not examine the
 register. Instead, it looks directly at an event as it is coming in on the
 event bus, and returns ``True`` if that event's tag matches. For example:
@@ -348,3 +357,254 @@ It is possible to persist the register data to disk when a master is stopped
 gracefully, and reload it from disk when the master starts up again. This
 functionality is provided by the returner subsystem, and is enabled whenever
 any returner containing a ``load_reg`` and a ``save_reg`` function is used.
+
+The built-in ``local_cache`` returner implements these hooks, so a simple way
+to persist the register is:
+
+.. code-block:: yaml
+
+    register_returner: local_cache
+
+
+Concrete Thorium Patterns
+=========================
+The API reference explains each Thorium module in isolation, but Thorium
+becomes much easier to understand when you think in terms of small pipelines:
+
+#. collect interesting events into a register
+#. evaluate that register or the current event batch
+#. trigger a local, runner, or wheel action
+
+The examples below are designed to show those patterns directly.
+
+
+Trigger After Several Matching Events
+-------------------------------------
+One of Thorium's most useful patterns is reacting only after several related
+events have occurred. This avoids reacting to every transient event
+individually.
+
+The following example stores the most recent deployment failures in a register
+and only fires once at least three failures have been seen:
+
+.. code-block:: yaml
+
+    deploy_failures:
+      reg.list:
+        - add:
+          - id
+          - reason
+        - match: acme/deploy/failed
+        - stamp: True
+        - prune: 10
+
+    enough_failures:
+      check.len_gte:
+        - name: deploy_failures
+        - value: 3
+
+    notify_ops:
+      runner.cmd:
+        - func: manage.up
+        - require:
+          - check: enough_failures
+
+Thorium is doing three different jobs here:
+
+* ``reg.list`` collects the event payload fields you care about.
+* ``check.len_gte`` turns that historical context into a gate.
+* ``runner.cmd`` hands off to a master-side runner only when the gate is open.
+
+This is the general shape you want whenever you need "do something after N
+events", "act on bursts", or "only react if the issue keeps happening".
+
+
+Compute a Rolling Average Before Acting
+---------------------------------------
+Thorium is not limited to one-off event matching. The combination of
+``reg.list`` and ``calc.*`` can treat recent events as a sliding data set.
+
+The following example stores load samples from custom events and only triggers
+an orchestration run when the mean of the last five samples is at least ``4``:
+
+.. code-block:: yaml
+
+    load_samples:
+      reg.list:
+        - add:
+          - load
+          - minion
+        - match: acme/telemetry/load
+        - stamp: True
+        - prune: 20
+
+    sustained_high_load:
+      calc.mean:
+        - name: load_samples
+        - num: 5
+        - ref: load
+        - minimum: 4
+
+    scale_out:
+      runner.cmd:
+        - func: state.orchestrate
+        - mods: orch.scale_out
+        - require:
+          - calc: sustained_high_load
+
+This pattern is useful when you want to react to trends instead of single
+samples. The register keeps the recent window, and ``calc.mean`` computes the
+decision value at runtime.
+
+
+Throttle Reactions With ``timer.hold``
+--------------------------------------
+Once a check starts returning ``True``, it will continue to do so until the
+register changes. In practice you often want a cooldown so that the same action
+is not launched on every Thorium loop.
+
+``timer.hold`` provides that flow-control primitive:
+
+.. code-block:: yaml
+
+    service_failures:
+      reg.list:
+        - add:
+          - id
+          - service
+        - match: acme/service/down
+        - prune: 20
+
+    repeated_failures:
+      check.len_gte:
+        - name: service_failures
+        - value: 3
+
+    cooldown:
+      timer.hold:
+        - seconds: 900
+        - require:
+          - check: repeated_failures
+
+    restart_service:
+      local.cmd:
+        - tgt: 'G@roles:web'
+        - tgt_type: compound
+        - func: service.restart
+        - arg:
+          - nginx
+        - require:
+          - timer: cooldown
+
+The timer state remains ``False`` until the hold period has elapsed, and then
+briefly returns ``True`` so the dependent action can run. This makes it a good
+fit for rate limiting, cooldowns, and periodic rechecks.
+
+
+Choose The Right Action Wrapper
+-------------------------------
+Thorium can react in three different places, and the right choice depends on
+where the work needs to happen:
+
+* ``local.cmd`` runs an execution module on one or more minions.
+* ``runner.cmd`` launches a runner on the master.
+* ``wheel.cmd`` launches a wheel command for master maintenance tasks.
+
+These wrappers all fit naturally behind the same gate:
+
+.. code-block:: yaml
+
+    important_event:
+      check.event
+
+    verify_minions:
+      local.cmd:
+        - name: verify_minions
+        - tgt: '*'
+        - func: test.ping
+        - require:
+          - check: important_event
+
+    orchestrate_response:
+      runner.cmd:
+        - func: state.orchestrate
+        - mods: orch.respond
+        - require:
+          - check: important_event
+
+    reject_old_key:
+      wheel.cmd:
+        - fun: key.reject
+        - match: legacy-minion
+        - require:
+          - check: important_event
+
+If the reaction is "do something on minions", use ``local.cmd``. If the
+reaction is "start a master-side workflow", use ``runner.cmd``. If the
+reaction is "modify master metadata or PKI state", use ``wheel.cmd``.
+
+
+Inspect And Persist The Register
+--------------------------------
+Thorium is much easier to debug when you can inspect the register directly.
+This is especially helpful when you are first developing a formula.
+
+The following example saves a register snapshot to disk every time it changes:
+
+.. code-block:: yaml
+
+    tracked_ids:
+      reg.set:
+        - add: id
+        - match: acme/custom/event
+
+    tracked_ids_snapshot:
+      file.save:
+        - name: /tmp/tracked_ids.json
+        - filter: True
+        - require:
+          - reg: tracked_ids
+
+``filter: True`` is important when the register contains types such as
+``set()`` that are not JSON-serializable by default.
+
+This pattern is useful for:
+
+* confirming that your event tag glob is matching what you expect
+* inspecting the exact register shape before adding checks or calculations
+* keeping a lightweight audit trail during Thorium development
+
+
+Expanded Health Automation Example
+----------------------------------
+The built-in ``status`` and ``key`` modules are often the first place people
+encounter Thorium, but they are also a good example of multi-step automation.
+
+The following formula tracks status beacon events, snapshots the status
+register, and rejects keys for minions that have not checked in recently:
+
+.. code-block:: yaml
+
+    status_register:
+      status.reg
+
+    status_snapshot:
+      file.save:
+        - name: status_snapshot
+        - require:
+          - status: status_register
+
+    reject_stale_keys:
+      key.timeout:
+        - reject: 300
+        - require:
+          - status: status_register
+
+``status.reg`` listens for ``salt/beacon/*/status/*`` events and stores the
+latest payload and receive time for each minion. ``key.timeout`` then compares
+those timestamps to the current accepted key list and deletes or rejects keys
+that have gone silent.
+
+This pattern shows that Thorium is more than an event trigger. It can maintain
+state across many events, compare that state to master data, and then take a
+master-side action when the aggregate picture warrants it.

--- a/salt/thorium/calc.py
+++ b/salt/thorium/calc.py
@@ -1,6 +1,9 @@
 """
-Used to manage the thorium register. The thorium register is where compound
-values are stored and computed, such as averages etc.
+Perform calculations against values stored in the Thorium register.
+
+These states are useful when Thorium should react to trends in recent event
+data instead of reacting to a single event. They are most often paired with
+``reg.list`` so that a rolling window of values can be evaluated.
 
 .. versionadded:: 2016.11.0
 
@@ -40,11 +43,13 @@ def calc(name, num, oper, minimum=0, maximum=0, ref=None):
 
     .. code-block:: yaml
 
-        foo:
+        load_samples:
           calc.calc:
-            - name: myregentry
+            - name: load_samples
             - num: 5
             - oper: mean
+            - ref: load
+            - minimum: 4
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if name not in __reg__:
@@ -142,14 +147,19 @@ def mean(name, num, minimum=0, maximum=0, ref=None):
     """
     Calculates the mean of the ``num`` most recent values. Requires a list.
 
+    When the register contains dictionaries from ``reg.list``, use ``ref`` to
+    select the field to evaluate.
+
     USAGE:
 
     .. code-block:: yaml
 
-        foo:
+        load_samples:
           calc.mean:
-            - name: myregentry
+            - name: load_samples
             - num: 5
+            - ref: load
+            - minimum: 4
     """
     return calc(
         name=name, num=num, oper="mean", minimum=minimum, maximum=maximum, ref=ref

--- a/salt/thorium/check.py
+++ b/salt/thorium/check.py
@@ -1,8 +1,9 @@
 """
-The check Thorium state is used to create gateways to commands, the checks
-make it easy to make states that watch registers for changes and then just
-succeed or fail based on the state of the register, this creates the pattern
-of having a command execution get gated by a check state via a requisite.
+Create gate states that succeed or fail based on Thorium register contents or
+incoming events.
+
+These states are usually placed between a register-building state and an action
+state. The action then uses a requisite to run only when the check succeeds.
 """
 
 import logging
@@ -204,13 +205,20 @@ def contains(
 ):
     """
     Only succeed if the value in the given register location contains
-    the given value
+    the given value.
+
+    This is most useful with ``reg.set`` for simple membership checks. When the
+    ``count_*`` options are used, the check compares how many times a value
+    appears in the register.
 
     USAGE:
 
     .. code-block:: yaml
 
         foo:
+          reg.set:
+            - add: bar
+            - match: my/custom/event
           check.contains:
             - value: itni
 
@@ -256,8 +264,11 @@ def contains(
 
 def event(name):
     """
-    Chekcs for a specific event match and returns result True if the match
-    happens
+    Check the current Thorium event batch for a matching event tag and return
+    ``True`` if the match happens.
+
+    Use this when you want a direct event-to-action trigger without storing the
+    event in a register first.
 
     USAGE:
 

--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -1,5 +1,9 @@
 """
-Writes matches to disk to verify activity, helpful when testing
+Write Thorium register data to disk.
+
+This module is mainly used for observability and debugging while building
+Thorium formulas. It lets you snapshot the in-memory register so you can see
+exactly what data Thorium has accumulated.
 
 Normally this is used by giving the name of the file (without a path) that the
 data will be saved to. If for instance you use ``foo`` as the name:
@@ -52,6 +56,9 @@ def save(name, filter=False):
     If an absolute path is specified, then the directory will be created
     non-recursively if it doesn't exist.
 
+    If the register contains Python types such as ``set()``, pass
+    ``filter: True`` to coerce the data into JSON-safe simple types.
+
     USAGE:
 
     .. code-block:: yaml
@@ -61,6 +68,10 @@ def save(name, filter=False):
 
         /tmp/foo:
           file.save
+
+        tracked_ids:
+          file.save:
+            - filter: True
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if name.startswith("/"):

--- a/salt/thorium/key.py
+++ b/salt/thorium/key.py
@@ -1,5 +1,8 @@
 """
-The key Thorium State is used to apply changes to the accepted/rejected/pending keys
+Apply Thorium decisions to accepted, rejected, and pending minion keys.
+
+This module is intended for workflows where Thorium tracks minion health and
+then removes or rejects keys for minions that have stopped reporting.
 
 .. versionadded:: 2016.11.0
 """
@@ -22,7 +25,11 @@ def timeout(name, delete=0, reject=0):
     """
     If any minion's status is older than the timeout value then apply the
     given action to the timed out key. This example will remove keys to
-    minions that have not checked in for 300 seconds (5 minutes)
+    minions that have not checked in for 300 seconds (5 minutes).
+
+    This state depends on the ``status`` register created by ``status.reg``.
+    ``delete`` removes keys entirely, while ``reject`` leaves them visible in a
+    rejected state.
 
     USAGE:
 
@@ -36,6 +43,12 @@ def timeout(name, delete=0, reject=0):
             - require:
               - status: statreg
             - delete: 300
+
+        reject_keys:
+          key.timeout:
+            - require:
+              - status: statreg
+            - reject: 300
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     now = time.time()

--- a/salt/thorium/local.py
+++ b/salt/thorium/local.py
@@ -1,5 +1,9 @@
 """
-Run remote execution commands via the local client
+Run remote execution commands from Thorium via the local client.
+
+This module is the Thorium bridge into normal execution modules. Use it when a
+Thorium formula should cause work to happen on one or more minions after a
+check, timer, or event gate succeeds.
 """
 
 import salt.client
@@ -7,7 +11,10 @@ import salt.client
 
 def cmd(name, tgt, func, arg=(), tgt_type="glob", ret="", kwarg=None, **kwargs):
     """
-    Execute a remote execution command
+    Execute an asynchronous remote execution command.
+
+    The state return contains the queued JID, which makes this state useful as
+    the action stage of a Thorium pipeline.
 
     USAGE:
 
@@ -31,6 +38,16 @@ def cmd(name, tgt, func, arg=(), tgt_type="glob", ret="", kwarg=None, **kwargs):
             - func: test.sleep
             - kwarg:
               length: 30
+
+        gated_restart:
+          local.cmd:
+            - tgt: 'G@roles:web'
+            - tgt_type: compound
+            - func: service.restart
+            - arg:
+              - nginx
+            - require:
+              - timer: cooldown
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     with salt.client.get_local_client(mopts=__opts__) as client:

--- a/salt/thorium/reg.py
+++ b/salt/thorium/reg.py
@@ -1,6 +1,9 @@
 """
-Used to manage the thorium register. The thorium register is where compound
-values are stored and computed, such as averages etc.
+Populate and manage the Thorium register.
+
+Thorium formulas usually start here. The ``reg`` states collect fields from
+matching events and store them in memory so later ``check``, ``calc``, or
+action states can make decisions based on more than one event.
 """
 
 import salt.utils.stringutils
@@ -13,7 +16,10 @@ __func_alias__ = {
 
 def set_(name, add, match):
     """
-    Add a value to the named set
+    Add a value to the named set.
+
+    Use this when you want a unique collection of values, such as the set of
+    minion IDs or object names seen in matching events.
 
     USAGE:
 
@@ -23,6 +29,11 @@ def set_(name, add, match):
           reg.set:
             - add: bar
             - match: my/custom/event
+
+        seen_minions:
+          reg.set:
+            - add: id
+            - match: acme/custom/event
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if name not in __reg__:
@@ -43,11 +54,14 @@ def set_(name, add, match):
 
 def list_(name, add, match, stamp=False, prune=0):
     """
-    Add the specified values to the named list
+    Add the specified values to the named list.
 
     If ``stamp`` is True, then the timestamp from the event will also be added
     if ``prune`` is set to an integer higher than ``0``, then only the last
     ``prune`` values will be kept in the list.
+
+    Use this form when you want a recent history of matching events rather than
+    a de-duplicated set.
 
     USAGE:
 
@@ -58,6 +72,15 @@ def list_(name, add, match, stamp=False, prune=0):
             - add: bar
             - match: my/custom/event
             - stamp: True
+
+        deploy_failures:
+          reg.list:
+            - add:
+              - id
+              - reason
+            - match: acme/deploy/failed
+            - stamp: True
+            - prune: 10
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if not isinstance(add, list):

--- a/salt/thorium/runner.py
+++ b/salt/thorium/runner.py
@@ -1,5 +1,9 @@
 """
-React by calling asynchronous runners
+React by calling asynchronous runners from Thorium.
+
+Use this module when the reaction belongs on the master rather than on minions.
+Typical uses include launching orchestration, scheduling cleanup, or invoking
+other runner-based workflows after Thorium has aggregated and evaluated events.
 """
 
 import salt.runner
@@ -7,7 +11,10 @@ import salt.runner
 
 def cmd(name, func=None, arg=(), **kwargs):
     """
-    Execute a runner asynchronous:
+    Execute a runner asynchronously.
+
+    Any additional keyword arguments passed to this Thorium state are forwarded
+    to the runner function.
 
     USAGE:
 
@@ -23,9 +30,17 @@ def cmd(name, func=None, arg=(), **kwargs):
         run_cloud:
           runner.cmd:
             - func: cloud.create
-            - kwargs:
-                provider: my-ec2-config
-                instances: myinstance
+            - provider: my-ec2-config
+            - instances: myinstance
+
+        orchestrate_remediation:
+          runner.cmd:
+            - func: state.orchestrate
+            - mods: orch.remediate
+            - pillar:
+                target: db01
+            - require:
+              - check: sustained_high_load
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if func is None:

--- a/salt/thorium/status.py
+++ b/salt/thorium/status.py
@@ -1,6 +1,9 @@
 """
-This thorium state is used to track the status beacon events and keep track of
-the active status of minions
+Track status beacon events and maintain a register of active minions.
+
+This module is the foundation for health-oriented Thorium formulas. It records
+the latest status beacon payload and the receive time for each minion so later
+states can reason about stale or missing check-ins.
 
 .. versionadded:: 2016.11.0
 """
@@ -14,6 +17,23 @@ def reg(name):
     Activate this register to turn on a minion status tracking register, this
     register keeps the current status beacon data and the time that each beacon
     was last checked in.
+
+    This state watches events whose tag matches ``salt/beacon/*/status/*``.
+    It is commonly paired with ``key.timeout`` to reject or delete keys for
+    minions that stop reporting.
+
+    USAGE:
+
+    .. code-block:: yaml
+
+        status_register:
+          status.reg
+
+        reject_stale_keys:
+          key.timeout:
+            - reject: 300
+            - require:
+              - status: status_register
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     now = time.time()

--- a/salt/thorium/timer.py
+++ b/salt/thorium/timer.py
@@ -1,6 +1,8 @@
 """
-Allow for flow based timers. These timers allow for a sleep to exist across
-multiple runs of the flow
+Allow flow-based timers inside Thorium formulas.
+
+These timers keep state across multiple Thorium evaluation cycles, which makes
+them useful for cooldowns, delayed reactions, and rate limiting.
 """
 
 import time
@@ -10,7 +12,11 @@ def hold(name, seconds):
     """
     Wait for a given period of time, then fire a result of True, requiring
     this state allows for an action to be blocked for evaluation based on
-    time
+    time.
+
+    A common pattern is to require a ``check.*`` state first and then require
+    this timer from the action state so the action only runs after the hold
+    period has elapsed.
 
     USAGE:
 
@@ -19,6 +25,12 @@ def hold(name, seconds):
         hold_on_a_moment:
           timer.hold:
             - seconds: 30
+
+        cooldown:
+          timer.hold:
+            - seconds: 900
+            - require:
+              - check: repeated_failures
     """
     ret = {"name": name, "result": False, "comment": "", "changes": {}}
     start = time.time()

--- a/salt/thorium/wheel.py
+++ b/salt/thorium/wheel.py
@@ -1,5 +1,9 @@
 """
-React by calling asynchronous runners
+React by calling asynchronous wheel functions from Thorium.
+
+This is useful for master-side maintenance operations such as key management or
+other wheel actions that should only happen after Thorium has observed and
+evaluated a stream of events.
 """
 
 import salt.wheel
@@ -7,7 +11,10 @@ import salt.wheel
 
 def cmd(name, fun=None, arg=(), **kwargs):
     """
-    Execute a runner asynchronous:
+    Execute a wheel function asynchronously.
+
+    Any additional keyword arguments passed to this Thorium state are forwarded
+    to the wheel function.
 
     USAGE:
 
@@ -17,6 +24,13 @@ def cmd(name, fun=None, arg=(), **kwargs):
           wheel.cmd:
             - fun: key.delete
             - match: minion_id
+
+        reject_stale_key:
+          wheel.cmd:
+            - fun: key.reject
+            - match: old-minion
+            - require:
+              - check: important_event
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": True}
     if fun is None:

--- a/tests/pytests/unit/thorium/test_examples.py
+++ b/tests/pytests/unit/thorium/test_examples.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for Thorium documentation examples.
+"""
+
+import json
+
+import pytest
+
+import salt.thorium.calc as thorium_calc
+import salt.thorium.check as thorium_check
+import salt.thorium.file as thorium_file
+import salt.thorium.key as thorium_key
+import salt.thorium.local as thorium_local
+import salt.thorium.reg as thorium_reg
+import salt.thorium.runner as thorium_runner
+import salt.thorium.status as thorium_status
+import salt.thorium.timer as thorium_timer
+import salt.thorium.wheel as thorium_wheel
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def thorium_env(master_opts, tmp_path):
+    opts = master_opts.copy()
+    opts["cachedir"] = str(tmp_path / "cache")
+    return {"reg": {}, "context": {}, "events": [], "opts": opts}
+
+
+def test_reg_set_and_check_contains_example(thorium_env):
+    """
+    The basic reg.set + check.contains example should succeed once the event is seen.
+    """
+    event = {"tag": "my/custom/event", "data": {"bar": "somedata"}}
+    with patch.object(thorium_reg, "__reg__", thorium_env["reg"], create=True), patch.object(
+        thorium_reg, "__events__", [event], create=True
+    ), patch.object(thorium_check, "__reg__", thorium_env["reg"], create=True):
+        thorium_reg.set_("foo", add="bar", match="my/custom/event")
+        ret = thorium_check.contains("foo", "somedata")
+
+    assert ret["result"] is True
+    assert thorium_env["reg"]["foo"]["val"] == {"somedata"}
+
+
+def test_threshold_example_uses_register_length_gate(thorium_env):
+    """
+    The deployment failure example should fire once enough events were collected.
+    """
+    events = [
+        {
+            "tag": "acme/deploy/failed",
+            "data": {"id": "minion-1", "reason": "timeout", "_stamp": "2026-03-27"},
+        },
+        {
+            "tag": "acme/deploy/failed",
+            "data": {"id": "minion-2", "reason": "timeout", "_stamp": "2026-03-27"},
+        },
+        {
+            "tag": "acme/deploy/failed",
+            "data": {"id": "minion-3", "reason": "timeout", "_stamp": "2026-03-27"},
+        },
+    ]
+    with patch.object(thorium_reg, "__reg__", thorium_env["reg"], create=True), patch.object(
+        thorium_reg, "__events__", events, create=True
+    ), patch.object(thorium_check, "__reg__", thorium_env["reg"], create=True):
+        thorium_reg.list_(
+            "deploy_failures",
+            add=["id", "reason"],
+            match="acme/deploy/failed",
+            stamp=True,
+            prune=10,
+        )
+
+        ret = thorium_check.len_gte("deploy_failures", 3)
+
+    assert ret["result"] is True
+    assert len(thorium_env["reg"]["deploy_failures"]["val"]) == 3
+    assert thorium_env["reg"]["deploy_failures"]["val"][0]["id"] == "minion-1"
+
+
+def test_calc_mean_example_computes_threshold_on_recent_samples(thorium_env):
+    """
+    The rolling-average example should compute the expected mean and pass the gate.
+    """
+    thorium_env["reg"]["load_samples"] = {
+        "val": [{"load": 1}, {"load": 3}, {"load": 5}, {"load": 7}, {"load": 9}]
+    }
+    with patch.object(thorium_calc, "__reg__", thorium_env["reg"], create=True):
+        ret = thorium_calc.mean("load_samples", num=5, ref="load", minimum=4)
+
+    assert ret["result"] is True
+    assert ret["changes"]["Operator"] == "mean"
+    assert ret["changes"]["Number of values"] == 5
+    assert ret["changes"]["Answer"] == 5
+
+
+def test_timer_hold_example_creates_a_cooldown_gate(thorium_env):
+    """
+    The cooldown example should stay false until enough time has elapsed.
+    """
+    with patch.object(thorium_timer, "__context__", thorium_env["context"], create=True), patch(
+        "salt.thorium.timer.time.time", side_effect=[100, 1001]
+    ):
+        first = thorium_timer.hold("cooldown", 900)
+        second = thorium_timer.hold("cooldown", 900)
+
+    assert first["result"] is False
+    assert second["result"] is True
+
+
+def test_status_and_key_timeout_example_rejects_stale_keys(thorium_env):
+    """
+    The status + key.timeout example should reject a minion once its status is stale.
+    """
+    event = {
+        "tag": "salt/beacon/minion-1/status/update",
+        "data": {
+            "id": "minion-1",
+            "data": {"loadavg": [0.1, 0.2, 0.3], "cpupercent": [1, 2, 3]},
+        },
+    }
+    with patch.object(thorium_status, "__reg__", thorium_env["reg"], create=True), patch.object(
+        thorium_status, "__events__", [event], create=True
+    ), patch("salt.thorium.status.time.time", return_value=1000):
+        thorium_status.reg("status_register")
+
+    fake_keyapi = MagicMock()
+    fake_keyapi.list_status.return_value = {"minions": ["minion-1"]}
+    with patch.object(thorium_key, "__reg__", thorium_env["reg"], create=True), patch.object(
+        thorium_key, "__context__", thorium_env["context"], create=True
+    ), patch.object(thorium_key, "__opts__", thorium_env["opts"], create=True), patch.object(
+        thorium_key, "_get_key_api", return_value=fake_keyapi
+    ), patch("salt.thorium.key.time.time", return_value=1401):
+        ret = thorium_key.timeout("reject_stale_keys", reject=300)
+
+    assert ret["result"] is True
+    fake_keyapi.reject.assert_called_once_with("minion-1")
+    assert "minion-1" not in thorium_env["reg"]["status"]["val"]
+
+
+def test_file_save_filter_example_writes_json_safe_register_snapshot(tmp_path, thorium_env):
+    """
+    The register snapshot example should serialize filtered register data to disk.
+    """
+    target = tmp_path / "tracked_ids.json"
+    thorium_env["reg"]["tracked_ids"] = {"val": {"minion-1", "minion-2"}}
+
+    with patch.object(thorium_file, "__reg__", thorium_env["reg"], create=True), patch.object(
+        thorium_file, "__opts__", thorium_env["opts"], create=True
+    ):
+        ret = thorium_file.save(str(target), filter=True)
+
+    assert ret["result"] is True
+    assert target.exists()
+    payload = json.loads(target.read_text())
+    assert isinstance(payload["tracked_ids"]["val"], str)
+    assert "minion-1" in payload["tracked_ids"]["val"]
+    assert "minion-2" in payload["tracked_ids"]["val"]
+
+
+def test_local_cmd_example_queues_a_minion_execution(thorium_env):
+    """
+    The local.cmd wrapper example should queue the requested execution call.
+    """
+    client = MagicMock()
+    client.cmd_async.return_value = "20260327120000000000"
+    client_cm = MagicMock()
+    client_cm.__enter__.return_value = client
+    client_cm.__exit__.return_value = False
+
+    with patch.object(thorium_local, "__opts__", thorium_env["opts"], create=True), patch(
+        "salt.client.get_local_client", return_value=client_cm
+    ):
+        ret = thorium_local.cmd(
+            "gated_restart",
+            tgt="G@roles:web",
+            tgt_type="compound",
+            func="service.restart",
+            arg=("nginx",),
+        )
+
+    assert ret["result"] is True
+    assert ret["changes"]["jid"] == "20260327120000000000"
+    client.cmd_async.assert_called_once()
+    assert client.cmd_async.call_args.args == (
+        "G@roles:web",
+        "service.restart",
+        ("nginx",),
+    )
+    assert client.cmd_async.call_args.kwargs["tgt_type"] == "compound"
+    assert client.cmd_async.call_args.kwargs["kwarg"] is None
+    assert client.cmd_async.call_args.kwargs["ret"]["name"] == "gated_restart"
+    assert client.cmd_async.call_args.kwargs["ret"]["changes"]["jid"] == (
+        "20260327120000000000"
+    )
+
+
+def test_runner_cmd_example_forwards_kwargs_to_async_runner(thorium_env):
+    """
+    The runner.cmd example should pass kwargs through to the runner invocation.
+    """
+    runner_instance = MagicMock()
+
+    with patch.object(thorium_runner, "__opts__", thorium_env["opts"], create=True), patch(
+        "salt.runner.Runner", return_value=runner_instance
+    ) as runner_cls:
+        ret = thorium_runner.cmd(
+            "orchestrate_remediation",
+            func="state.orchestrate",
+            mods="orch.remediate",
+            pillar={"target": "db01"},
+        )
+
+    assert ret["result"] is True
+    runner_cls.assert_called_once()
+    runner_opts = runner_cls.call_args.args[0]
+    assert runner_opts["async"] is True
+    assert runner_opts["fun"] == "state.orchestrate"
+    assert runner_opts["arg"] == ()
+    assert runner_opts["kwarg"] == {
+        "mods": "orch.remediate",
+        "pillar": {"target": "db01"},
+    }
+    runner_instance.run.assert_called_once()
+
+
+def test_wheel_cmd_example_queues_master_side_wheel_action(thorium_env):
+    """
+    The wheel.cmd example should queue the expected wheel low data.
+    """
+    wheel_client = MagicMock()
+
+    with patch.object(thorium_wheel, "__opts__", thorium_env["opts"], create=True), patch(
+        "salt.wheel.WheelClient", return_value=wheel_client
+    ):
+        ret = thorium_wheel.cmd(
+            "reject_stale_key", fun="key.reject", match="old-minion"
+        )
+
+    assert ret["result"] is True
+    wheel_client.cmd_async.assert_called_once_with(
+        {"fun": "key.reject", "arg": (), "kwargs": {"match": "old-minion"}}
+    )

--- a/tests/pytests/unit/thorium/test_examples.py
+++ b/tests/pytests/unit/thorium/test_examples.py
@@ -31,9 +31,11 @@ def test_reg_set_and_check_contains_example(thorium_env):
     The basic reg.set + check.contains example should succeed once the event is seen.
     """
     event = {"tag": "my/custom/event", "data": {"bar": "somedata"}}
-    with patch.object(thorium_reg, "__reg__", thorium_env["reg"], create=True), patch.object(
-        thorium_reg, "__events__", [event], create=True
-    ), patch.object(thorium_check, "__reg__", thorium_env["reg"], create=True):
+    with patch.object(
+        thorium_reg, "__reg__", thorium_env["reg"], create=True
+    ), patch.object(thorium_reg, "__events__", [event], create=True), patch.object(
+        thorium_check, "__reg__", thorium_env["reg"], create=True
+    ):
         thorium_reg.set_("foo", add="bar", match="my/custom/event")
         ret = thorium_check.contains("foo", "somedata")
 
@@ -59,9 +61,11 @@ def test_threshold_example_uses_register_length_gate(thorium_env):
             "data": {"id": "minion-3", "reason": "timeout", "_stamp": "2026-03-27"},
         },
     ]
-    with patch.object(thorium_reg, "__reg__", thorium_env["reg"], create=True), patch.object(
-        thorium_reg, "__events__", events, create=True
-    ), patch.object(thorium_check, "__reg__", thorium_env["reg"], create=True):
+    with patch.object(
+        thorium_reg, "__reg__", thorium_env["reg"], create=True
+    ), patch.object(thorium_reg, "__events__", events, create=True), patch.object(
+        thorium_check, "__reg__", thorium_env["reg"], create=True
+    ):
         thorium_reg.list_(
             "deploy_failures",
             add=["id", "reason"],
@@ -97,9 +101,9 @@ def test_timer_hold_example_creates_a_cooldown_gate(thorium_env):
     """
     The cooldown example should stay false until enough time has elapsed.
     """
-    with patch.object(thorium_timer, "__context__", thorium_env["context"], create=True), patch(
-        "salt.thorium.timer.time.time", side_effect=[100, 1001]
-    ):
+    with patch.object(
+        thorium_timer, "__context__", thorium_env["context"], create=True
+    ), patch("salt.thorium.timer.time.time", side_effect=[100, 1001]):
         first = thorium_timer.hold("cooldown", 900)
         second = thorium_timer.hold("cooldown", 900)
 
@@ -118,18 +122,26 @@ def test_status_and_key_timeout_example_rejects_stale_keys(thorium_env):
             "data": {"loadavg": [0.1, 0.2, 0.3], "cpupercent": [1, 2, 3]},
         },
     }
-    with patch.object(thorium_status, "__reg__", thorium_env["reg"], create=True), patch.object(
-        thorium_status, "__events__", [event], create=True
-    ), patch("salt.thorium.status.time.time", return_value=1000):
+    with patch.object(
+        thorium_status, "__reg__", thorium_env["reg"], create=True
+    ), patch.object(thorium_status, "__events__", [event], create=True), patch(
+        "salt.thorium.status.time.time", return_value=1000
+    ):
         thorium_status.reg("status_register")
 
     fake_keyapi = MagicMock()
     fake_keyapi.list_status.return_value = {"minions": ["minion-1"]}
-    with patch.object(thorium_key, "__reg__", thorium_env["reg"], create=True), patch.object(
+    with patch.object(
+        thorium_key, "__reg__", thorium_env["reg"], create=True
+    ), patch.object(
         thorium_key, "__context__", thorium_env["context"], create=True
-    ), patch.object(thorium_key, "__opts__", thorium_env["opts"], create=True), patch.object(
+    ), patch.object(
+        thorium_key, "__opts__", thorium_env["opts"], create=True
+    ), patch.object(
         thorium_key, "_get_key_api", return_value=fake_keyapi
-    ), patch("salt.thorium.key.time.time", return_value=1401):
+    ), patch(
+        "salt.thorium.key.time.time", return_value=1401
+    ):
         ret = thorium_key.timeout("reject_stale_keys", reject=300)
 
     assert ret["result"] is True
@@ -137,16 +149,18 @@ def test_status_and_key_timeout_example_rejects_stale_keys(thorium_env):
     assert "minion-1" not in thorium_env["reg"]["status"]["val"]
 
 
-def test_file_save_filter_example_writes_json_safe_register_snapshot(tmp_path, thorium_env):
+def test_file_save_filter_example_writes_json_safe_register_snapshot(
+    tmp_path, thorium_env
+):
     """
     The register snapshot example should serialize filtered register data to disk.
     """
     target = tmp_path / "tracked_ids.json"
     thorium_env["reg"]["tracked_ids"] = {"val": {"minion-1", "minion-2"}}
 
-    with patch.object(thorium_file, "__reg__", thorium_env["reg"], create=True), patch.object(
-        thorium_file, "__opts__", thorium_env["opts"], create=True
-    ):
+    with patch.object(
+        thorium_file, "__reg__", thorium_env["reg"], create=True
+    ), patch.object(thorium_file, "__opts__", thorium_env["opts"], create=True):
         ret = thorium_file.save(str(target), filter=True)
 
     assert ret["result"] is True
@@ -167,9 +181,9 @@ def test_local_cmd_example_queues_a_minion_execution(thorium_env):
     client_cm.__enter__.return_value = client
     client_cm.__exit__.return_value = False
 
-    with patch.object(thorium_local, "__opts__", thorium_env["opts"], create=True), patch(
-        "salt.client.get_local_client", return_value=client_cm
-    ):
+    with patch.object(
+        thorium_local, "__opts__", thorium_env["opts"], create=True
+    ), patch("salt.client.get_local_client", return_value=client_cm):
         ret = thorium_local.cmd(
             "gated_restart",
             tgt="G@roles:web",
@@ -200,9 +214,9 @@ def test_runner_cmd_example_forwards_kwargs_to_async_runner(thorium_env):
     """
     runner_instance = MagicMock()
 
-    with patch.object(thorium_runner, "__opts__", thorium_env["opts"], create=True), patch(
-        "salt.runner.Runner", return_value=runner_instance
-    ) as runner_cls:
+    with patch.object(
+        thorium_runner, "__opts__", thorium_env["opts"], create=True
+    ), patch("salt.runner.Runner", return_value=runner_instance) as runner_cls:
         ret = thorium_runner.cmd(
             "orchestrate_remediation",
             func="state.orchestrate",
@@ -229,9 +243,9 @@ def test_wheel_cmd_example_queues_master_side_wheel_action(thorium_env):
     """
     wheel_client = MagicMock()
 
-    with patch.object(thorium_wheel, "__opts__", thorium_env["opts"], create=True), patch(
-        "salt.wheel.WheelClient", return_value=wheel_client
-    ):
+    with patch.object(
+        thorium_wheel, "__opts__", thorium_env["opts"], create=True
+    ), patch("salt.wheel.WheelClient", return_value=wheel_client):
         ret = thorium_wheel.cmd(
             "reject_stale_key", fun="key.reject", match="old-minion"
         )


### PR DESCRIPTION
### What does this PR do?

Expands the Thorium documentation with concrete cookbook-style examples and adds focused unit tests that exercise the documented patterns.

### What issues does this PR fix or reference?
Fixes N/A

### Previous Behavior
Thorium's topic documentation and generated reference pages documented only a small subset of the available patterns, with minimal end-to-end examples.

### New Behavior
The Thorium docs now include concrete examples for:
- `reg.set` with `check.contains`
- threshold gating with `reg.list` and `check.len_gte`
- rolling averages with `calc.mean`
- cooldowns with `timer.hold`
- wrapper selection across `local.cmd`, `runner.cmd`, and `wheel.cmd`
- register persistence with `file.save`
- health automation with `status.reg` and `key.timeout`

The branch also adds unit coverage for those example flows.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [x] Changelog
  Added `changelog/68857.changed.md` to record the Thorium documentation and example test coverage expansion.
- [x] Tests written/updated

### Commits signed with GPG?
No

### Testing
- `PYTHONPYCACHEPREFIX=/tmp/codex-pycache python3 -m py_compile salt/thorium/*.py`
- `git diff --check`
- `PYTHONPATH=/tmp/salt-test-deps python3 -m pytest -q tests/pytests/unit/thorium/test_examples.py`
- `PYTHONPATH=/tmp/salt-nox python3 -m nox -e "test-3(coverage=False)" -- tests/pytests/unit/thorium/test_examples.py`
- `PRE_COMMIT_HOME=/tmp/pre-commit-cache pre-commit run --files ...`
  Generic hooks passed and `black` reformatted the new test file. The remaining Salt-specific hook failures were local environment issues from homebrew `pre-commit` running under Python 3.14, while this repo only carries `requirements/static/ci` tool constraints through Python 3.13.
