### PR TITLE
Fix docstring/comment/log typos

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -327,7 +327,7 @@ class Minion(
             self.minion = salt.minion.MinionManager(self.config)
         except Exception:  # pylint: disable=broad-except
             log.error(
-                "An error occured while setting up the minion manager", exc_info=True
+                "An error occurred while setting up the minion manager", exc_info=True
             )
             self.shutdown(1)
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1255,7 +1255,7 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occured loading master pub-key")
+                    log.exception("Something unexpected occurred loading master pub-key")
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -388,7 +388,7 @@ async def post_master_init(self, master):
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 log.info(
-                    "An exception occured during initialization for %s, skipping: %s",
+                    "An exception occurred during initialization for %s, skipping: %s",
                     _id,
                     exc,
                 )
@@ -529,7 +529,7 @@ async def subproxy_post_master_init(minion_id, uid, opts, main_proxy, main_utils
         proxy_init_fn(proxyopts)
     except Exception as exc:  # pylint: disable=broad-except
         log.error(
-            "An exception occured during the initialization of minion %s: %s",
+            "An exception occurred during the initialization of minion %s: %s",
             minion_id,
             exc,
             exc_info=True,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1795,7 +1795,7 @@ class Minion(MinionBase):
                     break
                 await asyncio.sleep(0.3)
             else:
-                raise TimeoutError("Did not recieve return event")
+                raise TimeoutError("Did not receive return event")
             log.trace("Reply from main %s", request_id)
             return ret["ret"]
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -834,10 +834,10 @@ def sync_serializers(
         synced. Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Examples:
 
@@ -1041,10 +1041,10 @@ def sync_executors(
         Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Examples:
 
@@ -1082,10 +1082,10 @@ def sync_wrapper(
         Set to ``False`` to prevent this refresh.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     .. note::
         This function will raise an error if executed on a traditional (i.e.

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -445,7 +445,7 @@ def _gets_service_instance_via_proxy(fn):
 
                 # There are two cases:
                 #   1. service_instance was passed in as a positional parameter
-                #   2. service_instance was passed in as a named paramter
+                #   2. service_instance was passed in as a named parameter
                 if len(args) > idx:
                     # case 1: The call was made with enough positional
                     # parameters to include 'service_instance'

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -791,10 +791,10 @@ def sync_serializers(saltenv="base", extmod_whitelist=None, extmod_blacklist=Non
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 
@@ -822,10 +822,10 @@ def sync_executors(saltenv="base", extmod_whitelist=None, extmod_blacklist=None)
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 
@@ -853,10 +853,10 @@ def sync_wrapper(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
         one environment, pass a comma-separated list.
 
     extmod_whitelist : None
-        comma-seperated list of modules to sync
+        comma-separated list of modules to sync
 
     extmod_blacklist : None
-        comma-seperated list of modules to blacklist based on type
+        comma-separated list of modules to blacklist based on type
 
     CLI Example:
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -983,7 +983,7 @@ def _resolve_capabilities(pkgs, refresh=False, **kwargs):
     """
     Resolve capabilities in ``pkgs`` and exchange them with real package
     names, when the result is distinct.
-    This feature can be turned on while setting the paramter
+    This feature can be turned on while setting the parameter
     ``resolve_capabilities`` to True.
 
     Return the input dictionary with replaced capability names and as

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -337,7 +337,7 @@ class PublishClient(salt.transport.base.PublishClient):
             try:
                 return await asyncio.wait_for(self._socket.recv(), timeout=timeout)
             except asyncio.exceptions.TimeoutError:
-                log.trace("PublishClient recieve timedout: %d", timeout)
+                log.trace("PublishClient receive timedout: %d", timeout)
         else:
             return await self._socket.recv()
 

--- a/tests/integration/cloud/helpers/cloud_test_base.py
+++ b/tests/integration/cloud/helpers/cloud_test_base.py
@@ -79,7 +79,7 @@ class CloudTest(ShellCase):
             self.assertIn(
                 instance_name,
                 [i.strip(": ") for i in creation_ret],
-                "An error occured during instance creation:  |\n\t{}\n\t|".format(
+                "An error occurred during instance creation:  |\n\t{}\n\t|".format(
                     "\n\t".join(creation_ret)
                 ),
             )

--- a/tests/pytests/functional/master/test_event_publisher.py
+++ b/tests/pytests/functional/master/test_event_publisher.py
@@ -193,5 +193,5 @@ def test_publisher_mem(publisher, publish, listeners, stop_event):
         print(
             f"*** PEAK MEMORY: {max_mem:.2f} MB (increase: {max_mem - baseline:.2f} MB) ***\n"
         )
-        log.info("test_publisher_mem finished succesfully")
+        log.info("test_publisher_mem finished successfully")
         stop_event.clear()

--- a/tests/pytests/functional/utils/test_etcd_util.py
+++ b/tests/pytests/functional/utils/test_etcd_util.py
@@ -481,7 +481,7 @@ def test_tree(subtests, etcd_client, prefix, etcd_version):
             etcd_client.write_directory(f"{prefix}/2", None)
             assert etcd_client.tree(f"{prefix}/2") == {}
 
-    with subtests.test("we should be able to recieve the tree of a directory"):
+    with subtests.test("we should be able to receive the tree of a directory"):
         etcd_client.set(f"{prefix}/3/4", "three/four")
         expected = {
             "1": "one",
@@ -492,7 +492,7 @@ def test_tree(subtests, etcd_client, prefix, etcd_version):
             expected.pop("2")
         assert etcd_client.tree(prefix) == expected
 
-    with subtests.test("we should be able to recieve the tree of an outer directory"):
+    with subtests.test("we should be able to receive the tree of an outer directory"):
         etcd_client.set(f"{prefix}/5/6/7", "five/six/seven")
         expected = {
             "6": {"7": "five/six/seven"},


### PR DESCRIPTION
Small typo fixes in docstrings, comments, and one log message:

- `salt/modules/vsphere.py`: `named paramter` -> `named parameter`
- `salt/modules/saltutil.py`, `salt/runners/saltutil.py`: `comma-seperated` -> `comma-separated` (docstrings for sync/blacklist params)
- `salt/states/pkg.py`: `setting the paramter` -> `setting the parameter`
- `tests/.../test_event_publisher.py`: log `finished succesfully` -> `finished successfully`
- `tests/.../test_etcd_util.py`: subtest label `recieve the tree` -> `receive the tree`
- `tests/.../cloud_test_base.py`: error message `error occured` -> `error occurred`

No behavior changes.