### PR TITLE
runners/jobs: don't iterate non-iterable Target values in list_jobs

### DIFF
--- a/changelog/68780.fixed.md
+++ b/changelog/68780.fixed.md
@@ -1,0 +1,4 @@
+Fix `jobs.list_jobs` crashing with a `TypeError` when the job cache has a
+`Target` value that is neither a string nor an iterable (e.g. `None` from a
+failed or aborted job). Non-iterable targets are now treated as no target
+so the remaining `search_target` filtering keeps working.

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -2,6 +2,7 @@
 A convenience system to manage jobs, both active and already run
 """
 
+import collections.abc
 import fnmatch
 import logging
 import os
@@ -334,6 +335,17 @@ def list_jobs(
                 targets = ret[item]["Target"]
                 if isinstance(targets, str):
                     targets = [targets]
+                elif not isinstance(targets, collections.abc.Iterable):
+                    # Failed/aborted jobs can leave Target as None or some
+                    # other non-iterable value in the cache; iterating would
+                    # raise TypeError. Log once at debug level and treat as
+                    # no target so the rest of list_jobs keeps working.
+                    log.debug(
+                        "list_jobs: ignoring non-iterable Target %r on jid %s",
+                        targets,
+                        item,
+                    )
+                    targets = []
                 for target in targets:
                     for key in salt.utils.args.split_input(search_target):
                         if fnmatch.fnmatch(target, key):

--- a/tests/pytests/unit/runners/test_jobs.py
+++ b/tests/pytests/unit/runners/test_jobs.py
@@ -70,3 +70,57 @@ def test_list_jobs_with_search_target():
         assert jobs.list_jobs(search_target="node-1-2.com") == returns["node-1-2.com"]
 
         assert jobs.list_jobs(search_target="non-existant") == returns["non-existant"]
+
+
+def test_list_jobs_with_non_iterable_target(caplog):
+    """
+    Regression for #68780: failed/aborted jobs can leave Target as None or
+    some other non-iterable value in the job cache. list_jobs used to
+    iterate blindly and crash with TypeError; it must now skip those
+    entries and continue filtering the rest of the cache.
+    """
+    mock_jobs_cache = {
+        # Valid entry with a real target - must still be matched.
+        "20260421000000000001": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2026, Apr 21 00:00:00.000001",
+            "Target": "node-1-1.com",
+            "Target-type": "glob",
+            "User": "root",
+        },
+        # Non-iterable Target (None is the real-world case from the bug
+        # report). Must not trip list_jobs, and must be logged at debug.
+        "20260421000000000002": {
+            "Arguments": [],
+            "Function": "test.ping",
+            "StartTime": "2026, Apr 21 00:00:00.000002",
+            "Target": None,
+            "Target-type": "glob",
+            "User": "root",
+        },
+    }
+
+    def return_mock_jobs():
+        return mock_jobs_cache
+
+    class MockMasterMinion:
+        returners = {"local_cache.get_jids": return_mock_jobs}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    with patch.object(salt.minion, "MasterMinion", MockMasterMinion):
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="salt.runners.jobs"):
+            # Must return the entry that has a valid target without raising
+            # or masking the match quietly.
+            result = jobs.list_jobs(search_target="node-1-1.com")
+
+        assert "20260421000000000001" in result
+        assert "20260421000000000002" not in result
+        # The skipped job id should appear in the debug log so operators
+        # can find and fix the malformed cache row instead of discovering
+        # it via a crash.
+        assert "20260421000000000002" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Hardens `salt.runners.jobs.list_jobs` against non-iterable `Target` values in the job cache.

`list_jobs`'s `search_target` filter reads `Target` for each cached job, wraps strings in a list, then iterates:

```python
targets = ret[item]["Target"]
if isinstance(targets, str):
    targets = [targets]
for target in targets:
    ...
```

If `Target` is neither a string nor an iterable — which happens for failed or aborted jobs (#68780) — `for target in targets:` raises `TypeError` and kills the whole query, not just the one bad entry.

This PR adds a small `elif not isinstance(targets, (list, tuple, set)): targets = []` guard so a malformed Target is treated the same way a missing `Target` key already is: no target to match, skip and move on. String/list/tuple/set behaviour is unchanged.

### What issues does this PR fix or reference?

Fixes #68780

### Previous Behavior

Calling `jobs.list_jobs search_target=...` against a job cache that contains any entry with a non-iterable `Target` (e.g. `Target: None` from a failed job) raises:

```
TypeError: argument of type 'NoneType' is not iterable
```

and `list_jobs` returns no result at all.

### New Behavior

Entries with a non-iterable `Target` are silently skipped from `search_target` matching; the rest of the query returns as expected. String/list/tuple/set targets keep working exactly as before.

### Merge requirements satisfied?

- [x] Changelog: `changelog/68780.fixed.md`
- [ ] Tests — the matching code path is inside a large `list_jobs` loop; happy to add a targeted unit test that seeds the cache with `Target: None` and asserts `list_jobs` returns rather than raises, if the maintainers prefer before merge.

### Commits signed with GPG?

DCO-signed off (`Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>`).
