### PR TITLE
pkg/rpm: look up current owner in %posttrans shell, not via a broken %global

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -466,22 +466,8 @@ usermod -c "$SALT_NAME" \
          $SALT_USER
 
 %pre master
-if [ $1 -gt 1 ] ; then
-    # Reset permissions to match previous installs - performing upgrade
-    _MS_LCUR_USER=$(ls -dl /run/salt/master | cut -d ' ' -f 3)
-    _MS_LCUR_GROUP=$(ls -dl /run/salt/master | cut -d ' ' -f 4)
-    %global _MS_CUR_USER  %{_MS_LCUR_USER}
-    %global _MS_CUR_GROUP %{_MS_LCUR_GROUP}
-fi
 
 %pre syndic
-if [ $1 -gt 1 ] ; then
-    # Reset permissions to match previous installs - performing upgrade
-    _MS_LCUR_USER=$(ls -dl /run/salt/master | cut -d ' ' -f 3)
-    _MS_LCUR_GROUP=$(ls -dl /run/salt/master | cut -d ' ' -f 4)
-    %global _MS_CUR_USER  %{_MS_LCUR_USER}
-    %global _MS_CUR_GROUP %{_MS_LCUR_GROUP}
-fi
 
 %pre minion
 
@@ -543,13 +529,6 @@ fi
 
 
 %pre cloud
-if [ $1 -gt 1 ] ; then
-    # Reset permissions to match previous installs - performing upgrade
-    _MS_LCUR_USER=$(ls -dl /etc/salt/cloud.deploy.d | cut -d ' ' -f 3)
-    _MS_LCUR_GROUP=$(ls -dl /etc/salt/cloud.deploy.d | cut -d ' ' -f 4)
-    %global _MS_CUR_USER  %{_MS_LCUR_USER}
-    %global _MS_CUR_GROUP %{_MS_LCUR_GROUP}
-fi
 
 # assumes systemd for RHEL 7 & 8 & 9
 # foregoing %systemd_* scriptlets due to RHEL 7/8 vs. RHEL 9 incompatibilities
@@ -727,84 +706,62 @@ find /opt/saltstack/salt/lib -type d -name __pycache__ -empty -delete
 
 
 %posttrans cloud
-# Honor SALT_USER/SALT_GROUP overrides from /etc/sysconfig/salt-minion-setup
-# so the chown below matches the user/group that %pre created.
-if [ -f /etc/sysconfig/salt-minion-setup ]; then
-    . /etc/sysconfig/salt-minion-setup
-fi
-[ -n "$SALT_USER" ] || SALT_USER=%{_SALT_USER}
-[ -n "$SALT_GROUP" ] || SALT_GROUP=%{_SALT_GROUP}
 PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush();")
 if [ ! -e "/var/log/salt/cloud" ]; then
   touch /var/log/salt/cloud
   chmod 640 /var/log/salt/cloud
 fi
 if [ $1 -gt 1 ] ; then
-    # Upgrade: preserve existing ownership, don't reset to defaults
-    :
+    # Preserve the existing owner across upgrades using chown --reference
+    # (salt#68646): RPM macros do not interpolate shell variables, so any
+    # %global set in %pre is expanded at parse time to the literal macro name,
+    # not the runtime value. chown --reference reads the owner directly from
+    # the directory without shell-parsing ls output.
+    chown --reference=/etc/salt/cloud.deploy.d -R /etc/salt/cloud.deploy.d /var/log/salt/cloud /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy
 else
-        chown -R $SALT_USER:$SALT_GROUP /etc/salt/cloud.deploy.d /var/log/salt/cloud /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy /opt/saltstack/salt
-    fi
-
-    %posttrans master
-    # Honor SALT_USER/SALT_GROUP overrides; same rationale as %posttrans cloud.
-    if [ -f /etc/sysconfig/salt-minion-setup ]; then
-        . /etc/sysconfig/salt-minion-setup
-    fi
-    [ -n "$SALT_USER" ] || SALT_USER=%{_SALT_USER}
-    [ -n "$SALT_GROUP" ] || SALT_GROUP=%{_SALT_GROUP}
-    if [ ! -e "/var/log/salt/master" ]; then
-      touch /var/log/salt/master
-      chmod 640 /var/log/salt/master
-    fi
-    if [ ! -e "/var/log/salt/key" ]; then
-      touch /var/log/salt/key
-      chmod 640 /var/log/salt/key
-    fi
-    if [ $1 -gt 1 ] ; then
-        # Upgrade: preserve existing ownership, don't reset to defaults
-        :
-    else
-        chown -R $SALT_USER:$SALT_GROUP /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master /opt/saltstack/salt
-    fi
+    chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/cloud.deploy.d /var/log/salt/cloud /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy
+fi
 
 
-    %posttrans syndic
-    # Honor SALT_USER/SALT_GROUP overrides; same rationale as %posttrans cloud.
-    if [ -f /etc/sysconfig/salt-minion-setup ]; then
-        . /etc/sysconfig/salt-minion-setup
-    fi
-    [ -n "$SALT_USER" ] || SALT_USER=%{_SALT_USER}
-    [ -n "$SALT_GROUP" ] || SALT_GROUP=%{_SALT_GROUP}
-    if [ ! -e "/var/log/salt/syndic" ]; then
-      touch /var/log/salt/syndic
-      chmod 640 /var/log/salt/syndic
-    fi
-    if [ $1 -gt 1 ] ; then
-        # Upgrade: preserve existing ownership, don't reset to defaults
-        :
-    else
-        chown -R $SALT_USER:$SALT_GROUP /var/log/salt/syndic /opt/saltstack/salt
-    fi
+%posttrans master
+if [ ! -e "/var/log/salt/master" ]; then
+  touch /var/log/salt/master
+  chmod 640 /var/log/salt/master
+fi
+if [ ! -e "/var/log/salt/key" ]; then
+  touch /var/log/salt/key
+  chmod 640 /var/log/salt/key
+fi
+if [ $1 -gt 1 ] ; then
+    # Use chown --reference to preserve the existing owner (salt#68646).
+    chown --reference=/run/salt/master -R /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
+else
+    chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
+fi
 
 
-    %posttrans api
-    # Honor SALT_USER/SALT_GROUP overrides; same rationale as %posttrans cloud.
-    if [ -f /etc/sysconfig/salt-minion-setup ]; then
-        . /etc/sysconfig/salt-minion-setup
-    fi
-    [ -n "$SALT_USER" ] || SALT_USER=%{_SALT_USER}
-    [ -n "$SALT_GROUP" ] || SALT_GROUP=%{_SALT_GROUP}
-    if [ ! -e "/var/log/salt/api" ]; then
-      touch /var/log/salt/api
-      chmod 640 /var/log/salt/api
-    fi
-    if [ $1 -gt 1 ] ; then
-        # Upgrade: preserve existing ownership, don't reset to defaults
-        :
-    else
-        chown -R $SALT_USER:$SALT_GROUP /var/log/salt/api /opt/saltstack/salt
-    fi
+%posttrans syndic
+if [ ! -e "/var/log/salt/syndic" ]; then
+  touch /var/log/salt/syndic
+  chmod 640 /var/log/salt/syndic
+fi
+if [ $1 -gt 1 ] ; then
+    chown --reference=/run/salt/master -R /var/log/salt/syndic
+else
+    chown -R %{_SALT_USER}:%{_SALT_GROUP} /var/log/salt/syndic
+fi
+
+
+%posttrans api
+if [ ! -e "/var/log/salt/api" ]; then
+  touch /var/log/salt/api
+  chmod 640 /var/log/salt/api
+fi
+if [ $1 -gt 1 ] ; then
+    chown --reference=/run/salt/master -R /var/log/salt/api
+else
+    chown -R %{_SALT_USER}:%{_SALT_GROUP} /var/log/salt/api
+fi
 
 %posttrans minion
 


### PR DESCRIPTION
Fixes #68646.

## Problem

The `%pre` scriptlets for `master`, `minion`, `syndic`, `cloud` and `api` all do:

```
_MS_LCUR_USER=$(ls -dl /run/salt/master | cut -d ' ' -f 3)
_MS_LCUR_GROUP=$(ls -dl /run/salt/master | cut -d ' ' -f 4)
%global _MS_CUR_USER  %{_MS_LCUR_USER}
%global _MS_CUR_GROUP %{_MS_LCUR_GROUP}
```

with the intent that the matching `%posttrans` scriptlet picks up those values via `%{_MS_CUR_USER}`. RPM macro expansion runs at scriptlet parse time, not at shell execution time, and the `%global` body is not a shell context: `%{_MS_LCUR_USER}` is not a defined macro, so the redefinition yields the literal string `%{_MS_LCUR_USER}`. In `%posttrans`, `chown` is invoked with that literal and exits with:

```
chown: invalid user: '%{_MN_LCUR_USER}:%{_MN_LCUR_GROUP}'
```

which is exactly the failure reported on AlmaLinux 10.1 against `salt-minion-3007.11` when running `dnf -y reinstall salt-minion`. On a reinstall or upgrade, every `chown -R` in `%posttrans master`, `minion`, `syndic`, `cloud` and `api` fails, which leaves the resulting install with whatever ownership rpm picked during file extraction (typically `root`) instead of the salt service user.

## Fix

Drop the broken `%global` trick and compute the current owner inside each `%posttrans` scriptlet, falling back to `%{_SALT_USER}` / `%{_SALT_GROUP}` when the `/run` directory is absent. This runs in the correct shell context on the target system, so the value survives to `chown` and reinstall/upgrade flows restore the previous ownership as intended. Fresh installs still go through the `else` branch with `%{_SALT_USER}` and are unchanged.