### PR TITLE
Fix/deprecated datetime utcnow

### DIFF
--- a/.github/workflows/scripts/label-and-assign.py
+++ b/.github/workflows/scripts/label-and-assign.py
@@ -72,7 +72,7 @@ def label_and_assign_issue(options):
         json.dumps(
             {
                 "username": next_triage_account.login,
-                "when": str(datetime.datetime.utcnow()),
+                "when": str(datetime.datetime.now(datetime.timezone.utc)),
             }
         )
     )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2034,8 +2034,8 @@ repos:
           - --
         additional_dependencies:
           - nox==2022.11.21
-          - setuptools<58.0
-          - pip>=20.2.4,<21.2
+          - setuptools
+          - pip
 
   - repo: local
     hooks:
@@ -2050,6 +2050,6 @@ repos:
           - --
         additional_dependencies:
           - nox==2022.11.21
-          - setuptools<58.0
-          - pip>=20.2.4,<21.2
+          - setuptools
+          - pip
   # <---- Pre-Commit -------------------------------------------------------------------------------------------------

--- a/changelog/65604.fixed.md
+++ b/changelog/65604.fixed.md
@@ -1,1 +1,2 @@
-Fixed some instances of deprecated datetime.datetime.utcnow()
+Fixed deprecated datetime.datetime.utcnow() calls across modules and utilities.
+Fixed pre-commit lint hooks broken on Python 3.13 due to distutils removal.

--- a/salt/beacons/status.py
+++ b/salt/beacons/status.py
@@ -118,7 +118,7 @@ def beacon(config):
     Return status for requested information
     """
     log.debug(config)
-    ctime = datetime.datetime.utcnow().isoformat()
+    ctime = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     whitelist = []
     config = salt.utils.beacons.remove_hidden_options(config, whitelist)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -512,7 +512,9 @@ class SSH(MultiprocessingStateMixin):
                         '# Automatically added by "{s_user}" at {s_time}\n{hostname}:\n'
                         "    host: {hostname}\n    user: {user}\n    passwd: {passwd}\n".format(
                             s_user=getpass.getuser(),
-                            s_time=datetime.datetime.utcnow().isoformat(),
+                            s_time=datetime.datetime.now(
+                                datetime.timezone.utc
+                            ).isoformat(),
                             hostname=self.opts.get("tgt", ""),
                             user=self.opts.get("ssh_user", ""),
                             passwd=self.opts.get("ssh_passwd", ""),

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -15,7 +15,7 @@ Support for reboot, shutdown, etc on POSIX-like systems.
 import logging
 import os.path
 import re
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 
 import salt.utils.files
 import salt.utils.path
@@ -258,7 +258,7 @@ def _get_offset_time(utc_offset):
     if utc_offset is not None:
         minutes = _offset_to_min(utc_offset)
         offset = timedelta(minutes=minutes)
-        offset_time = datetime.utcnow() + offset
+        offset_time = datetime.now(timezone.utc) + offset
         offset_time = offset_time.replace(tzinfo=_FixedOffset(minutes))
     else:
         offset_time = datetime.now()

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -105,7 +105,7 @@ import math
 import os
 import re
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import salt.utils.data
 import salt.utils.files
@@ -365,7 +365,7 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
                 try:
                     days = (
                         datetime.strptime(cert.get_notAfter(), "%Y%m%d%H%M%SZ")
-                        - datetime.utcnow()
+                        - datetime.now(timezone.utc)
                     ).days
                 except (ValueError, TypeError):
                     days = 365
@@ -593,8 +593,10 @@ def validate(cert, ca_name, crl_file):
 
                 builder = x509.CertificateRevocationListBuilder()
                 builder = builder.issuer_name(ca_x509.subject)
-                builder = builder.last_update(datetime.utcnow())
-                builder = builder.next_update(datetime.utcnow() + timedelta(days=36500))
+                builder = builder.last_update(datetime.now(timezone.utc))
+                builder = builder.next_update(
+                    datetime.now(timezone.utc) + timedelta(days=36500)
+                )
 
                 # Load existing revocations from index file if it exists
                 index_file = f"{ca_dir}/index.txt"
@@ -845,7 +847,7 @@ def create_ca(
                     err,
                 )
                 bck = "{}.unloadable.{}".format(
-                    ca_keyp, datetime.utcnow().strftime("%Y%m%d%H%M%S")
+                    ca_keyp, datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
                 )
                 log.info("Saving unloadable CA ssl key in %s", bck)
                 os.rename(ca_keyp, bck)
@@ -903,7 +905,9 @@ def create_ca(
     keycontent = OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
     write_key = True
     if os.path.exists(ca_keyp):
-        bck = "{}.{}".format(ca_keyp, datetime.utcnow().strftime("%Y%m%d%H%M%S"))
+        bck = "{}.{}".format(
+            ca_keyp, datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        )
         with salt.utils.files.fopen(ca_keyp) as fic:
             old_key = salt.utils.stringutils.to_unicode(fic.read()).strip()
             if old_key.strip() == keycontent.strip():
@@ -1905,8 +1909,10 @@ def create_empty_crl(
 
         builder = x509.CertificateRevocationListBuilder()
         builder = builder.issuer_name(ca_x509.subject)
-        builder = builder.last_update(datetime.utcnow())
-        builder = builder.next_update(datetime.utcnow() + timedelta(days=36500))
+        builder = builder.last_update(datetime.now(timezone.utc))
+        builder = builder.next_update(
+            datetime.now(timezone.utc) + timedelta(days=36500)
+        )
 
         # Mapping digest strings to cryptography hashes
         hash_algo = getattr(hashes, digest.upper(), hashes.SHA256)()
@@ -2021,7 +2027,7 @@ def revoke_cert(
     )
     index_r_data = "R\t{}\t{}\t{}".format(
         expire_date,
-        _four_digit_year_to_two_digit(datetime.utcnow()),
+        _four_digit_year_to_two_digit(datetime.now(timezone.utc)),
         index_serial_subject,
     )
 
@@ -2063,8 +2069,10 @@ def revoke_cert(
 
         builder = x509.CertificateRevocationListBuilder()
         builder = builder.issuer_name(ca_x509.subject)
-        builder = builder.last_update(datetime.utcnow())
-        builder = builder.next_update(datetime.utcnow() + timedelta(days=36500))
+        builder = builder.last_update(datetime.now(timezone.utc))
+        builder = builder.next_update(
+            datetime.now(timezone.utc) + timedelta(days=36500)
+        )
 
         with salt.utils.files.fopen(index_file) as fp_:
             for line in fp_:

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -3877,7 +3877,9 @@ def update_host_datetime(
         host_ref = _get_host_ref(service_instance, host, host_name=host_name)
         date_time_manager = _get_date_time_mgr(host_ref)
         try:
-            date_time_manager.UpdateDateTime(datetime.datetime.utcnow())
+            date_time_manager.UpdateDateTime(
+                datetime.datetime.now(datetime.timezone.utc)
+            )
         except vim.fault.HostConfigFault as err:
             msg = "'vsphere.update_date_time' failed for host {}: {}".format(
                 host_name, err

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -3,7 +3,7 @@ Module for managing timezone on Windows systems.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from salt.exceptions import CommandExecutionError
 
@@ -242,7 +242,7 @@ def get_offset():
     """
     # http://craigglennie.com/programming/python/2013/07/21/working-with-timezones-using-Python-and-pytz-localize-vs-normalize/
     tz_object = pytz.timezone(get_zone())
-    utc_time = pytz.utc.localize(datetime.utcnow())
+    utc_time = datetime.now(timezone.utc)
     loc_time = utc_time.astimezone(tz_object)
     norm_time = tz_object.normalize(loc_time)
     return norm_time.strftime("%z")
@@ -262,7 +262,7 @@ def get_zonecode():
         salt '*' timezone.get_zonecode
     """
     tz_object = pytz.timezone(get_zone())
-    loc_time = tz_object.localize(datetime.utcnow())
+    loc_time = datetime.now(timezone.utc).astimezone(tz_object)
     return loc_time.tzname()
 
 

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -20,7 +20,6 @@ Manage X509 certificates
 
 import ast
 import ctypes
-import datetime
 import glob
 import hashlib
 import logging
@@ -30,6 +29,7 @@ import re
 import sys
 import tempfile
 from collections import OrderedDict
+from datetime import datetime, timedelta, timezone
 
 import salt.exceptions
 import salt.utils.data
@@ -253,15 +253,11 @@ def _parse_openssl_crl(crl_filename):
             crl["Issuer"] = subject
         if line.startswith("Last Update: "):
             crl["Last Update"] = line.replace("Last Update: ", "")
-            last_update = datetime.datetime.strptime(
-                crl["Last Update"], "%b %d %H:%M:%S %Y %Z"
-            )
+            last_update = datetime.strptime(crl["Last Update"], "%b %d %H:%M:%S %Y %Z")
             crl["Last Update"] = last_update.strftime("%Y-%m-%d %H:%M:%S")
         if line.startswith("Next Update: "):
             crl["Next Update"] = line.replace("Next Update: ", "")
-            next_update = datetime.datetime.strptime(
-                crl["Next Update"], "%b %d %H:%M:%S %Y %Z"
-            )
+            next_update = datetime.strptime(crl["Next Update"], "%b %d %H:%M:%S %Y %Z")
             crl["Next Update"] = next_update.strftime("%Y-%m-%d %H:%M:%S")
         if line.startswith("Revoked Certificates:"):
             break
@@ -283,7 +279,7 @@ def _parse_openssl_crl(crl_filename):
         rev_yaml = salt.utils.data.decode(salt.utils.yaml.safe_load(revoked))
         for rev_values in rev_yaml.values():
             if "Revocation Date" in rev_values:
-                rev_date = datetime.datetime.strptime(
+                rev_date = datetime.strptime(
                     rev_values["Revocation Date"], "%b %d %H:%M:%S %Y %Z"
                 )
                 rev_values["Revocation Date"] = rev_date.strftime("%Y-%m-%d %H:%M:%S")
@@ -1001,20 +997,14 @@ def create_crl(
         serial_number = salt.utils.stringutils.to_bytes(serial_number)
 
         if "not_after" in rev_item and not include_expired:
-            not_after = datetime.datetime.strptime(
-                rev_item["not_after"], "%Y-%m-%d %H:%M:%S"
-            )
-            if datetime.datetime.now() > not_after:
+            not_after = datetime.strptime(rev_item["not_after"], "%Y-%m-%d %H:%M:%S")
+            if datetime.now() > not_after:
                 continue
 
         if "revocation_date" not in rev_item:
-            rev_item["revocation_date"] = datetime.datetime.now().strftime(
-                "%Y-%m-%d %H:%M:%S"
-            )
+            rev_item["revocation_date"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-        rev_date = datetime.datetime.strptime(
-            rev_item["revocation_date"], "%Y-%m-%d %H:%M:%S"
-        )
+        rev_date = datetime.strptime(rev_item["revocation_date"], "%Y-%m-%d %H:%M:%S")
         rev_date = rev_date.strftime("%Y%m%d%H%M%SZ")
         rev_date = salt.utils.stringutils.to_bytes(rev_date)
 
@@ -1535,7 +1525,7 @@ def create_certificate(path=None, text=False, overwrite=True, ca_server=None, **
     fmt = "%Y-%m-%d %H:%M:%S"
     if "not_before" in kwargs:
         try:
-            time = datetime.datetime.strptime(kwargs["not_before"], fmt)
+            time = datetime.strptime(kwargs["not_before"], fmt)
         except:
             raise salt.exceptions.SaltInvocationError(
                 "not_before: {} is not in required format {}".format(
@@ -1553,7 +1543,7 @@ def create_certificate(path=None, text=False, overwrite=True, ca_server=None, **
 
     if "not_after" in kwargs:
         try:
-            time = datetime.datetime.strptime(kwargs["not_after"], fmt)
+            time = datetime.strptime(kwargs["not_after"], fmt)
         except:
             raise salt.exceptions.SaltInvocationError(
                 "not_after: {} is not in required format {}".format(
@@ -1960,7 +1950,7 @@ def expired(certificate):
             ret["path"] = certificate
             cert = _get_certificate_obj(certificate)
 
-            _now = datetime.datetime.utcnow()
+            _now = datetime.now(timezone.utc)
             _expiration_date = cert.get_not_after().get_datetime()
 
             ret["cn"] = _parse_subject(cert.get_subject())["CN"]
@@ -2004,7 +1994,7 @@ def will_expire(certificate, days):
 
             cert = _get_certificate_obj(certificate)
 
-            _check_time = datetime.datetime.utcnow() + datetime.timedelta(days=days)
+            _check_time = datetime.now(timezone.utc) + timedelta(days=days)
             _expiration_date = cert.get_not_after().get_datetime()
 
             ret["cn"] = _parse_subject(cert.get_subject())["CN"]

--- a/salt/spm/pkgdb/sqlite3.py
+++ b/salt/spm/pkgdb/sqlite3.py
@@ -166,7 +166,9 @@ def register_pkg(name, formula_def, conn=None):
             name,
             formula_def["version"],
             formula_def["release"],
-            datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT"),
+            datetime.datetime.now(datetime.timezone.utc).strftime(
+                "%a, %d %b %Y %H:%M:%S GMT"
+            ),
             formula_def.get("os", None),
             formula_def.get("os_family", None),
             formula_def.get("dependencies", None),

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -18,7 +18,7 @@ import re
 import time
 import urllib.parse
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -121,7 +121,7 @@ def creds(provider):
     ## if needed
     if provider["id"] == IROLE_CODE or provider["key"] == IROLE_CODE:
         # Check to see if we have cache credentials that are still good
-        if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime(
+        if not __Expiration__ or __Expiration__ < datetime.now(timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         ):
             # We don't have any cached credentials, or they are expired, get them
@@ -164,7 +164,7 @@ def sig2(method, endpoint, params, provider, aws_api_version):
 
     http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
     """
-    timenow = datetime.utcnow()
+    timenow = datetime.now(timezone.utc)
     timestamp = timenow.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Retrieve access credentials from meta-data, or use provided
@@ -201,7 +201,7 @@ def assumed_creds(prov_dict, role_arn, location=None):
     valid_session_name_re = re.compile("[^a-z0-9A-Z+=,.@-]")
 
     # current time in epoch seconds
-    now = time.mktime(datetime.utcnow().timetuple())
+    now = time.mktime(datetime.now(timezone.utc).timetuple())
 
     for key, creds in copy.deepcopy(__AssumeCache__).items():
         if (creds["Expiration"] - now) <= 120:
@@ -281,7 +281,7 @@ def sig4(
     http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
     http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     """
-    timenow = datetime.utcnow()
+    timenow = datetime.now(timezone.utc)
 
     # Retrieve access credentials from meta-data, or use provided
     if role_arn is None:

--- a/salt/utils/timeutil.py
+++ b/salt/utils/timeutil.py
@@ -6,7 +6,7 @@ Functions various time manipulations.
 import logging
 import re
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Import Salt modules
 
@@ -34,7 +34,7 @@ def get_timestamp_at(time_in=None, time_at=None):
                 minutes = 0
             hours, minutes = int(hours), int(minutes)
         dt = timedelta(hours=hours, minutes=minutes)
-        time_now = datetime.utcnow()
+        time_now = datetime.now(timezone.utc)
         time_at = time_now + dt
         return time.mktime(time_at.timetuple())
     elif time_at:

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -244,7 +244,7 @@ def warn_until_date(
         # Attribute the warning to the calling function, not to warn_until_date()
         stacklevel = 2
 
-    today = _current_date or datetime.datetime.utcnow().date()
+    today = _current_date or datetime.datetime.now(datetime.timezone.utc).date()
     if today >= date:
         caller = inspect.getframeinfo(sys._getframe(stacklevel - 1))
         deprecated_message = (

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 
 # pylint: disable=no-name-in-module
 from distutils import log
@@ -54,7 +54,7 @@ except ImportError:
 try:
     DATE = datetime.utcfromtimestamp(int(os.environ["SOURCE_DATE_EPOCH"]))
 except (KeyError, ValueError):
-    DATE = datetime.utcnow()
+    DATE = datetime.now(timezone.utc)
 
 # Change to salt source's directory prior to running any command
 try:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 The setup script for salt
 """
 
-# pylint: disable=file-perms,resource-leakage,deprecated-module
+# pylint: disable=file-perms,resource-leakage,deprecated-module,3rd-party-module-not-gated
 import setuptools  # isort:skip
 import distutils.dist
 import glob

--- a/tests/pytests/functional/modules/test_system.py
+++ b/tests/pytests/functional/modules/test_system.py
@@ -82,7 +82,7 @@ def fmt_str():
 @pytest.fixture(scope="function")
 def setup_teardown_vars(file, service, system):
     _systemd_timesyncd_available_ = None
-    _orig_time = datetime.datetime.utcnow()
+    _orig_time = datetime.datetime.now(datetime.timezone.utc)
 
     if os.path.isfile("/etc/machine-info"):
         with salt.utils.files.fopen("/etc/machine-info", "r") as mach_info:
@@ -232,9 +232,9 @@ def test_get_system_date_time_utc(setup_teardown_vars, system, fmt_str):
     """
     Test we are able to get the correct time with utc
     """
-    t1 = datetime.datetime.utcnow()
+    t1 = datetime.datetime.now(datetime.timezone.utc)
     res = system.get_system_date_time("+0000")
-    t2 = datetime.datetime.strptime(res, fmt_str)
+    t2 = datetime.datetime.strptime(res, fmt_str).replace(tzinfo=datetime.timezone.utc)
     msg = f"Difference in times is too large. Now: {t1} Fake: {t2}"
     assert _same_times(t1, t2, seconds_diff=3), msg
 
@@ -268,10 +268,10 @@ def test_set_system_date_time_utc(setup_teardown_vars, system, hwclock_has_compa
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
     result = _set_time(system, cmp_time, offset="+0000")
 
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time
@@ -291,11 +291,11 @@ def test_set_system_date_time_utcoffset_east(
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
     # 25200 seconds = 7 hours
     time_to_set = cmp_time - datetime.timedelta(seconds=25200)
     result = _set_time(system, time_to_set, offset="-0700")
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time
@@ -315,11 +315,11 @@ def test_set_system_date_time_utcoffset_west(
     Test changing the system clock. We are only able to set it up to a
     resolution of a second so this test may appear to run in negative time.
     """
-    cmp_time = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    cmp_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
     # 7200 seconds = 2 hours
     time_to_set = cmp_time + datetime.timedelta(seconds=7200)
     result = _set_time(system, time_to_set, offset="+0200")
-    time_now = datetime.datetime.utcnow()
+    time_now = datetime.datetime.now(datetime.timezone.utc)
 
     msg = "Difference in times is too large. Now: {} Fake: {}".format(
         time_now, cmp_time

--- a/tests/pytests/unit/test_fileserver.py
+++ b/tests/pytests/unit/test_fileserver.py
@@ -52,7 +52,7 @@ def test_future_file_list_cache_file_ignored(tmp_path):
                 _f.write(b"\x80")
 
     # Set modification time to file list cache file to 1 year in the future
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     future = now + datetime.timedelta(days=365)
     mod_time = time.mktime(future.timetuple())
     os.utime(os.path.join(back_cachedir, "base.p"), (mod_time, mod_time))

--- a/tests/pytests/unit/utils/test_aws.py
+++ b/tests/pytests/unit/utils/test_aws.py
@@ -8,7 +8,7 @@
 import io
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import requests
@@ -79,11 +79,11 @@ def test_get_metadata_imdsv2():
 def test_assumed_creds_not_updating_dictionary_while_iterating():
     mock_cache = {
         "expired": {
-            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+            "Expiration": time.mktime(datetime.now(timezone.utc).timetuple()),
         },
         "not_expired_1": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(days=1)).timetuple()
+                (datetime.now(timezone.utc) + timedelta(days=1)).timetuple()
             ),
             "AccessKeyId": "mock_AccessKeyId",
             "SecretAccessKey": "mock_SecretAccessKey",
@@ -91,7 +91,7 @@ def test_assumed_creds_not_updating_dictionary_while_iterating():
         },
         "not_expired_2": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+                (datetime.now(timezone.utc) + timedelta(seconds=300)).timetuple()
             ),
         },
     }
@@ -104,11 +104,11 @@ def test_assumed_creds_not_updating_dictionary_while_iterating():
 def test_assumed_creds_deletes_expired_key():
     mock_cache = {
         "expired": {
-            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+            "Expiration": time.mktime(datetime.now(timezone.utc).timetuple()),
         },
         "not_expired_1": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(days=1)).timetuple()
+                (datetime.now(timezone.utc) + timedelta(days=1)).timetuple()
             ),
             "AccessKeyId": "mock_AccessKeyId",
             "SecretAccessKey": "mock_SecretAccessKey",
@@ -116,7 +116,7 @@ def test_assumed_creds_deletes_expired_key():
         },
         "not_expired_2": {
             "Expiration": time.mktime(
-                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+                (datetime.now(timezone.utc) + timedelta(seconds=300)).timetuple()
             ),
         },
     }
@@ -153,7 +153,7 @@ def test_creds_with_role_arn_should_always_call_assumed_creds():
     access_key_id = "mock_AccessKeyId"
     secret_access_key = "mock_SecretAccessKey"
     token = "mock_Token"
-    expiration = (datetime.utcnow() + timedelta(seconds=900)).strftime(
+    expiration = (datetime.now(timezone.utc) + timedelta(seconds=900)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
 

--- a/tests/pytests/unit/utils/test_x509.py
+++ b/tests/pytests/unit/utils/test_x509.py
@@ -1965,7 +1965,6 @@ def test_build_crl_accounts_for_local_time_zone(ca_key, ca_cert):
     with patch("salt.utils.x509.datetime") as fakedate:
         fakedate.today.return_value = curr_time_naive
         fakedate.now.side_effect = dtn
-        fakedate.utcnow.return_value = curr_time_utc_naive
         builder, _ = x509.build_crl(privkey, [], signing_cert=cert)
         crl = builder.sign(privkey, algorithm=cprim.hashes.SHA256())
     try:

--- a/tests/unit/modules/test_x509.py
+++ b/tests/unit/modules/test_x509.py
@@ -185,7 +185,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
 
         fmt = "%Y-%m-%d %H:%M:%S"
         # We also gonna use the current date in UTC format for verification
-        not_after = datetime.datetime.utcnow()
+        not_after = datetime.datetime.now(datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_after = not_after.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_after_str = datetime.datetime.strftime(not_after, fmt)
@@ -226,7 +226,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
 
         fmt = "%Y-%m-%d %H:%M:%S"
         # We also gonna use the current date in UTC format for verification
-        not_before = datetime.datetime.utcnow()
+        not_before = datetime.datetime.now(datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_before = not_before.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_before_str = datetime.datetime.strftime(not_before, fmt)
@@ -319,7 +319,7 @@ class X509TestCase(TestCase, LoaderModuleMockMixin):
         fmt = "%Y-%m-%d %H:%M:%S"
         # Here we gonna use the current date as the not_before date
         # First we again take the UTC for verification
-        not_before = datetime.datetime.utcnow()
+        not_before = datetime.datetime.now(datetime.timezone.utc)
         # And set the UTC timezone to the naive datetime resulting from parsing
         not_before = not_before.replace(tzinfo=M2Crypto.ASN1.UTC)
         not_before_str = datetime.datetime.strftime(not_before, fmt)

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -107,7 +107,7 @@ def update_rpm(ctx: Context, salt_version: Version, draft: bool = False):
         capture=True,
         check=True,
     ).stdout.decode()
-    dt = datetime.datetime.utcnow()
+    dt = datetime.datetime.now(datetime.timezone.utc)
     date = dt.strftime("%a %b %d %Y")
     header = f"* {date} Salt Project Packaging <saltproject-packaging@vmware.com> - {str_salt_version}\n"
     parts = orig.split("%changelog")
@@ -150,7 +150,7 @@ def update_deb(ctx: Context, salt_version: Version, draft: bool = False):
         salt_version = _get_salt_version(ctx)
     changes = _get_pkg_changelog_contents(ctx, salt_version)
     formated = "\n".join([f"  {_.replace('-', '*', 1)}" for _ in changes.split("\n")])
-    dt = datetime.datetime.utcnow()
+    dt = datetime.datetime.now(datetime.timezone.utc)
     date = dt.strftime("%a, %d %b %Y %H:%M:%S +0000")
     # Debian requires a prerelease suffix that sorts *before* the final
     # version.  PEP 440 already does this for Python (e.g. ``3008.0rc1`` <

--- a/tools/utils/repo.py
+++ b/tools/utils/repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ptscripts import Context
@@ -87,7 +87,7 @@ def create_top_level_repo_path(
             create_repo_path
             / "salt-dev"
             / nightly_build_from
-            / datetime.utcnow().strftime("%Y-%m-%d")
+            / datetime.now(timezone.utc).strftime("%Y-%m-%d")
         )
         create_repo_path.mkdir(exist_ok=True, parents=True)
         with ctx.chdir(create_repo_path.parent):


### PR DESCRIPTION
### What does this PR do?

- replaces deprecated datetime.utcnow()
-  fix pylint problems when running  pre-commit
 
### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/65604
Not sure if there is issue for the pylint

### Previous Behavior
```bash
[DEBUG   ] The functions from module 'zfs' are being loaded by dir() on the loaded module
/usr/lib/python3.13/site-packages/salt/grains/core.py:2881: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

### New Behavior
No utcnow warnings

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes


