### PR TITLE
fix: guard against non-iterable target in list_jobs search_target

### DIFF
--- a/changelog/68780.fixed.md
+++ b/changelog/68780.fixed.md
@@ -1,0 +1,1 @@
+Guard against non-iterable `Target` in cached job entries when filtering by `search_target` in `salt-run jobs.list_jobs`.

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -334,6 +334,8 @@ def list_jobs(
                 targets = ret[item]["Target"]
                 if isinstance(targets, str):
                     targets = [targets]
+                elif not isinstance(targets, (list, tuple)):
+                    targets = []
                 for target in targets:
                     for key in salt.utils.args.split_input(search_target):
                         if fnmatch.fnmatch(target, key):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -335,6 +335,9 @@ def list_jobs(
                 if isinstance(targets, str):
                     targets = [targets]
                 elif not isinstance(targets, (list, tuple)):
+                    log.warning(
+                        "Job %s has non-iterable Target %r; skipping", item, targets
+                    )
                     targets = []
                 for target in targets:
                     for key in salt.utils.args.split_input(search_target):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -334,9 +334,13 @@ def list_jobs(
                 targets = ret[item]["Target"]
                 if isinstance(targets, str):
                     targets = [targets]
-                elif not isinstance(targets, (list, tuple)):
+                elif hasattr(targets, "__iter__"):
+                    targets = list(targets)
+                else:
                     log.warning(
-                        "Job %s has non-iterable Target %r; skipping", item, targets
+                        "Job %s has a non-iterable Target value %r; skipping",
+                        item,
+                        targets,
                     )
                     targets = []
                 for target in targets:

--- a/tests/pytests/unit/runners/test_jobs.py
+++ b/tests/pytests/unit/runners/test_jobs.py
@@ -70,3 +70,45 @@ def test_list_jobs_with_search_target():
         assert jobs.list_jobs(search_target="node-1-2.com") == returns["node-1-2.com"]
 
         assert jobs.list_jobs(search_target="non-existant") == returns["non-existant"]
+
+
+def test_list_jobs_with_non_iterable_target():
+    """
+    test jobs.list_jobs does not crash when Target is not iterable (e.g. int)
+
+    Regression test for https://github.com/saltstack/salt/issues/68780
+    """
+    mock_jobs_cache = {
+        "20160524035503086853": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2016, May 24 03:55:03.086853",
+            "Target": 3,
+            "Target-type": "glob",
+            "User": "root",
+        },
+        "20160524035524895387": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2016, May 24 03:55:24.895387",
+            "Target": "node-1-1.com",
+            "Target-type": "glob",
+            "User": "sudo_ubuntu",
+        },
+    }
+
+    def return_mock_jobs():
+        return mock_jobs_cache
+
+    class MockMasterMinion:
+
+        returners = {"local_cache.get_jids": return_mock_jobs}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    with patch.object(salt.minion, "MasterMinion", MockMasterMinion):
+        # Should not raise TypeError; the non-iterable target job is skipped
+        result = jobs.list_jobs(search_target="node-1-1.com")
+        assert "20160524035524895387" in result
+        assert "20160524035503086853" not in result

--- a/tests/pytests/unit/runners/test_jobs.py
+++ b/tests/pytests/unit/runners/test_jobs.py
@@ -112,3 +112,45 @@ def test_list_jobs_with_non_iterable_target():
         result = jobs.list_jobs(search_target="node-1-1.com")
         assert "20160524035524895387" in result
         assert "20160524035503086853" not in result
+
+
+def test_list_jobs_with_set_target():
+    """
+    test jobs.list_jobs handles Target stored as a set (any non-str iterable)
+
+    Regression test for https://github.com/saltstack/salt/issues/68780
+    """
+    mock_jobs_cache = {
+        "20160524035503086853": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2016, May 24 03:55:03.086853",
+            "Target": {"node-1-1.com", "node-1-2.com"},
+            "Target-type": "list",
+            "User": "root",
+        },
+        "20160524035524895387": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2016, May 24 03:55:24.895387",
+            "Target": "node-2-1.com",
+            "Target-type": "glob",
+            "User": "sudo_ubuntu",
+        },
+    }
+
+    def return_mock_jobs():
+        return mock_jobs_cache
+
+    class MockMasterMinion:
+
+        returners = {"local_cache.get_jids": return_mock_jobs}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    with patch.object(salt.minion, "MasterMinion", MockMasterMinion):
+        # Should not raise TypeError; set target should be iterated correctly
+        result = jobs.list_jobs(search_target="node-1-1.com")
+        assert "20160524035503086853" in result
+        assert "20160524035524895387" not in result


### PR DESCRIPTION
When `search_target` is used in `list_jobs`, the code assumes `Target` is always a string or list. Execution and state failures can leave `Target` as a non-iterable value (e.g. an integer), which causes a `TypeError` when iterating.

This adds a type check that converts non-iterable, non-string targets to an empty list so they are safely skipped instead of crashing.

Includes a unit test covering the non-iterable target case.

Closes #68780