### PR TITLE
Add publish_timeout config option defaulting to 30s

### DIFF
--- a/changelog/68597.fixed.md
+++ b/changelog/68597.fixed.md
@@ -1,0 +1,1 @@
+Decouple the pub timeout from opts timeout. Programatic useage of client now has a 30 second timeout.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -390,7 +390,7 @@ class LocalClient:
                 tgt_type,
                 ret,
                 jid=jid,
-                timeout=self._get_timeout(timeout),
+                timeout=self._get_timeout(timeout) if timeout is not None else None,
                 listen=listen,
                 **kwargs,
             )
@@ -454,7 +454,7 @@ class LocalClient:
                 tgt_type,
                 ret,
                 jid=jid,
-                timeout=self._get_timeout(timeout),
+                timeout=self._get_timeout(timeout) if timeout is not None else None,
                 io_loop=io_loop,
                 listen=listen,
                 **kwargs,
@@ -1850,7 +1850,7 @@ class LocalClient:
         tgt_type="glob",
         ret="",
         jid="",
-        timeout=15,
+        timeout=None,
         listen=False,
         **kwargs,
     ):
@@ -1875,6 +1875,9 @@ class LocalClient:
             minions:
                 A set, the targets that the tgt passed should match.
         """
+        if timeout is None:
+            timeout = self.opts.get("publish_timeout", 15)
+
         # Make sure the publisher is running by checking the unix socket
         if self.opts.get("ipc_mode", "") != "tcp" and not os.path.exists(
             os.path.join(self.opts["sock_dir"], "publish_pull.ipc")
@@ -1951,7 +1954,7 @@ class LocalClient:
         tgt_type="glob",
         ret="",
         jid="",
-        timeout=15,
+        timeout=None,
         io_loop=None,
         listen=True,
         **kwargs,
@@ -1977,6 +1980,9 @@ class LocalClient:
             minions:
                 A set, the targets that the tgt passed should match.
         """
+        if timeout is None:
+            timeout = self.opts.get("publish_timeout", 15)
+
         # Make sure the publisher is running by checking the unix socket
         if self.opts.get("ipc_mode", "") != "tcp" and not os.path.exists(
             os.path.join(self.opts["sock_dir"], "publish_pull.ipc")

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1876,7 +1876,7 @@ class LocalClient:
                 A set, the targets that the tgt passed should match.
         """
         if timeout is None:
-            timeout = self.opts.get("publish_timeout", 15)
+            timeout = self.opts.get("publish_timeout", 30)
 
         # Make sure the publisher is running by checking the unix socket
         if self.opts.get("ipc_mode", "") != "tcp" and not os.path.exists(
@@ -1981,7 +1981,7 @@ class LocalClient:
                 A set, the targets that the tgt passed should match.
         """
         if timeout is None:
-            timeout = self.opts.get("publish_timeout", 15)
+            timeout = self.opts.get("publish_timeout", 30)
 
         # Make sure the publisher is running by checking the unix socket
         if self.opts.get("ipc_mode", "") != "tcp" and not os.path.exists(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1335,6 +1335,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "sock_pool_size": 1,
         "ret_port": 4506,
         "timeout": 5,
+        "publish_timeout": 15,
         "keep_jobs": 24,
         "keep_jobs_seconds": 86400,
         "archive_jobs": False,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1335,7 +1335,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "sock_pool_size": 1,
         "ret_port": 4506,
         "timeout": 5,
-        "publish_timeout": 15,
+        "publish_timeout": 30,
         "keep_jobs": 24,
         "keep_jobs_seconds": 86400,
         "archive_jobs": False,

--- a/tests/pytests/unit/test_client.py
+++ b/tests/pytests/unit/test_client.py
@@ -469,7 +469,7 @@ def _make_channel_mock(return_payload):
 
 def test_pub_uses_publish_timeout_from_config(master_opts):
     """
-    pub() must honour a custom publish_timeout set in opts, overriding the 15s default.
+    pub() must honor a custom publish_timeout set in opts, overriding the 15s default.
     """
     master_opts = dict(master_opts, publish_timeout=30)
     with client.LocalClient(mopts=master_opts) as local_client:
@@ -486,7 +486,7 @@ def test_pub_uses_publish_timeout_from_config(master_opts):
 
 def test_pub_async_uses_publish_timeout_from_config(master_opts):
     """
-    pub_async() must honour a custom publish_timeout set in opts.
+    pub_async() must honor a custom publish_timeout set in opts.
     """
     master_opts = dict(master_opts, publish_timeout=30)
     with client.LocalClient(mopts=master_opts) as local_client:
@@ -538,7 +538,7 @@ def test_run_job_passes_none_to_pub_when_no_timeout(master_opts):
 def test_run_job_passes_explicit_timeout_to_pub(master_opts):
     """
     run_job() called with an explicit timeout must forward that value to pub()
-    unchanged so caller-controlled timeouts are honoured (e.g. CLI -t flag).
+    unchanged so caller-controlled timeouts are honored (e.g. CLI -t flag).
     """
     with client.LocalClient(mopts=master_opts) as local_client:
         with patch.object(

--- a/tests/pytests/unit/test_client.py
+++ b/tests/pytests/unit/test_client.py
@@ -296,16 +296,16 @@ def test_invalid_event_tag_65727(master_opts, caplog):
 
 def test_publish_timeout_in_default_master_opts():
     """
-    publish_timeout must be present in DEFAULT_MASTER_OPTS with a value of 15
+    publish_timeout must be present in DEFAULT_MASTER_OPTS with a value of 30
     so that any LocalClient not given explicit opts still gets a sane pub timeout.
     """
     assert "publish_timeout" in salt.config.DEFAULT_MASTER_OPTS
-    assert salt.config.DEFAULT_MASTER_OPTS["publish_timeout"] == 15
+    assert salt.config.DEFAULT_MASTER_OPTS["publish_timeout"] == 30
 
 
 def test_pub_default_timeout(master_opts):
     """
-    Test that LocalClient.pub uses a default timeout of 15 seconds.
+    Test that LocalClient.pub uses a default timeout of 30 seconds.
     """
     with client.LocalClient(mopts=master_opts) as local_client:
         with patch("os.path.exists", return_value=True):
@@ -326,11 +326,11 @@ def test_pub_default_timeout(master_opts):
                 # Call pub without specifying timeout
                 result = local_client.pub("*", "test.ping")
 
-                # Verify the channel.send was called with timeout=15
+                # Verify the channel.send was called with timeout=30
                 assert mock_channel.send.called
                 call_kwargs = mock_channel.send.call_args
                 # The timeout is passed to channel.send in the first call
-                assert call_kwargs[1]["timeout"] == 15
+                assert call_kwargs[1]["timeout"] == 30
 
 
 def test_pub_explicit_timeout(master_opts):
@@ -364,7 +364,7 @@ def test_pub_explicit_timeout(master_opts):
 
 def test_pub_async_default_timeout(master_opts):
     """
-    Test that LocalClient.pub_async uses a default timeout of 15 seconds.
+    Test that LocalClient.pub_async uses a default timeout of 30 seconds.
     """
     with client.LocalClient(mopts=master_opts) as local_client:
         with patch("os.path.exists", return_value=True):
@@ -401,11 +401,11 @@ def test_pub_async_default_timeout(master_opts):
                     # Call pub_async without specifying timeout
                     local_client.pub_async("*", "test.ping")
 
-                    # Verify _prep_pub was called with timeout=15
+                    # Verify _prep_pub was called with timeout=30
                     assert len(prep_pub_calls) == 1
                     # _prep_pub signature: (tgt, fun, arg, tgt_type, ret, jid, timeout, **kwargs)
                     assert (
-                        prep_pub_calls[0][0][6] == 15
+                        prep_pub_calls[0][0][6] == 30
                     )  # timeout is the 7th positional arg
 
 
@@ -469,7 +469,7 @@ def _make_channel_mock(return_payload):
 
 def test_pub_uses_publish_timeout_from_config(master_opts):
     """
-    pub() must honor a custom publish_timeout set in opts, overriding the 15s default.
+    pub() must honor a custom publish_timeout set in opts, overriding the 30s default.
     """
     master_opts = dict(master_opts, publish_timeout=30)
     with client.LocalClient(mopts=master_opts) as local_client:
@@ -522,7 +522,7 @@ def test_pub_async_uses_publish_timeout_from_config(master_opts):
 def test_run_job_passes_none_to_pub_when_no_timeout(master_opts):
     """
     run_job() called without an explicit timeout must pass timeout=None to pub()
-    so that pub() resolves the value via publish_timeout (15 by default) rather
+    so that pub() resolves the value via publish_timeout (30 by default) rather
     than the 5-second salt command timeout.
     """
     with client.LocalClient(mopts=master_opts) as local_client:
@@ -553,7 +553,7 @@ def test_run_job_passes_explicit_timeout_to_pub(master_opts):
 def test_run_job_async_passes_none_to_pub_async_when_no_timeout(master_opts):
     """
     run_job_async() called without an explicit timeout must pass timeout=None
-    to pub_async() so that pub_async() uses publish_timeout (15 by default).
+    to pub_async() so that pub_async() uses publish_timeout (30 by default).
     """
     captured = {}
 

--- a/tests/pytests/unit/test_client.py
+++ b/tests/pytests/unit/test_client.py
@@ -7,6 +7,10 @@ import logging
 
 import pytest
 
+import salt.client
+import salt.config
+import salt.ext.tornado.gen
+import salt.ext.tornado.ioloop
 import salt.utils.platform
 from salt import client
 from salt.exceptions import (
@@ -290,6 +294,15 @@ def test_invalid_event_tag_65727(master_opts, caplog):
             assert "Skipping non return event: salt/job/0815/return/" in caplog.text
 
 
+def test_publish_timeout_in_default_master_opts():
+    """
+    publish_timeout must be present in DEFAULT_MASTER_OPTS with a value of 15
+    so that any LocalClient not given explicit opts still gets a sane pub timeout.
+    """
+    assert "publish_timeout" in salt.config.DEFAULT_MASTER_OPTS
+    assert salt.config.DEFAULT_MASTER_OPTS["publish_timeout"] == 15
+
+
 def test_pub_default_timeout(master_opts):
     """
     Test that LocalClient.pub uses a default timeout of 15 seconds.
@@ -441,3 +454,139 @@ def test_pub_async_explicit_timeout(master_opts):
                     assert (
                         prep_pub_calls[0][0][6] == 30
                     )  # timeout is the 7th positional arg
+
+
+def _make_channel_mock(return_payload):
+    """
+    Build a ReqChannel context-manager mock whose .send() returns return_payload.
+    """
+    mock_channel = MagicMock()
+    mock_channel.__enter__ = MagicMock(return_value=mock_channel)
+    mock_channel.__exit__ = MagicMock(return_value=False)
+    mock_channel.send = MagicMock(return_value=return_payload)
+    return mock_channel
+
+
+def test_pub_uses_publish_timeout_from_config(master_opts):
+    """
+    pub() must honour a custom publish_timeout set in opts, overriding the 15s default.
+    """
+    master_opts = dict(master_opts, publish_timeout=30)
+    with client.LocalClient(mopts=master_opts) as local_client:
+        mock_channel = _make_channel_mock(
+            {"load": {"jid": "test_jid", "minions": ["m1"]}}
+        )
+        with patch("os.path.exists", return_value=True), patch(
+            "salt.channel.client.ReqChannel.factory", return_value=mock_channel
+        ):
+            local_client.event.connect_pub = MagicMock(return_value=True)
+            local_client.pub("*", "test.ping")
+            assert mock_channel.send.call_args[1]["timeout"] == 30
+
+
+def test_pub_async_uses_publish_timeout_from_config(master_opts):
+    """
+    pub_async() must honour a custom publish_timeout set in opts.
+    """
+    master_opts = dict(master_opts, publish_timeout=30)
+    with client.LocalClient(mopts=master_opts) as local_client:
+        captured = {}
+
+        @salt.ext.tornado.gen.coroutine
+        def mock_send(payload, timeout=None):
+            captured["timeout"] = timeout
+            raise salt.ext.tornado.gen.Return(
+                {"load": {"jid": "test_jid", "minions": ["m1"]}}
+            )
+
+        mock_channel = MagicMock()
+        mock_channel.__enter__ = MagicMock(return_value=mock_channel)
+        mock_channel.__exit__ = MagicMock(return_value=False)
+        mock_channel.send = mock_send
+
+        with patch("os.path.exists", return_value=True), patch(
+            "salt.channel.client.AsyncReqChannel.factory", return_value=mock_channel
+        ):
+            local_client.event.connect_pub = MagicMock(return_value=True)
+            io_loop = salt.ext.tornado.ioloop.IOLoop()
+            io_loop.run_sync(lambda: local_client.pub_async("*", "test.ping"))
+
+        assert captured["timeout"] == 30
+
+
+# ---------------------------------------------------------------------------
+# run_job / run_job_async – timeout propagation to pub / pub_async
+# ---------------------------------------------------------------------------
+
+
+def test_run_job_passes_none_to_pub_when_no_timeout(master_opts):
+    """
+    run_job() called without an explicit timeout must pass timeout=None to pub()
+    so that pub() resolves the value via publish_timeout (15 by default) rather
+    than the 5-second salt command timeout.
+    """
+    with client.LocalClient(mopts=master_opts) as local_client:
+        with patch.object(
+            local_client,
+            "pub",
+            return_value={"jid": "1234", "minions": ["m1"]},
+        ) as mock_pub:
+            local_client.run_job("*", "test.ping")
+            assert mock_pub.call_args[1]["timeout"] is None
+
+
+def test_run_job_passes_explicit_timeout_to_pub(master_opts):
+    """
+    run_job() called with an explicit timeout must forward that value to pub()
+    unchanged so caller-controlled timeouts are honoured (e.g. CLI -t flag).
+    """
+    with client.LocalClient(mopts=master_opts) as local_client:
+        with patch.object(
+            local_client,
+            "pub",
+            return_value={"jid": "1234", "minions": ["m1"]},
+        ) as mock_pub:
+            local_client.run_job("*", "test.ping", timeout=30)
+            assert mock_pub.call_args[1]["timeout"] == 30
+
+
+def test_run_job_async_passes_none_to_pub_async_when_no_timeout(master_opts):
+    """
+    run_job_async() called without an explicit timeout must pass timeout=None
+    to pub_async() so that pub_async() uses publish_timeout (15 by default).
+    """
+    captured = {}
+
+    @salt.ext.tornado.gen.coroutine
+    def fake_pub_async(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        raise salt.ext.tornado.gen.Return({"jid": "1234", "minions": ["m1"]})
+
+    with client.LocalClient(mopts=master_opts) as local_client:
+        with patch.object(local_client, "pub_async", side_effect=fake_pub_async):
+            io_loop = salt.ext.tornado.ioloop.IOLoop()
+            io_loop.run_sync(lambda: local_client.run_job_async("*", "test.ping"))
+
+    assert captured["timeout"] is None
+
+
+def test_run_job_async_passes_explicit_timeout_to_pub_async(master_opts):
+    """
+    run_job_async() called with an explicit timeout must forward that value to
+    pub_async() unchanged.
+    """
+    captured = {}
+
+    @salt.ext.tornado.gen.coroutine
+    def fake_pub_async(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        raise salt.ext.tornado.gen.Return({"jid": "1234", "minions": ["m1"]})
+
+    with client.LocalClient(mopts=master_opts) as local_client:
+        with patch.object(local_client, "pub_async", side_effect=fake_pub_async):
+            io_loop = salt.ext.tornado.ioloop.IOLoop()
+            io_loop.run_sync(
+                lambda: local_client.run_job_async("*", "test.ping", timeout=30)
+            )
+
+    assert captured["timeout"] == 30


### PR DESCRIPTION
Decouples the pub timeout from opts["timeout"] (the minion response timeout) so programmatic LocalClient usage is not affected by the 5s salt command timeout default.


Fixes #68597
