### PR TITLE
[3006.x] Fix hostnamectl skip for CI without system D-Bus

### DIFF
--- a/tests/pytests/functional/modules/test_system.py
+++ b/tests/pytests/functional/modules/test_system.py
@@ -25,13 +25,27 @@ def check_hostnamectl():
         if not salt.utils.platform.is_linux():
             check_hostnamectl.memo = False
         else:
-            proc = subprocess.run(["hostnamectl"], capture_output=True, check=False)
-            check_hostnamectl.memo = (
-                b"Failed to connect to bus: No such file or directory" in proc.stderr
-                or b"Failed to create bus connection: No such file or directory"
-                in proc.stderr
-                or b"Failed to query system properties" in proc.stderr
-            )
+            # Probe the same invocation as system.get_computer_desc: bare
+            # `hostnamectl` can succeed while status/--pretty needs the system bus
+            # (e.g. GitHub Actions / minimal images without /run/dbus/system_bus_socket).
+            hostnamectl_bin = shutil.which("hostnamectl")
+            if not hostnamectl_bin:
+                check_hostnamectl.memo = False
+            else:
+                proc = subprocess.run(
+                    [hostnamectl_bin, "status", "--pretty"],
+                    capture_output=True,
+                    check=False,
+                )
+                out = proc.stdout + proc.stderr
+                check_hostnamectl.memo = (
+                    b"Failed to connect to bus: No such file or directory" in out
+                    or b"Failed to create bus connection: No such file or directory"
+                    in out
+                    or b"Failed to query system properties" in out
+                    or b"Failed to connect to system scope bus via local transport"
+                    in out
+                )
     return check_hostnamectl.memo
 
 


### PR DESCRIPTION
## Summary

Same change as for `master`: functional tests `test_set_computer_desc` and `test_set_computer_desc_multiline` fail in CI when the system D-Bus socket is missing. Newer `hostnamectl` reports `Failed to connect to system scope bus via local transport`, which the existing skip logic did not detect. Bare `hostnamectl` can succeed while `hostnamectl status --pretty` (used by `system.get_computer_desc`) still requires the bus.

## What changed

- Probe `hostnamectl status --pretty` instead of bare `hostnamectl`.
- Scan combined stdout and stderr for D-Bus errors.
- Treat `Failed to connect to system scope bus via local transport` as degraded and skip affected tests.

## Related

- Port of the fix targeting `master` (PR 68917).

