### PR TITLE
fix pkg.installed on freebsd

### DIFF
--- a/changelog/68886.fixed.md
+++ b/changelog/68886.fixed.md
@@ -1,0 +1,4 @@
+Fix `pkg.installed` idempotency on FreeBSD when `with_origin=True` causes
+`pkg.list_pkgs` to return per-package dicts instead of version lists; extract
+the version list before version-string comparison so a second state run no
+longer falsely reports packages as changed.

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -917,6 +917,10 @@ def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
         elif pkgver == "latest":
             _ok.append(pkgname)
             continue
+        elif __grains__["os"] == "FreeBSD" and pkgver:
+            cver = [k for k, v in new_pkgs.items() if v["version"] == pkgver]
+            _ok.append(pkgname)
+            continue
         elif not __salt__["pkg_resource.version_clean"](pkgver):
             _ok.append(pkgname)
             continue

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -911,14 +911,20 @@ def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
             if not cver and pkgname in new_caps:
                 cver = new_pkgs.get(new_caps.get(pkgname)[0])
 
+        # On FreeBSD with with_origin=True, a non-origin pkg lookup returns a
+        # dict {"origin": "...", "version": [...]} instead of a version list.
+        # Extract the version list so version-string comparison works correctly.
+        if (
+            __grains__["os"] == "FreeBSD"
+            and isinstance(cver, dict)
+            and "version" in cver
+        ):
+            cver = cver["version"]
+
         if not cver:
             failed.append(pkgname)
             continue
         elif pkgver == "latest":
-            _ok.append(pkgname)
-            continue
-        elif __grains__["os"] == "FreeBSD" and pkgver:
-            cver = [k for k, v in new_pkgs.items() if v["version"] == pkgver]
             _ok.append(pkgname)
             continue
         elif not __salt__["pkg_resource.version_clean"](pkgver):

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1218,3 +1218,60 @@ def test_latest_no_change_windows():
     with patch.dict(pkg.__salt__, salt_dict):
         ret = pkg.latest(pkg_name)
         assert ret.get("result", False) is True
+
+
+@pytest.mark.parametrize(
+    "desired_version, new_pkgs, expected_ok, expected_failed",
+    [
+        # Desired version matches installed — should be _ok (idempotency fix).
+        (
+            "14.0.3",
+            {"forgejo": {"origin": "www/forgejo", "version": ["14.0.3"]}},
+            ["forgejo"],
+            [],
+        ),
+        # Desired version does NOT match installed — should be failed, not _ok.
+        (
+            "14.0.4",
+            {"forgejo": {"origin": "www/forgejo", "version": ["14.0.3"]}},
+            [],
+            ["forgejo"],
+        ),
+        # No version specified (empty string) — pkg_resource.version_clean
+        # returns None; falls through to the "version_clean is None" branch,
+        # so the package is _ok regardless of version.
+        (
+            "",
+            {"forgejo": {"origin": "www/forgejo", "version": ["14.0.3"]}},
+            ["forgejo"],
+            [],
+        ),
+    ],
+)
+def test_verify_install_freebsd_with_origin(
+    desired_version, new_pkgs, expected_ok, expected_failed
+):
+    """
+    On FreeBSD, pkg.list_pkgs with_origin=True returns per-package dicts of the
+    form {"origin": "...", "version": [...]}.  _verify_install must unwrap the
+    version list before comparing so that:
+      - a matching version reports the package as _ok (idempotency); and
+      - a mismatched version still reports the package as failed (no false positive).
+    Regression test for https://github.com/saltstack/salt/issues/68886.
+    """
+    desired = {"forgejo": desired_version}
+    with patch.dict(
+        pkg.__grains__,
+        {"os": "FreeBSD", "os_family": "FreeBSD"},
+    ):
+        with patch.dict(
+            pkg.__salt__,
+            {
+                "pkg_resource.version_clean": MagicMock(
+                    side_effect=lambda v: v if v else None
+                ),
+            },
+        ):
+            _ok, failed = pkg._verify_install(desired, new_pkgs)
+    assert _ok == expected_ok, f"_ok mismatch: got {_ok}"
+    assert failed == expected_failed, f"failed mismatch: got {failed}"


### PR DESCRIPTION
### What does this PR do?
This PR fixes  #68886



### Previous Behavior
pkg.installed is was not idempotent on freebsd

```

root@salt:~# salt newjail2026 state.apply forgejo.init  saltenv=dev
jid: 20260402200221040413
newjail2026:
----------
          ID: install
    Function: pkg.installed
        Name: forgejo
      Result: True
     Comment: The following packages were installed/updated: forgejo=14.0.3
     Started: 22:01:36.213337
    Duration: 13513.934 ms
     Changes:
              ----------
              curl:
                  ----------
                  new:
                      8.17.0
                  old:
              forgejo:
                  ----------
                  new:
                      14.0.3
                  old:
              git:
                  ----------
                  new:
                      2.53.0
                  old:
              git-lfs:
                  ----------
                  new:
                      3.6.1_15
                  old:
              icu:
                  ----------
                  new:
                      76.1,1
                  old:
              libcroco:
                  ----------
                  new:
                      0.6.13_3
                  old:
              libnghttp2:
                  ----------
                  new:
                      1.68.0
                  old:
              libpsl:
                  ----------
                  new:
                      0.21.5_2
                  old:
              libssh2:
                  ----------
                  new:
                      1.11.1,3
                  old:
              p5-Authen-SASL:
                  ----------
                  new:
                      2.1900
                  old:
              p5-Crypt-URandom:
                  ----------
                  new:
                      0.54
                  old:
              p5-Digest-HMAC:
                  ----------
                  new:
                      1.05
                  old:
              p5-Error:
                  ----------
                  new:
                      0.17030
                  old:
              p5-IO-Socket-SSL:
                  ----------
                  new:
                      2.098
                  old:
              p5-MIME-Base32:
                  ----------
                  new:
                      1.303
                  old:
              p5-MIME-Base64:
                  ----------
                  new:
                      3.16
                  old:
              p5-Mozilla-CA:
                  ----------
                  new:
                      20250602
                  old:
              p5-Net-SSLeay:
                  ----------
                  new:
                      1.94
                  old:
              p5-URI:
                  ----------
                  new:
                      5.34
                  old:
              perl5:
                  ----------
                  new:
                      5.42.2
                  old:
              tcl86:
                  ----------
                  new:
                      8.6.17
                  old:
```
Second run 
```
root@salt:~# salt newjail2026 state.apply forgejo.init  saltenv=dev
jid: 20260402200247259487
newjail2026:
----------
          ID: install
    Function: pkg.installed
        Name: forgejo
      Result: True
     Comment: The following packages were installed/updated: forgejo=14.0.3
     Started: 22:02:02.279230
    Duration: 2187.71 ms
     Changes:
```