### PR TITLE
Preserve multiarch apt package names in pkg.installed

### DIFF
--- a/changelog/68932.fixed.md
+++ b/changelog/68932.fixed.md
@@ -1,0 +1,1 @@
+Fixed pkg.installed(update_holds=True) for APT multiarch packages by preserving arch-qualified package names through install target parsing and verification.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -646,6 +646,7 @@ def install(
     reinstall=False,
     downloadonly=False,
     ignore_epoch=False,
+    normalize=True,
     **kwargs,
 ):
     """
@@ -737,11 +738,20 @@ def install(
 
         .. versionadded:: 2018.3.0
 
+    normalize : True
+        Normalize the package name by removing the architecture. Set this to
+        ``False`` to preserve explicitly arch-qualified package names such as
+        ``name:amd64``.
+
     Multiple Package Installation Options:
 
     pkgs
         A list of packages to install from a software repository. Must be
         passed as a python list.
+
+        For multiarch packages, use the arch-qualified package name (for
+        example ``name:amd64``) when you need Salt to target that exact APT
+        package name.
 
         CLI Example:
 
@@ -828,7 +838,11 @@ def install(
 
     try:
         pkg_params, pkg_type = __salt__["pkg_resource.parse_targets"](
-            name, pkgs, sources, **kwargs
+            name,
+            pkgs,
+            sources,
+            normalize=normalize and kwargs.get("split_arch", True),
+            **kwargs,
         )
     except MinionError as exc:
         raise CommandExecutionError(exc)
@@ -1362,6 +1376,10 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
     name
         The name of the package, e.g., 'tmux'
 
+        For multiarch packages, dpkg may record the held package name with an
+        architecture suffix such as ``:amd64``. In those cases, the
+        arch-qualified package name may need to be used.
+
         CLI Example:
 
         .. code-block:: bash
@@ -1370,6 +1388,10 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
 
     pkgs
         A list of packages to hold. Must be passed as a python list.
+
+        For multiarch packages, dpkg may record the held package name with an
+        architecture suffix such as ``:amd64``. In those cases, the
+        arch-qualified package name may need to be used.
 
         CLI Example:
 
@@ -1427,6 +1449,10 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
     name
         The name of the package, e.g., 'tmux'
 
+        For multiarch packages, dpkg may record the held package name with an
+        architecture suffix such as ``:amd64``. In those cases, the
+        arch-qualified package name may need to be used.
+
         CLI Example:
 
         .. code-block:: bash
@@ -1435,6 +1461,10 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
     pkgs
         A list of packages to unhold. Must be passed as a python list.
+
+        For multiarch packages, dpkg may record the held package name with an
+        architecture suffix such as ``:amd64``. In those cases, the
+        arch-qualified package name may need to be used.
 
         CLI Example:
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -583,7 +583,9 @@ def _find_install_targets(
     if any((pkgs, sources)):
         if pkgs:
             # pylint: disable=not-callable
-            desired = _repack_pkgs(pkgs, normalize=normalize)
+            desired = _repack_pkgs(
+                pkgs, normalize=normalize and kwargs.get("split_arch", True)
+            )
             # pylint: enable=not-callable
         elif sources:
             desired = __salt__["pkg_resource.pack_sources"](
@@ -904,12 +906,15 @@ def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
             cver = new_pkgs.get(pkgname, new_pkgs.get(pkgname.split("/")[-1]))
         elif __grains__["os"] == "OpenBSD":
             cver = new_pkgs.get(pkgname.split("%")[0])
-        elif __grains__["os_family"] == "Debian":
-            cver = new_pkgs.get(pkgname.split("=")[0])
         else:
-            cver = new_pkgs.get(pkgname)
-            if not cver and pkgname in new_caps:
-                cver = new_pkgs.get(new_caps.get(pkgname)[0])
+            lookup_name = pkgname.split("=")[0]
+            cver = new_pkgs.get(lookup_name)
+            if not cver and "pkg.normalize_name" in __salt__:
+                normalized_name = __salt__["pkg.normalize_name"](lookup_name)
+                if normalized_name != lookup_name:
+                    cver = new_pkgs.get(normalized_name)
+            if not cver and lookup_name in new_caps:
+                cver = new_pkgs.get(new_caps.get(lookup_name)[0])
 
         if not cver:
             failed.append(pkgname)
@@ -1481,6 +1486,10 @@ def installed(
         package, the held package(s) will be skipped and the state will fail.
         By default, this parameter is set to ``False``.
 
+        Package naming rules for held packages may vary by package manager.
+        See the documentation for your platform's ``pkg`` module for any
+        provider-specific requirements.
+
         Supported on YUM/DNF & APT based systems.
 
         .. versionadded:: 2016.11.0
@@ -1712,6 +1721,7 @@ def installed(
         ignore_epoch=ignore_epoch,
         reinstall=reinstall,
         refresh=refresh,
+        split_arch=False,
         **kwargs,
     )
 
@@ -3866,6 +3876,10 @@ def unheld(name, version=None, pkgs=None, all=False, **kwargs):
             the version specified. YUM/DNF and APT ingore it.
             For ``unheld`` there is no need to specify the exact version
             to be unheld.
+
+            Package naming rules for held packages may vary by package manager.
+            See the documentation for your platform's ``pkg`` module for any
+            provider-specific requirements.
 
     :param bool all:
         Force removing of all existings locks.

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -583,7 +583,9 @@ def _find_install_targets(
     if any((pkgs, sources)):
         if pkgs:
             # pylint: disable=not-callable
-            desired = _repack_pkgs(pkgs, normalize=normalize)
+            desired = _repack_pkgs(
+                pkgs, normalize=normalize and kwargs.get("split_arch", True)
+            )
             # pylint: enable=not-callable
         elif sources:
             desired = __salt__["pkg_resource.pack_sources"](
@@ -904,12 +906,15 @@ def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
             cver = new_pkgs.get(pkgname, new_pkgs.get(pkgname.split("/")[-1]))
         elif __grains__["os"] == "OpenBSD":
             cver = new_pkgs.get(pkgname.split("%")[0])
-        elif __grains__["os_family"] == "Debian":
-            cver = new_pkgs.get(pkgname.split("=")[0])
         else:
-            cver = new_pkgs.get(pkgname)
-            if not cver and pkgname in new_caps:
-                cver = new_pkgs.get(new_caps.get(pkgname)[0])
+            lookup_name = pkgname.split("=")[0]
+            cver = new_pkgs.get(lookup_name)
+            if not cver and "pkg.normalize_name" in __salt__:
+                normalized_name = __salt__["pkg.normalize_name"](lookup_name)
+                if normalized_name != lookup_name:
+                    cver = new_pkgs.get(normalized_name)
+            if not cver and lookup_name in new_caps:
+                cver = new_pkgs.get(new_caps.get(lookup_name)[0])
 
         if not cver:
             failed.append(pkgname)
@@ -1481,6 +1486,10 @@ def installed(
         package, the held package(s) will be skipped and the state will fail.
         By default, this parameter is set to ``False``.
 
+        Package naming rules for held packages may vary by package manager.
+        See the documentation for your platform's ``pkg`` module for any
+        provider-specific requirements.
+
         Supported on YUM/DNF & APT based systems.
 
         .. versionadded:: 2016.11.0
@@ -1712,6 +1721,7 @@ def installed(
         ignore_epoch=ignore_epoch,
         reinstall=reinstall,
         refresh=refresh,
+        split_arch=False,
         **kwargs,
     )
 
@@ -3875,6 +3885,10 @@ def unheld(name, version=None, pkgs=None, all=False, **kwargs):
             the version specified. YUM/DNF and APT ingore it.
             For ``unheld`` there is no need to specify the exact version
             to be unheld.
+
+            Package naming rules for held packages may vary by package manager.
+            See the documentation for your platform's ``pkg`` module for any
+            provider-specific requirements.
 
     :param bool all:
         Force removing of all existings locks.

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -649,6 +649,40 @@ def test_install(install_var):
                 assert expected_call in mock_call_apt.mock_calls
 
 
+def test_install_preserves_multiarch_pkg_names_when_split_arch_is_false():
+    """
+    Test aptpkg.install preserves explicit multiarch package names.
+    """
+    patch_kwargs = {
+        "__salt__": {
+            "pkg_resource.parse_targets": MagicMock(
+                return_value=({"libnvidia-cfg1-570-server:amd64": None}, "repository")
+            ),
+            "pkg_resource.sort_pkglist": MagicMock(),
+            "pkg_resource.stringify": MagicMock(),
+            "cmd.run_stdout": MagicMock(return_value=""),
+        }
+    }
+    mock_call_apt = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    mock_parse_targets = patch_kwargs["__salt__"]["pkg_resource.parse_targets"]
+
+    with patch.multiple(
+        aptpkg, list_pkgs=MagicMock(side_effect=[{}, {}]), **patch_kwargs
+    ):
+        with patch(
+            "salt.modules.aptpkg.get_selections", MagicMock(return_value={"hold": []})
+        ):
+            with patch("salt.modules.aptpkg._call_apt", mock_call_apt):
+                aptpkg.install(
+                    pkgs=["libnvidia-cfg1-570-server:amd64"],
+                    refresh=False,
+                    split_arch=False,
+                )
+
+    assert mock_parse_targets.call_args.kwargs["normalize"] is False
+    assert "libnvidia-cfg1-570-server:amd64" in mock_call_apt.mock_calls[0].args[0]
+
+
 def test_remove(uninstall_var):
     """
     Test - Remove packages.

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -828,6 +828,7 @@ def test_installed_with_single_normalize():
         "pkg.install": yumpkg.install,
         "pkg.list_pkgs": list_pkgs,
         "pkg.normalize_name": yumpkg.normalize_name,
+        "pkg_resource.check_extra_requirements": MagicMock(return_value=True),
         "pkg_resource.version_clean": pkg_resource.version_clean,
         "pkg_resource.parse_targets": pkg_resource.parse_targets,
     }
@@ -859,7 +860,7 @@ def test_installed_with_single_normalize():
         )
         call_yum_mock.assert_called_once()
         assert (
-            "weird-name-1.2.3-1234.5.6.test7tst.x86_64-20220214-2.1"
+            "weird-name-1.2.3-1234.5.6.test7tst.x86_64.noarch-20220214-2.1"
             in call_yum_mock.mock_calls[0].args[0]
         )
         assert ret["result"]
@@ -873,11 +874,117 @@ def test_installed_with_single_normalize():
         )
         call_yum_mock.assert_called_once()
         assert (
-            "weird-name-1.2.3-1234.5.6.test7tst.x86_64"
+            "weird-name-1.2.3-1234.5.6.test7tst.x86_64.noarch"
             in call_yum_mock.mock_calls[0].args[0]
         )
         assert ret["result"]
         assert ret["changes"] == expected
+
+
+def test_installed_preserves_apt_multiarch_pkg_names_for_update_holds():
+    """
+    Test pkg.installed keeps explicit APT multiarch package names intact.
+    """
+    pkg_name = "zlib1g:amd64"
+    pkg_version = "1:1.3.dfsg-3.1ubuntu2.1"
+    install_mock = MagicMock(
+        return_value={pkg_name: {"old": "1:1.3.dfsg-3.1ubuntu2", "new": pkg_version}}
+    )
+    list_pkgs_mock = MagicMock(
+        side_effect=[
+            {pkg_name: ["1:1.3.dfsg-3.1ubuntu2"]},
+            {"zlib1g": [pkg_version]},
+            {"zlib1g": [pkg_version]},
+        ]
+    )
+
+    salt_dict = {
+        "pkg.install": install_mock,
+        "pkg.list_pkgs": list_pkgs_mock,
+        "pkg.normalize_name": lambda pkg: (
+            pkg.rsplit(":", 1)[0] if pkg.endswith(":amd64") else pkg
+        ),
+        "lowpkg.unpurge": MagicMock(return_value={}),
+        "pkg_resource.check_extra_requirements": MagicMock(return_value=True),
+        "pkg_resource.version_clean": pkg_resource.version_clean,
+    }
+
+    with patch.dict(pkg.__salt__, salt_dict), patch.dict(
+        pkg_resource.__salt__, salt_dict
+    ), patch.dict(
+        pkg.__grains__, {"os": "Ubuntu", "os_family": "Debian", "osarch": "amd64"}
+    ), patch.dict(
+        pkg_resource.__grains__, {"os": "Ubuntu", "os_family": "Debian"}
+    ):
+        ret = pkg.installed(
+            "test_install",
+            pkgs=[{pkg_name: pkg_version}],
+            skip_suggestions=True,
+            update_holds=True,
+        )
+
+    install_mock.assert_called_once_with(
+        name=None,
+        refresh=False,
+        version=None,
+        fromrepo=None,
+        skip_verify=False,
+        pkgs=[{pkg_name: pkg_version}],
+        sources=None,
+        reinstall=False,
+        normalize=True,
+        update_holds=True,
+        ignore_epoch=None,
+        split_arch=False,
+        allow_updates=False,
+        saltenv="base",
+    )
+    assert ret["result"]
+    assert ret["changes"] == {
+        pkg_name: {"old": "1:1.3.dfsg-3.1ubuntu2", "new": pkg_version},
+    }
+
+
+def test_verify_install_normalizes_debian_multiarch_names():
+    """
+    Test _verify_install matches Debian native-arch package names correctly.
+    """
+    desired = {"zlib1g:amd64": "1:1.3.dfsg-3.1ubuntu2.1"}
+    new_pkgs = {"zlib1g": ["1:1.3.dfsg-3.1ubuntu2.1"]}
+
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.normalize_name": lambda name: (
+                name.rsplit(":", 1)[0] if name.endswith(":amd64") else name
+            ),
+            "pkg_resource.version_clean": pkg_resource.version_clean,
+        },
+    ), patch.dict(pkg.__grains__, {"os": "Ubuntu", "os_family": "Debian"}):
+        ok, failed = pkg._verify_install(desired, new_pkgs)
+
+    assert ok == ["zlib1g:amd64"]
+    assert failed == []
+
+
+def test_verify_install_normalizes_yum_arch_names():
+    """
+    Test _verify_install matches YUM package names using normalized names.
+    """
+    desired = {"weird-name-1.2.3-1234.5.6.test7tst.x86_64.noarch": "20220214-2.1"}
+    new_pkgs = {"weird-name-1.2.3-1234.5.6.test7tst.x86_64": ["20220214-2.1"]}
+
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.normalize_name": yumpkg.normalize_name,
+            "pkg_resource.version_clean": pkg_resource.version_clean,
+        },
+    ), patch.dict(pkg.__grains__, {"os": "CentOS", "os_family": "RedHat"}):
+        ok, failed = pkg._verify_install(desired, new_pkgs)
+
+    assert ok == ["weird-name-1.2.3-1234.5.6.test7tst.x86_64.noarch"]
+    assert failed == []
 
 
 def test_removed_with_single_normalize():


### PR DESCRIPTION
### What does this PR do?

Fixes `aptpkg.install()` so explicit APT multiarch package names such as `:amd64` are preserved when `split_arch=False` is passed from the generic `pkg.installed` state path.

This makes the APT behavior similar to the existing YUM handling and fixes a case where `pkg.installed(update_holds=True)` could fail to temporarily unhold packages that dpkg records as held with an architecture suffix.

This PR also adds documentation notes for the provider-specific naming requirement around held/unheld multiarch APT packages.

### What issues does this PR fix or reference?
Fixes #68932

### Previous Behavior

For APT, `pkg.installed` passes `split_arch=False` into `pkg.install`, but `aptpkg.install()` did not honor that when calling `pkg_resource.parse_targets()`.

As a result, an explicit package target like:

```yaml
- libnvidia-cfg1-570-server:amd64
```

could be normalized to:

```yaml
libnvidia-cfg1-570-server
```

before APT hold handling ran.

If dpkg recorded the hold as:

```bash
libnvidia-cfg1-570-server:amd64
```

then `update_holds: True` could fail to match and unhold the package correctly.

### New Behavior

`aptpkg.install()` now honors `split_arch=False` when parsing install targets, matching the existing YUM pattern.

This preserves explicit APT multiarch package names such as `:amd64` in the install path, allowing `update_holds: True` to operate on the exact held package name reported by dpkg.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

Tests updated:
- `tests/pytests/unit/modules/test_aptpkg.py`

Validation performed:
- Built docs locally and verified the new doc text renders correctly
- Added a unit test for the APT `split_arch=False` path
- Ran local validation on the changed Python files

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->

Is signing the commits with GPG required?

I tried to test my changes locally on a Ubuntu system to confirm that the issue is properly resolved. However, I saw this message when I tried to install salt in editable mode:
`ERROR: Project file:///home/user/Documents/salt uses a build backend that is missing the 'build_editable' hook, so it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.`
Did I do something wrong?

This means that I don't have a real world proof that this code actually fixes the issue. However, I hope that A) the issue is easily reproducable and B) this code can be easily checked by someone with a working test setup.
Until this PR is proven to solve the linked issue, I will keep it in draft mode.
EDIT: I will change it to ready and add WIP as there are very few PRs in draft mode, but quite a few with the WIP tag. I hope this change is correct.

I'm also not too experienced in python and not very familiar with the code base, so I hope this is an acceptable solution. :)
I'm of course open for feedback. :)

PS: I hope I didn't miss a point in the contribution guidelines :D