### PR TITLE
Increase salt CLI timeout in reauth scenario tests

### DIFF
--- a/changelog/68924.fixed.md
+++ b/changelog/68924.fixed.md
@@ -1,0 +1,1 @@
+Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s).

--- a/tests/pytests/scenarios/reauth/conftest.py
+++ b/tests/pytests/scenarios/reauth/conftest.py
@@ -57,4 +57,4 @@ def salt_key_cli(salt_master):
 @pytest.fixture(scope="package")
 def salt_cli(salt_master):
     assert salt_master.is_running()
-    return salt_master.salt_cli()
+    return salt_master.salt_cli(timeout=30)


### PR DESCRIPTION
### What does this PR do?

Sets `salt_cli(timeout=30)` in `tests/pytests/scenarios/reauth/conftest.py`, matching `tests/pytests/integration/conftest.py`.

### What issues does this PR fix or reference?

Fixes flaky Windows CI in `tests/pytests/scenarios/reauth/test_reauth.py`: the `salt` CLI was using the master config default (`--timeout=5`). After master/minion restart and reauth, the second `test.ping` could time out with "Minion did not return" on slow Windows runners.

### Previous Behavior

`salt_master.salt_cli()` with no timeout → saltfactories uses master `timeout` (often 5s).

### New Behavior

Explicit 30s CLI timeout for both `test.ping` calls in the reauth scenario.

### Tests written?

Existing scenario test; verified locally with `pytest tests/pytests/scenarios/reauth/test_reauth.py --run-slow` (optional `SALT_CI_REAUTH_MASTER_WAIT` to shorten the mid-test sleep).

### Commits signed with GPG?

N/A

Made with [Cursor](https://cursor.com)