### PR TITLE
Fixes support for syslog when salt is running as non-root user

### DIFF
--- a/changelog/61286.fixed.md
+++ b/changelog/61286.fixed.md
@@ -1,0 +1,4 @@
+salt-syndic fail to properly switch to different user with log file:///dev/log.
+It improves the support of logging through syslog for salt processes running 
+as non-root users, such as salt-syndic and salt, by ensuring that the logging
+configuration correctly handles the log file path when using syslog.

--- a/changelog/61286.fixed.md
+++ b/changelog/61286.fixed.md
@@ -1,4 +1,4 @@
 salt-syndic fail to properly switch to different user with log file:///dev/log.
-It improves the support of logging through syslog for salt processes running 
+It improves the support of logging through syslog for salt processes running
 as non-root users, such as salt-syndic and salt, by ensuring that the logging
 configuration correctly handles the log file path when using syslog.

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -40,6 +40,7 @@ import salt.utils.xdg
 import salt.utils.yaml
 import salt.version as version
 from salt.defaults import DEFAULT_TARGET_DELIM
+from salt.utils.validate.path import is_syslog_path
 from salt.utils.validate.path import is_writeable
 from salt.utils.verify import insecure_log, verify_log, verify_log_files
 
@@ -833,7 +834,7 @@ class LogLevelMixIn(metaclass=MixInMeta):
             ),
         )
 
-        if not is_writeable(logfile, check_parent=True):
+        if not is_syslog_path(logfile) and not is_writeable(logfile, check_parent=True):
             # Since we're not be able to write to the log file or its parent
             # directory (if the log file does not exit), are we the same user
             # as the one defined in the configuration file?

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -40,8 +40,7 @@ import salt.utils.xdg
 import salt.utils.yaml
 import salt.version as version
 from salt.defaults import DEFAULT_TARGET_DELIM
-from salt.utils.validate.path import is_syslog_path
-from salt.utils.validate.path import is_writeable
+from salt.utils.validate.path import is_syslog_path, is_writeable
 from salt.utils.verify import insecure_log, verify_log, verify_log_files
 
 log = logging.getLogger(__name__)

--- a/salt/utils/validate/path.py
+++ b/salt/utils/validate/path.py
@@ -8,7 +8,67 @@
     Several path related validators
 """
 
+import logging.handlers
 import os
+import pathlib
+import stat
+from urllib.parse import urlparse
+
+
+def is_syslog_path(path):
+    """
+    Check if a given path is a syslog path.
+
+    <file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>
+
+    log-facility is optional; must be a valid syslog facility in upper case (e.g. "LOG_USER", "LOG_DAEMON", etc.)
+    see https://docs.python.org/3/library/logging.handlers.html#logging.handlers.SysLogHandler
+
+    :param path: The path to check
+    :returns: True or False
+    """
+
+    parsed_log_path = urlparse(path)
+
+    if parsed_log_path.scheme in ("tcp", "udp", "file"):
+        if parsed_log_path.scheme == "file" and parsed_log_path.path:
+            path = pathlib.Path(parsed_log_path.path)
+            facility_name = path.name.upper()
+            if facility_name.startswith("LOG_"):
+                facility = getattr(logging.handlers.SysLogHandler, facility_name, None)
+                if facility is None:
+                    return False
+                file_path = str(path.resolve().parent)
+            else:
+                file_path = str(path.resolve())
+
+            # Check if file_path is a Unix socket
+            if os.path.exists(file_path):
+                mode = os.stat(file_path).st_mode
+                if stat.S_ISSOCK(mode):
+                    return os.access(file_path, os.W_OK)
+                else:
+                    return False
+            else:
+                return False
+
+        elif parsed_log_path.path:
+            # In case of udp or tcp with a facility specified
+            path = pathlib.Path(parsed_log_path.path)
+            facility_name = path.stem.upper()
+            if not facility_name.startswith("LOG_"):
+                return False
+
+            facility = getattr(logging.handlers.SysLogHandler, facility_name, None)
+            if facility is None:
+                return False
+            else:
+                return True
+
+        else:
+            # This is the case of udp or tcp without a facility specified
+            return True
+    return False
 
 
 def is_writeable(path, check_parent=False):

--- a/tests/unit/utils/validate/test_path.py
+++ b/tests/unit/utils/validate/test_path.py
@@ -1,0 +1,39 @@
+from salt.utils.validate import path
+from tests.support.unit import TestCase
+
+
+class ValidatePathTestCase(TestCase):
+    """
+    TestCase for salt.utils.validate.path module
+    """
+
+    def test_is_syslog_path(self):
+
+        """
+        Test syslog path
+        """
+
+        valid_paths = [
+            "file:///dev/log",
+            "file:///dev/log/LOG_USER",
+            "udp://loghost:10514",
+            "udp://loghost:10514/LOG_USER",
+            "udp://loghost/LOG_USER",
+            "tcp://loghost:10514",
+            "tcp://loghost:10514/LOG_USER",
+            "tcp://loghost/USER"
+        ]
+
+        invalid_paths = [
+            "/dev/log",
+            "file:///dev/log/USER",
+            "udp://loghost/USER",
+            "tcp://loghost/USER",
+            "unix:///dev/log"
+        ]
+
+        for addr in valid_paths:
+            self.assertTrue(path.is_syslog_path(addr))
+
+        for addr in invalid_paths:
+            self.assertFalse(path.is_syslog_path(addr))

--- a/tests/unit/utils/validate/test_path.py
+++ b/tests/unit/utils/validate/test_path.py
@@ -8,7 +8,6 @@ class ValidatePathTestCase(TestCase):
     """
 
     def test_is_syslog_path(self):
-
         """
         Test syslog path
         """
@@ -21,7 +20,6 @@ class ValidatePathTestCase(TestCase):
             "udp://loghost/LOG_USER",
             "tcp://loghost:10514",
             "tcp://loghost:10514/LOG_USER",
-            "tcp://loghost/USER"
         ]
 
         invalid_paths = [
@@ -29,7 +27,7 @@ class ValidatePathTestCase(TestCase):
             "file:///dev/log/USER",
             "udp://loghost/USER",
             "tcp://loghost/USER",
-            "unix:///dev/log"
+            "unix:///dev/log",
         ]
 
         for addr in valid_paths:


### PR DESCRIPTION
## What does this PR do?

Adds support for `file://` scheme in syslog handler configuration.

## What issues does this PR fix or reference?

Closes #68801 (previous PR targeting master, reopened for 3006.x as requested by @dwoz)

## Previous Commits

Cherry-picked from previous PR #68801 and rebased onto 3006.x
