### PR TITLE
docs: fix 'comma-seperated' typo in saltutil docstrings

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -834,10 +834,10 @@ def sync_serializers(
         synced. Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Examples:
 
@@ -1041,10 +1041,10 @@ def sync_executors(
         Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Examples:
 
@@ -1082,10 +1082,10 @@ def sync_wrapper(
         Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     .. note::
         This function will raise an error if executed on a traditional (i.e.

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -791,10 +791,10 @@ def sync_serializers(saltenv="base", extmod_whitelist=None, extmod_blacklist=Non
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 
@@ -822,10 +822,10 @@ def sync_executors(saltenv="base", extmod_whitelist=None, extmod_blacklist=None)
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 
@@ -853,10 +853,10 @@ def sync_wrapper(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 


### PR DESCRIPTION
Fixes a recurring typo in docstrings: `comma-seperated` → `comma-separated`.

Twelve occurrences across two files:

- `salt/runners/saltutil.py` (6 occurrences)
- `salt/modules/saltutil.py` (6 occurrences)

Docstring-only change, no runtime impact.