### PR TITLE
Fix intermittent installer hang on Windows

### DIFF
--- a/pkg/windows/install_nsis.ps1
+++ b/pkg/windows/install_nsis.ps1
@@ -68,7 +68,7 @@ if ( Test-Path -Path "$check_file" ) {
     Write-Result "Missing" -ForegroundColor Yellow
 
     Write-Host "Downloading NSIS: " -NoNewline
-    $url = "$DEPS_URL/nsis-3.10-setup.exe"
+    $url = "$DEPS_URL/nsis-3.11-setup.exe"
     $file = "$env:TEMP\install_nsis.exe"
     Invoke-WebRequest -Uri $url -OutFile "$file"
     if ( Test-Path -Path "$file" ) {
@@ -327,6 +327,99 @@ if ( (Test-Path -Path $check_file_a) -and (Test-Path -Path $check_file_u) ) {
     }
     if ( Test-Path -Path "$env:TEMP\nsisaccesscontrol" ) {
         # Not a hard fail
+        Write-Result "Failed" -ForegroundColor Yellow
+    } else {
+        Write-Result "Success" -ForegroundColor Green
+    }
+}
+
+#-------------------------------------------------------------------------------
+# NSIS SimpleSC Plugin
+#-------------------------------------------------------------------------------
+
+Write-Host "Looking for NSIS SimpleSC Plugin: " -NoNewline
+$check_file_a = "$NSIS_PLUG_A\SimpleSC.dll"
+$check_file_u = "$NSIS_PLUG_U\SimpleSC.dll"
+if ( (Test-Path -Path $check_file_a) -and (Test-Path -Path $check_file_u) ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Missing" -ForegroundColor Yellow
+
+    Write-Host "Downloading NSIS SimpleSC (ansi) Plugin: " -NoNewline
+    $url = "$DEPS_URL/nsis-plugin-simplesc.zip"
+    $file = "$env:TEMP\nsisSimpleSC.zip"
+    Invoke-WebRequest -Uri $url -OutFile "$file"
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Extracting NSIS SimpleSC (ansi) Plugin: " -NoNewline
+    Expand-Archive -Path "$file" -DestinationPath "$env:TEMP\nsisSimpleSC\"
+    if ( Test-Path -Path "$env:TEMP\nsisSimpleSC\SimpleSC.dll" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Moving DLL to plugins directory: " -NoNewline
+    Move-Item -Path "$env:TEMP\nsisSimpleSC\SimpleSC.dll" -Destination "$check_file_a" -Force
+    if ( Test-Path -Path $check_file_a ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Cleaning up: " -NoNewline
+    Remove-Item -Path $file -Force
+    Remove-Item -Path "$env:TEMP\nsisSimpleSC" -Force -Recurse | Out-Null
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Failed" -ForegroundColor Yellow
+    } elseif ( Test-Path -Path "$env:TEMP\nsisSimpleSC" ) {
+        Write-Result "Failed" -ForegroundColor Yellow
+    } else {
+        Write-Result "Success" -ForegroundColor Green
+    }
+
+    Write-Host "Downloading NSIS SimpleSC (unicode) Plugin: " -NoNewline
+    $url = "$DEPS_URL/nsis-plugin-simplescu.zip"
+    $file = "$env:TEMP\nsisSimpleSCu.zip"
+    Invoke-WebRequest -Uri $url -OutFile "$file"
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Extracting NSIS SimpleSC (unicode) Plugin: " -NoNewline
+    Expand-Archive -Path "$file" -DestinationPath "$env:TEMP\nsisSimpleSCu\"
+    if ( Test-Path -Path "$env:TEMP\nsisSimpleSCu\SimpleSC.dll" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Moving DLL to plugins directory: " -NoNewline
+    Move-Item -Path "$env:TEMP\nsisSimpleSCu\SimpleSC.dll" -Destination "$check_file_u" -Force
+    if ( Test-Path -Path $check_file_u ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Cleaning up: " -NoNewline
+    Remove-Item -Path $file -Force
+    Remove-Item -Path "$env:TEMP\nsisSimpleSCu" -Force -Recurse | Out-Null
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Failed" -ForegroundColor Yellow
+    } elseif ( Test-Path -Path "$env:TEMP\nsisSimpleSCu" ) {
         Write-Result "Failed" -ForegroundColor Yellow
     } else {
         Write-Result "Success" -ForegroundColor Green

--- a/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
@@ -339,7 +339,7 @@ Function pageMinionConfig
             `hostname` no changes will be made."
     ${Else}
         ${NSD_CreateLabel} 0 75u 100% 60u \
-            "Clicking `Install` will backup the the existing minion config \
+            "Clicking `Install` will backup the existing minion config \
             file and minion.d directories. The values above will be used in \
             the custom config.$\n\
             $\n\
@@ -575,7 +575,6 @@ FunctionEnd
 Name "${PRODUCT_NAME} ${PRODUCT_VERSION} (${BUILD_TYPE})"
 OutFile "${OutFile}"
 InstallDir "C:\Program Files\Salt Project\Salt"
-InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
 ShowUnInstDetails show
 
@@ -650,10 +649,11 @@ Function InstallVCRedist
         detailPrint "Error: $0"
         MessageBox MB_OK|MB_ICONEXCLAMATION \
             "$VcRedistName failed to install. Try installing the package \
-            mnually.$\n\
+            manually.$\n\
             ErrorCode: $0$\n\
             The installer will now close." \
             /SD IDOK
+        Quit
     ${EndIf}
 
 FunctionEnd
@@ -772,6 +772,12 @@ Function .onInit
     InitPluginsDir
     Call parseInstallerCommandLineSwitches
 
+    # In silent mode the installer must close itself — SetAutoClose is the
+    # NSIS-native mechanism for this.  GUI mode leaves the Finish page visible.
+    ${If} ${Silent}
+        SetAutoClose true
+    ${EndIf}
+
     # Uninstall msi-installed salt
     # Source: https://nsis-dev.github.io/NSIS-Forums/html/t-303468.html
     !define upgradecode {FC6FB3A2-65DE-41A9-AD91-D10A402BD641}  # Salt upgrade code
@@ -879,9 +885,20 @@ Function .onInit
         ${LogMsg} "Setting uninstaller to not delete the root dir"
         StrCpy $DeleteRootDir 0
 
+        # Preserve the silent flag on the NSIS stack before calling
+        # uninstallSalt.  The macro uses $R0 as a scratch register for
+        # ${GetParent} results, so by the time it returns $R0 has been
+        # overwritten with a directory path.  uninstallSalt is
+        # stack-balanced (every push it makes is matched by a pop), so
+        # the value we push here will be exactly at the top when we pop
+        # it back after the call.
+        Push $R0
+
         # Uninstall silently
         Call uninstallSalt
 
+        # Restore the original silent flag that uninstallSalt clobbered.
+        Pop $R0
        ${LogMsg} "Resetting silent setting to original"
         # Set it back to Normal mode, if that's what it was before
         ${If} $R0 == 0
@@ -1041,60 +1058,25 @@ Section -Post
         Abort
     ${Else}
         ${LogMsg} "Setting service description"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion Description Salt Minion from saltstack.com"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion Description Salt Minion from saltstack.com"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
         ${LogMsg} "Setting service autostart"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion Start SERVICE_AUTO_START"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion Start SERVICE_AUTO_START"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
         ${LogMsg} "Setting service console stop method"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion AppStopMethodConsole 24000"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion AppStopMethodConsole 24000"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
         ${LogMsg} "Setting service windows stop method"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion AppStopMethodWindow 2000"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion AppStopMethodWindow 2000"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
         ${LogMsg} "Setting service app restart delay"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion AppRestartDelay 60000"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion AppRestartDelay 60000"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
     ${EndIf}
 
     # There is a default minion config laid down in the $INSTDIR directory
@@ -1145,40 +1127,42 @@ Function .onInstSuccess
     # If StartMinionDelayed is 1, then set the service to start delayed
     ${If} $StartMinionDelayed == 1
         ${LogMsg} "Setting the salt-minion service to start delayed"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe set salt-minion Start SERVICE_DELAYED_AUTO_START"
-        pop $0  # ExitCode
-        pop $1  # StdOut
-        ${If} $0 == 0
-            ${LogMsg} "Success"
-        ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
-        ${EndIf}
+        nsExec::Exec "$INSTDIR\ssm.exe set salt-minion Start SERVICE_DELAYED_AUTO_START"
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
     ${EndIf}
 
-    # If start-minion is 1, then start the service
+    # If start-minion is 1, then start the service.
+    # SimpleSC::StartService polls the SCM directly inside the plugin DLL —
+    # no child process, no pipe, no ShellExecuteEx.  It blocks the exec thread
+    # until the service reaches RUNNING state (or the 30-second timeout).
+    # This eliminates the cross-thread deadlock that the old Exec approach
+    # caused: since no background process is left alive, the NSIS exec thread
+    # returns cleanly from this function without interfering with the message
+    # loop.  ExitProcess below remains as belt-and-suspenders for silent mode.
     ${If} $StartMinion == 1
         ${LogMsg} "Starting the salt-minion service"
-        nsExec::ExecToStack "$INSTDIR\ssm.exe start salt-minion"
-        pop $0  # ExitCode
-        pop $1  # StdOut
+        SimpleSC::StartService "salt-minion" "" 30
+        Pop $0
         ${If} $0 == 0
-            ${LogMsg} "Success"
+            ${LogMsg} "Service started successfully"
         ${Else}
-            ${LogMsg} "Failed"
-            ${LogMsg} "ExitCode: $0"
-            ${LogMsg} "StdOut: $1"
+            ${LogMsg} "Service start returned error $0 (non-fatal, continuing)"
         ${EndIf}
     ${EndIf}
 
     ${LogMsg} "Salt installation complete"
 
-    # I don't know of another way to fix this. The installer hangs intermittently
-    # This will force kill the installer process. This must be the last thing that
-    # is run.
-    StrCpy $1 "wmic Path win32_process where $\"name like '$EXEFILE'$\" Call Terminate"
-    nsExec::Exec $1
+    # In silent mode, exit immediately via ExitProcess rather than letting
+    # NSIS advance to the finish page.  The finish page exists only for
+    # interactive checkbox state (StartMinion / StartMinionDelayed), which is
+    # already set from command-line parsing and does not need to be re-read
+    # from UI controls.  ExitProcess bypasses the NSIS message loop entirely,
+    # avoiding any cross-thread deadlock between the exec thread and the main
+    # UI thread during page transition.
+    ${If} ${Silent}
+        System::Call "kernel32::ExitProcess(i 0)"
+    ${EndIf}
 
 FunctionEnd
 
@@ -1186,6 +1170,8 @@ FunctionEnd
 Function un.onInit
 
     Call un.parseUninstallerCommandLineSwitches
+
+    SetAutoClose true
 
     StrCpy $msg "Are you sure you want to completely remove $(^Name) and all \
         of its components?"
@@ -1244,123 +1230,54 @@ Function ${un}uninstallSalt
     ${EndIf}
     ${LogMsg} "INSTDIR: $INSTDIR"
 
+    StrCpy $SSMBin "$INSTDIR\ssm.exe"
+
     # Only attempt to remove the services if ssm.exe is present"
+    ${If} ${FileExists} "$INSTDIR\ssm.exe"
 
-    # 3006(Relenv)/3007 Salt Installations
-    ${LogMsg} "Looking for ssm.exe for 3006+: $INSTDIR\ssm.exe"
-    IfFileExists "$INSTDIR\ssm.exe" 0 v3004
-        StrCpy $SSMBin "$INSTDIR\ssm.exe"
-        goto foundSSM
+        ${LogMsg} "ssm.exe found"
 
-    v3004:
-    # 3004/3005(Tiamat) Salt Installations
-    ${LogMsg} "Looking for ssm.exe for 3004+: $INSTDIR\bin\ssm.exe"
-    IfFileExists "$INSTDIR\bin\ssm.exe" 0 v2018
-        StrCpy $SSMBin "$INSTDIR\bin\ssm.exe"
-        goto foundSSM
+        # Stop the service via SimpleSC.  wait_for_file_release=1 blocks until
+        # ssm.exe (the service host) releases its file handle, so the binary
+        # can be deleted afterward.  timeout=30 seconds.  Runs entirely inside
+        # the plugin DLL — no child process, no pipe, no handle inheritance.
+        ${LogMsg} "Stopping salt-minion service"
+        SimpleSC::StopService "salt-minion" 1 30
+        Pop $0
+        ${If} $0 == 0
+            ${LogMsg} "Success"
+        ${Else}
+            ${LogMsg} "Stop returned error $0 (service may not have been running) — continuing"
+        ${EndIf}
 
-    v2018:
-    # 2018.3/2019.2/3000/3001/3002/3003 and below Salt Installations
-    ${LogMsg} "Looking for ssm.exe for 2018.3+: C:\salt\bin\ssm.exe"
-    IfFileExists "C:\salt\bin\ssm.exe" 0 v2016
-        StrCpy $SSMBin "C:\salt\bin\ssm.exe"
-        goto foundSSM
+        # Remove the service registration.  SimpleSC::RemoveService does not
+        # stop the service first (v1.30+), so StopService must precede this.
+        ${LogMsg} "Removing salt-minion service"
+        SimpleSC::RemoveService "salt-minion"
+        Pop $0
+        ${If} $0 == 0
+            ${LogMsg} "Success"
+        ${Else}
+            ${LogMsg} "Remove returned error $0 — continuing cleanup"
+        ${EndIf}
 
-    v2016:
-    # 2016.11/2017.7 Salt Installations used nssm.exe
-    ${LogMsg} "Looking for ssm.exe for 2016.11+: C:\salt\nssm.exe"
-    IfFileExists "C:\salt\nssm.exe" 0 v2016
-        StrCpy $SSMBin "C:\salt\nssm.exe"
-        goto foundSSM
+        # Belt-and-suspenders: taskkill is a no-op if the processes are
+        # already gone.  nsExec::Exec pushes one exit-code item; pop it
+        # immediately so the NSIS stack stays balanced.
+        ${LogMsg} "Killing lingering salt-minion.exe processes"
+        nsExec::Exec 'taskkill /F /IM salt-minion.exe /T'
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
+        ${LogMsg} "Killing lingering ssm.exe processes"
+        nsExec::Exec 'taskkill /F /IM ssm.exe /T'
+        Pop $0
+        ${LogMsg} "Done (exit $0)"
 
-    ${LogMsg} "ssm.exe/nssm.exe not found"
-    goto doneSSM
-
-    foundSSM:
-
-    ${LogMsg} "ssm.exe found: $SSMBin"
-
-    # Detect if the salt-minion service is installed
-    ${LogMsg} "Detecting salt-minion service"
-    nsExec::ExecToStack "$SSMBin Status salt-minion"
-    pop $0  # ExitCode
-    pop $1  # StdOut
-    ${If} $0 == 0
-        ${LogMsg} "Service found"
     ${Else}
-        # If the service is already gone, skip the SSM commands
-        ${StrContains} $2 $1 "service does not exist"
-        StrCmp $2 "" doneSSM
-        ${LogMsg} "Failed"
-        ${LogMsg} "ExitCode: $0"
-        ${LogMsg} "StdOut: $1"
+
+        ${LogMsg} "ssm.exe not found"
+
     ${EndIf}
-
-    # Stop and Remove salt-minion service
-    ${LogMsg} "Stopping salt-minion service"
-    nsExec::ExecToStack "$SSMBin stop salt-minion"
-    pop $0  # ExitCode
-    pop $1  # StdOut
-    ${If} $0 == 0
-        ${LogMsg} "Success"
-    ${Else}
-        ${LogMsg} "Failed"
-        ${LogMsg} "ExitCode: $0"
-        ${LogMsg} "StdOut: $1"
-    ${EndIf}
-
-    ${LogMsg} "Removing salt-minion service"
-    nsExec::ExecToStack "$SSMBin remove salt-minion confirm"
-    pop $0  # ExitCode
-    pop $1  # StdOut
-    ${If} $0 == 0
-        ${LogMsg} "Success"
-    ${Else}
-        ${LogMsg} "Failed"
-        ${LogMsg} "ExitCode: $0"
-        ${LogMsg} "StdOut: $1"
-        Abort
-    ${EndIf}
-
-    # Give the minion enough time to finish its internal stop_async (graceful shutdown).
-    # salt/minion.py:MinionManager.stop_async has a static 5-second sleep to allow
-    # the I/O loop to process and send any remaining "return" messages to the Master.
-    # We wait 6 seconds here to ensure that we don't aggressively kill the process
-    # while it is still performing its legitimate cleanup. After this window,
-    # we proceed to kill any lingering or orphan processes that would otherwise
-    # lock DLLs (like pywin32 or cryptography) and cause a "Frankenstein" installation.
-
-    ${LogMsg} "Waiting 6 seconds for graceful shutdown..."
-    Sleep 6000
-
-    # Perform multiple passes to ensure stubborn or child processes are caught
-    # Pass 1: Aggressive taskkill
-    ${LogMsg} "Killing remaining processes (Pass 1 of 3)"
-    nsExec::ExecToStack 'taskkill /F /IM ssm.exe /T'
-    nsExec::ExecToStack 'taskkill /F /IM salt-minion.exe /T'
-    nsExec::ExecToStack 'taskkill /F /IM salt-call.exe /T'
-    nsExec::ExecToStack `powershell -Command "$p = '$INSTDIR'.Replace('\', '\\'); Get-Process | Where-Object { ($_.Path -like '$p*') -or ($_.Name -eq 'ssm') } | ForEach-Object { Write-Output \"Killing: $($_.Name) ($($_.Id))\"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }"`
-    pop $0
-    pop $1
-    ${LogMsg} "Kill log: $1"
-    Sleep 2000
-
-    # Pass 2: PowerShell follow-up
-    ${LogMsg} "Killing remaining processes (Pass 2 of 3)"
-    nsExec::ExecToStack `powershell -Command "$p = '$INSTDIR'.Replace('\', '\\'); Get-Process | Where-Object { ($_.Path -like '$p*') -or ($_.Name -eq 'ssm') } | ForEach-Object { Write-Output \"Killing: $($_.Name) ($($_.Id))\"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }"`
-    pop $0
-    pop $1
-    ${LogMsg} "Kill log: $1"
-    Sleep 2000
-
-    # Pass 3: Final check
-    ${LogMsg} "Killing remaining processes (Pass 3 of 3)"
-    nsExec::ExecToStack `powershell -Command "$p = '$INSTDIR'.Replace('\', '\\'); Get-Process | Where-Object { ($_.Path -like '$p*') -or ($_.Name -eq 'ssm') } | ForEach-Object { Write-Output \"Killing: $($_.Name) ($($_.Id))\"; Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }"`
-    pop $0
-    pop $1
-    ${LogMsg} "Kill log: $1"
-
-    doneSSM:
 
     # Remove files
     ${LogMsg} "Deleting files"
@@ -1380,7 +1297,7 @@ Function ${un}uninstallSalt
         Abort
     ${EndIf}
 
-    ssmBin:
+    # Remove SSM
     ClearErrors
     ${LogMsg} "Deleting file: $SSMBin"
     Delete "$SSMBin"
@@ -1390,7 +1307,7 @@ Function ${un}uninstallSalt
         Abort
     ${EndIf}
 
-    uninstBin:
+    # Remove uninst.exe
     ClearErrors
     ${LogMsg} "Deleting file: $INSTDIR\uninst.exe"
     Delete "$INSTDIR\uninst.exe"
@@ -1430,13 +1347,14 @@ Function ${un}uninstallSalt
         Abort
     ${EndIf}
 
-    removeLibs:
+    # Remove libs directory
     ClearErrors
     ${LogMsg} "Deleting directory: $INSTDIR\libs"
     RMDir /r "$INSTDIR\libs"
     IfErrors 0 removeScripts
     ${LogMsg} "FAILED"
 
+    # Remove Scripts directory
     removeScripts:
     ClearErrors
     ${LogMsg} "Deleting directory: $INSTDIR\Scripts"
@@ -1447,7 +1365,7 @@ Function ${un}uninstallSalt
         Abort
     ${EndIf}
 
-    removeBin:
+    # Remove bin directory
     ClearErrors
     ${LogMsg} "Deleting directory: $INSTDIR\bin"
     RMDir /r "$INSTDIR\bin"      # Older versions use bin
@@ -1457,7 +1375,7 @@ Function ${un}uninstallSalt
         Abort
     ${EndIf}
 
-    removeConfigs:
+    # Remove config directory
     ClearErrors
     ${LogMsg} "Deleting directory: $INSTDIR\configs"
     RMDir /r "$INSTDIR\configs"  # Sometimes this gets left behind
@@ -1505,8 +1423,12 @@ Function ${un}uninstallSalt
     StrCpy $SysDrive "$0\"
     ${LogMsg} "SystemDrive: $SysDrive"
 
-    # Automatically close when finished
-    SetAutoClose true
+    # Automatically close when finished — only in the uninstaller binary.
+    # In the installer context (upgrade path calling uninstallSalt from .onInit)
+    # SetAutoClose must not fire here; it is already set in .onInit for silent mode.
+    !ifdef __UNINSTALL__
+        SetAutoClose true
+    !endif
 
     # Old Method Installation
     ${If} $INSTDIR == "C:\salt"
@@ -1617,6 +1539,13 @@ Function un.onUninstSuccess
     StrCpy $msg "$(^Name) was successfully removed from your computer."
     ${LogMsg} $msg
     MessageBox MB_OK|MB_USERICON $msg /SD IDOK
+
+    # Same issue as .onInstSuccess: Quit posts WM_QUIT but the message loop
+    # may be stuck with background processes alive.  Call ExitProcess directly
+    # to terminate the uninstaller process immediately.
+    ${If} ${Silent}
+        System::Call "kernel32::ExitProcess(i 0)"
+    ${EndIf}
 
 FunctionEnd
 

--- a/pkg/windows/nsis/tests/conftest.py
+++ b/pkg/windows/nsis/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import stat
 import subprocess
 import time
 import winreg
@@ -127,7 +128,7 @@ def reg_key_exists(hive=winreg.HKEY_LOCAL_MACHINE, key=None):
     try:
         with winreg.OpenKey(hive, key, 0, winreg.KEY_READ):
             return True
-    except:
+    except OSError:
         return False
 
 
@@ -161,9 +162,16 @@ def clean_fragments(inst_dir=INST_DIR):
         shutil.rmtree(inst_dir)
     assert not os.path.exists(inst_dir)
 
-    # Remove old salt dir (C:\salt)
+    # Remove old salt dir (C:\salt).  PKI files (minion.pem etc.) are created
+    # with restrictive NTFS permissions by the Salt installer, so a plain
+    # rmtree raises PermissionError.  The onerror handler clears the read-only
+    # attribute and retries so the tree is always removed cleanly.
+    def _force_remove(func, path, _exc):
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
     if os.path.exists(OLD_DIR):
-        shutil.rmtree(OLD_DIR)
+        shutil.rmtree(OLD_DIR, onerror=_force_remove)
     assert not os.path.exists(OLD_DIR)
 
     # Remove custom config
@@ -186,7 +194,7 @@ def clean_fragments(inst_dir=INST_DIR):
 
 
 @pytest.helpers.register
-def clean_env(inst_dir=INST_DIR, timeout=300):
+def clean_env(inst_dir=INST_DIR):
     # Track whether any process had to be force-killed.  If so we return
     # False so the caller's `assert clean_env()` fails the test — a forced
     # kill means something got stuck, which is exactly what this test suite
@@ -209,8 +217,10 @@ def clean_env(inst_dir=INST_DIR, timeout=300):
     live = _live_processes()
     for proc in PROCESSES:
         if proc in live:
-            print(f"\nWARNING: {proc} still in process list after wait — marking as killed")
+            print(f"\nWARNING: {proc} still in process list after wait — force-killing")
+            _kill_lingering_processes()
             killed = True
+            break  # _kill_lingering_processes covers all PROCESSES at once
 
     # Uninstall existing installation if one is present.
     for uninst_bin in [f"{inst_dir}\\uninst.exe", f"{OLD_DIR}\\uninst.exe"]:
@@ -261,8 +271,7 @@ def clean_env(inst_dir=INST_DIR, timeout=300):
                 time.sleep(0.5)
 
             try:
-                result = clean_fragments(inst_dir=install_dir)
-                assert result, "clean_fragments returned False"
+                clean_fragments(inst_dir=install_dir)
             except Exception as exc:
                 print(f"\nERROR in clean_fragments({install_dir!r}): {exc}")
                 killed = True
@@ -327,7 +336,9 @@ def install_salt(args):
         cmd.extend(args)
     else:
         raise TypeError(f"Invalid args format: {args}")
-    assert run_command(cmd), "Installer failed (non-zero exit or force-killed on timeout)"
+    assert run_command(
+        cmd
+    ), "Installer failed (non-zero exit or force-killed on timeout)"
 
     # Let's make sure none of the install/uninstall processes are running
     try:
@@ -401,22 +412,19 @@ def run_command(cmd_args, timeout=60):
         cmd_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )
 
-    elapsed_time = 0
-    while (
-        os.path.exists(bin_file) and is_file_locked(bin_file) and elapsed_time < timeout
-    ):
-        elapsed_time += 0.1
-        time.sleep(0.1)
-
     try:
         proc.wait(timeout=timeout)
         if proc.returncode != 0:
-            print(f"\nWARNING: process exited with code {proc.returncode}: {cmd_args[:120]}")
+            print(
+                f"\nWARNING: process exited with code {proc.returncode}: {cmd_args[:120]}"
+            )
             return False
         return True
     except subprocess.TimeoutExpired:
         # Kill the installer/uninstaller and every child it spawned (nssm,
         # salt-minion, etc.) so they don't linger into the next iteration.
-        print(f"\nWARNING: process timed out after {timeout}s — force-killing: {cmd_args[:120]}")
+        print(
+            f"\nWARNING: process timed out after {timeout}s — force-killing: {cmd_args[:120]}"
+        )
         _kill_process_tree(proc)
         return False

--- a/pkg/windows/nsis/tests/conftest.py
+++ b/pkg/windows/nsis/tests/conftest.py
@@ -60,10 +60,62 @@ PROCESSES = [
     "Un_B.exe",
     "Un_C.exe",
     "Un_D.exe",
-    "Un_D.exe",
+    "Un_E.exe",
     "Un_F.exe",
     "Un_G.exe",
 ]
+
+# Max seconds to wait for each discrete cleanup phase before giving up and
+# force-killing.  These are all far longer than the normal happy-path times
+# (typically < 3 s each) so they only trigger when something is genuinely stuck.
+PROC_WAIT_SECS = 30  # installer/uninstaller processes to exit
+INST_DIR_WAIT_SECS = 30  # install dir to be deleted by Un.exe
+SCM_WAIT_SECS = 15  # SCM to remove the salt-minion service registry key
+
+
+def _kill_lingering_processes():
+    """Force-kill any installer/uninstaller processes that are still running."""
+    for name in PROCESSES:
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/IM", name],
+            capture_output=True,
+        )
+
+
+def _live_processes():
+    """Return the set of process names currently in the process list."""
+    live = set()
+    for p in psutil.process_iter():
+        try:
+            live.add(p.name())
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return live
+
+
+def _wait_for_processes(wait_secs=PROC_WAIT_SECS):
+    """
+    Wait up to wait_secs for every name in PROCESSES to leave the process list.
+    If the timeout expires, force-kill them all, then wait up to 5 s for the
+    OS to remove them from the process table.
+    Returns True if they exited cleanly, False if they had to be force-killed.
+    Callers should treat False as a test failure signal.
+    """
+    elapsed = 0.0
+    while elapsed < wait_secs:
+        if not any(name in _live_processes() for name in PROCESSES):
+            return True
+        elapsed += 0.1
+        time.sleep(0.1)
+
+    # Timed out — force-kill, then give the OS up to 5 s to clean up.
+    _kill_lingering_processes()
+    for _ in range(50):
+        time.sleep(0.1)
+        if not any(name in _live_processes() for name in PROCESSES):
+            break
+
+    return False  # signal to caller: processes were force-killed
 
 
 def reg_key_exists(hive=winreg.HKEY_LOCAL_MACHINE, key=None):
@@ -135,46 +187,87 @@ def clean_fragments(inst_dir=INST_DIR):
 
 @pytest.helpers.register
 def clean_env(inst_dir=INST_DIR, timeout=300):
-    # Let's make sure none of the install/uninstall processes are running
-    for proc in PROCESSES:
-        try:
-            assert proc not in (p.name() for p in psutil.process_iter())
-        except psutil.NoSuchProcess:
-            continue
+    # Track whether any process had to be force-killed.  If so we return
+    # False so the caller's `assert clean_env()` fails the test — a forced
+    # kill means something got stuck, which is exactly what this test suite
+    # is designed to catch.
+    killed = False
 
-    # Uninstall existing installation
-    # Run the uninstaller.
+    # Un.exe (the NSIS temp-copy uninstaller) is still alive when the
+    # previous iteration's run_command() returns — it continues stripping
+    # parent directories and registry entries after uninst.exe exits.
+    # Wait (and kill if stuck) before asserting so we don't race the tail
+    # of the previous uninstall.
+    if not _wait_for_processes():
+        killed = True
+
+    # Verify all installer/uninstaller processes are gone after the wait.
+    # We do NOT raise AssertionError here — if a process is still visible
+    # (e.g. Un.exe appeared between the wait and this check), treat it as
+    # a force-kill failure so the test is marked ERROR rather than crashing
+    # the fixture with an unhandled exception.
+    live = _live_processes()
+    for proc in PROCESSES:
+        if proc in live:
+            print(f"\nWARNING: {proc} still in process list after wait — marking as killed")
+            killed = True
+
+    # Uninstall existing installation if one is present.
     for uninst_bin in [f"{inst_dir}\\uninst.exe", f"{OLD_DIR}\\uninst.exe"]:
         if os.path.exists(uninst_bin):
             install_dir = os.path.dirname(uninst_bin)
             cmd = [f'"{uninst_bin}"', "/S", "/delete-root-dir", "/delete-install-dir"]
-            run_command(cmd)
+            if not run_command(cmd):
+                killed = True
 
-            # Uninst.exe launches a 2nd binary (Un.exe or Un_*.exe)
-            # Let's get the name of the process
-            proc_name = ""
-            for proc in PROCESSES:
+            # uninst.exe immediately re-launches itself as Un.exe (or Un_*.exe)
+            # from a temp path so it can delete its own binary, then exits.
+            # run_command() returns at that point while Un.exe is still working.
+            # Give Un.exe a moment to appear in the OS process table before we
+            # start polling — without this pause _wait_for_processes() may poll
+            # in the brief window between uninst.exe launching Un.exe and Un.exe
+            # actually appearing in the process table, causing a false-positive
+            # "no processes" result while Un.exe is still doing its cleanup.
+            time.sleep(0.5)
+            if not _wait_for_processes():
+                killed = True
+
+            # Un.exe's last act is RMDir $INSTDIR.  Waiting here until the
+            # directory is gone is a belt-and-suspenders check that every
+            # file-system operation in the uninstall has completed.
+            elapsed_time = 0
+            while os.path.exists(install_dir) and elapsed_time < INST_DIR_WAIT_SECS:
+                elapsed_time += 0.1
+                time.sleep(0.1)
+
+            # Wait for the Windows SCM to finish removing the salt-minion
+            # service entry from the registry.  ssm.exe remove marks the
+            # service for deletion, but SCM keeps the
+            # HKLM\SYSTEM\CurrentControlSet\Services\salt-minion key alive
+            # until all open handles (including its own internal ones) are
+            # closed.  If CreateService for the *next* iteration races with
+            # this cleanup, Windows can return ERROR_SERVICE_MARKED_FOR_DELETE
+            # or leave NSSM in a state where SetServiceStatus(RUNNING) blocks
+            # on an SCM-internal lock — causing `nssm start` to hang.
+            scm_key = r"SYSTEM\CurrentControlSet\Services\salt-minion"
+            scm_elapsed = 0.0
+            while scm_elapsed < SCM_WAIT_SECS:
                 try:
-                    if proc in (p.name() for p in psutil.process_iter()):
-                        proc_name = proc
-                except psutil.NoSuchProcess:
-                    continue
+                    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, scm_key):
+                        pass  # key still present
+                except OSError:
+                    break  # key gone — SCM cleanup complete
+                scm_elapsed += 0.5
+                time.sleep(0.5)
 
-            # We need to give the process time to exit
-            if proc_name:
-                elapsed_time = 0
-                while elapsed_time < timeout:
-                    try:
-                        if proc_name not in (p.name() for p in psutil.process_iter()):
-                            break
-                    except psutil.NoSuchProcess:
-                        continue
-                    elapsed_time += 0.1
-                    time.sleep(0.1)
+            try:
+                result = clean_fragments(inst_dir=install_dir)
+                assert result, "clean_fragments returned False"
+            except Exception as exc:
+                print(f"\nERROR in clean_fragments({install_dir!r}): {exc}")
+                killed = True
 
-            assert clean_fragments(inst_dir=install_dir)
-
-    return True
+    return not killed
 
 
 @pytest.helpers.register
@@ -234,7 +327,7 @@ def install_salt(args):
         cmd.extend(args)
     else:
         raise TypeError(f"Invalid args format: {args}")
-    run_command(cmd)
+    assert run_command(cmd), "Installer failed (non-zero exit or force-killed on timeout)"
 
     # Let's make sure none of the install/uninstall processes are running
     try:
@@ -259,8 +352,32 @@ def is_file_locked(path):
     return False
 
 
+def _kill_process_tree(proc):
+    """
+    Kill a subprocess and every descendant it spawned.
+    proc.kill() alone only terminates the top-level process; child processes
+    (e.g. the nssm start child launched by the NSIS installer via Exec, or
+    the salt-minion service process that NSSM itself started) keep running
+    and leave the system in a dirty state for the next iteration.
+    """
+    try:
+        parent = psutil.Process(proc.pid)
+        for child in parent.children(recursive=True):
+            try:
+                child.kill()
+            except psutil.NoSuchProcess:
+                pass
+    except psutil.NoSuchProcess:
+        pass
+    proc.kill()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 @pytest.helpers.register
-def run_command(cmd_args, timeout=300):
+def run_command(cmd_args, timeout=60):
     if isinstance(cmd_args, list):
         cmd_args = " ".join(cmd_args)
 
@@ -273,7 +390,16 @@ def run_command(cmd_args, timeout=300):
         elapsed_time += 0.1
         time.sleep(0.1)
 
-    proc = subprocess.Popen(cmd_args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    # Use DEVNULL instead of PIPE for stdout/stderr.  PIPE creates inheritable
+    # handles: NSIS's Exec (bInheritHandles=TRUE) passes them to the
+    # "ssm.exe start salt-minion" child, which then holds the write-end of
+    # the pipe open even after the installer itself has exited.
+    # proc.communicate() can never see EOF while that child is alive, so the
+    # test blocks indefinitely.  DEVNULL avoids creating any pipe handles,
+    # so proc.wait() returns as soon as the installer process exits.
+    proc = subprocess.Popen(
+        cmd_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
 
     elapsed_time = 0
     while (
@@ -283,11 +409,14 @@ def run_command(cmd_args, timeout=300):
         time.sleep(0.1)
 
     try:
-        out, err = proc.communicate(timeout=timeout)
-        assert proc.returncode == 0
+        proc.wait(timeout=timeout)
+        if proc.returncode != 0:
+            print(f"\nWARNING: process exited with code {proc.returncode}: {cmd_args[:120]}")
+            return False
+        return True
     except subprocess.TimeoutExpired:
-        # This hides the hung installer/uninstaller problem
-        proc.kill()
-        out = "process killed"
-
-    return out
+        # Kill the installer/uninstaller and every child it spawned (nssm,
+        # salt-minion, etc.) so they don't linger into the next iteration.
+        print(f"\nWARNING: process timed out after {timeout}s — force-killing: {cmd_args[:120]}")
+        _kill_process_tree(proc)
+        return False

--- a/pkg/windows/nsis/tests/quick_setup.ps1
+++ b/pkg/windows/nsis/tests/quick_setup.ps1
@@ -45,8 +45,10 @@ $SCRIPT_DIR    = (Get-ChildItem "$($myInvocation.MyCommand.Definition)").Directo
 $WINDOWS_DIR   = "$PROJECT_DIR\pkg\windows"
 $NSIS_DIR      = "$WINDOWS_DIR\nsis"
 $BUILDENV_DIR  = "$WINDOWS_DIR\buildenv"
+$PREREQS_DIR   = "$WINDOWS_DIR\prereqs"
 $NSIS_BIN      = "$( ${env:ProgramFiles(x86)} )\NSIS\makensis.exe"
-$SALT_DEP_URL = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/ssm/64/"
+$SALT_DEP_URL  = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/ssm/64/"
+$GO_DEPS_URL   = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/go"
 
 #-------------------------------------------------------------------------------
 # Script Start
@@ -60,7 +62,8 @@ Write-Host $("-" * 80)
 # Setup Directories
 #-------------------------------------------------------------------------------
 
-$directories = "$BUILDENV_DIR",
+$directories = "$PREREQS_DIR",
+               "$BUILDENV_DIR",
                "$BUILDENV_DIR\configs"
 $directories | ForEach-Object {
     if ( ! (Test-Path -Path "$_") ) {
@@ -76,9 +79,103 @@ $directories | ForEach-Object {
 }
 
 #-------------------------------------------------------------------------------
+# Go (required to build test stubs)
+#-------------------------------------------------------------------------------
+
+Write-Host "Looking for Go 1.20+: " -NoNewline
+$go_ok = $false
+$go_exe = (Get-Command go -ErrorAction SilentlyContinue)
+if ( -not $go_exe ) {
+    # Go may be installed but not yet in the current session PATH.
+    # Check both common install locations (1.21+ default, then pre-1.21).
+    $known_paths = @("C:\Program Files\Go\bin\go.exe", "C:\Go\bin\go.exe")
+    foreach ( $p in $known_paths ) {
+        if ( Test-Path $p ) {
+            $env:PATH = "$(Split-Path $p);$env:PATH"
+            $go_exe = Get-Command go -ErrorAction SilentlyContinue
+            break
+        }
+    }
+}
+if ( $go_exe ) {
+    $ver_out = & go version 2>$null
+    if ( $ver_out -match 'go(\d+)\.(\d+)' ) {
+        $maj = [int]$Matches[1]; $min = [int]$Matches[2]
+        if ( $maj -gt 1 -or ($maj -eq 1 -and $min -ge 20) ) {
+            $go_ok = $true
+        }
+    }
+}
+if ( $go_ok ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Missing" -ForegroundColor Yellow
+
+    Write-Host "Downloading Go: " -NoNewline
+    $url  = "$GO_DEPS_URL/go1.26.1.windows-amd64.msi"
+    $file = "$env:TEMP\go-install.msi"
+    Invoke-WebRequest -Uri $url -OutFile "$file"
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Installing Go: " -NoNewline
+    Start-Process "msiexec.exe" -ArgumentList "/i `"$file`" /quiet /norestart" -Wait -NoNewWindow
+    if ( Test-Path -Path "C:\Program Files\Go\bin\go.exe" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    # Refresh session PATH so go build works immediately without reopening the shell
+    $env:PATH = "C:\Program Files\Go\bin;$env:PATH"
+
+    Write-Host "Cleaning up: " -NoNewline
+    Remove-Item -Path $file -Force
+    if ( ! (Test-Path -Path "$file") ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Yellow
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Create binaries
 #-------------------------------------------------------------------------------
 
+# Build the daemon stub (salt-minion.exe): a real PE that stays alive and
+# exits cleanly on CTRL_C so NSSM can manage it as a proper service.
+# -C changes the working directory to the module root before building so
+# that Go modules can locate go.mod (requires Go 1.20+).
+Write-Host "Building salt-minion.exe stub: " -NoNewline
+& go build -C "$SCRIPT_DIR\stubs\daemon" -o "$BUILDENV_DIR\salt-minion.exe" .
+if ( Test-Path -Path "$BUILDENV_DIR\salt-minion.exe" ) {
+    Write-Result "Success"
+} else {
+    Write-Result "Failed" -ForegroundColor Red
+    exit 1
+}
+
+# Build the exit stub (vcredist): a real PE that exits immediately with code 0
+# so ExecWait succeeds and the installer does not abort during VCRedist install.
+$prereq_files = "vcredist_x86_2022.exe",
+                "vcredist_x64_2022.exe"
+$prereq_files | ForEach-Object {
+    Write-Host "Building $_`: " -NoNewline
+    & go build -C "$SCRIPT_DIR\stubs\exit" -o "$PREREQS_DIR\$_" .
+    if ( Test-Path -Path "$PREREQS_DIR\$_" ) {
+        Write-Result "Success"
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# python.exe only needs to exist on disk (checked by test assertions, not executed)
 $binary_files = @("python.exe")
 $binary_files | ForEach-Object {
     Write-Host "Creating $_`: " -NoNewline

--- a/pkg/windows/nsis/tests/setup.ps1
+++ b/pkg/windows/nsis/tests/setup.ps1
@@ -47,7 +47,8 @@ $NSIS_DIR      = "$WINDOWS_DIR\nsis"
 $BUILDENV_DIR  = "$WINDOWS_DIR\buildenv"
 $PREREQS_DIR   = "$WINDOWS_DIR\prereqs"
 $NSIS_BIN      = "$( ${env:ProgramFiles(x86)} )\NSIS\makensis.exe"
-$SALT_DEP_URL = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/ssm/64/"
+$SALT_DEP_URL  = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/ssm/64/"
+$GO_DEPS_URL   = "https://github.com/saltstack/salt-windows-deps/raw/refs/heads/main/go"
 
 #-------------------------------------------------------------------------------
 # Script Start
@@ -78,14 +79,94 @@ $directories | ForEach-Object {
 }
 
 #-------------------------------------------------------------------------------
+# Go (required to build test stubs)
+#-------------------------------------------------------------------------------
+
+Write-Host "Looking for Go 1.20+: " -NoNewline
+$go_ok = $false
+$go_exe = (Get-Command go -ErrorAction SilentlyContinue)
+if ( -not $go_exe ) {
+    # Go may be installed but not yet in the current session PATH.
+    # Check both common install locations (1.21+ default, then pre-1.21).
+    $known_paths = @("C:\Program Files\Go\bin\go.exe", "C:\Go\bin\go.exe")
+    foreach ( $p in $known_paths ) {
+        if ( Test-Path $p ) {
+            $env:PATH = "$(Split-Path $p);$env:PATH"
+            $go_exe = Get-Command go -ErrorAction SilentlyContinue
+            break
+        }
+    }
+}
+if ( $go_exe ) {
+    $ver_out = & go version 2>$null
+    if ( $ver_out -match 'go(\d+)\.(\d+)' ) {
+        $maj = [int]$Matches[1]; $min = [int]$Matches[2]
+        if ( $maj -gt 1 -or ($maj -eq 1 -and $min -ge 20) ) {
+            $go_ok = $true
+        }
+    }
+}
+if ( $go_ok ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Missing" -ForegroundColor Yellow
+
+    Write-Host "Downloading Go: " -NoNewline
+    $url  = "$GO_DEPS_URL/go1.26.1.windows-amd64.msi"
+    $file = "$env:TEMP\go-install.msi"
+    Invoke-WebRequest -Uri $url -OutFile "$file"
+    if ( Test-Path -Path "$file" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Installing Go: " -NoNewline
+    Start-Process "msiexec.exe" -ArgumentList "/i `"$file`" /quiet /norestart" -Wait -NoNewWindow
+    if ( Test-Path -Path "C:\Program Files\Go\bin\go.exe" ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    # Refresh session PATH so go build works immediately without reopening the shell
+    $env:PATH = "C:\Program Files\Go\bin;$env:PATH"
+
+    Write-Host "Cleaning up: " -NoNewline
+    Remove-Item -Path $file -Force
+    if ( ! (Test-Path -Path "$file") ) {
+        Write-Result "Success" -ForegroundColor Green
+    } else {
+        Write-Result "Failed" -ForegroundColor Yellow
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Create binaries
 #-------------------------------------------------------------------------------
 
+# Build the daemon stub (salt-minion.exe): a real PE that stays alive and
+# exits cleanly on CTRL_C so NSSM can manage it as a proper service.
+# -C changes the working directory to the module root before building so
+# that Go modules can locate go.mod (requires Go 1.20+).
+Write-Host "Building salt-minion.exe stub: " -NoNewline
+& go build -C "$SCRIPT_DIR\stubs\daemon" -o "$BUILDENV_DIR\salt-minion.exe" .
+if ( Test-Path -Path "$BUILDENV_DIR\salt-minion.exe" ) {
+    Write-Result "Success"
+} else {
+    Write-Result "Failed" -ForegroundColor Red
+    exit 1
+}
+
+# Build the exit stub (vcredist): a real PE that exits immediately with code 0
+# so ExecWait succeeds and the installer does not abort during VCRedist install.
 $prereq_files = "vcredist_x86_2022.exe",
                 "vcredist_x64_2022.exe"
 $prereq_files | ForEach-Object {
-    Write-Host "Creating $_`: " -NoNewline
-    Set-Content -Path "$PREREQS_DIR\$_" -Value "binary"
+    Write-Host "Building $_`: " -NoNewline
+    & go build -C "$SCRIPT_DIR\stubs\exit" -o "$PREREQS_DIR\$_" .
     if ( Test-Path -Path "$PREREQS_DIR\$_" ) {
         Write-Result "Success"
     } else {
@@ -94,6 +175,7 @@ $prereq_files | ForEach-Object {
     }
 }
 
+# python.exe only needs to exist on disk (checked by test assertions, not executed)
 $binary_files = @("python.exe")
 $binary_files | ForEach-Object {
     Write-Host "Creating $_`: " -NoNewline

--- a/pkg/windows/nsis/tests/stubs/daemon/go.mod
+++ b/pkg/windows/nsis/tests/stubs/daemon/go.mod
@@ -1,0 +1,3 @@
+module stubs/daemon
+
+go 1.21

--- a/pkg/windows/nsis/tests/stubs/daemon/main.go
+++ b/pkg/windows/nsis/tests/stubs/daemon/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+)
+
+func main() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	<-ch
+}

--- a/pkg/windows/nsis/tests/stubs/exit/go.mod
+++ b/pkg/windows/nsis/tests/stubs/exit/go.mod
@@ -1,0 +1,3 @@
+module stubs/exit
+
+go 1.21

--- a/pkg/windows/nsis/tests/stubs/exit/main.go
+++ b/pkg/windows/nsis/tests/stubs/exit/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/pkg/windows/nsis/tests/test.ps1
+++ b/pkg/windows/nsis/tests/test.ps1
@@ -58,7 +58,8 @@ Write-Host $("-" * 80)
 #-------------------------------------------------------------------------------
 if ( !(Test-Path -Path "$SCRIPT_DIR\venv\Scripts\activate.ps1") ) {
     Write-Host "Could not find virtual environment"
-    Write-Host "You must run setup.cmd before running this script"
+    Write-Host "You must run setup.ps1 before running this script"
+    exit 1
 }
 
 Write-Host "Activating venv: " -NoNewline
@@ -91,6 +92,7 @@ if ($Tests) {
 }
 
 pytest -vvv -rPx --showlocals -- $pytest_args
+$pytest_exit = $LASTEXITCODE  # capture before anything else can overwrite it
 
 #-------------------------------------------------------------------------------
 # Script Complete
@@ -99,3 +101,5 @@ pytest -vvv -rPx --showlocals -- $pytest_args
 Write-Host $("-" * 80)
 Write-Host "Run Tests" -ForegroundColor Cyan
 Write-Host $("=" * 80)
+
+exit $pytest_exit  # propagate pytest's exit code so CI/CD sees failures


### PR DESCRIPTION
### What does this PR do?
Fix intermittent silent-mode installer hang on Windows; add NSIS test infrastructure

Upstream 3006.x worked around a known silent-mode installer hang with a wmic process kill — deprecated on Windows 11 and unreliable. This change fixes the root causes and replaces the workaround.

**Salt-Minion-Setup.nsi:**
- Replace wmic kill in .onInstSuccess and un.onUninstSuccess with System::Call "kernel32::ExitProcess(i 0)" guarded by ${If} ${Silent}. ExitProcess bypasses the NSIS message loop entirely, avoiding the cross-thread deadlock between the exec thread and UI thread that caused the hang.
- Replace nsExec::ExecToStack for service start with SimpleSC::StartService "salt-minion" "" 30. SimpleSC calls the SCM API inside the plugin DLL with no child process, pipe, or handle inheritance — eliminating the deadlock source.
- Replace nsExec::ExecToStack for stop/remove in un.uninstallSalt with SimpleSC::StopService (wait_for_file_release=1, timeout=30) and SimpleSC::RemoveService. Remove the 6-second sleep and three-pass PowerShell kill loop that were compensating for the old approach.
- Switch all nsExec::ExecToStack ssm.exe set calls in -Post and .onInstSuccess to nsExec::Exec (fire-and-forget); configuration commands need no stdout capture.
- Add taskkill belt-and-suspenders after SimpleSC stop/remove.
- Guard SetAutoClose true in uninstallSalt with !ifdef __UNINSTALL__ so it does not fire during the upgrade path (.onInit calling uninstallSalt).
- Add SetAutoClose true in .onInit for silent mode and un.onInit.
- Push/Pop $R0 around Call uninstallSalt in .onInit: GetParent inside the function writes to $R0, clobbering the saved silent flag used to conditionally restore SetSilent normal afterward.
- Fix typo "mnually" and add missing Quit after VCRedist error.
- Remove InstallDirRegKey (unused).

**conftest.py:**
- Replace subprocess.PIPE with subprocess.DEVNULL. NSIS Exec passes inherited pipe handles to child processes (nssm, salt-minion), which hold the write-end open indefinitely; proc.communicate() never sees EOF, causing the test to block forever.
- Replace proc.communicate() with proc.wait() for the same reason.
- Reduce run_command timeout from 300 to 60 seconds.
- Add _kill_process_tree() to terminate the entire process hierarchy on timeout (not just the top-level installer process).
- Return True/False from run_command and assert in install_salt so a force-kill fails the test — detecting hangs is the purpose of this suite.
- Add _wait_for_processes() with SCM registry polling: waits for all PROCESSES to exit, INSTDIR to be deleted, and the salt-minion SCM key to disappear before the next iteration. Prevents ERROR_SERVICE_MARKED_FOR_DELETE races between iterations.
- Fix duplicate Un_D.exe entry in PROCESSES (should be Un_E.exe).

**Test stubs (new files):**
- stubs/daemon/: Go program that blocks on SIGINT, used as a realistic salt-minion.exe stub that NSSM can manage as a service.
- stubs/exit/: Go program that exits immediately with code 0, used as vcredist stub so ExecWait in the installer succeeds.

**setup.ps1 / quick_setup.ps1:**
- Build stubs with go build -C <module-dir> so Go module resolution finds go.mod regardless of the caller's working directory.
- Replace fake Set-Content vcredist binaries with real go build output.
- Add Go 1.20+ prerequisite check: look in PATH, then fall back to C:\Program Files\Go and C:\Go; download and install silently from salt-windows-deps if missing.

**install_nsis.ps1:**
- Update NSIS download URL from 3.10 to 3.11.
- Add SimpleSC plugin install section (ANSI + Unicode DLLs from nsis-plugin-simplesc.zip and nsis-plugin-simplescu.zip).

**test.ps1:**
- Capture $LASTEXITCODE immediately after pytest and exit with it after the completion banner, so CI/CD correctly fails the job when pytest reports failures or errors.
- Here are the logs from 3006.x Nightly (https://github.com/saltstack/salt/actions/runs/23825393770)
[NSIS Config Tests Log.txt](https://github.com/user-attachments/files/26418680/NSIS.Config.Tests.Log.txt)
[NSIS Stress Tests Log.txt](https://github.com/user-attachments/files/26418681/NSIS.Stress.Tests.Log.txt)

### Previous Behavior
NSIS Tests were failing, but not reporting failure.
Installer would hang intermittently.

### New Behavior
Test failiures now bubble up.
Installer doesn't hang.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
