### PR TITLE
utils/systemd: stop using capture_output so Python 3.6 targets keep working

### DIFF
--- a/changelog/68778.fixed.md
+++ b/changelog/68778.fixed.md
@@ -1,0 +1,4 @@
+Fix `salt.utils.systemd` using `subprocess.run(capture_output=True)`, which was
+added in Python 3.7, so salt-ssh targets that still have Python 3.6 available
+can import the module. Replaced with the equivalent `stdout=subprocess.PIPE`,
+`stderr=subprocess.PIPE` form.

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -90,10 +90,14 @@ def status(context=None):
             return context[contextkey]
     elif context is not None:
         raise SaltInvocationError("context must be a dictionary if passed")
+    # Use stdout=/stderr=PIPE rather than capture_output so this module
+    # works on the python 3.6 interpreters that salt-ssh still has to
+    # tolerate on older distros (#68778). capture_output is 3.7+.
     proc = subprocess.run(
         ["systemctl", "status"],
         check=False,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     ret = (
         b"Failed to get D-Bus connection: No such file or directory" not in proc.stderr
@@ -175,7 +179,8 @@ def _pid_to_service_systemctl(pid):
             systemd_cmd,
             check=True,
             text=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         status_json = salt.utils.json.find_json(systemd_output.stdout)
     except (ValueError, subprocess.CalledProcessError):


### PR DESCRIPTION
### What does this PR do?

Replaces the two `subprocess.run(..., capture_output=True)` calls in `salt/utils/systemd.py` with the older-compatible `stdout=subprocess.PIPE, stderr=subprocess.PIPE` form.

`capture_output` was added in Python 3.7. salt-ssh still advertises 3.6 as a possible target python on older distros (see #68778), so the two call sites in `_status()` and `_pid_to_service_systemctl` would raise `TypeError` the moment they executed on a 3.6 remote — which is exactly what the reporter hits.

Behaviour on 3.7+ is unchanged.

### What issues does this PR fix or reference?

Fixes #68778

### Previous Behavior

On salt-ssh runs where the remote happens to still be on Python 3.6, any `salt.utils.systemd` import path that touched `_status` or `_pid_to_service_systemctl` raised:

```
TypeError: __init__() got an unexpected keyword argument 'capture_output'
```

### New Behavior

Both helpers now build the pipes explicitly:

```python
subprocess.run(
    ["systemctl", "status"],
    check=False,
    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,
)
```

### Merge requirements satisfied?

- [x] Changelog: `changelog/68778.fixed.md`
- [ ] Tests — the two call sites shell out to `systemctl`, which isn't straightforward to unit-test without an extra fixture. Happy to add one if the maintainers prefer before merge.

### Commits signed with GPG?

DCO-signed off (`Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>`).
