### PR TITLE
Add podman socket compatability

### DIFF
--- a/changelog/68867.added.md
+++ b/changelog/68867.added.md
@@ -1,0 +1,4 @@
+Detect Podman emulating the Docker API socket and filter out Podman-specific
+environment variables (``HOSTNAME``, ``HOME``, ``container_uuid``) when
+comparing containers, so that ``docker.compare_containers`` returns a stable
+diff when Salt is managing containers via a Podman socket.

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -285,6 +285,36 @@ __outputter__ = {
     "highstate": "highstate",
 }
 
+# Variable for tracking podman-specific behavior
+_is_podman = False
+
+def _filter_podman_prefixes(val, prefixes=['HOSTNAME', 'HOME', 'container_uuid']):
+    """
+    Filter out items starting with any of the given prefixes if and only if
+    interaction with a podman socket is suspected, and return sorted list.
+
+    This function is required as Podman adds unecessary environment variables
+    
+    Args:
+        val: Iterable of strings to filter and sort
+        prefixes: Iterable of string prefixes to exclude
+        
+    Returns:
+        Sorted list with items not starting with any prefix
+    """
+    if not _is_podman:
+        return sorted(val)
+
+    #res = list(filter(lambda x: any(x.startswith(prefix) for prefix in prefixes)), val)
+    #res = [item for item in val if not any(item.startswith(prefix) for prefix in prefixes)]
+    res = list()
+    for item in val:
+        if not any(item.startswith(prefix) for prefix in prefixes):
+            res.append(item)
+        else:
+            log.warning("Filtering Podman-specific value %s", item)
+
+    return sorted(res)
 
 def __virtual__():
     """
@@ -399,6 +429,7 @@ def _get_client(timeout=NOTSET, **kwargs):
                     docker_machine_tls["ClientKeyPath"],
                 ),
                 ca_cert=docker_machine_tls["CaCertPath"],
+                assert_hostname=False,
                 verify=True,
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -412,6 +443,15 @@ def _get_client(timeout=NOTSET, **kwargs):
         # pylint: disable=not-callable
         ret = docker.Client(**client_kwargs)
         # pylint: enable=not-callable
+
+    global _is_podman
+    _is_podman = any(
+        'podman' in component.get('Name', '').lower()
+        for component in ret.version().get('Components', [])
+    )
+
+    if _is_podman:
+        log.warning("Detected Podman emulating Docker API")
 
     log.debug("docker-py API version: %s", getattr(ret, "api_version", None))
     return ret
@@ -974,7 +1014,7 @@ def compare_containers(first, second, ignore=None):
     ret = {}
     for conf_dict in ("Config", "HostConfig"):
         for item in result1[conf_dict]:
-            if item in ignore:
+            if item in ignore or item == "Annotations":
                 continue
             val1 = result1[conf_dict][item]
             val2 = result2[conf_dict].get(item)
@@ -987,21 +1027,28 @@ def compare_containers(first, second, ignore=None):
                 if image1 != image2:
                     ret.setdefault(conf_dict, {})[item] = {"old": image1, "new": image2}
             else:
+                if item == "Binds":
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
+                if item == "CapDrop":
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
                 if item == "Links":
                     val1 = sorted(_scrub_links(val1, first))
                     val2 = sorted(_scrub_links(val2, second))
                 if item == "Ulimits":
                     val1 = _ulimit_sort(val1)
                     val2 = _ulimit_sort(val2)
+                # Podman seems to set variables we did not expect, so we are filtering them out here:
                 if item == "Env":
-                    val1 = sorted(val1)
-                    val2 = sorted(val2)
+                    val1 = _filter_podman_prefixes(val1)
+                    val2 = _filter_podman_prefixes(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {"old": val1, "new": val2}
         # Check for optionally-present items that were in the second container
         # and not the first.
         for item in result2[conf_dict]:
-            if item in ignore or item in ret.get(conf_dict, {}):
+            if item in ignore or item in ret.get(conf_dict, {}) or item == "Annotations":
                 # We're either ignoring this or we already processed this
                 # when iterating through result1. Either way, skip it.
                 continue
@@ -1016,6 +1063,12 @@ def compare_containers(first, second, ignore=None):
                 if image1 != image2:
                     ret.setdefault(conf_dict, {})[item] = {"old": image1, "new": image2}
             else:
+                if item == "Binds":
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
+                if item == "CapDrop":
+                    val1 = sorted(val1)
+                    val2 = sorted(val2)
                 if item == "Links":
                     val1 = sorted(_scrub_links(val1, first))
                     val2 = sorted(_scrub_links(val2, second))
@@ -1023,8 +1076,8 @@ def compare_containers(first, second, ignore=None):
                     val1 = _ulimit_sort(val1)
                     val2 = _ulimit_sort(val2)
                 if item == "Env":
-                    val1 = sorted(val1)
-                    val2 = sorted(val2)
+                    val1 = _filter_podman_prefixes(val1)
+                    val2 = _filter_podman_prefixes(val2)
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {"old": val1, "new": val2}
     return ret
@@ -7081,3 +7134,4 @@ def sls_build(
         stop(id_)
         rm_(id_)
     return ret
+

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -288,26 +288,27 @@ __outputter__ = {
 # Variable for tracking podman-specific behavior
 _is_podman = False
 
-def _filter_podman_prefixes(val, prefixes=['HOSTNAME', 'HOME', 'container_uuid']):
+
+def _filter_podman_prefixes(val, prefixes=None):
     """
     Filter out items starting with any of the given prefixes if and only if
     interaction with a podman socket is suspected, and return sorted list.
 
     This function is required as Podman adds unecessary environment variables
-    
+
     Args:
         val: Iterable of strings to filter and sort
         prefixes: Iterable of string prefixes to exclude
-        
+
     Returns:
         Sorted list with items not starting with any prefix
     """
+    if prefixes is None:
+        prefixes = ["HOSTNAME", "HOME", "container_uuid"]
     if not _is_podman:
         return sorted(val)
 
-    #res = list(filter(lambda x: any(x.startswith(prefix) for prefix in prefixes)), val)
-    #res = [item for item in val if not any(item.startswith(prefix) for prefix in prefixes)]
-    res = list()
+    res = []
     for item in val:
         if not any(item.startswith(prefix) for prefix in prefixes):
             res.append(item)
@@ -315,6 +316,7 @@ def _filter_podman_prefixes(val, prefixes=['HOSTNAME', 'HOME', 'container_uuid']
             log.warning("Filtering Podman-specific value %s", item)
 
     return sorted(res)
+
 
 def __virtual__():
     """
@@ -429,7 +431,6 @@ def _get_client(timeout=NOTSET, **kwargs):
                     docker_machine_tls["ClientKeyPath"],
                 ),
                 ca_cert=docker_machine_tls["CaCertPath"],
-                assert_hostname=False,
                 verify=True,
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -446,8 +447,8 @@ def _get_client(timeout=NOTSET, **kwargs):
 
     global _is_podman
     _is_podman = any(
-        'podman' in component.get('Name', '').lower()
-        for component in ret.version().get('Components', [])
+        "podman" in component.get("Name", "").lower()
+        for component in ret.version().get("Components", [])
     )
 
     if _is_podman:
@@ -1048,7 +1049,11 @@ def compare_containers(first, second, ignore=None):
         # Check for optionally-present items that were in the second container
         # and not the first.
         for item in result2[conf_dict]:
-            if item in ignore or item in ret.get(conf_dict, {}) or item == "Annotations":
+            if (
+                item in ignore
+                or item in ret.get(conf_dict, {})
+                or item == "Annotations"
+            ):
                 # We're either ignoring this or we already processed this
                 # when iterating through result1. Either way, skip it.
                 continue
@@ -7134,4 +7139,3 @@ def sls_build(
         stop(id_)
         rm_(id_)
     return ret
-

--- a/tests/pytests/unit/modules/dockermod/test_module.py
+++ b/tests/pytests/unit/modules/dockermod/test_module.py
@@ -1364,3 +1364,119 @@ def test_port():
             "bar": {"6666/tcp": ports["bar"]["6666/tcp"]},
             "baz": {},
         }
+
+
+def test_filter_podman_prefixes_non_podman():
+    """
+    When _is_podman is False, _filter_podman_prefixes returns a sorted list
+    with no filtering applied.
+    """
+    vals = ["HOSTNAME=myhost", "FOO=bar", "HOME=/root", "ZZZ=last"]
+    with patch.object(docker_mod, "_is_podman", False):
+        result = docker_mod._filter_podman_prefixes(vals)
+    assert result == sorted(vals)
+
+
+def test_filter_podman_prefixes_podman_filters():
+    """
+    When _is_podman is True, _filter_podman_prefixes removes items whose keys
+    start with any of the default Podman-specific prefixes.
+    """
+    vals = [
+        "HOSTNAME=myhost",
+        "HOME=/root",
+        "container_uuid=abc123",
+        "FOO=bar",
+        "HELLO=world",
+    ]
+    with patch.object(docker_mod, "_is_podman", True):
+        result = docker_mod._filter_podman_prefixes(vals)
+    assert result == ["FOO=bar", "HELLO=world"]
+
+
+def test_filter_podman_prefixes_custom_prefixes():
+    """
+    _filter_podman_prefixes respects a caller-supplied prefix list when
+    _is_podman is True.
+    """
+    vals = ["SECRET=value", "FOO=bar", "HELLO=world"]
+    with patch.object(docker_mod, "_is_podman", True):
+        result = docker_mod._filter_podman_prefixes(vals, prefixes=["SECRET"])
+    assert result == ["FOO=bar", "HELLO=world"]
+
+
+def test_compare_container_annotations_ignored():
+    """
+    Annotations present in one container but absent in the other should not
+    be reported as a difference (Podman injects Annotations that Docker does
+    not expose).
+    """
+
+    def _inspect_container_effect(id_):
+        ret = {
+            "container1": {
+                "Config": {},
+                "HostConfig": {"Annotations": {"io.podman.annotations.label": "x"}},
+            },
+            "container2": {
+                "Config": {},
+                "HostConfig": {},
+            },
+        }
+        return ret[id_]
+
+    inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+
+    with patch.object(docker_mod, "inspect_container", inspect_container_mock):
+        ret = docker_mod.compare_containers("container1", "container2")
+    assert ret == {}
+
+
+def test_compare_container_binds_order():
+    """
+    compare_containers should treat Binds lists as equal regardless of order.
+    """
+
+    def _inspect_container_effect(id_):
+        ret = {
+            "container1": {
+                "Config": {},
+                "HostConfig": {"Binds": ["/a:/a", "/b:/b"]},
+            },
+            "container2": {
+                "Config": {},
+                "HostConfig": {"Binds": ["/b:/b", "/a:/a"]},
+            },
+        }
+        return ret[id_]
+
+    inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+
+    with patch.object(docker_mod, "inspect_container", inspect_container_mock):
+        ret = docker_mod.compare_containers("container1", "container2")
+    assert ret == {}
+
+
+def test_compare_container_capdrop_order():
+    """
+    compare_containers should treat CapDrop lists as equal regardless of order.
+    """
+
+    def _inspect_container_effect(id_):
+        ret = {
+            "container1": {
+                "Config": {},
+                "HostConfig": {"CapDrop": ["NET_RAW", "MKNOD"]},
+            },
+            "container2": {
+                "Config": {},
+                "HostConfig": {"CapDrop": ["MKNOD", "NET_RAW"]},
+            },
+        }
+        return ret[id_]
+
+    inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+
+    with patch.object(docker_mod, "inspect_container", inspect_container_mock):
+        ret = docker_mod.compare_containers("container1", "container2")
+    assert ret == {}


### PR DESCRIPTION
### What does this PR do?

This PR checks to see if the docker socket is actually a Podman instance emulating docker.

### What issues does this PR fix or reference?

Workaround for https://github.com/saltstack/salt/discussions/67528

### Previous Behavior
Podman support was flaky

### New Behavior
If and only if Podman is detected, some adjustments are made,  e.g. filtering environment variables that only Podman uses.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
