### PR TITLE
Add module and states to manage EFI entries on linux

### DIFF
--- a/changelog/68951.added.md
+++ b/changelog/68951.added.md
@@ -1,0 +1,1 @@
+Added module and states to manage EFI entries on linux

--- a/doc/ref/modules/all/salt.modules.efi.rst
+++ b/doc/ref/modules/all/salt.modules.efi.rst
@@ -1,0 +1,5 @@
+salt.modules.efi
+====================
+
+.. automodule:: salt.modules.efi
+    :members:

--- a/doc/ref/states/all/salt.states.efi.rst
+++ b/doc/ref/states/all/salt.states.efi.rst
@@ -1,0 +1,5 @@
+salt.states.efi
+====================
+
+.. automodule:: salt.states.efi
+    :members:

--- a/salt/modules/efi.py
+++ b/salt/modules/efi.py
@@ -1,0 +1,101 @@
+"""
+Manage UEFI boot entries using efibootmgr
+"""
+
+import re
+import salt.utils.path
+
+
+def __virtual__():
+    if __grains__.get("kernel") != "Linux":
+        return (False, "efi module only supports Linux")
+    elif salt.utils.path.which("efibootmgr"):
+        return "efi"
+    return (False, "efibootmgr not found")
+
+
+def list_entries():
+    """
+    List EFI boot entries
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.list_entries
+    """
+    ret = {}
+    cmd = "efibootmgr -v"
+    out = __salt__["cmd.run_stdout"](cmd)
+
+    # Regex to capture BootXXXX* <label> <path>
+    entry_re = re.compile(r"Boot([0-9A-F]{4})\*\s+(.*)\s+(.*)")
+
+    for line in out.splitlines():
+        match = entry_re.match(line)
+        if match:
+            bootnum, label, path = match.groups()
+            ret[bootnum] = {"label": label, "path": path}
+
+    return ret
+
+
+def get_bootorder():
+    """
+    Get the current boot order
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.get_bootorder
+    """
+    cmd = "efibootmgr -v"
+    out = __salt__["cmd.run_stdout"](cmd)
+
+    match = re.search(r"BootOrder:\s*(.*)", out)
+    if match:
+        return match.group(1).split(",")
+    return []
+
+
+def add_entry(label, loader, disk="/dev/sda", part=1):
+    """
+    Add a new EFI entry
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.add_entry label=Debian loader='\\EFI\\debian\\grub.efi'
+    """
+    cmd = f"efibootmgr -c -d '{disk}' -p '{part}' -L '{label}' -l '{loader}'"
+    return __salt__["cmd.retcode"](cmd) == 0
+
+
+def remove_entry(bootnum):
+    """
+    Remove an EFI entry
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.remove_entry 0001
+    """
+    cmd = f"efibootmgr -b '{bootnum}' -B"
+    return __salt__["cmd.retcode"](cmd) == 0
+
+
+def set_bootorder(bootorder):
+    """
+    Set boot order
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.set_bootorder '["0001", "0002"]'
+    """
+    cmd = f"efibootmgr -o '{','.join(bootorder)}'"
+    return __salt__["cmd.retcode"](cmd) == 0

--- a/salt/modules/efi.py
+++ b/salt/modules/efi.py
@@ -1,0 +1,102 @@
+"""
+Manage UEFI boot entries using efibootmgr
+"""
+
+import re
+import salt.utils.path
+
+
+def __virtual__():
+    if __grains__.get("kernel") != "Linux":
+        return (False, "efi module only supports Linux")
+    elif salt.utils.path.which("efibootmgr"):
+        return "efi"
+    return (False, "efibootmgr not found")
+
+
+def list_entries():
+    """
+    List EFI boot entries
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.list_entries
+    """
+    ret = {}
+    out = __salt__["cmd.run_stdout"](["efibootmgr", "-v"])
+
+    # Regex to capture BootXXXX* <label> <path>
+    entry_re = re.compile(r"Boot([0-9A-F]{4})\*\s+(.*)\s+(.*)")
+
+    for line in out.splitlines():
+        match = entry_re.match(line)
+        if match:
+            bootnum, label, path = match.groups()
+            ret[bootnum] = {"label": label, "path": path}
+
+    return ret
+
+
+def get_bootorder():
+    """
+    Get the current boot order
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.get_bootorder
+    """
+    out = __salt__["cmd.run_stdout"](["efibootmgr", "-v"])
+
+    match = re.search(r"BootOrder:\s*(.*)", out)
+    if match:
+        return match.group(1).split(",")
+    return []
+
+
+def add_entry(label, loader, disk="/dev/sda", part=1):
+    """
+    Add a new EFI entry
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.add_entry label=Debian loader='\\EFI\\debian\\grub.efi'
+    """
+    return (
+        __salt__["cmd.retcode"](
+            ["efibootmgr", "-c", "-d", disk, "-p", part, "-L", label, "-l", loader]
+        )
+        == 0
+    )
+
+
+def remove_entry(bootnum):
+    """
+    Remove an EFI entry
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.remove_entry 0001
+    """
+    return __salt__["cmd.retcode"](["efibootmgr", "-b", bootnum, "-B"]) == 0
+
+
+def set_bootorder(bootorder):
+    """
+    Set boot order
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' efi.set_bootorder '["0001", "0002"]'
+    """
+
+    return __salt__["cmd.retcode"](["efibootmgr", "-o" ",".join(bootorder)]) == 0

--- a/salt/states/efi.py
+++ b/salt/states/efi.py
@@ -1,0 +1,158 @@
+"""
+Manage UEFI boot entries
+"""
+
+
+def present(name, loader, disk="/dev/sda", part=1, index=None):
+    """
+    Ensure EFI entry is present
+
+    Example:
+
+    .. code-block:: yaml
+
+        my_efi_entry:
+          efi.present:
+            - name: Debian
+            - loader: '\\EFI\\debian\\grub.efi'
+            - index: 0
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": []}
+
+    entries = __salt__["efi.list_entries"]()
+    # Find bootnum
+    bootnum = None
+    for bn, info in entries.items():
+        if info["label"] == name:
+            bootnum = bn
+            break
+
+    added = False
+    if not bootnum:
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"].append(f"EFI entry '{name}' would be added.")
+        elif __salt__["efi.add_entry"](name, loader, disk, part):
+            added = True
+            ret["changes"]["new"] = name
+            ret["comment"].append(f"EFI entry '{name}' added.")
+            # Re-fetch bootnum
+            new_entries = __salt__["efi.list_entries"]()
+            for bn, info in new_entries.items():
+                if info["label"] == name:
+                    bootnum = bn
+                    break
+
+        else:
+            ret["result"] = False
+            ret["comment"].append(f"Failed to add EFI entry '{name}'.")
+            return ret
+
+    order_updated = False
+    if bootnum and index is not None:
+        order = __salt__["efi.get_bootorder"]()
+        if bootnum in order:
+            order.remove(bootnum)
+
+        # Ensure index is within bounds
+        idx = max(0, min(len(order), index))
+        order.insert(idx, bootnum)
+
+        # Check if order actually changed
+        current_order = __salt__["efi.get_bootorder"]()
+        if order != current_order:
+            if __opts__["test"]:
+                ret["result"] = None
+                ret["comment"].append(f"Boot order would be updated to index {idx}.")
+            elif __salt__["efi.set_bootorder"](order):
+                order_updated = True
+                ret["changes"]["bootorder"] = order
+                ret["comment"].append(f"Boot order updated to index {idx}.")
+            else:
+                ret["result"] = False
+                ret["comment"].append("Failed to update boot order.")
+        elif not added:
+            ret["comment"].append("Boot order is already correct.")
+
+    if not added and not order_updated and not ret["comment"]:
+        ret["comment"].append(f"EFI entry '{name}' is already present.")
+
+    ret["comment"] = " ".join(ret["comment"])
+    return ret
+
+
+def absent(name):
+    """
+    Ensure EFI entry is absent
+
+    Example:
+
+    .. code-block:: yaml
+
+        my_efi_entry:
+          efi.absent:
+            - name: Debian
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    entries = __salt__["efi.list_entries"]()
+    # Find bootnum
+    bootnum = None
+    for bn, info in entries.items():
+        if info["label"] == name:
+            bootnum = bn
+            break
+
+    if not bootnum:
+        ret["comment"] = f"EFI entry '{name}' is already absent."
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"EFI entry '{name}' would be removed."
+        return ret
+
+    if __salt__["efi.remove_entry"](bootnum):
+        ret["changes"] = {"old": name}
+        ret["comment"] = f"EFI entry '{name}' removed."
+    else:
+        ret["result"] = False
+        ret["comment"] = f"Failed to remove EFI entry '{name}'."
+
+    return ret
+
+
+def order_set(name, bootorder):
+    """
+    Ensure boot order is set
+
+    Example:
+
+    .. code-block:: yaml
+
+        my_boot_order:
+          efi.order_set:
+            - bootorder:
+              - 0001
+              - 0002
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    current_order = __salt__["efi.get_bootorder"]()
+    if current_order == bootorder:
+        ret["comment"] = "Boot order is already set."
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Boot order would be set to {bootorder}."
+        return ret
+
+    if __salt__["efi.set_bootorder"](bootorder):
+        ret["changes"] = {"old": current_order, "new": bootorder}
+        ret["comment"] = "Boot order set."
+    else:
+        ret["result"] = False
+        ret["comment"] = "Failed to set boot order."
+
+    return ret

--- a/tests/pytests/unit/modules/test_efi.py
+++ b/tests/pytests/unit/modules/test_efi.py
@@ -1,0 +1,74 @@
+"""
+:codeauthor: SaltStack
+"""
+
+import pytest
+import salt.modules.efi as efi
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        efi: {
+            "__grains__": {"kernel": "Linux"},
+            "__salt__": {
+                "cmd.run_stdout": MagicMock(),
+                "cmd.retcode": MagicMock(),
+            },
+        }
+    }
+
+
+def test_virtual_linux():
+    with patch("salt.utils.path.which", MagicMock(return_value="/usr/sbin/efibootmgr")):
+        assert efi.__virtual__() == "efi"
+
+
+def test_virtual_non_linux():
+    with patch("salt.modules.efi.__grains__", {"kernel": "Windows"}):
+        assert efi.__virtual__() == (False, "efi module only supports Linux")
+
+
+def test_list_entries():
+    mock_out = "\n".join(
+        [
+            "BootCurrent: 0001",
+            "Timeout: 1 seconds",
+            "BootOrder: 0001,0002",
+            "Boot0001* debian\t"
+            "HD(1,GPT,00000000-0000-0000-0000-000000000000,0x800,0x100000)"
+            "/File(\\EFI\\DEBIAN\\SHIMX64.EFI)",
+        ]
+    )
+    with patch(
+        "salt.modules.efi.__salt__",
+        {"cmd.run_stdout": MagicMock(return_value=mock_out)},
+    ):
+        entries = efi.list_entries()
+        assert "0001" in entries
+        assert entries["0001"]["label"] == "debian"
+
+
+def test_get_bootorder():
+    mock_out = "BootCurrent: 0001\nBootOrder: 0001,0002"
+    with patch(
+        "salt.modules.efi.__salt__",
+        {"cmd.run_stdout": MagicMock(return_value=mock_out)},
+    ):
+        assert efi.get_bootorder() == ["0001", "0002"]
+
+
+def test_add_entry():
+    with patch("salt.modules.efi.__salt__", {"cmd.retcode": MagicMock(return_value=0)}):
+        assert efi.add_entry("Debian", "\\EFI\\debian\\grub.efi") is True
+
+
+def test_remove_entry():
+    with patch("salt.modules.efi.__salt__", {"cmd.retcode": MagicMock(return_value=0)}):
+        assert efi.remove_entry("0001") is True
+
+
+def test_set_bootorder():
+    with patch("salt.modules.efi.__salt__", {"cmd.retcode": MagicMock(return_value=0)}):
+        assert efi.set_bootorder(["0001", "0002"]) is True

--- a/tests/pytests/unit/states/test_efi.py
+++ b/tests/pytests/unit/states/test_efi.py
@@ -1,0 +1,117 @@
+import pytest
+import salt.states.efi as efi
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        efi: {
+            "__salt__": {
+                "efi.list_entries": MagicMock(),
+                "efi.add_entry": MagicMock(),
+                "efi.remove_entry": MagicMock(),
+                "efi.get_bootorder": MagicMock(),
+                "efi.set_bootorder": MagicMock(),
+            },
+            "__opts__": {"test": False},
+        }
+    }
+
+
+def test_present_new_entry():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.list_entries": MagicMock(return_value={}),
+            "efi.add_entry": MagicMock(return_value=True),
+            "efi.get_bootorder": MagicMock(return_value=["0001"]),
+            "efi.set_bootorder": MagicMock(return_value=True),
+        },
+    ):
+        ret = efi.present("Debian", "\\EFI\\debian\\grub.efi", index=0)
+        assert ret["result"] is True
+        assert "new" in ret["changes"]
+
+
+def test_present_already_exists():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.list_entries": MagicMock(return_value={"0001": {"label": "Debian"}}),
+        },
+    ):
+        ret = efi.present("Debian", "\\EFI\\debian\\grub.efi")
+        assert ret["result"] is True
+        assert "already present" in ret["comment"]
+
+
+def test_present_already_exists_update_order():
+    # Mocking: Entry exists, boot order needs change, set_bootorder succeeds
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.list_entries": MagicMock(return_value={"0001": {"label": "Debian"}}),
+            # Current order: ["0002", "0001"]. Desired index=0 means ["0001", "0002"]
+            "efi.get_bootorder": MagicMock(
+                side_effect=[["0002", "0001"], ["0002", "0001"]]
+            ),
+            "efi.set_bootorder": MagicMock(return_value=True),
+        },
+    ):
+        ret = efi.present("Debian", "\\EFI\\debian\\grub.efi", index=0)
+        assert ret["result"] is True
+        assert "bootorder" in ret["changes"]
+        assert "Boot order updated" in ret["comment"]
+
+
+def test_absent_existing_entry():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.list_entries": MagicMock(return_value={"0001": {"label": "Debian"}}),
+            "efi.remove_entry": MagicMock(return_value=True),
+        },
+    ):
+        ret = efi.absent("Debian")
+        assert ret["result"] is True
+        assert "removed" in ret["comment"]
+        assert "old" in ret["changes"]
+
+
+def test_absent_already_absent():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.list_entries": MagicMock(return_value={}),
+        },
+    ):
+        ret = efi.absent("Debian")
+        assert ret["result"] is True
+        assert "already absent" in ret["comment"]
+
+
+def test_order_set():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.get_bootorder": MagicMock(return_value=["0002", "0001"]),
+            "efi.set_bootorder": MagicMock(return_value=True),
+        },
+    ):
+        ret = efi.order_set("set_order", ["0001", "0002"])
+        assert ret["result"] is True
+        assert "old" in ret["changes"]
+        assert "new" in ret["changes"]
+
+
+def test_order_set_already_correct():
+    with patch(
+        "salt.states.efi.__salt__",
+        {
+            "efi.get_bootorder": MagicMock(return_value=["0001", "0002"]),
+        },
+    ):
+        ret = efi.order_set("set_order", ["0001", "0002"])
+        assert ret["result"] is True
+        assert "already set" in ret["comment"]


### PR DESCRIPTION
### What does this PR do?

Add a new module `salt.modules.efi` to manage EFI entries, and the associated `salt.states.efi`. Only the `linux` platform is supported, and `efibootmgr` is a hard dependency.

### Merge requirements satisfied?
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes