### PR TITLE
docs(file state): fix 'crete' -> 'create' typo in directory clean example

### DIFF
--- a/changelog/68316.fixed.md
+++ b/changelog/68316.fixed.md
@@ -1,0 +1,1 @@
+Fix typo ("crete" -> "create") in docstring example for `file.directory` state in `salt/states/file.py`.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4264,7 +4264,7 @@ def directory(
     Because ``cmd.run`` has no way of communicating that it's creating a file,
     ``will_always_clean`` will remove the newly created file. Of course, every
     time the states run the same thing will happen - the
-    ``silly_way_of_creating_a_file`` will crete the file and
+    ``silly_way_of_creating_a_file`` will create the file and
     ``will_always_clean`` will always remove it. Over and over again, no matter
     how many times you run it.
 


### PR DESCRIPTION
## Summary

Fix one-word typo inside the `salt.states.file.directory` docstring example
(`salt/states/file.py` line 4267):

Before:
```
``silly_way_of_creating_a_file`` will crete the file and
```

After:
```
``silly_way_of_creating_a_file`` will create the file and
```

The example is rendered on https://docs.saltproject.io under
`salt.states.file.directory`, so this also fixes the published docs.

Added `changelog/68316.fixed.md` per `CONTRIBUTING.rst`.

Closes #68316

## Testing

Documentation-only change — no code paths affected. No tests run.