### PR TITLE
Upgrade relenv to 0.22.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,8 +441,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -458,8 +458,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -475,8 +475,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -491,10 +491,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.10.19"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -511,7 +511,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.11"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -529,7 +529,7 @@ jobs:
       ci-python-version: "3.11"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       workflow-slug: ci
       default-timeout: 180

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -458,7 +458,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -475,7 +475,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -491,7 +491,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -508,7 +508,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -529,7 +529,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -491,8 +491,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -508,8 +508,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -529,8 +529,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -549,10 +549,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.10.19"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -569,7 +569,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.11"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -587,7 +587,7 @@ jobs:
       ci-python-version: "3.11"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       workflow-slug: nightly
       default-timeout: 360

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -476,8 +476,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -493,8 +493,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -510,8 +510,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -526,10 +526,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.10.19"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -546,7 +546,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.11"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -564,7 +564,7 @@ jobs:
       ci-python-version: "3.11"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       workflow-slug: scheduled
       default-timeout: 360

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -476,7 +476,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -493,7 +493,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -510,7 +510,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -468,8 +468,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -486,8 +486,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -508,8 +508,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.6"
-      python-version: "3.10.19"
+      relenv-version: "0.22.7"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -528,10 +528,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.10.19"
+      python-version: "3.10.20"
       ci-python-version: "3.11"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -548,7 +548,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.11"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -566,7 +566,7 @@ jobs:
       ci-python-version: "3.11"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.19
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       workflow-slug: staging
       default-timeout: 180

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -468,7 +468,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -486,7 +486,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "onedir"
@@ -508,7 +508,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.5"
+      relenv-version: "0.22.6"
       python-version: "3.10.19"
       ci-python-version: "3.11"
       source: "src"

--- a/changelog/68884.fixed.md
+++ b/changelog/68884.fixed.md
@@ -1,0 +1,12 @@
+Upgrade relenv to 0.22.6
+
+* SQLite 3.51.3.0
+  - CVE-2025-70873: Heap memory disclosure in zipfile extension
+  - CVE-2025-7709: Integer overflow in FTS5 extension
+  - Fixes WAL-reset bug preventing database corruption
+* XZ Utils 5.8.3
+  - CVE-2026-34743: Buffer overflow in lzma_index_append()
+* Expat 2.7.5
+  - CVE-2026-32776: NULL pointer dereference in external parameter entities
+  - CVE-2026-32777: Infinite loop in entityValueProcessor
+  - CVE-2026-32778: NULL pointer dereference during OOM recovery

--- a/changelog/68884.fixed.md
+++ b/changelog/68884.fixed.md
@@ -1,5 +1,8 @@
-Upgrade relenv to 0.22.6
+Upgrade relenv to 0.22.7
 
+* Upgread Python Versions 3.12.13, 3.11.15, 3.10.20
+  - CVE-2024-6923: Header injection in email module
+  - CVE-2026-24515, CVE-2026-25210, CVE-2025-59375: XML memory amplification and libexpat vulnerabilities
 * SQLite 3.51.3.0
   - CVE-2025-70873: Heap memory disclosure in zipfile extension
   - CVE-2025-7709: Integer overflow in FTS5 extension

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.19"
-relenv_version: "0.22.5"
+relenv_version: "0.22.6"
 release_branches:
   - "3006.x"
   - "3007.x"

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
-python_version: "3.10.19"
-relenv_version: "0.22.6"
+python_version: "3.10.20"
+relenv_version: "0.22.7"
 release_branches:
   - "3006.x"
   - "3007.x"


### PR DESCRIPTION
* Upgread Python Versions 3.12.13, 3.11.15, 3.10.20
  - CVE-2024-6923: Header injection in email module
  - CVE-2026-24515, CVE-2026-25210, CVE-2025-59375: XML memory amplification and libexpat vulnerabilities
* SQLite 3.51.3.0
  - CVE-2025-70873: Heap memory disclosure in zipfile extension
  - CVE-2025-7709: Integer overflow in FTS5 extension
  - Fixes WAL-reset bug preventing database corruption
* XZ Utils 5.8.3
  - CVE-2026-34743: Buffer overflow in lzma_index_append()
* Expat 2.7.5
  - CVE-2026-32776: NULL pointer dereference in external parameter entities
  - CVE-2026-32777: Infinite loop in entityValueProcessor
  - CVE-2026-32778: NULL pointer dereference during OOM recovery

Fixes #68884