### PR TITLE
Clean up linode-python packages for retired Linode API v3

### DIFF
--- a/changelog/68871.removed.md
+++ b/changelog/68871.removed.md
@@ -1,0 +1,1 @@
+Removed linode-python package dependency for retired Linode API v3

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -303,10 +303,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -236,10 +236,6 @@ kubernetes==35.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.8.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.10/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -330,10 +330,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -293,10 +293,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -229,10 +229,6 @@ kubernetes==35.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.8.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.11/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -321,10 +321,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -288,10 +288,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -225,10 +225,6 @@ kubernetes==35.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.8.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.12/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -316,10 +316,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -294,10 +294,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -224,10 +224,6 @@ kubernetes==35.0.0
     # via -r requirements/static/ci/common.in
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -321,10 +321,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -315,10 +315,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -263,10 +263,6 @@ kubernetes==35.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.8.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.9/freebsd.txt
-    #   -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -346,10 +346,6 @@ libnacl==1.8.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt

--- a/requirements/static/pkg/darwin.in
+++ b/requirements/static/pkg/darwin.in
@@ -3,4 +3,3 @@
 # If they are macOS specific, place "; sys_platform == 'darwin'" in front of the requirement.
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-linode-python>=1.1.1

--- a/requirements/static/pkg/freebsd.in
+++ b/requirements/static/pkg/freebsd.in
@@ -10,7 +10,6 @@ python-gnupg>=0.4.4
 setproctitle>=1.2.3
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-linode-python>=1.1.1
 distro>=1.3.0
 importlib-metadata>=8.7.0
 # cheroot 8.5.2 fails to build with modern setuptools due to setuptools_scm_git_archive dependency

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -15,5 +15,4 @@ timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
 importlib-metadata>=8.7.0
 cryptography>=42.0.0
-linode-python>=1.1.1
 more-itertools>=9.1.0

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -82,8 +82,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/darwin.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -94,8 +94,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2 ; sys_platform == 'win32'

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -88,8 +88,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -83,8 +83,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/windows.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -80,8 +80,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/darwin.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -92,8 +92,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2 ; sys_platform == 'win32'

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -86,8 +86,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -81,8 +81,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/windows.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -78,8 +78,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/darwin.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -90,8 +90,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2 ; sys_platform == 'win32'

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -84,8 +84,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -79,8 +79,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/windows.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -78,8 +78,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/darwin.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.5

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -87,8 +87,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2 ; sys_platform == 'win32'

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -84,8 +84,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.5

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -76,8 +76,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/windows.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -82,8 +82,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/darwin.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -104,8 +104,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/freebsd.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2 ; sys_platform == 'win32'

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -88,8 +88,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 markupsafe==2.1.3

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -83,8 +83,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/windows.in
 looseversion==1.3.0
     # via -r requirements/base.txt
 lxml==6.0.2

--- a/requirements/static/pkg/windows.in
+++ b/requirements/static/pkg/windows.in
@@ -3,4 +3,3 @@
 # If they are windows specific, place "; sys_platform == 'win32'" in front of the requirement.
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-linode-python>=1.1.1


### PR DESCRIPTION
### What does this PR do?

Clean up an unmaintained package for retired Linode APIv3.

### Previous Behavior
The unmaintained package is in the requirements files

### New Behavior
It has been removed from the requirements files.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with ~~GPG~~ SSH?
Yes (signed with SSH)