### PR TITLE
add V1 task creation for windows schedule tasks

### DIFF
--- a/changelog/68983.added.md
+++ b/changelog/68983.added.md
@@ -1,0 +1,1 @@
+Add ability to create V1 scheduled tasks in Windows

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -108,6 +108,8 @@ duration = {
     "4 hours": "PT4H",
     "8 hours": "PT8H",
     "12 hours": "PT12H",
+    "24 hours": "PT24H",
+    "72 hours": "PT72H",
     "1 day": ["P1D", "PT24H"],
     "3 days": ["P3D", "PT72H"],
     "30 days": "P30D",
@@ -168,6 +170,7 @@ results = {
     0x800704DD: "The service is not available (Run only when logged in?)",
     0xC000013A: "The application terminated as a result of CTRL+C",
     0xC06D007E: "Unknown software exception",
+    0x8007045B: "A shutdown is in progress",
 }
 
 
@@ -527,7 +530,7 @@ def list_actions(name, location="\\"):
 
 
 def create_task(
-    name, location="\\", user_name="System", password=None, force=False, **kwargs
+    name, location="\\", user_name="System", password=None, force=False, compatibility=2, **kwargs
 ):
     r"""
     Create a new task in the designated location. This function has many keyword
@@ -566,6 +569,11 @@ def create_task(
             If the task exists, overwrite the existing task.
 
             Default is ``False``.
+
+        compatibility (:obj:`int`, optional):
+            The task compatibility level
+
+            Default is 2
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``.
@@ -852,6 +860,7 @@ def edit_task(
     force_stop=None,
     delete_after=None,
     multiple_instances=None,
+    compatibility=None,
     **kwargs,
 ):
     r"""
@@ -1067,6 +1076,16 @@ def edit_task(
 
             Default is ``None``.
 
+        compatibility (:obj:`int`, optional):
+            Sets the task compatibility level. Valid values are:
+            
+            - 0
+            - 1
+            - 2
+            - 3
+
+            Default is ``None``.
+
     Returns:
         bool: ``True`` if successful, otherwise ``False``.
 
@@ -1145,6 +1164,8 @@ def edit_task(
         # Settings: General Tab
         if hidden is not None:
             task_definition.Settings.Hidden = hidden
+        if compatibility:
+            task_definition.Settings.Compatibility = compatibility
 
         # Settings: Conditions Tab (Idle)
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380669(v=vs.85).aspx
@@ -2461,7 +2482,7 @@ def add_trigger(
         if trigger_types[trigger_type] == TASK_TRIGGER_EVENT:
             # Check for required kwargs
             if kwargs.get("subscription", False):
-                trigger.Id = "Event_ID1"
+                trigger.Id = "Event_{}".format(kwargs.get("subscription"))
                 trigger.Subscription = kwargs.get("subscription")
             else:
                 return 'Required parameter "subscription" not passed'
@@ -2471,12 +2492,12 @@ def add_trigger(
 
         # Daily Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_DAILY:
-            trigger.Id = "Daily_ID1"
+            trigger.Id = "Daily__{}".format(start_boundary)
             trigger.DaysInterval = kwargs.get("days_interval", 1)
 
         # Weekly Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_WEEKLY:
-            trigger.Id = "Weekly_ID1"
+            trigger.Id = "Weekly_{}".format(start_boundary)
             trigger.WeeksInterval = kwargs.get("weeks_interval", 1)
             if kwargs.get("days_of_week", False):
                 bits_days = 0
@@ -2488,7 +2509,7 @@ def add_trigger(
 
         # Monthly Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_MONTHLY:
-            trigger.Id = "Monthly_ID1"
+            trigger.Id = "Monthly_{}".format(start_boundary)
             if kwargs.get("months_of_year", False):
                 bits_months = 0
                 for month in kwargs.get("months_of_year"):

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -2482,7 +2482,7 @@ def add_trigger(
         if trigger_types[trigger_type] == TASK_TRIGGER_EVENT:
             # Check for required kwargs
             if kwargs.get("subscription", False):
-                trigger.Id = f"Event_{wargs.get('subscription')}"
+                trigger.Id = f"Event_{kwargs.get('subscription')}"
                 trigger.Subscription = kwargs.get("subscription")
             else:
                 return 'Required parameter "subscription" not passed'

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -530,7 +530,13 @@ def list_actions(name, location="\\"):
 
 
 def create_task(
-    name, location="\\", user_name="System", password=None, force=False, compatibility=2, **kwargs
+    name,
+    location="\\",
+    user_name="System",
+    password=None,
+    force=False,
+    compatibility=2,
+    **kwargs,
 ):
     r"""
     Create a new task in the designated location. This function has many keyword
@@ -571,9 +577,15 @@ def create_task(
             Default is ``False``.
 
         compatibility (:obj:`int`, optional):
-            The task compatibility level
+            The task compatibility level. Determines which versions of Windows
+            the task is compatible with. Valid values are:
 
-            Default is 2
+            - 0: Windows Server 2003, Windows XP, or Windows 2000
+            - 1: Windows Vista, Windows Server 2008 (V1 task)
+            - 2: Windows 7, Windows Server 2008 R2 (V2 task, default)
+            - 3: Windows 10
+
+            Default is ``2``.
 
     Returns:
         bool: ``True`` if successful, otherwise ``False``.
@@ -602,6 +614,7 @@ def create_task(
             task_definition=task_definition,
             user_name=user_name,
             password=password,
+            compatibility=compatibility,
             **kwargs,
         )
 
@@ -1077,12 +1090,13 @@ def edit_task(
             Default is ``None``.
 
         compatibility (:obj:`int`, optional):
-            Sets the task compatibility level. Valid values are:
-            
-            - 0
-            - 1
-            - 2
-            - 3
+            Sets the task compatibility level. Determines which versions of
+            Windows the task is compatible with. Valid values are:
+
+            - 0: Windows Server 2003, Windows XP, or Windows 2000
+            - 1: Windows Vista, Windows Server 2008 (V1 task)
+            - 2: Windows 7, Windows Server 2008 R2 (V2 task)
+            - 3: Windows 10
 
             Default is ``None``.
 
@@ -1164,7 +1178,7 @@ def edit_task(
         # Settings: General Tab
         if hidden is not None:
             task_definition.Settings.Hidden = hidden
-        if compatibility:
+        if compatibility is not None:
             task_definition.Settings.Compatibility = compatibility
 
         # Settings: Conditions Tab (Idle)

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -2482,7 +2482,7 @@ def add_trigger(
         if trigger_types[trigger_type] == TASK_TRIGGER_EVENT:
             # Check for required kwargs
             if kwargs.get("subscription", False):
-                trigger.Id = "Event_{}".format(kwargs.get("subscription"))
+                trigger.Id = f"Event_{wargs.get('subscription')}"
                 trigger.Subscription = kwargs.get("subscription")
             else:
                 return 'Required parameter "subscription" not passed'
@@ -2492,12 +2492,12 @@ def add_trigger(
 
         # Daily Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_DAILY:
-            trigger.Id = "Daily__{}".format(start_boundary)
+            trigger.Id = f"Daily__{start_boundary}"
             trigger.DaysInterval = kwargs.get("days_interval", 1)
 
         # Weekly Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_WEEKLY:
-            trigger.Id = "Weekly_{}".format(start_boundary)
+            trigger.Id = f"Weekly_{start_boundary}"
             trigger.WeeksInterval = kwargs.get("weeks_interval", 1)
             if kwargs.get("days_of_week", False):
                 bits_days = 0
@@ -2509,7 +2509,7 @@ def add_trigger(
 
         # Monthly Trigger Parameters
         elif trigger_types[trigger_type] == TASK_TRIGGER_MONTHLY:
-            trigger.Id = "Monthly_{}".format(start_boundary)
+            trigger.Id = f"Monthly_{start_boundary}"
             if kwargs.get("months_of_year", False):
                 bits_months = 0
                 for month in kwargs.get("months_of_year"):

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -578,7 +578,8 @@ def create_task(
 
         compatibility (:obj:`int`, optional):
             The task compatibility level. Determines which versions of Windows
-            the task is compatible with. Valid values are:
+            the task is compatible with. Corresponds to the ``Configure for``
+            dropdown in the Task Scheduler GUI. Valid values are:
 
             - 0: Windows Server 2003, Windows XP, or Windows 2000
             - 1: Windows Vista, Windows Server 2008 (V1 task)
@@ -1091,7 +1092,9 @@ def edit_task(
 
         compatibility (:obj:`int`, optional):
             Sets the task compatibility level. Determines which versions of
-            Windows the task is compatible with. Valid values are:
+            Windows the task is compatible with. Corresponds to the
+            ``Configure for`` dropdown in the Task Scheduler GUI. Valid values
+            are:
 
             - 0: Windows Server 2003, Windows XP, or Windows 2000
             - 1: Windows Vista, Windows Server 2008 (V1 task)

--- a/tests/pytests/unit/modules/test_win_task_compatibility.py
+++ b/tests/pytests/unit/modules/test_win_task_compatibility.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for the compatibility parameter in win_task.create_task and
+win_task.edit_task. These tests use mocks and run on any platform.
+"""
+
+import sys
+import types
+
+import pytest
+
+from tests.support.mock import MagicMock, patch
+
+# Inject a stub win32com into sys.modules if not already present so that
+# salt.modules.win_task can be imported on non-Windows hosts.
+if "win32com" not in sys.modules:
+    _win32com = types.ModuleType("win32com")
+    _win32com_client = types.ModuleType("win32com.client")
+    _win32com_client.Dispatch = MagicMock()
+    _win32com.client = _win32com_client
+    sys.modules["win32com"] = _win32com
+    sys.modules["win32com.client"] = _win32com_client
+if "pythoncom" not in sys.modules:
+    sys.modules["pythoncom"] = types.ModuleType("pythoncom")
+if "pywintypes" not in sys.modules:
+    sys.modules["pywintypes"] = types.ModuleType("pywintypes")
+
+import salt.modules.win_task as win_task  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "compatibility",
+    [
+        0,  # Windows 2000/XP/2003
+        1,  # Windows Vista/2008 (V1 task)
+        2,  # Windows 7/2008 R2 (V2 task)
+        3,  # Windows 10
+    ],
+)
+def test_edit_task_compatibility(compatibility):
+    """
+    edit_task sets Settings.Compatibility to the given value when a
+    task_definition is passed directly (no COM lookup needed).
+    """
+    mock_task_def = MagicMock()
+    mock_task_def.Principal.UserID = "SYSTEM"
+    mock_task_def.Principal.LogonType = 5  # TASK_LOGON_SERVICE_ACCOUNT
+
+    with patch("salt.utils.winapi.Com", MagicMock()):
+        win_task.edit_task(
+            task_definition=mock_task_def,
+            compatibility=compatibility,
+        )
+
+    assert mock_task_def.Settings.Compatibility == compatibility
+
+
+def test_edit_task_compatibility_none_leaves_unset():
+    """
+    edit_task does not touch Settings.Compatibility when compatibility=None.
+    """
+    mock_task_def = MagicMock()
+    mock_task_def.Principal.UserID = "SYSTEM"
+    mock_task_def.Principal.LogonType = 5
+
+    # Snapshot the auto-generated MagicMock child before the call
+    sentinel = mock_task_def.Settings.Compatibility
+
+    with patch("salt.utils.winapi.Com", MagicMock()):
+        win_task.edit_task(
+            task_definition=mock_task_def,
+            compatibility=None,
+        )
+
+    # If the branch was skipped, the attribute is still the same mock object
+    assert mock_task_def.Settings.Compatibility is sentinel
+
+
+def test_create_task_passes_compatibility_to_edit_task():
+    """
+    create_task forwards its compatibility= argument to edit_task so that
+    Settings.Compatibility is set on the new task definition.
+    """
+    mock_task_def = MagicMock()
+    mock_task_def.Principal.UserID = "SYSTEM"
+    mock_task_def.Principal.LogonType = 5
+
+    mock_task_service = MagicMock()
+    mock_task_service.NewTask.return_value = mock_task_def
+
+    with (
+        patch("salt.utils.winapi.Com", MagicMock()),
+        patch.object(
+            win_task.win32com.client, "Dispatch", return_value=mock_task_service
+        ),
+        patch.object(win_task, "list_tasks", return_value=[]),
+        patch.object(win_task, "add_action", return_value=True),
+        patch.object(win_task, "add_trigger", return_value=True),
+        patch.object(win_task, "_save_task_definition", return_value=True),
+    ):
+        win_task.create_task(
+            "TestTask",
+            user_name="System",
+            force=True,
+            compatibility=1,
+            action_type="Execute",
+            cmd="cmd.exe",
+        )
+
+    assert mock_task_def.Settings.Compatibility == 1


### PR DESCRIPTION
### What does this PR do?
Add the ability to create V1 scheduled tasks in Windows using the compatibility argument
### What issues does this PR fix or reference?
Fixes

### Previous Behavior
All tasks were V2 tasks

### New Behavior
The default is V2 but this can be overriden with the compatibility argument

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
