### PR TITLE
Fix Docker 409 when starting vault functional test container

### DIFF
--- a/changelog/68961.fixed.md
+++ b/changelog/68961.fixed.md
@@ -1,0 +1,4 @@
+Fixed Docker 409 "name already in use" errors when creating the vault
+functional test container by using a unique random container name via
+``random_string("vault-")``, preventing conflicts from stale containers
+left by interrupted runs or CI runner reuse.

--- a/tests/pytests/functional/modules/test_vault.py
+++ b/tests/pytests/functional/modules/test_vault.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 from saltfactories.daemons.container import Container
+from saltfactories.utils import random_string
 
 import salt.utils.path
 from tests.support.runtests import RUNTIME_VARS
@@ -83,7 +84,7 @@ def vault_container_version(request, salt_factories, vault_port, shell):
     }
 
     factory = salt_factories.get_container(
-        "vault",
+        random_string("vault-"),
         f"ghcr.io/saltstack/salt-ci-containers/vault:{vault_version}",
         check_ports=[vault_port],
         container_run_kwargs={


### PR DESCRIPTION
The vault functional tests used a fixed Docker container name `vault`, which triggers `409 Conflict` when a container with that name already exists (stale container from a failed/interrupted run, `pytest --lf` reruns, or CI runner reuse).

Use `saltfactories.utils.random_string("vault-")` for the container name, matching the pattern used elsewhere (e.g. MySQL CI containers).

Refs: nightly functional failures on `test_vault.py` with Docker APIError 409.

