### PR TITLE
Fix source package builds failing with LookupError: hatchling is already being built

### DIFF
--- a/changelog/68858.fixed.md
+++ b/changelog/68858.fixed.md
@@ -1,0 +1,1 @@
+Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build.

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -618,7 +618,7 @@ def onedir_dependencies(
         "-v",
         "--use-pep517",
         "--no-cache-dir",
-        "--only-binary=maturin,apache-libcloud,pymssql",
+        "--only-binary=maturin,apache-libcloud,pymssql,hatchling",
     ]
     if platform == "windows":
         python_bin = env_scripts_dir / "python"
@@ -627,7 +627,7 @@ def onedir_dependencies(
         python_bin = env_scripts_dir / "python3"
         install_args.append("--no-binary=:all:")
         install_args.append(
-            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver"
+            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling"
         )
 
     # Cryptography needs openssl dir set to link to the proper openssl libs.


### PR DESCRIPTION
## Problem

The nightly `Build Source Packages` jobs (DEB and RPM) started failing with:

```
LookupError: hatchling-1.29.0.tar.gz is already being built
```

## Root Cause

Three conditions converged:

1. **`pip == 25.2`** was pinned in `requirements/constraints.txt`. pip 25.2 introduced stricter parallel PEP 517 build isolation (`parallel_builds=True`), which makes the build tracker raise a `LookupError` when a package is encountered twice in the same build graph.

2. **`--no-binary :all:`** is used on Linux to force source builds of all packages. This causes pip to spin up an isolated subprocess to install each package's PEP 517 build backend.

3. **`hatchling` is self-referential** — its own `pyproject.toml` lists `hatchling` as the build backend. So when pip tries to source-build any package that uses hatchling, it needs to install hatchling first, which triggers another hatchling source build → pip's build tracker detects the cycle and raises `LookupError`.

## Fix

Add `hatchling` to `--only-binary` in `onedir_dependencies()` in `tools/pkg/build.py` so pip always installs it from its pre-built universal wheel, bypassing the circular source-build entirely.

## Testing

Trigger the nightly workflow — the `Build Source Packages / DEB` and `Build Source Packages / RPM` jobs should pass.

Fixes #68858