### PR TITLE
crypt: clean_key the master pub before signing the pre-computed signature

### DIFF
--- a/changelog/68930.fixed.md
+++ b/changelog/68930.fixed.md
@@ -1,0 +1,13 @@
+Fix `master_use_pubkey_signature: True` always failing signature verification.
+
+`crypt.gen_signature` signed the raw bytes of `master.pub`, which include
+the trailing newline that `cryptography`'s PEM encoder writes per RFC 7468.
+The auth reply path, however, sends the public key through `clean_key()`
+which strips that trailing newline. As a result the minion verified a
+signature computed over a 451-byte input against a 450-byte public key and
+always reported "signature verification failed!" -- regardless of which
+signing backend was in use.
+
+Apply `clean_key()` to the public-key bytes before signing so the signed
+payload matches what the master actually transmits and what the minion
+actually verifies.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -409,6 +409,16 @@ def gen_signature(priv_path, pub_path, sign_path, passphrase=None):
     with salt.utils.files.fopen(pub_path) as fp_:
         mpub_64 = fp_.read()
 
+    # Sign the canonical PEM that the master will ship to minions. The
+    # auth reply path goes through MasterKeys.get_pub_str(), which applies
+    # clean_key() to strip the PEM trailing newline before putting the
+    # public key on the wire. If we sign the raw file here we embed that
+    # trailing "\n" in the signed bytes, and minion-side verification
+    # against the clean_key()'d pub_key always fails with "signature
+    # verification failed!" (#68930). Apply clean_key() up front so the
+    # signed bytes match what the minion actually checks.
+    mpub_64 = clean_key(mpub_64)
+
     mpub_sig = sign_message(priv_path, mpub_64, passphrase)
     mpub_sig_64 = binascii.b2a_base64(mpub_sig)
     if os.path.isfile(sign_path):


### PR DESCRIPTION
### What does this PR do?

Fixes `master_use_pubkey_signature: True` always failing signature verification regardless of signing backend.

`crypt.gen_signature` signs the raw bytes of `master.pub`, which include the trailing newline `cryptography`'s PEM encoder writes per RFC 7468. The auth reply path, however, ships the public key through `clean_key()` (`MasterKeys.get_pub_str`) which strips that trailing newline. The minion then verifies a signature computed over a 451-byte input against a 450-byte public key and always reports `"signature verification failed!"`.

Apply `clean_key()` to the public-key bytes before signing so the signed payload matches what the master transmits and what the minion actually verifies.

### What issues does this PR fix or reference?

Fixes #68930

### Previous Behavior

Pre-computed master pubkey signatures never verified. Dynamic signing (without `master_use_pubkey_signature`) still worked because it signs the bytes returned by `get_pub_str()` directly.

### New Behavior

Pre-computed signatures verify correctly. Dynamic signing path unchanged.

### Merge requirements satisfied?

- [x] Changelog entry added: `changelog/68930.fixed.md`

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
