### PR TITLE
states/docker_container: pass temp container name, not dict, to _replace

### DIFF
--- a/changelog/68959.fixed.md
+++ b/changelog/68959.fixed.md
@@ -1,0 +1,13 @@
+Fix `docker_container.running` destroying the original container on the
+force-replace / `mod_watch` path.
+
+The `skip_comparison` branch called the local `_replace(name, temp_container)`
+helper with `temp_container`, the dict returned by `docker.create`, instead
+of the temp container's name. `_replace` forwards its second arg to
+`docker.rename`, which passes it to `inspect_container` — a dict raises
+`TypeError` at that point, *after* `docker.rm` has already stopped and
+removed the original container. The minion is left with the original
+container destroyed and the temp container stranded under its generated
+temporary name. The other `_replace` call site (the detected-config-diff
+path at line ~1890) already passed `temp_container_name`; this change
+aligns the force-replace path with it.

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -2005,7 +2005,13 @@ def running(
         if not exists:
             comments.append(f"Created container '{name}'")
         else:
-            if not _replace(name, temp_container):
+            # _replace expects container names/IDs (strings) — it forwards the
+            # second arg to docker.rename, which passes it to inspect_container.
+            # Passing the temp_container dict raises TypeError after the
+            # original container has already been removed, stranding the temp
+            # container under its generated name. Use temp_container_name to
+            # match the other _replace call site at line ~1890.
+            if not _replace(name, temp_container_name):
                 ret["result"] = False
                 return _format_comments(ret, comments)
         ret["changes"].setdefault("container_id", {})["added"] = temp_container["Id"]


### PR DESCRIPTION
### What does this PR do?

Fixes `docker_container.running` destroying the original container on the force-replace / `mod_watch` path.

The `skip_comparison` branch at line 2008 called the local `_replace(name, temp_container)` helper with `temp_container` — the dict returned by `docker.create` — instead of the temp container's name. `_replace` forwards its second arg to `docker.rename`, which passes it to `inspect_container`. A dict raises `TypeError` there, but only **after** `docker.rm(name, stop=True)` has already removed the original container. The minion is left with the original container destroyed and the temp container stranded under its generated temp name. The state returns `result: False` but the damage is done.

The other `_replace` call site (the detected-config-diff path at line ~1890) already passed `temp_container_name`. This PR aligns the force-replace path with it.

### What issues does this PR fix or reference?

Fixes #68959

### Previous Behavior

Running `docker_container.running` with `force: True` (or via `mod_watch`) on an existing container caused the original container to be destroyed and a temp container left stranded, requiring manual cleanup.

### New Behavior

`_replace` now receives the temp container's name, so `docker.rename` succeeds and the replacement completes atomically.

### Merge requirements satisfied?

- [x] Changelog entry added: `changelog/68959.fixed.md`

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
