### PR TITLE
states/docker_container: pass temp_container_name, not the dict, to _replace

### DIFF
--- a/changelog/68959.fixed.md
+++ b/changelog/68959.fixed.md
@@ -1,0 +1,6 @@
+Fix `docker_container.running` destroying the original container on the
+`force=True` / `skip_comparison` path by passing the temp container's dict
+instead of its name to `_replace`. `docker.rename` then failed after
+`docker.rm` had already removed the original, leaving the minion with the
+temp container stranded under its generated name. `_replace` now receives
+`temp_container_name` on both call sites, matching the non-force path.

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -2005,7 +2005,7 @@ def running(
         if not exists:
             comments.append(f"Created container '{name}'")
         else:
-            if not _replace(name, temp_container):
+            if not _replace(name, temp_container_name):
                 ret["result"] = False
                 return _format_comments(ret, comments)
         ret["changes"].setdefault("container_id", {})["added"] = temp_container["Id"]

--- a/tests/pytests/unit/states/test_docker_container.py
+++ b/tests/pytests/unit/states/test_docker_container.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for the docker_container state module.
+"""
+
+import pytest
+
+import salt.states.docker_container as docker_state
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        docker_state: {
+            "__opts__": {"test": False},
+            "__context__": {},
+        },
+    }
+
+
+def _running_state_salt(temp_container, *, current_image_id="img-original"):
+    """
+    Build a ``__salt__`` mapping sufficient to drive the ``running`` state
+    through to the ``skip_comparison`` / force-replace branch where the
+    pre-existing container is replaced by the temp container.
+    """
+    return {
+        "docker.resolve_image_id": MagicMock(return_value="img-new"),
+        "docker.inspect_container": MagicMock(return_value={"Image": current_image_id}),
+        "docker.state": MagicMock(return_value="running"),
+        "docker.create": MagicMock(return_value=temp_container),
+        "docker.rm": MagicMock(return_value=["mycontainer"]),
+        "docker.rename": MagicMock(return_value=True),
+        "docker.start": MagicMock(return_value={"state": {"new": "running"}}),
+        "docker.compare_container_networks": MagicMock(return_value={}),
+        "config.option": MagicMock(return_value={}),
+    }
+
+
+def test_running_force_replace_passes_temp_container_name_to_rename():
+    """
+    Regression test for issue #68959: on the ``force=True`` /
+    ``skip_comparison`` path of ``docker_container.running``, the local
+    ``_replace(orig, new)`` helper must receive ``temp_container_name``
+    (a string), not the dict returned by ``docker.create``.
+
+    Prior to the fix, ``_replace`` was called with the dict, which was
+    then forwarded as the first positional argument to ``docker.rename``.
+    ``docker.rename`` calls ``inspect_container`` on that argument, so it
+    raised on the dict -- after ``docker.rm`` had already removed the
+    original container, leaving the minion with the original destroyed
+    and the temp container stranded under its generated name.
+
+    This test pins the contract by asserting ``docker.rename`` is called
+    with a string container name, not a dict. It fails on the buggy code
+    (the first positional arg is a dict) and passes after the fix.
+    """
+    temp_container = {"Name": "Salt_Temp_abc123", "Id": "deadbeef"}
+    salt_mocks = _running_state_salt(temp_container)
+
+    with patch.dict(docker_state.__dict__, {"__salt__": salt_mocks}):
+        ret = docker_state.running(
+            name="mycontainer",
+            image="myimage",
+            force=True,
+        )
+
+    # Sanity: we actually exercised the force-replace path.
+    salt_mocks["docker.rm"].assert_called()
+    salt_mocks["docker.rename"].assert_called_once()
+
+    # The bug: docker.rename(new, orig). ``new`` must be a string
+    # (``temp_container["Name"]``), not the dict returned by docker.create.
+    call_args, _ = salt_mocks["docker.rename"].call_args
+    assert call_args[0] == temp_container["Name"], (
+        "docker.rename's first positional arg should be temp_container_name "
+        f"(a string), got {call_args[0]!r}"
+    )
+    assert not isinstance(call_args[0], dict), (
+        "docker.rename was called with a dict (the temp container struct) "
+        "instead of the temp container name; this is the #68959 bug"
+    )
+
+    # And the second positional is the target name we asked to replace.
+    assert call_args[1] == "mycontainer"
+
+    assert ret["result"] is True


### PR DESCRIPTION
### What does this PR do?

Fixes a wrong-argument bug in `salt/states/docker_container.py`'s `running()` state.

`running()` creates a temp container from `docker.create` and captures two related values:

- `temp_container`, the full dict returned by `docker.create`
- `temp_container_name`, `temp_container["Name"]`, a string

The detected-config-diff path correctly passes the string to the local `_replace(orig, new)` helper:

```python
if not _replace(name, temp_container_name):
```

The `skip_comparison` / `force=True` path (also reached from `mod_watch`) passed the dict instead:

```python
if not _replace(name, temp_container):  # <-- wrong argument
```

`_replace` immediately calls `docker.rm(name, stop=True)` on the *original* container and then `docker.rename(new, orig)`. `docker.rename`'s first argument is forwarded to `inspect_container`, which expects a string name/ID. Handing it a dict raises a `CommandExecutionError`, and by then the original container has already been removed. The state returns `result: False`, but the minion is left with the original container destroyed and the temp container stranded under its generated temp name.

This PR passes `temp_container_name` on the second call site too, matching the first path.

### What issues does this PR fix or reference?

Fixes #68959

### Previous Behavior

`docker_container.running` with `force=True` (or triggered via `mod_watch`) on an existing container whose spec matches the desired spec would:

1. Remove the original container via `docker.rm`.
2. Fail to rename the temp container (`docker.rename` raises on the dict argument).
3. Return `result: False` with the original container destroyed and the temp container present but renamed to something like `Salt_Temp_XXXX`.

### New Behavior

`_replace(name, temp_container_name)` is called with the string container name on both paths. The force-replace path now correctly swaps the temp container into place, matching the non-force path's behaviour.

### Merge requirements satisfied?

- [x] Changelog: `changelog/68959.fixed.md`
- [ ] Tests, this is a pure wrong-argument fix that mirrors the existing `_replace(name, temp_container_name)` call site at line ~1890. Happy to add a targeted regression test against `docker.rename` if maintainers prefer.

### Commits signed with GPG?

Commits are DCO-signed off (`Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>`) per the repository's contribution flow.