### PR TITLE
Use single JID for entire batch run

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -207,6 +207,13 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test chage -I -1 -m 0 -M 99999 -E -1 root
 
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
+
       - name: "Show container inspect ${{ matrix.container }}"
         run: |
           /usr/bin/docker inspect ${{ github.run_id }}_salt-test
@@ -552,6 +559,13 @@ jobs:
         if: startsWith(matrix.slug, 'photonos-')
         run: |
           docker exec ${{ github.run_id }}_salt-test chage -I -1 -m 0 -M 99999 -E -1 root
+
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
 
       - name: "Show container inspect ${{ matrix.container }}"
         run: |

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -150,6 +150,13 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test-pkg chage -I -1 -m 0 -M 99999 -E -1 root
 
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test-pkg \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
+
       - name: Decompress .nox Directory
         run: |
           docker exec ${{ github.run_id}}_salt-test-pkg python3 -m nox --force-color -e decompress-dependencies -- linux ${{ matrix.arch }}

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 import salt.client
 import salt.exceptions
 import salt.output
+import salt.utils.jid
 import salt.utils.stringutils
 
 log = logging.getLogger(__name__)
@@ -148,6 +149,7 @@ class Batch:
         # wait the specified time before decide a job is actually done
         bwait = self.opts.get("batch_wait", 0)
         wait = []
+        batch_jid = salt.utils.jid.gen_jid(self.opts)
 
         if self.options:
             show_jid = self.options.show_jid
@@ -209,6 +211,7 @@ class Batch:
                     show_jid=show_jid,
                     verbose=show_verbose,
                     gather_job_timeout=self.opts["gather_job_timeout"],
+                    jid=batch_jid,
                     **self.eauth,
                 )
                 # add it to our iterators and to the minion_tracker

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -975,6 +975,8 @@ class LocalClient:
             if not pub_data:
                 yield pub_data
             else:
+                # Filter out 'jid' to avoid conflict with the positional arg
+                iter_kwargs = {k: v for k, v in kwargs.items() if k != "jid"}
                 for fn_ret in self.get_iter_returns(
                     pub_data["jid"],
                     pub_data["minions"],
@@ -982,7 +984,7 @@ class LocalClient:
                     tgt=tgt,
                     tgt_type=tgt_type,
                     block=False,
-                    **kwargs,
+                    **iter_kwargs,
                 ):
                     if fn_ret and any([show_jid, verbose]):
                         for minion in fn_ret:

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -282,9 +282,25 @@ def save_minions(jid, minions, syndic_id=None):
             except OSError:
                 pass
 
-        # When multiple Salt Syndic masters return, a race condition can occur when writing to this same file.
+        # Merge with any existing minion list (e.g. from prior batch
+        # iterations sharing the same JID, or syndic masters).
+        existing_minions = set()
+        if os.path.isfile(minions_path):
+            try:
+                with salt.utils.files.fopen(minions_path, "rb") as rfh:
+                    existing_data = salt.payload.load(rfh)
+                    if existing_data is not None:
+                        try:
+                            existing_minions.update(existing_data)
+                        except (TypeError, ValueError):
+                            pass
+            except (OSError, salt.exceptions.SaltDeserializationError):
+                pass
+
+        merged_minions = sorted(existing_minions.union(minions))
+
         with salt.utils.atomicfile.atomic_open(minions_path, "w+b") as wfh:
-            salt.payload.dump(minions, wfh)
+            salt.payload.dump(merged_minions, wfh)
     except OSError as exc:
         log.error(
             "Failed to write minion list %s to job cache file %s: %s",

--- a/tests/pytests/functional/cli/test_batch.py
+++ b/tests/pytests/functional/cli/test_batch.py
@@ -5,6 +5,8 @@ tests.pytests.functional.cli.test_batch
 
 import salt.cli.batch
 import salt.config
+import salt.returners.local_cache as local_cache
+import salt.utils.files
 import salt.utils.jid
 from tests.support.mock import Mock, patch
 
@@ -183,3 +185,233 @@ def test_batch_issue_56273():
         values = list(val.values())
         assert len(values) == 1
         assert values[0] is True
+
+
+class MockPubSingleJid:
+    """
+    Mock salt.client.LocalClient.pub that captures passed JIDs.
+    """
+
+    calls = 0
+    initial_ping = False
+    captured_jids = []
+    batch_tgts = []
+
+    def __call__(self, tgt, fun, *args, **kwargs):
+        passed_jid = kwargs.get("jid", "")
+        if tgt == "minion*" and fun == "test.ping":
+            MockPubSingleJid.calls += 1
+            MockPubSingleJid.initial_ping = salt.utils.jid.gen_jid({})
+            pub_ret = {
+                "jid": MockPubSingleJid.initial_ping,
+                "minions": ["minion0", "minion1", "minion2", "minion3"],
+            }
+        elif fun == "state.sls":
+            MockPubSingleJid.calls += 1
+            MockPubSingleJid.captured_jids.append(passed_jid)
+            MockPubSingleJid.batch_tgts.append(list(tgt))
+            # Use the passed JID if provided, otherwise generate one
+            jid = passed_jid if passed_jid else salt.utils.jid.gen_jid({})
+            pub_ret = {"jid": jid, "minions": tgt}
+        elif fun == "saltutil.find_job":
+            jid = salt.utils.jid.gen_jid({})
+            pub_ret = {"jid": jid, "minions": tgt}
+        return pub_ret
+
+
+class MockSubscriberSingleJid:
+    """
+    Mock subscriber that returns results for all minions using the passed JIDs.
+    """
+
+    calls = 0
+    pubret = None
+
+    def __init__(self, *args, **kwargs):
+        return
+
+    def recv(self, timeout=None):
+        if MockSubscriberSingleJid.pubret.initial_ping:
+            jid = MockSubscriberSingleJid.pubret.initial_ping
+            if MockSubscriberSingleJid.calls == 0:
+                MockSubscriberSingleJid.calls += 1
+                return self._ret(jid, minion_id="minion0", fun="test.ping")
+            elif MockSubscriberSingleJid.calls == 1:
+                MockSubscriberSingleJid.calls += 1
+                return self._ret(jid, minion_id="minion1", fun="test.ping")
+            elif MockSubscriberSingleJid.calls == 2:
+                MockSubscriberSingleJid.calls += 1
+                return self._ret(jid, minion_id="minion2", fun="test.ping")
+            elif MockSubscriberSingleJid.calls == 3:
+                MockSubscriberSingleJid.calls += 1
+                return self._ret(jid, minion_id="minion3", fun="test.ping")
+
+        captured = MockSubscriberSingleJid.pubret.captured_jids
+        tgts = MockSubscriberSingleJid.pubret.batch_tgts
+
+        if len(captured) >= 1 and MockSubscriberSingleJid.calls == 4:
+            # First batch, first minion
+            MockSubscriberSingleJid.calls += 1
+            return self._ret(captured[0], minion_id=tgts[0][0], fun="state.sls")
+        if len(captured) >= 1 and MockSubscriberSingleJid.calls == 5:
+            # First batch, second minion
+            MockSubscriberSingleJid.calls += 1
+            return self._ret(captured[0], minion_id=tgts[0][1], fun="state.sls")
+        if len(captured) >= 2 and MockSubscriberSingleJid.calls == 6:
+            # Second batch, first minion
+            MockSubscriberSingleJid.calls += 1
+            return self._ret(captured[1], minion_id=tgts[1][0], fun="state.sls")
+        if len(captured) >= 2 and MockSubscriberSingleJid.calls == 7:
+            # Second batch, second minion
+            MockSubscriberSingleJid.calls += 1
+            return self._ret(captured[1], minion_id=tgts[1][1], fun="state.sls")
+        return
+
+    def _ret(self, jid, minion_id, fun, _return=True, _retcode=0):
+        dumped = salt.payload.dumps(
+            {
+                "fun_args": [],
+                "jid": jid,
+                "return": _return,
+                "retcode": 0,
+                "success": True,
+                "cmd": "_return",
+                "fun": fun,
+                "id": minion_id,
+                "_stamp": "2021-05-24T01:23:25.373194",
+            },
+            use_bin_type=True,
+        )
+        tag = f"salt/job/{jid}/ret/{minion_id}".encode()
+        return b"".join([tag, b"\n\n", dumped])
+
+    def connect(self, timeout=None):
+        pass
+
+
+def test_batch_single_jid():
+    """
+    Test that batch mode uses a single JID for all batch iterations.
+    4 minions, batch size 2 → 2 iterations, same JID.
+    """
+    # Reset class state
+    MockPubSingleJid.calls = 0
+    MockPubSingleJid.initial_ping = False
+    MockPubSingleJid.captured_jids = []
+    MockPubSingleJid.batch_tgts = []
+    MockSubscriberSingleJid.calls = 0
+    MockSubscriberSingleJid.pubret = None
+
+    mock_pub = MockPubSingleJid()
+    MockSubscriberSingleJid.pubret = mock_pub
+
+    def returns_for_job(jid):
+        return True
+
+    opts = {
+        "conf_file": "",
+        "tgt": "minion*",
+        "fun": "state.sls",
+        "arg": ["foo"],
+        "timeout": 1,
+        "gather_job_timeout": 1,
+        "batch": 2,
+        "extension_modules": "",
+    }
+    with patch("salt.transport.tcp.PublishClient", MockSubscriberSingleJid):
+        batch = salt.cli.batch.Batch(opts, quiet=True)
+        with patch.object(batch.local, "pub", Mock(side_effect=mock_pub)):
+            with patch.object(
+                batch.local, "returns_for_job", Mock(side_effect=returns_for_job)
+            ):
+                ret = list(batch.run())
+
+    # All 4 minions should return results
+    assert len(ret) == 4
+    for val, _ in ret:
+        values = list(val.values())
+        assert len(values) == 1
+        assert values[0] is True
+
+    # Both batch iterations should have received the same JID
+    assert len(mock_pub.captured_jids) == 2
+    assert mock_pub.captured_jids[0] == mock_pub.captured_jids[1]
+    assert mock_pub.captured_jids[0] != ""
+
+
+def test_batch_single_jid_job_cache_merge(tmp_path):
+    """
+    Scenario test: batch produces a single JID, and the job cache accumulates
+    all minions from every batch iteration under that JID.
+
+    Exercises batch.run() → single JID generation, then simulates what the
+    master does after each pub (save_load + save_minions per iteration), and
+    finally verifies get_load returns the complete union of minions.
+    """
+    # Reset class state
+    MockPubSingleJid.calls = 0
+    MockPubSingleJid.initial_ping = False
+    MockPubSingleJid.captured_jids = []
+    MockPubSingleJid.batch_tgts = []
+    MockSubscriberSingleJid.calls = 0
+    MockSubscriberSingleJid.pubret = None
+
+    mock_pub = MockPubSingleJid()
+    MockSubscriberSingleJid.pubret = mock_pub
+
+    def returns_for_job(jid):
+        return True
+
+    opts = {
+        "conf_file": "",
+        "tgt": "minion*",
+        "fun": "state.sls",
+        "arg": ["foo"],
+        "timeout": 1,
+        "gather_job_timeout": 1,
+        "batch": 2,
+        "extension_modules": "",
+    }
+
+    # Phase 1: Run batch, capture the single JID and per-iteration targets
+    with patch("salt.transport.tcp.PublishClient", MockSubscriberSingleJid):
+        batch = salt.cli.batch.Batch(opts, quiet=True)
+        with patch.object(batch.local, "pub", Mock(side_effect=mock_pub)):
+            with patch.object(
+                batch.local, "returns_for_job", Mock(side_effect=returns_for_job)
+            ):
+                ret = list(batch.run())
+
+    assert len(ret) == 4
+    assert len(mock_pub.captured_jids) == 2
+    batch_jid = mock_pub.captured_jids[0]
+    assert batch_jid == mock_pub.captured_jids[1]
+
+    # Phase 2: Simulate what the master does after each pub — call
+    # save_load once (first iteration) then save_minions per iteration.
+    cache_dir = str(tmp_path / "cache")
+    cache_opts = {"cachedir": cache_dir, "hash_type": "sha256"}
+
+    clear_load = {
+        "fun": "state.sls",
+        "jid": batch_jid,
+        "tgt": "",
+        "tgt_type": "list",
+        "user": "root",
+    }
+
+    with patch.object(local_cache, "__opts__", cache_opts, create=True):
+        local_cache.save_load(batch_jid, clear_load)
+        for tgt_list in mock_pub.batch_tgts:
+            local_cache.save_minions(batch_jid, tgt_list)
+
+        # Phase 3: Verify get_load returns the complete union
+        result = local_cache.get_load(batch_jid)
+
+    all_minions = set()
+    for tgt_list in mock_pub.batch_tgts:
+        all_minions.update(tgt_list)
+
+    assert result["jid"] == batch_jid
+    assert result["Minions"] == sorted(all_minions)
+    assert len(result["Minions"]) == 4

--- a/tests/pytests/unit/cli/test_batch.py
+++ b/tests/pytests/unit/cli/test_batch.py
@@ -89,18 +89,12 @@ def test_return_value_in_run_for_ret(batch):
     ret = Batch.run(batch)
     # We need to fetch at least one object to trigger the relevant code path.
     x = next(ret)
-    batch.local.cmd_iter_no_block.assert_called_with(
-        ["baz", "bar", "foo"],
-        "test",
-        "foo",
-        5,
-        "list",
-        raw=False,
-        ret="my_return",
-        show_jid=False,
-        verbose=False,
-        gather_job_timeout=5,
-    )
+    batch.local.cmd_iter_no_block.assert_called_once()
+    call_kwargs = batch.local.cmd_iter_no_block.call_args
+    assert call_kwargs.kwargs["ret"] == "my_return"
+    assert call_kwargs.kwargs["show_jid"] is False
+    assert call_kwargs.kwargs["verbose"] is False
+    assert call_kwargs.kwargs["gather_job_timeout"] == 5
 
 
 def test_return_value_in_run_for_return(batch):
@@ -123,15 +117,126 @@ def test_return_value_in_run_for_return(batch):
     ret = Batch.run(batch)
     # We need to fetch at least one object to trigger the relevant code path.
     x = next(ret)
-    batch.local.cmd_iter_no_block.assert_called_with(
-        ["baz", "bar", "foo"],
-        "test",
-        "foo",
-        5,
-        "list",
-        raw=False,
-        ret="my_return",
-        show_jid=False,
-        verbose=False,
-        gather_job_timeout=5,
+    batch.local.cmd_iter_no_block.assert_called_once()
+    call_kwargs = batch.local.cmd_iter_no_block.call_args
+    assert call_kwargs.kwargs["ret"] == "my_return"
+    assert call_kwargs.kwargs["show_jid"] is False
+    assert call_kwargs.kwargs["verbose"] is False
+    assert call_kwargs.kwargs["gather_job_timeout"] == 5
+
+
+def test_single_jid_across_batch_iterations(batch):
+    """
+    With 4 minions and batch size 2, cmd_iter_no_block should be called
+    twice with the same jid kwarg.
+    """
+    batch.opts = {
+        "batch": "2",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 5,
+    }
+    batch.gather_minions = MagicMock(
+        return_value=[["m1", "m2", "m3", "m4"], [], []],
     )
+
+    def _make_iter(*args, **kwargs):
+        """Return an iterator that yields results for targeted minions."""
+        minions = args[0]
+        for m in minions:
+            yield {m: {"ret": True, "retcode": 0}}
+
+    batch.local.cmd_iter_no_block = MagicMock(side_effect=_make_iter)
+    ret = list(Batch.run(batch))
+
+    assert batch.local.cmd_iter_no_block.call_count == 2
+    jids = [call.kwargs["jid"] for call in batch.local.cmd_iter_no_block.call_args_list]
+    assert jids[0] == jids[1]
+    assert jids[0] != ""
+
+
+def test_single_jid_passed_to_cmd_iter_no_block(batch):
+    """
+    Verify cmd_iter_no_block receives a non-empty jid string kwarg.
+    """
+    batch.opts = {
+        "batch": "100%",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 5,
+    }
+    batch.gather_minions = MagicMock(
+        return_value=[["m1", "m2"], [], []],
+    )
+    batch.local.cmd_iter_no_block = MagicMock(return_value=iter([]))
+    ret = Batch.run(batch)
+    next(ret)
+    call_kwargs = batch.local.cmd_iter_no_block.call_args
+    assert "jid" in call_kwargs.kwargs
+    assert isinstance(call_kwargs.kwargs["jid"], str)
+    assert len(call_kwargs.kwargs["jid"]) > 0
+
+
+def test_single_jid_with_failhard(batch):
+    """
+    With failhard=True and first minion returning error, verify early
+    termination and that JID was passed to the single cmd_iter_no_block call.
+    """
+    batch.opts = {
+        "batch": "2",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 5,
+        "failhard": True,
+    }
+    batch.gather_minions = MagicMock(
+        return_value=[["m1", "m2", "m3", "m4"], [], []],
+    )
+
+    def _make_iter(*args, **kwargs):
+        minions = args[0]
+        for m in minions:
+            yield {m: {"ret": True, "retcode": 1}}
+
+    batch.local.cmd_iter_no_block = MagicMock(side_effect=_make_iter)
+    ret = list(Batch.run(batch))
+
+    # failhard should stop after first batch
+    assert batch.local.cmd_iter_no_block.call_count == 1
+    call_kwargs = batch.local.cmd_iter_no_block.call_args
+    assert "jid" in call_kwargs.kwargs
+    assert isinstance(call_kwargs.kwargs["jid"], str)
+    assert len(call_kwargs.kwargs["jid"]) > 0
+
+
+def test_single_jid_single_batch(batch):
+    """
+    All minions fit in one batch (batch="100%"). Verify cmd_iter_no_block
+    called once with jid kwarg.
+    """
+    batch.opts = {
+        "batch": "100%",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 5,
+    }
+    batch.gather_minions = MagicMock(
+        return_value=[["m1", "m2", "m3"], [], []],
+    )
+
+    def _make_iter(*args, **kwargs):
+        minions = args[0]
+        for m in minions:
+            yield {m: {"ret": True, "retcode": 0}}
+
+    batch.local.cmd_iter_no_block = MagicMock(side_effect=_make_iter)
+    ret = list(Batch.run(batch))
+
+    assert batch.local.cmd_iter_no_block.call_count == 1
+    call_kwargs = batch.local.cmd_iter_no_block.call_args
+    assert "jid" in call_kwargs.kwargs
+    assert len(ret) == 3

--- a/tests/pytests/unit/returners/local_cache/test_local_cache.py
+++ b/tests/pytests/unit/returners/local_cache/test_local_cache.py
@@ -308,3 +308,120 @@ def test_get_load_minions_data_invalid_no_exception(tmp_cache_dir, caplog):
             "contains invalid minion data" in record.message
             for record in caplog.records
         )
+
+
+def test_save_minions_merges_on_same_jid(tmp_cache_dir):
+    """
+    Two calls to save_minions with disjoint minion lists on the same JID
+    should result in the union of all minions.
+    """
+    jid = "20240101120000000000"
+    opts = {"cachedir": str(tmp_cache_dir), "hash_type": "sha256"}
+
+    with patch.dict(local_cache.__opts__, opts):
+        local_cache.save_minions(jid, ["minion1", "minion2"])
+        local_cache.save_minions(jid, ["minion3", "minion4"])
+
+        jid_dir = salt.utils.jid.jid_dir(
+            jid, os.path.join(str(tmp_cache_dir), "jobs"), "sha256"
+        )
+        minions_path = os.path.join(jid_dir, ".minions.p")
+        with salt.utils.files.fopen(minions_path, "rb") as rfh:
+            result = salt.payload.load(rfh)
+
+    assert sorted(result) == ["minion1", "minion2", "minion3", "minion4"]
+
+
+def test_save_minions_no_duplicates_on_overlap(tmp_cache_dir):
+    """
+    Two calls with overlapping minions should produce no duplicates, sorted.
+    """
+    jid = "20240101120000000000"
+    opts = {"cachedir": str(tmp_cache_dir), "hash_type": "sha256"}
+
+    with patch.dict(local_cache.__opts__, opts):
+        local_cache.save_minions(jid, ["minion1", "minion2", "minion3"])
+        local_cache.save_minions(jid, ["minion2", "minion3", "minion4"])
+
+        jid_dir = salt.utils.jid.jid_dir(
+            jid, os.path.join(str(tmp_cache_dir), "jobs"), "sha256"
+        )
+        minions_path = os.path.join(jid_dir, ".minions.p")
+        with salt.utils.files.fopen(minions_path, "rb") as rfh:
+            result = salt.payload.load(rfh)
+
+    assert result == ["minion1", "minion2", "minion3", "minion4"]
+
+
+def test_save_minions_first_call_creates_file(tmp_cache_dir):
+    """
+    A single call to save_minions with no pre-existing file should create it
+    with the correct content.
+    """
+    jid = "20240101120000000000"
+    opts = {"cachedir": str(tmp_cache_dir), "hash_type": "sha256"}
+
+    with patch.dict(local_cache.__opts__, opts):
+        local_cache.save_minions(jid, ["minion1", "minion2"])
+
+        jid_dir = salt.utils.jid.jid_dir(
+            jid, os.path.join(str(tmp_cache_dir), "jobs"), "sha256"
+        )
+        minions_path = os.path.join(jid_dir, ".minions.p")
+        assert os.path.isfile(minions_path)
+        with salt.utils.files.fopen(minions_path, "rb") as rfh:
+            result = salt.payload.load(rfh)
+
+    assert sorted(result) == ["minion1", "minion2"]
+
+
+def test_save_minions_handles_corrupt_existing_file(tmp_cache_dir):
+    """
+    If the existing .minions.p file contains corrupt data, save_minions should
+    still write the new minions without crashing.
+    """
+    jid = "20240101120000000000"
+    opts = {"cachedir": str(tmp_cache_dir), "hash_type": "sha256"}
+
+    with patch.dict(local_cache.__opts__, opts):
+        jid_dir = salt.utils.jid.jid_dir(
+            jid, os.path.join(str(tmp_cache_dir), "jobs"), "sha256"
+        )
+        os.makedirs(jid_dir, exist_ok=True)
+
+        # Write corrupt data
+        minions_path = os.path.join(jid_dir, ".minions.p")
+        with salt.utils.files.fopen(minions_path, "wb") as fh:
+            fh.write(b"corrupt data that is not valid msgpack")
+
+        local_cache.save_minions(jid, ["minion1", "minion2"])
+
+        with salt.utils.files.fopen(minions_path, "rb") as rfh:
+            result = salt.payload.load(rfh)
+
+    assert sorted(result) == ["minion1", "minion2"]
+
+
+def test_get_load_returns_merged_minions(tmp_cache_dir):
+    """
+    save_load + save_minions with different minion sets on the same JID should
+    result in get_load returning the full union of minions.
+    """
+    jid = "20240101120000000000"
+    opts = {"cachedir": str(tmp_cache_dir), "hash_type": "sha256"}
+    clear_load = {
+        "fun": "test.ping",
+        "jid": jid,
+        "tgt": "",
+        "tgt_type": "list",
+        "user": "root",
+    }
+
+    with patch.dict(local_cache.__opts__, opts):
+        local_cache.save_load(jid, clear_load)
+        local_cache.save_minions(jid, ["minion1", "minion2"])
+        local_cache.save_minions(jid, ["minion3", "minion4"])
+
+        result = local_cache.get_load(jid)
+
+    assert result["Minions"] == ["minion1", "minion2", "minion3", "minion4"]


### PR DESCRIPTION
Batch mode previously generated a separate JID per batch iteration, making it impossible to track a batch operation as a single job via salt-run jobs.lookup_jid. Generate one JID at the start of batch.run() and pass it to every cmd_iter_no_block call so all iterations share it.

In local_cache.save_minions(), change from overwrite to read-merge-write so that each batch iteration accumulates its minion list under the shared JID rather than replacing the previous iteration's list.

In client.cmd_iter_no_block(), filter the jid kwarg before passing to get_iter_returns to avoid conflicting with its positional jid argument.

Fixes #25362, #58502

