### PR TITLE
Fix/68930 gen signature clean key

### DIFF
--- a/changelog/68930.fixed.md
+++ b/changelog/68930.fixed.md
@@ -1,0 +1,1 @@
+Fix gen_signature() signing raw pub key content instead of clean_key'd content, causing master_use_pubkey_signature verification to always fail.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -395,7 +395,7 @@ def gen_signature(priv_path, pub_path, sign_path, passphrase=None):
     """
 
     with salt.utils.files.fopen(pub_path) as fp_:
-        mpub_64 = fp_.read()
+        mpub_64 = clean_key(fp_.read())
 
     mpub_sig = sign_message(priv_path, mpub_64, passphrase)
     mpub_sig_64 = binascii.b2a_base64(mpub_sig)

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -417,7 +417,7 @@ def gen_signature(priv_path, pub_path, sign_path, passphrase=None):
     """
 
     with salt.utils.files.fopen(pub_path) as fp_:
-        mpub_64 = fp_.read()
+        mpub_64 = clean_key(fp_.read())
 
     mpub_sig = sign_message(priv_path, mpub_64, passphrase)
     mpub_sig_64 = binascii.b2a_base64(mpub_sig)

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -5,7 +5,7 @@ import pytest
 
 import salt.crypt as crypt
 import salt.exceptions
-from tests.support.mock import patch
+from tests.support.mock import mock_open, patch
 
 
 @pytest.fixture
@@ -243,3 +243,47 @@ def test_async_auth_cache_token(minion_root, io_loop):
         auth.gen_token("salt")
         auth.gen_token("salt")
         moc.assert_called_once()
+
+
+@pytest.mark.parametrize("linesep", ["\r\n", "\r", "\n"])
+def test_gen_signature_signs_clean_key(key_data, linesep):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/68930
+
+    gen_signature() must apply clean_key() before signing so the signed
+    content matches what get_pub_str() sends to minions.
+    """
+    raw_pub_on_disk = linesep.join(key_data)
+    expected = crypt.clean_key(raw_pub_on_disk)
+
+    with (
+        patch("salt.utils.files.fopen", mock_open(read_data=raw_pub_on_disk)),
+        patch("os.path.isfile", return_value=False),
+        patch("salt.crypt.sign_message", return_value=b"fakesig") as mock_sign,
+    ):
+        crypt.gen_signature("priv_path", "pub_path", "sig_path")
+
+    _, signed_content, _ = mock_sign.call_args[0]
+    assert signed_content == expected
+
+
+@pytest.mark.parametrize("linesep", ["\r\n", "\r", "\n"])
+def test_gen_signature_signs_clean_key_trailing_newline(key_data, linesep):
+    """
+    Same as above but with a trailing newline, which is the common case
+    because the cryptography library writes PEM files with one.
+    """
+    raw_pub_on_disk = linesep.join(key_data) + linesep
+    expected = crypt.clean_key(raw_pub_on_disk)
+
+    assert raw_pub_on_disk != expected
+
+    with (
+        patch("salt.utils.files.fopen", mock_open(read_data=raw_pub_on_disk)),
+        patch("os.path.isfile", return_value=False),
+        patch("salt.crypt.sign_message", return_value=b"fakesig") as mock_sign,
+    ):
+        crypt.gen_signature("priv_path", "pub_path", "sig_path")
+
+    _, signed_content, _ = mock_sign.call_args[0]
+    assert signed_content == expected

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -5,7 +5,7 @@ import pytest
 
 import salt.crypt as crypt
 import salt.exceptions
-from tests.support.mock import patch
+from tests.support.mock import mock_open, patch
 
 
 @pytest.fixture
@@ -350,3 +350,47 @@ def test_verify_master_caches_clean_key_on_first_contact(
 
     assert result == "aes-key"
     assert m_pub_fn.read_text() == cached_pub_key
+
+
+@pytest.mark.parametrize("linesep", ["\r\n", "\r", "\n"])
+def test_gen_signature_signs_clean_key(key_data, linesep):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/68930
+
+    gen_signature() must apply clean_key() before signing so the signed
+    content matches what get_pub_str() sends to minions.
+    """
+    raw_pub_on_disk = linesep.join(key_data)
+    expected = crypt.clean_key(raw_pub_on_disk)
+
+    with (
+        patch("salt.utils.files.fopen", mock_open(read_data=raw_pub_on_disk)),
+        patch("os.path.isfile", return_value=False),
+        patch("salt.crypt.sign_message", return_value=b"fakesig") as mock_sign,
+    ):
+        crypt.gen_signature("priv_path", "pub_path", "sig_path")
+
+    _, signed_content, _ = mock_sign.call_args[0]
+    assert signed_content == expected
+
+
+@pytest.mark.parametrize("linesep", ["\r\n", "\r", "\n"])
+def test_gen_signature_signs_clean_key_trailing_newline(key_data, linesep):
+    """
+    Same as above but with a trailing newline, which is the common case
+    because the cryptography library writes PEM files with one.
+    """
+    raw_pub_on_disk = linesep.join(key_data) + linesep
+    expected = crypt.clean_key(raw_pub_on_disk)
+
+    assert raw_pub_on_disk != expected
+
+    with (
+        patch("salt.utils.files.fopen", mock_open(read_data=raw_pub_on_disk)),
+        patch("os.path.isfile", return_value=False),
+        patch("salt.crypt.sign_message", return_value=b"fakesig") as mock_sign,
+    ):
+        crypt.gen_signature("priv_path", "pub_path", "sig_path")
+
+    _, signed_content, _ = mock_sign.call_args[0]
+    assert signed_content == expected


### PR DESCRIPTION
### What does this PR do?

Applies `clean_key()` to the pub key content in `gen_signature()` before signing, so the signature matches what `get_pub_str()` sends to minions.

### What issues does this PR fix or reference?
Fixes #68930

### Previous Behavior

`gen_signature()` signed the raw pub key file content (which includes a trailing newline from PEM encoding). Meanwhile, `get_pub_str()` sends `clean_key(pub)` to minions. When minions called `verify_pubkey_sig()`, the signature never matched the received content, causing `master_use_pubkey_signature: True` to always fail verification.

### New Behavior

`gen_signature()` now applies `clean_key()` to the file content before signing. The signed content matches what minions receive via `get_pub_str()`, so `verify_pubkey_sig()` succeeds.

This is the same pattern applied in #66153 for the minion key auth path in `salt/channel/server.py`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No