### PR TITLE
Fix log of dead processes in reap_stray_processes

### DIFF
--- a/changelog/68927.fixed.md
+++ b/changelog/68927.fixed.md
@@ -1,0 +1,1 @@
+- Fix logging in potentially dead process in reap_stray_processes fixture

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -895,11 +895,15 @@ def reap_stray_processes(pid: int = os.getpid()):
         if alive:
             # Give up
             for child in alive:
-                log.warning(
-                    "Process %s survived SIGKILL, giving up:\n%s",
-                    child,
-                    pprint.pformat(child.as_dict()),
-                )
+                try:
+                    log.warning(
+                        "Process %s survived SIGKILL, giving up:\n%s",
+                        child,
+                        pprint.pformat(child.as_dict()),
+                    )
+                except psutil.NoSuchProcess:
+                    # Process killed between the alive check and the log statement
+                    continue
 
 
 # Only allow star importing the functions defined in this module


### PR DESCRIPTION
If reap_stray_processes cannot kill a process,
it logs which process it gived up on. However,
if the process exits after the alive check and
before the log, this causes psutil.NoSuchProcess
exception

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
