### PR TITLE
debpkg include 0/1 as valid options when parsing bool values in deb822

### DIFF
--- a/changelog/68996.fixed.md
+++ b/changelog/68996.fixed.md
@@ -1,0 +1,1 @@
+debpkg include 0/1 as valid options when parsing bool values in deb822

--- a/salt/utils/pkg/deb.py
+++ b/salt/utils/pkg/deb.py
@@ -24,9 +24,9 @@ def string_to_bool(s):
     if isinstance(s, bool):
         return s
     s = s.lower()
-    if s in ("no", "false", "without", "off", "disable"):
+    if s in ("no", "false", "without", "off", "disable", "0"):
         return False
-    elif s in ("yes", "true", "with", "on", "enable"):
+    elif s in ("yes", "true", "with", "on", "enable", "1"):
         return True
     raise ValueError(f"Unable to convert to boolean: {s}")
 

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -253,7 +253,7 @@ def deb822_repo_bool_false_file(
     disabled_line = f"Enabled: {request.param}\n"
     repo = tmp_path / "sources.list.d" / "test.sources"
     repo.parent.mkdir(parents=True, exist_ok=True)
-    repo.write_text(f"{deb822_repo_content}\n{disabled_line}", encoding="UTF-8")
+    repo.write_text(f"{deb822_repo_content}{disabled_line}", encoding="UTF-8")
     return repo
 
 
@@ -268,12 +268,12 @@ def deb822_repo_bool_true_file(
     enabled_line = f"Enabled: {request.param}\n"
     repo = tmp_path / "sources.list.d" / "test.sources"
     repo.parent.mkdir(parents=True, exist_ok=True)
-    repo.write_text(f"{deb822_repo_content}\n{enabled_line}", encoding="UTF-8")
+    repo.write_text(f"{deb822_repo_content}{enabled_line}", encoding="UTF-8")
     return repo
 
 
 @pytest.fixture
-def mock_apt_config(deb822_repo_file: pathlib.Path, tmp_path: pathlib.Path):
+def mock_apt_config(request, tmp_path: pathlib.Path):
     """
     Mocking common to deb822 testing so that apt_pkg uses the
     tmp_path/sources.list.d as the sourceparts location
@@ -285,7 +285,7 @@ def mock_apt_config(deb822_repo_file: pathlib.Path, tmp_path: pathlib.Path):
         {"config.option": MagicMock()},
     ) as mock_config, patch(
         "salt.utils.pkg.deb._APT_SOURCES_PARTSDIR",
-        os.path.dirname(str(deb822_repo_file)),
+        os.path.dirname(str(request.getfixturevalue(request.param))),
     ), patch(
         "salt.utils.pkg.deb._APT_SOURCES_LIST",
         str(tmp_sources_list),
@@ -293,6 +293,7 @@ def mock_apt_config(deb822_repo_file: pathlib.Path, tmp_path: pathlib.Path):
         yield mock_config
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
 def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can modify an existing repository in the deb822 format.
@@ -308,6 +309,7 @@ def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config)
     assert f"URIs: {uri}" in repo_file
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
 def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can add a repository in the deb822 format.
@@ -321,6 +323,7 @@ def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
     assert f"URIs: {uri}" in repo_file
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
 def test_del_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can delete a repository in the deb822 format.
@@ -341,6 +344,7 @@ def test_del_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
         assert not os.path.isfile(str(deb822_repo_file))
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
 def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can match a repository in the deb822 format.
@@ -354,6 +358,7 @@ def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     assert result["uri"] == uri
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_bool_false_file'], indirect=True)
 def test_get_repo_deb822_with_false(
     deb822_repo_bool_false_file: pathlib.Path, mock_apt_config
 ):
@@ -369,6 +374,7 @@ def test_get_repo_deb822_with_false(
     assert result["enabled"] is False
 
 
+@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_bool_true_file'], indirect=True)
 def test_get_repo_deb822_with_true(
     deb822_repo_bool_true_file: pathlib.Path, mock_apt_config
 ):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -293,7 +293,7 @@ def mock_apt_config(request, tmp_path: pathlib.Path):
         yield mock_config
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
+@pytest.mark.parametrize("mock_apt_config", ["deb822_repo_file"], indirect=True)
 def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can modify an existing repository in the deb822 format.
@@ -309,7 +309,7 @@ def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config)
     assert f"URIs: {uri}" in repo_file
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
+@pytest.mark.parametrize("mock_apt_config", ["deb822_repo_file"], indirect=True)
 def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can add a repository in the deb822 format.
@@ -323,7 +323,7 @@ def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
     assert f"URIs: {uri}" in repo_file
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
+@pytest.mark.parametrize("mock_apt_config", ["deb822_repo_file"], indirect=True)
 def test_del_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can delete a repository in the deb822 format.
@@ -344,7 +344,7 @@ def test_del_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
         assert not os.path.isfile(str(deb822_repo_file))
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_file'], indirect=True)
+@pytest.mark.parametrize("mock_apt_config", ["deb822_repo_file"], indirect=True)
 def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     """
     Test that aptpkg can match a repository in the deb822 format.
@@ -358,7 +358,9 @@ def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
     assert result["uri"] == uri
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_bool_false_file'], indirect=True)
+@pytest.mark.parametrize(
+    "mock_apt_config", ["deb822_repo_bool_false_file"], indirect=True
+)
 def test_get_repo_deb822_with_false(
     deb822_repo_bool_false_file: pathlib.Path, mock_apt_config
 ):
@@ -374,7 +376,9 @@ def test_get_repo_deb822_with_false(
     assert result["enabled"] is False
 
 
-@pytest.mark.parametrize('mock_apt_config', ['deb822_repo_bool_true_file'], indirect=True)
+@pytest.mark.parametrize(
+    "mock_apt_config", ["deb822_repo_bool_true_file"], indirect=True
+)
 def test_get_repo_deb822_with_true(
     deb822_repo_bool_true_file: pathlib.Path, mock_apt_config
 ):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -370,7 +370,7 @@ def test_get_repo_deb822_with_false(
 
 
 def test_get_repo_deb822_with_true(
-    deb822_repo_bool_false_file: pathlib.Path, mock_apt_config
+    deb822_repo_bool_true_file: pathlib.Path, mock_apt_config
 ):
     """
     Test that aptpkg can parse False correctly.

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -240,6 +240,38 @@ def deb822_repo_file(tmp_path: pathlib.Path, deb822_repo_content: str):
     return repo
 
 
+@pytest.fixture(
+    params=["no", "false", "without", "off", "disable", "DisAble", "WithOUT", "0"]
+)
+def deb822_repo_bool_false_file(
+    request, tmp_path: pathlib.Path, deb822_repo_content: str
+):
+    """
+    Create a Debian-style repository in the deb822 format with a False bool and return
+    the path of the repository file.
+    """
+    disabled_line = f"Enabled: {request.param}\n"
+    repo = tmp_path / "sources.list.d" / "test.sources"
+    repo.parent.mkdir(parents=True, exist_ok=True)
+    repo.write_text(f"{deb822_repo_content}\n{disabled_line}", encoding="UTF-8")
+    return repo
+
+
+@pytest.fixture(params=["yes", "true", "with", "on", "enable", "EnAble", "With", "1"])
+def deb822_repo_bool_true_file(
+    request, tmp_path: pathlib.Path, deb822_repo_content: str
+):
+    """
+    Create a Debian-style repository in the deb822 format with a True bool and return
+    the path of the repository file.
+    """
+    enabled_line = f"Enabled: {request.param}\n"
+    repo = tmp_path / "sources.list.d" / "test.sources"
+    repo.parent.mkdir(parents=True, exist_ok=True)
+    repo.write_text(f"{deb822_repo_content}\n{enabled_line}", encoding="UTF-8")
+    return repo
+
+
 @pytest.fixture
 def mock_apt_config(deb822_repo_file: pathlib.Path, tmp_path: pathlib.Path):
     """
@@ -320,6 +352,36 @@ def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
 
     assert bool(result)
     assert result["uri"] == uri
+
+
+def test_get_repo_deb822_with_false(
+    deb822_repo_bool_false_file: pathlib.Path, mock_apt_config
+):
+    """
+    Test that aptpkg can parse False correctly.
+    """
+    uri = "http://cz.archive.ubuntu.com/ubuntu/"
+    repo = f"deb {uri} noble main"
+
+    result = aptpkg.get_repo(repo)
+
+    assert bool(result)
+    assert result["enabled"] is False
+
+
+def test_get_repo_deb822_with_true(
+    deb822_repo_bool_false_file: pathlib.Path, mock_apt_config
+):
+    """
+    Test that aptpkg can parse False correctly.
+    """
+    uri = "http://cz.archive.ubuntu.com/ubuntu/"
+    repo = f"deb {uri} noble main"
+
+    result = aptpkg.get_repo(repo)
+
+    assert bool(result)
+    assert result["enabled"] is False
 
 
 def test_version(lowpkg_info_var):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -381,7 +381,7 @@ def test_get_repo_deb822_with_true(
     result = aptpkg.get_repo(repo)
 
     assert bool(result)
-    assert result["enabled"] is False
+    assert result["enabled"] is True
 
 
 def test_version(lowpkg_info_var):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #68996

### Previous Behavior
Stacktrace occurred when a deb file was parsed when "0" or "1" were used as False / True

### New Behavior
Stacktrace no longer occurs

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
