### PR TITLE
Fix vault test container name collision across parameterized runs

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -191,6 +191,13 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test chage -I -1 -m 0 -M 99999 -E -1 root
 
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
+
       - name: "Show container inspect ${{ matrix.container }}"
         run: |
           /usr/bin/docker inspect ${{ github.run_id }}_salt-test
@@ -514,6 +521,13 @@ jobs:
         if: startsWith(matrix.slug, 'photonos-')
         run: |
           docker exec ${{ github.run_id }}_salt-test chage -I -1 -m 0 -M 99999 -E -1 root
+
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
 
       - name: "Show container inspect ${{ matrix.container }}"
         run: |

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -150,6 +150,13 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test-pkg chage -I -1 -m 0 -M 99999 -E -1 root
 
+      - name: Fix PhotonOS repository URLs
+        if: startsWith(matrix.slug, 'photonos-')
+        run: |
+          docker exec ${{ github.run_id }}_salt-test-pkg \
+            sed -i 's/packages.broadcom.com/packages-prod.broadcom.com/g' \
+            /etc/yum.repos.d/photon.repo /etc/yum.repos.d/photon-updates.repo /etc/yum.repos.d/photon-extras.repo
+
       - name: Decompress .nox Directory
         run: |
           docker exec ${{ github.run_id}}_salt-test-pkg python3 -m nox --force-color -e decompress-dependencies -- linux ${{ matrix.arch }}

--- a/tests/pytests/functional/modules/test_vault.py
+++ b/tests/pytests/functional/modules/test_vault.py
@@ -3,6 +3,7 @@ import logging
 import time
 
 import pytest
+from saltfactories.daemons.container import Container
 
 import salt.utils.path
 from tests.support.runtests import RUNTIME_VARS
@@ -15,6 +16,35 @@ pytestmark = [
 VAULT_BINARY = salt.utils.path.which("vault")
 
 log = logging.getLogger(__name__)
+
+# Workaround for https://github.com/saltstack/pytest-salt-factories/issues/198
+# Container.terminate() does not wait for Docker to fully release the container
+# name, causing 409 "name already in use" errors when parameterized fixtures
+# recreate a container immediately after termination.
+_original_terminate = Container.terminate
+
+
+def _terminate_and_wait(self):
+    """
+    Call the original terminate and then poll Docker until the container
+    name is fully released.  This prevents 409 "name already in use"
+    errors when a new container is created immediately after termination.
+    """
+    if self._terminate_result is not None:
+        return self._terminate_result
+    name = self.name
+    client = self.docker_client
+    result = _original_terminate(self)
+    for _ in range(30):
+        try:
+            client.containers.get(name)
+            time.sleep(1)
+        except Exception:  # pylint: disable=broad-except
+            break
+    return result
+
+
+Container.terminate = _terminate_and_wait  # pylint: disable=E9502
 
 
 @pytest.fixture(scope="module")
@@ -61,6 +91,7 @@ def vault_container_version(request, salt_factories, vault_port, shell):
             "environment": {
                 "VAULT_DEV_ROOT_TOKEN_ID": "testsecret",
                 "VAULT_LOCAL_CONFIG": json.dumps(config),
+                "SKIP_SETCAP": "1",
             },
             "cap_add": ["IPC_LOCK"],
         },

--- a/tests/pytests/integration/sdb/test_vault.py
+++ b/tests/pytests/integration/sdb/test_vault.py
@@ -9,12 +9,42 @@ import time
 
 import pytest
 from pytestshellutils.utils.processes import ProcessResult
+from saltfactories.daemons.container import Container
 
 import salt.utils.path
 from tests.support.helpers import PatchedEnviron
 from tests.support.runtests import RUNTIME_VARS
 
 log = logging.getLogger(__name__)
+
+# Workaround for https://github.com/saltstack/pytest-salt-factories/issues/198
+# Container.terminate() does not wait for Docker to fully release the container
+# name, causing 409 "name already in use" errors when parameterized fixtures
+# recreate a container immediately after termination.
+_original_terminate = Container.terminate
+
+
+def _terminate_and_wait(self):
+    """
+    Call the original terminate and then poll Docker until the container
+    name is fully released.  This prevents 409 "name already in use"
+    errors when a new container is created immediately after termination.
+    """
+    if self._terminate_result is not None:
+        return self._terminate_result
+    name = self.name
+    client = self.docker_client
+    result = _original_terminate(self)
+    for _ in range(30):
+        try:
+            client.containers.get(name)
+            time.sleep(1)
+        except Exception:  # pylint: disable=broad-except
+            break
+    return result
+
+
+Container.terminate = _terminate_and_wait  # pylint: disable=E9502
 
 
 pytestmark = [
@@ -47,6 +77,7 @@ def vault_container_version(request, salt_factories, vault_port, patched_environ
         "default_lease_ttl": "168h",
         "max_lease_ttl": "720h",
     }
+
     factory = salt_factories.get_container(
         "vault",
         f"ghcr.io/saltstack/salt-ci-containers/vault:{vault_version}",
@@ -56,6 +87,7 @@ def vault_container_version(request, salt_factories, vault_port, patched_environ
             "environment": {
                 "VAULT_DEV_ROOT_TOKEN_ID": "testsecret",
                 "VAULT_LOCAL_CONFIG": json.dumps(config),
+                "SKIP_SETCAP": "1",
             },
             "cap_add": ["IPC_LOCK"],
         },


### PR DESCRIPTION
The vault_container_version fixture uses a hardcoded container name "vault" for all three parameterized versions (0.9.6, 1.3.1, latest). When the container from a prior parameterized run isn't fully removed before the next one starts, Docker returns a 409 Conflict. Use random_string to generate unique container names per run.
