### PR TITLE
Fix beacon delete not closing beacon modules

### DIFF
--- a/changelog/66449.fixed.md
+++ b/changelog/66449.fixed.md
@@ -1,4 +1,6 @@
 Fixed inotify file descriptor leak in beacons. When beacons are refreshed
 (e.g. during module refresh or pillar refresh), the old beacon modules are now
 properly closed before creating new ones, preventing exhaustion of the inotify
-instance limit.
+instance limit. Also fixed beacon delete not calling the beacon's close
+function, causing resource leaks and CPU spin after deleting beacons at runtime
+via ``beacons.delete``.

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -26,6 +26,40 @@ class Beacon:
         self.beacons = salt.loader.beacons(opts, functions)
         self.interval_map = interval_map or dict()
 
+    def _close_beacon(self, name):
+        """
+        Close a single beacon module if it has a close function.
+        This releases resources like inotify file descriptors.
+        """
+        beacon_config = self.opts["beacons"].get(name)
+        if beacon_config is None:
+            return
+
+        current_beacon_config = None
+        if isinstance(beacon_config, list):
+            current_beacon_config = {}
+            list(map(current_beacon_config.update, beacon_config))
+        elif isinstance(beacon_config, dict):
+            current_beacon_config = beacon_config
+
+        if current_beacon_config is None:
+            return
+
+        beacon_name = name
+        if self._determine_beacon_config(current_beacon_config, "beacon_module"):
+            beacon_name = current_beacon_config["beacon_module"]
+
+        close_str = f"{beacon_name}.close"
+        if close_str in self.beacons:
+            try:
+                config = copy.deepcopy(beacon_config)
+                if isinstance(config, list):
+                    config.append({"_beacon_name": name})
+                log.debug("Closing beacon %s", name)
+                self.beacons[close_str](config)
+            except Exception:  # pylint: disable=broad-except
+                log.debug("Failed to close beacon %s", name, exc_info=True)
+
     def close_beacons(self):
         """
         Close all beacon modules that have a close function.
@@ -39,33 +73,7 @@ class Beacon:
         for mod in beacons:
             if mod == "enabled":
                 continue
-
-            current_beacon_config = None
-            if isinstance(beacons[mod], list):
-                current_beacon_config = {}
-                list(map(current_beacon_config.update, beacons[mod]))
-            elif isinstance(beacons[mod], dict):
-                current_beacon_config = beacons[mod]
-
-            if current_beacon_config is None:
-                continue
-
-            beacon_name = None
-            if self._determine_beacon_config(current_beacon_config, "beacon_module"):
-                beacon_name = current_beacon_config["beacon_module"]
-            else:
-                beacon_name = mod
-
-            close_str = f"{beacon_name}.close"
-            if close_str in self.beacons:
-                try:
-                    config = copy.deepcopy(beacons[mod])
-                    if isinstance(config, list):
-                        config.append({"_beacon_name": mod})
-                    log.debug("Closing beacon %s", mod)
-                    self.beacons[close_str](config)
-                except Exception:  # pylint: disable=broad-except
-                    log.debug("Failed to close beacon %s", mod, exc_info=True)
+            self._close_beacon(mod)
 
     def process(self, config, grains):
         """
@@ -446,6 +454,9 @@ class Beacon:
             complete = False
         else:
             if name in self.opts["beacons"]:
+                # Close the beacon module to release resources (e.g. inotify fds)
+                # before removing it from the configuration.
+                self._close_beacon(name)
                 del self.opts["beacons"][name]
                 comment = f"Deleting beacon item: {name}"
             else:

--- a/tests/pytests/unit/test_beacons.py
+++ b/tests/pytests/unit/test_beacons.py
@@ -287,3 +287,78 @@ def test_close_beacons_dict_config(minion_opts):
     close_mock.assert_called_once()
     call_args = close_mock.call_args[0][0]
     assert isinstance(call_args, dict)
+
+
+def test_delete_beacon_calls_close(minion_opts):
+    """
+    Test that delete_beacon() calls the beacon's close function before
+    removing it, so resources like inotify file descriptors are released.
+    """
+    minion_opts["id"] = "minion"
+    minion_opts["__role"] = "minion"
+    minion_opts["beacons"] = {
+        "inotify": [
+            {"files": {"/etc/fstab": {}}},
+        ],
+    }
+
+    beacon = salt.beacons.Beacon(minion_opts, [])
+    close_mock = MagicMock()
+    beacon.beacons["inotify.close"] = close_mock
+
+    with patch("salt.utils.event.get_event"):
+        beacon.delete_beacon("inotify")
+
+    close_mock.assert_called_once()
+    call_args = close_mock.call_args[0][0]
+    assert isinstance(call_args, list)
+    assert {"_beacon_name": "inotify"} in call_args
+    assert "inotify" not in minion_opts["beacons"]
+
+
+def test_delete_beacon_calls_close_with_beacon_module(minion_opts):
+    """
+    Test that delete_beacon() respects beacon_module and calls close
+    on the correct underlying module.
+    """
+    minion_opts["id"] = "minion"
+    minion_opts["__role"] = "minion"
+    minion_opts["beacons"] = {
+        "watch_apache": [
+            {"processes": {"apache2": "stopped"}},
+            {"beacon_module": "ps"},
+        ],
+    }
+
+    beacon = salt.beacons.Beacon(minion_opts, [])
+    close_mock = MagicMock()
+    beacon.beacons["ps.close"] = close_mock
+
+    with patch("salt.utils.event.get_event"):
+        beacon.delete_beacon("watch_apache")
+
+    close_mock.assert_called_once()
+    call_args = close_mock.call_args[0][0]
+    assert {"_beacon_name": "watch_apache"} in call_args
+    assert "watch_apache" not in minion_opts["beacons"]
+
+
+def test_delete_beacon_without_close(minion_opts):
+    """
+    Test that delete_beacon() works when the beacon module has no close function.
+    """
+    minion_opts["id"] = "minion"
+    minion_opts["__role"] = "minion"
+    minion_opts["beacons"] = {
+        "status": [
+            {"time": ["all"]},
+        ],
+    }
+
+    beacon = salt.beacons.Beacon(minion_opts, [])
+    assert "status.close" not in beacon.beacons
+
+    with patch("salt.utils.event.get_event"):
+        beacon.delete_beacon("status")
+
+    assert "status" not in minion_opts["beacons"]


### PR DESCRIPTION
When beacons.delete is called, the beacon is removed from opts but the beacon module's close() function is never called. This leaves resources like inotify file descriptors and notifier threads active, causing CPU spin that never recovers.

Extract _close_beacon() helper from close_beacons() and call it from delete_beacon() before removing the beacon from opts.

Fixes #66449

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
