### PR TITLE
Fix 'occured' -> 'occurred' typos in salt logging strings

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -327,7 +327,7 @@ class Minion(
             self.minion = salt.minion.MinionManager(self.config)
         except Exception:  # pylint: disable=broad-except
             log.error(
-                "An error occured while setting up the minion manager", exc_info=True
+                "An error occurred while setting up the minion manager", exc_info=True
             )
             self.shutdown(1)
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1255,7 +1255,7 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occured loading master pub-key")
+                    log.exception("Something unexpected occurred loading master pub-key")
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1255,7 +1255,9 @@ class AsyncAuth:
                 try:
                     mkey = PublicKey.from_file(m_path)
                 except Exception:  # pylint: disable=broad-except
-                    log.exception("Something unexpected occurred loading master pub-key")
+                    log.exception(
+                        "Something unexpected occurred loading master pub-key"
+                    )
                     return "", ""
                 digest = hashlib.sha256(key_str).hexdigest()
                 digest = salt.utils.stringutils.to_bytes(digest)


### PR DESCRIPTION
Two log messages used `occured` instead of `occurred`:

- `salt/crypt.py:1258` — `log.exception('Something unexpected occured loading master pub-key')`
- `salt/cli/daemons.py:330` — `log.error('An error occured while setting up the minion manager')`

Both messages reach operators in salt-master / salt-minion logs. Python `ast.parse` stays clean for both files.