### PR TITLE
fix: correct 'occured'/'recieve' typos in log messages

### DIFF
--- a/changelog/68943.fixed.md
+++ b/changelog/68943.fixed.md
@@ -1,0 +1,1 @@
+Fixed typos in log messages: "occured" → "occurred" and "recieve" → "receive" in salt/crypt.py, salt/cli/daemons.py, salt/metaproxy/deltaproxy.py, salt/minion.py, and salt/transport/zeromq.py.

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -327,7 +327,7 @@ class Minion(
             self.minion = salt.minion.MinionManager(self.config)
         except Exception:  # pylint: disable=broad-except
             log.error(
-                "An error occured while setting up the minion manager", exc_info=True
+                "An error occurred while setting up the minion manager", exc_info=True
             )
             self.shutdown(1)
 

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -333,7 +333,7 @@ class Minion(
             self.minion = salt.minion.MinionManager(self.config)
         except Exception:  # pylint: disable=broad-except
             log.error(
-                "An error occured while setting up the minion manager", exc_info=True
+                "An error occurred while setting up the minion manager", exc_info=True
             )
             self.shutdown(1)
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1255,7 +1255,7 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occured loading master pub-key")
+                    log.exception("Something unexpected occurred loading master pub-key")
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1487,7 +1487,7 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occured loading master pub-key")
+                    log.exception("Something unexpected occurred loading master pub-key")
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1487,7 +1487,9 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occurred loading master pub-key")
+                    log.exception(
+                        "Something unexpected occurred loading master pub-key"
+                    )
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -388,7 +388,7 @@ async def post_master_init(self, master):
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 log.info(
-                    "An exception occured during initialization for %s, skipping: %s",
+                    "An exception occurred during initialization for %s, skipping: %s",
                     _id,
                     exc,
                 )
@@ -529,7 +529,7 @@ async def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils
         proxy_init_fn(proxyopts)
     except Exception as exc:  # pylint: disable=broad-except
         log.error(
-            "An exception occured during the initialization of minion %s: %s",
+            "An exception occurred during the initialization of minion %s: %s",
             minion_id,
             exc,
             exc_info=True,

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -385,7 +385,7 @@ async def post_master_init(self, master):
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 log.info(
-                    "An exception occured during initialization for %s, skipping: %s",
+                    "An exception occurred during initialization for %s, skipping: %s",
                     _id,
                     exc,
                 )
@@ -526,7 +526,7 @@ async def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils
         proxy_init_fn(proxyopts)
     except Exception as exc:  # pylint: disable=broad-except
         log.error(
-            "An exception occured during the initialization of minion %s: %s",
+            "An exception occurred during the initialization of minion %s: %s",
             minion_id,
             exc,
             exc_info=True,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1795,7 +1795,7 @@ class Minion(MinionBase):
                     break
                 await asyncio.sleep(0.3)
             else:
-                raise TimeoutError("Did not recieve return event")
+                raise TimeoutError("Did not receive return event")
             log.trace("Reply from main %s", request_id)
             return ret["ret"]
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2110,7 +2110,7 @@ class Minion(MinionBase):
                     break
                 await asyncio.sleep(0.3)
             else:
-                raise SaltReqTimeoutError("Did not recieve return event")
+                raise SaltReqTimeoutError("Did not receive return event")
             log.trace("Reply from main %s", request_id)
             return ret["ret"]
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -337,7 +337,7 @@ class PublishClient(salt.transport.base.PublishClient):
             try:
                 return await asyncio.wait_for(self._socket.recv(), timeout=timeout)
             except asyncio.exceptions.TimeoutError:
-                log.trace("PublishClient recieve timedout: %d", timeout)
+                log.trace("PublishClient receive timedout: %d", timeout)
         else:
             return await self._socket.recv()
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -391,7 +391,7 @@ class PublishClient(salt.transport.base.PublishClient):
             events = await self._socket.poll(timeout=int(timeout * 1000))
             if events:
                 return await self._socket.recv()
-            log.trace("PublishClient recieve timedout: %s", timeout)
+            log.trace("PublishClient receive timedout: %s", timeout)
         else:
             return await self._socket.recv()
 


### PR DESCRIPTION
Fixes typos in user-visible log messages and a `TimeoutError`:

- `salt/crypt.py`: `occured loading master pub-key` → `occurred ...`
- `salt/metaproxy/deltaproxy.py`: two `exception occured during ...` → `exception occurred during ...`
- `salt/transport/zeromq.py`: `PublishClient recieve timedout` → `PublishClient receive timedout`
- `salt/cli/daemons.py`: `An error occured while setting up the minion manager` → `... occurred ...`
- `salt/minion.py`: `TimeoutError('Did not recieve return event')` → `... receive ...`

Message-only change, no behavior change.