### PR TITLE
Resources: configurable pillar key; clear when key omitted

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -463,6 +463,8 @@ VALID_OPTS = immutabletypes.freeze(
         "return_retry_tries": int,
         # Configures amount of retries for Syndic to Master of Masters
         "syndic_retries": int,
+        # Top-level pillar key for per-type resource configuration (default: resources)
+        "resource_pillar_key": str,
         # Specify one or more returners in which all events will be sent to. Requires that the returners
         # in question have an event_return(event) function!
         "event_return": (list, str),
@@ -1277,6 +1279,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "return_retry_timer": 5,
         "return_retry_timer_max": 10,
         "return_retry_tries": 3,
+        "resource_pillar_key": "resources",
         "syndic_retries": 3,
         "random_reauth_delay": 10,
         "winrepo_source_dir": "salt://win/repo-ng/",

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -59,6 +59,7 @@ import salt.utils.minions
 import salt.utils.network
 import salt.utils.platform
 import salt.utils.process
+import salt.utils.resources
 import salt.utils.schedule
 import salt.utils.ssdp
 import salt.utils.state
@@ -556,30 +557,27 @@ class MinionBase:
         Build ``opts["resources"]`` by calling each resource type's
         ``discover(opts)`` function.
 
-        Resource types are read from ``opts["pillar"]["resources"]``.  A
-        temporary resource loader is used to call each type's
+        Resource types are read from the pillar subtree at
+        ``opts["pillar"][opts["resource_pillar_key"]]`` (default key
+        ``"resources"``, configurable via minion option ``resource_pillar_key``).
+        A temporary resource loader is used to call each type's
         ``discover(opts)``; the return value is a dict of
         ``{resource_type: [resource_id, ...]}``.
 
-        If the pillar contains no ``resources`` key at all, any resources
-        already present in ``opts["resources"]`` (e.g. set directly in the
-        minion config file) are preserved as-is.  This supports testing and
-        simple deployments where pillar-driven discovery is not needed.
+        If the merged pillar contains no key by that name, that is treated the
+        same as an empty mapping: no pillar-declared resource types, so
+        discovery returns an empty dict (no stale IDs left in
+        ``opts["resources"]``).
 
-        If the pillar *does* contain a ``resources`` key (even if its value is
-        empty / all entries removed), that is treated as an authoritative
-        declaration and the result will reflect only what the pillar says.
-        This ensures that removing a resource type from the pillar and running
-        sync_all actually clears it at runtime.
+        If the pillar *does* contain that key (even if its value is empty /
+        all entries removed), that is an authoritative declaration and the
+        result reflects only what the pillar says (via ``discover()`` per
+        type).
 
         Called from :meth:`gen_modules` after pillar is compiled and before
         the per-type execution-module loaders are created.
         """
-        pillar = self.opts.get("pillar", {})
-        if "resources" not in pillar:
-            # Pillar has no opinion — preserve whatever is already in opts.
-            return {k: list(v) for k, v in self.opts.get("resources", {}).items()}
-        pillar_resources = pillar.get("resources") or {}
+        pillar_resources = salt.utils.resources.pillar_resources_tree(self.opts)
 
         # A minimal resource loader is sufficient here — discover() only reads
         # from the opts dict passed to it and does not need other dunders.

--- a/salt/resource/dummy.py
+++ b/salt/resource/dummy.py
@@ -29,6 +29,7 @@ from contextlib import contextmanager
 
 import salt.utils.files
 import salt.utils.msgpack
+import salt.utils.resources
 
 log = logging.getLogger(__name__)
 
@@ -118,15 +119,15 @@ def init(opts):
     Initialize the dummy resource type for this minion.
 
     Called once when the resource type is loaded, before any per-resource
-    operations are performed.  Reads the resource type configuration from
-    ``opts["pillar"]["resources"]["dummy"]`` and sets up shared type-level
+    operations are performed.  Reads the resource type configuration from the
+    ``dummy`` entry under the pillar subtree selected by ``resource_pillar_key``
+    (see :func:`salt.utils.resources.pillar_resources_tree`) and sets up shared type-level
     state in ``__context__["dummy_resource"]``.
 
     :param dict opts: The Salt opts dict.
     """
     resource_ids = (
-        opts.get("pillar", {})
-        .get("resources", {})
+        salt.utils.resources.pillar_resources_tree(opts)
         .get("dummy", {})
         .get("resource_ids", [])
     )
@@ -157,7 +158,8 @@ def discover(opts):
 
     Called by ``saltutil.refresh_resources`` to populate the master's
     Resource Registry.  For the dummy module the list of IDs is read from
-    ``opts["pillar"]["resources"]["dummy"]["resource_ids"]``.
+    ``resource_ids`` under the ``dummy`` type in the configured resource pillar
+    subtree.
 
     Returns a list of bare resource IDs (not full SRNs) — e.g.
     ``["dummy-01", "dummy-02"]``.
@@ -166,8 +168,7 @@ def discover(opts):
     :rtype: list[str]
     """
     resource_ids = (
-        opts.get("pillar", {})
-        .get("resources", {})
+        salt.utils.resources.pillar_resources_tree(opts)
         .get("dummy", {})
         .get("resource_ids", [])
     )

--- a/salt/resource/ssh.py
+++ b/salt/resource/ssh.py
@@ -11,7 +11,8 @@ execution (``cmd_run``, ``ping``) and :class:`salt.client.ssh.Single` with
 the salt-thin bundle for grain collection (``grains.items``), giving the same
 complete, accurate grain set that ``salt-ssh`` provides.
 
-Configuration (via Pillar)::
+Configuration (via Pillar; top-level key defaults to ``resources``, overridable
+with minion option ``resource_pillar_key``)::
 
     resources:
       ssh:
@@ -80,6 +81,7 @@ import salt.fileclient
 import salt.utils.json
 import salt.utils.network
 import salt.utils.path
+import salt.utils.resources
 
 log = logging.getLogger(__name__)
 
@@ -300,14 +302,15 @@ def init(opts):
     Initialize the ``ssh`` resource type for this minion.
 
     Called once when the resource type is loaded, before any per-resource
-    operations are dispatched.  Reads host configs from
-    ``opts["pillar"]["resources"]["ssh"]["hosts"]``, caches them in
+    operations are dispatched.  Reads host configs from the ``ssh`` entry under
+    the pillar subtree selected by ``resource_pillar_key`` (see
+    :func:`salt.utils.resources.pillar_resources_tree`), caches them in
     ``__context__["ssh_resource"]``, and pre-resolves the SSH binary version
     so that :func:`_shell_opts` never has to run a subprocess during a job.
 
     :param dict opts: The Salt opts dict.
     """
-    resource_cfg = opts.get("pillar", {}).get("resources", {}).get("ssh", {})
+    resource_cfg = salt.utils.resources.pillar_resources_tree(opts).get("ssh", {})
     hosts = resource_cfg.get("hosts", {})
     __context__[CONTEXT_KEY] = {  # pylint: disable=undefined-variable
         "initialized": True,
@@ -363,15 +366,17 @@ def discover(opts):
     """
     Return the list of SSH resource IDs managed by this minion.
 
-    The list is the set of keys under
-    ``opts["pillar"]["resources"]["ssh"]["hosts"]``.  Adding or removing a
+    The list is the set of keys under ``hosts`` for the ``ssh`` type under the
+    configured resource pillar subtree.  Adding or removing a
     host from that Pillar key and running ``saltutil.refresh_resources``
     updates the Master's Resource Registry without any process restart.
 
     :param dict opts: The Salt opts dict.
     :rtype: list[str]
     """
-    hosts = opts.get("pillar", {}).get("resources", {}).get("ssh", {}).get("hosts", {})
+    hosts = (
+        salt.utils.resources.pillar_resources_tree(opts).get("ssh", {}).get("hosts", {})
+    )
     resource_ids = list(hosts)
     log.debug("ssh resource discover() returning: %s", resource_ids)
     return resource_ids

--- a/salt/utils/resources.py
+++ b/salt/utils/resources.py
@@ -1,0 +1,27 @@
+"""
+Helpers for Salt resource minions: configurable pillar key and lookups.
+"""
+
+
+def resource_pillar_key(opts):
+    """
+    Return the top-level pillar key used for per-type resource configuration.
+
+    Configured by minion option ``resource_pillar_key`` (default ``resources``).
+    """
+    return opts.get("resource_pillar_key", "resources")
+
+
+def pillar_resources_tree(opts):
+    """
+    Return the merged pillar mapping under the configured resource pillar key.
+
+    If the key is absent, returns ``{}`` (same as an empty declaration).
+    Non-dict values are treated as empty.
+    """
+    key = resource_pillar_key(opts)
+    pillar = opts.get("pillar", {})
+    if key not in pillar:
+        return {}
+    pr = pillar.get(key)
+    return pr if isinstance(pr, dict) else {}

--- a/salt/utils/resources.py
+++ b/salt/utils/resources.py
@@ -2,14 +2,26 @@
 Helpers for Salt resource minions: configurable pillar key and lookups.
 """
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 def resource_pillar_key(opts):
     """
     Return the top-level pillar key used for per-type resource configuration.
 
     Configured by minion option ``resource_pillar_key`` (default ``resources``).
+    Empty values are rejected with a warning and treated as ``"resources"``.
     """
-    return opts.get("resource_pillar_key", "resources")
+    key = opts.get("resource_pillar_key", "resources")
+    if not key:
+        log.warning(
+            "resource_pillar_key is empty; using default 'resources'. "
+            "Set resource_pillar_key to a non-empty string in the minion config."
+        )
+        key = "resources"
+    return key
 
 
 def pillar_resources_tree(opts):

--- a/tests/pytests/integration/resources/conftest.py
+++ b/tests/pytests/integration/resources/conftest.py
@@ -1,19 +1,54 @@
 """
 Integration test fixtures for Salt Resources.
 
-Spins up a master and a minion configured with two dummy resources
-(dummy-01, dummy-02).  All tests in this package run against these
-two daemons.
+Spins up a master and a minion whose dummy resources (dummy-01, dummy-02) are
+declared only in Pillar under ``resources:`` — not in the minion config file.
+All tests in this package run against these two daemons.
 """
 
+import textwrap
 import time
 
 import pytest
 
 from tests.conftest import FIPS_TESTRUN
 
+MINION_ID = "resources-minion"
+
 # Dummy resource IDs that the minion manages in every test in this package.
 DUMMY_RESOURCES = ["dummy-01", "dummy-02"]
+
+
+@pytest.fixture(scope="package")
+def pillar_tree_dummy_resources(salt_master):
+    """
+    Pillar declaring ``resources.dummy.resource_ids`` for the test minion.
+
+    Resource discovery reads this tree via ``pillar_resources_tree``; the minion
+    must not rely on a static ``resources:`` key in minion opts.
+    """
+    top_file = textwrap.dedent(
+        f"""
+        base:
+          '{MINION_ID}':
+            - dummy_resources
+        """
+    )
+    pillar_sls = textwrap.dedent(
+        """
+        resources:
+          dummy:
+            resource_ids:
+              - dummy-01
+              - dummy-02
+        """
+    )
+    top_tempfile = salt_master.pillar_tree.base.temp_file("top.sls", top_file)
+    sls_tempfile = salt_master.pillar_tree.base.temp_file(
+        "dummy_resources.sls", pillar_sls
+    )
+    with top_tempfile, sls_tempfile:
+        yield
 
 
 @pytest.fixture(scope="package")
@@ -36,19 +71,17 @@ def salt_master(request, salt_factories):
 
 
 @pytest.fixture(scope="package")
-def salt_minion(salt_master):
+def salt_minion(salt_master, pillar_tree_dummy_resources):
     config_overrides = {
         "fips_mode": FIPS_TESTRUN,
         "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
         "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
-        # Configure dummy resources so the minion dispatches resource jobs.
-        "resources": {"dummy": DUMMY_RESOURCES},
         # Use threads (not processes) — this is the path our Race 1/Race 2 fixes
         # target and the most common deployment mode for resource-managing minions.
         "multiprocessing": False,
     }
     factory = salt_master.salt_minion_daemon(
-        "resources-minion",
+        MINION_ID,
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
@@ -57,6 +90,9 @@ def salt_minion(salt_master):
     )
     with factory.started(start_timeout=120):
         salt_call_cli = factory.salt_call_cli()
+        ret = salt_call_cli.run("saltutil.refresh_pillar", wait=True, _timeout=120)
+        assert ret.returncode == 0, ret
+        assert ret.data is True, ret
         ret = salt_call_cli.run("saltutil.sync_all", _timeout=120)
         assert ret.returncode == 0, ret
         # The minion fires _register_resources_with_master() as a background

--- a/tests/pytests/integration/resources/test_dummy_resource.py
+++ b/tests/pytests/integration/resources/test_dummy_resource.py
@@ -6,13 +6,8 @@ These tests verify the full dispatch pipeline:
   salt CLI → master targeting (CkMinions) → minion (_resolve_resource_targets)
   → resource loader → return → master re-key → CLI response
 
-The minion under test is configured with::
-
-    resources:
-      dummy:
-        - dummy-01
-        - dummy-02
-    multiprocessing: False
+The minion under test loads dummy resources from Pillar only (``resources.dummy``
+with ``resource_ids``) and uses ``multiprocessing: False``.
 
 The ``dummy`` resource module (``salt/resource/dummy.py``) and its execution
 module (``salt/modules/dummyresource_test.py``) are pure-Python in-process

--- a/tests/pytests/unit/test_minion_resources.py
+++ b/tests/pytests/unit/test_minion_resources.py
@@ -240,14 +240,15 @@ def test_resource_ctxvar_concurrent_threads_isolated():
 # ---------------------------------------------------------------------------
 
 
-def test_discover_resources_no_pillar_key_preserves_opts(minion_with_resources):
+def test_discover_resources_no_pillar_key_clears_like_empty(minion_with_resources):
     """
     When the pillar contains no 'resources' key at all, _discover_resources
-    preserves whatever is already in opts["resources"].
+    must behave like pillar['resources'] == {}: return {} and not preserve
+    stale opts["resources"].
     """
     minion_with_resources.opts["pillar"] = {}
     result = minion_with_resources._discover_resources()
-    assert result == {k: list(v) for k, v in RESOURCES.items()}
+    assert result == {}
 
 
 def test_discover_resources_empty_pillar_key_clears_opts(minion_with_resources):

--- a/tests/pytests/unit/utils/test_resources.py
+++ b/tests/pytests/unit/utils/test_resources.py
@@ -1,0 +1,30 @@
+"""
+Tests for salt.utils.resources (configurable resource pillar key).
+"""
+
+import salt.utils.resources
+
+
+def test_resource_pillar_key_default():
+    assert salt.utils.resources.resource_pillar_key({}) == "resources"
+    assert salt.utils.resources.resource_pillar_key({"resource_pillar_key": "x"}) == "x"
+
+
+def test_pillar_resources_tree_default_key():
+    opts = {"pillar": {"resources": {"ssh": {}}}}
+    assert salt.utils.resources.pillar_resources_tree(opts) == {"ssh": {}}
+
+
+def test_pillar_resources_tree_custom_key():
+    opts = {"resource_pillar_key": "my_res", "pillar": {"my_res": {"a": 1}}}
+    assert salt.utils.resources.pillar_resources_tree(opts) == {"a": 1}
+
+
+def test_pillar_resources_tree_missing_key_same_as_empty():
+    opts = {"pillar": {}}
+    assert salt.utils.resources.pillar_resources_tree(opts) == {}
+
+
+def test_pillar_resources_tree_wrong_type():
+    opts = {"pillar": {"resources": "bad"}}
+    assert salt.utils.resources.pillar_resources_tree(opts) == {}

--- a/tests/pytests/unit/utils/test_resources.py
+++ b/tests/pytests/unit/utils/test_resources.py
@@ -2,12 +2,26 @@
 Tests for salt.utils.resources (configurable resource pillar key).
 """
 
+import logging
+
+import pytest
+
 import salt.utils.resources
 
 
 def test_resource_pillar_key_default():
     assert salt.utils.resources.resource_pillar_key({}) == "resources"
     assert salt.utils.resources.resource_pillar_key({"resource_pillar_key": "x"}) == "x"
+
+
+@pytest.mark.parametrize("bad", ("", None))
+def test_resource_pillar_key_empty_warns_and_defaults(bad, caplog):
+    caplog.set_level(logging.WARNING)
+    assert (
+        salt.utils.resources.resource_pillar_key({"resource_pillar_key": bad})
+        == "resources"
+    )
+    assert "resource_pillar_key is empty" in caplog.text
 
 
 def test_pillar_resources_tree_default_key():


### PR DESCRIPTION
Add minion option resource_pillar_key (default resources) with VALID_OPTS and DEFAULT_MINION_OPTS entries. Introduce salt.utils.resources helpers so discovery and ssh/dummy resource modules read the same pillar subtree.

_discover_resources now uses pillar_resources_tree(), so a missing top-level pillar key clears opts['resources'] like an empty mapping, without preserving stale discovery output.

Update unit tests for discovery behavior and add tests for the new helpers.
