### PR TITLE
  Windows cmd.run: gate prepend_cmd quoting for win_runas only; fix test_cmd_builtins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ htmlcov/
 /*.iml
 *.sublime-project
 *.sublime-workspace
+.cursor
+.cursorrules
 
 # ignore ctags file
 tags

--- a/changelog/68448.fixed.md
+++ b/changelog/68448.fixed.md
@@ -1,0 +1,1 @@
+Quote cmd.exe /c payloads on Windows so compound commands (e.g. cd ... & dir) work with runas; with cmd.exe, that wrapping is applied whenever runas is set, not only when python_shell is true

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -419,11 +419,13 @@ def _run(
             ):
                 cmd = _prep_powershell_cmd(win_shell, cmd, encoded_cmd)
             elif any(win_shell_lower.endswith(word) for word in ["cmd.exe"]):
-                # runas uses win_runas/CreateProcess*; the user command must be the
-                # single quoted argument to cmd /c (see prepend_cmd) so & | etc.
-                # are handled by cmd.exe, not split by shlex or the outer process.
+                # win_runas uses CreateProcess*; the user string must be one quoted
+                # /c argument (see prepend_cmd). Subprocess/TimedProc does not need
+                # that wrap; apply it only when runas is set.
                 if python_shell or runas:
-                    cmd = salt.platform.win.prepend_cmd(win_shell, cmd)
+                    cmd = salt.platform.win.prepend_cmd(
+                        win_shell, cmd, quote_c_payload=bool(runas)
+                    )
                     # prepend_cmd may have silently converted -Command { } to
                     # -EncodedCommand; treat that the same as encoded_cmd=True so
                     # the CLIXML PowerShell emits to stderr is suppressed.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -419,7 +419,10 @@ def _run(
             ):
                 cmd = _prep_powershell_cmd(win_shell, cmd, encoded_cmd)
             elif any(win_shell_lower.endswith(word) for word in ["cmd.exe"]):
-                if python_shell:
+                # runas uses win_runas/CreateProcess*; the user command must be the
+                # single quoted argument to cmd /c (see prepend_cmd) so & | etc.
+                # are handled by cmd.exe, not split by shlex or the outer process.
+                if python_shell or runas:
                     cmd = salt.platform.win.prepend_cmd(win_shell, cmd)
                     # prepend_cmd may have silently converted -Command { } to
                     # -EncodedCommand; treat that the same as encoded_cmd=True so

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -419,12 +419,27 @@ def _run(
             ):
                 cmd = _prep_powershell_cmd(win_shell, cmd, encoded_cmd)
             elif any(win_shell_lower.endswith(word) for word in ["cmd.exe"]):
-                # win_runas uses CreateProcess*; the user string must be one quoted
-                # /c argument (see prepend_cmd). Subprocess/TimedProc does not need
-                # that wrap; apply it only when runas is set.
+                # win_runas: use CreateProcess-style one ``/c`` argument (see
+                # ``prepend_cmd``) only when the line can be misparsed at the
+                # process boundary: argv lists (e.g. :func:`script`) and plain
+                # ``cmd.exe /c path`` lines are fine with list2cmdline + unquoted
+                # /c; compound ``&``/``|`` *strings* need the extra wrap. Literal
+                # paths with spaces but no metacharacters must stay unwrapped.
+                win_cmd_is_argv = isinstance(cmd, (list, tuple))
+                win_cmd_needs_cswitch = (
+                    bool(runas)
+                    and (not win_cmd_is_argv)
+                    and (
+                        python_shell
+                        or (isinstance(cmd, str) and (("&" in cmd) or ("|" in cmd)))
+                    )
+                )
                 if python_shell or runas:
                     cmd = salt.platform.win.prepend_cmd(
-                        win_shell, cmd, quote_c_payload=bool(runas)
+                        win_shell,
+                        cmd,
+                        quote_c_payload=win_cmd_needs_cswitch,
+                        msvc_quote_bare_path_string=bool(runas) and (not python_shell),
                     )
                     # prepend_cmd may have silently converted -Command { } to
                     # -EncodedCommand; treat that the same as encoded_cmd=True so

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -501,6 +501,8 @@ def get_user_sid(username):
 
         salt '*' user.get_user_sid jsnuffy
     """
+    if not isinstance(username, str):
+        username = str(username)
     domain = win32api.GetComputerName()
     if username.find("\\") != -1:
         domain = username.split("\\")[0]

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1341,14 +1341,26 @@ def CreateProcessWithLogonW(
     return process_info
 
 
+def _cmd_exe_cswitch_quoted_argument(payload: str) -> str:
+    """
+    Wrap ``payload`` for use as the argument to ``cmd.exe``'s ``/c`` switch.
+
+    Doubles embedded double quotes per ``cmd.exe`` parsing rules so the entire
+    payload is one argument when passed through ``CreateProcess`` /
+    ``CreateProcessWithTokenW`` command lines (so ``&``, ``|``, etc. are not
+    parsed at the outer process level).
+    """
+    return '"' + payload.replace('"', '""') + '"'
+
+
 def prepend_cmd(win_shell, cmd):
     """
     Prep cmd when shell is cmd.exe. Always use a command string instead of a
     list to satisfy both CreateProcess and CreateProcessWithToken.
 
-    cmd must be double-quoted to ensure proper handling of space characters.
-    The first opening quote and the closing quote are stripped automatically by
-    the Win32 API.
+    The user payload is wrapped in double quotes after ``/c`` so compound
+    commands (e.g. ``cd /d ... & dir``) and paths with spaces behave correctly
+    under ``CreateProcessWithTokenW``.
     """
     if isinstance(cmd, (list, tuple)):
         args = subprocess.list2cmdline(cmd)
@@ -1363,9 +1375,7 @@ def prepend_cmd(win_shell, cmd):
         # object instead of executing it. Converting to -EncodedCommand avoids this
         # and also sidesteps cmd.exe quoting issues with double quotes inside the block.
         args = _maybe_encode_powershell_block(args)
-    new_cmd = f"{win_shell} /c {args}"
-
-    return new_cmd
+    return f"{win_shell} /c {_cmd_exe_cswitch_quoted_argument(args)}"
 
 
 # Matches: powershell[-Command { block }] when the block is the last argument.

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1353,14 +1353,25 @@ def _cmd_exe_cswitch_quoted_argument(payload: str) -> str:
     return '"' + payload.replace('"', '""') + '"'
 
 
-def prepend_cmd(win_shell, cmd):
+def prepend_cmd(win_shell, cmd, quote_c_payload=True):
     """
     Prep cmd when shell is cmd.exe. Always use a command string instead of a
-    list to satisfy both CreateProcess and CreateProcessWithToken.
+    list to satisfy both :class:`subprocess.Popen` and CreateProcess.
 
-    The user payload is wrapped in double quotes after ``/c`` so compound
-    commands (e.g. ``cd /d ... & dir``) and paths with spaces behave correctly
-    under ``CreateProcessWithTokenW``.
+    Args:
+        win_shell: Path to ``cmd.exe``.
+        cmd: String or argv sequence. Lists/tuples are passed through
+            ``list2cmdline`` first.
+        quote_c_payload: If ``True`` (default), wrap the entire user payload
+            in double quotes after ``/c`` and double internal double quotes so
+            the whole command is a single argument (required for
+            ``CreateProcessWithTokenW`` and :mod:`win_runas <salt.utils.win_runas>`).
+            If ``False``, use ``cmd /c`` plus the raw payload (no outer wrap) so
+            command parsing matches the normal :class:`subprocess` / ``TimedProc``
+            path (e.g. ``set /p`` and special characters).
+
+    Returns:
+        A full command line string starting with ``win_shell``.
     """
     if isinstance(cmd, (list, tuple)):
         args = subprocess.list2cmdline(cmd)
@@ -1375,6 +1386,8 @@ def prepend_cmd(win_shell, cmd):
         # object instead of executing it. Converting to -EncodedCommand avoids this
         # and also sidesteps cmd.exe quoting issues with double quotes inside the block.
         args = _maybe_encode_powershell_block(args)
+    if not quote_c_payload:
+        return f"{win_shell} /c {args}"
     return f"{win_shell} /c {_cmd_exe_cswitch_quoted_argument(args)}"
 
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -19,18 +19,13 @@ import subprocess
 from ctypes import wintypes
 
 # pylint: disable=3rd-party-module-not-gated
-try:
-    import ntsecuritycon
-    import psutil
-    import win32api
-    import win32con
-    import win32process
-    import win32security
-    import win32service
-
-    HAS_PYWIN32 = True
-except ImportError:
-    HAS_PYWIN32 = False
+import ntsecuritycon
+import psutil
+import win32api
+import win32con
+import win32process
+import win32security
+import win32service
 
 # pylint: enable=3rd-party-module-not-gated
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1164,8 +1164,8 @@ def CreateProcessWithTokenW(
         ctypes.byref(startupinfo),
         ctypes.byref(process_info),
     )
-    winerr = win32api.GetLastError()
     if ret == 0:
+        winerr = win32api.GetLastError()
         exc = OSError(win32api.FormatMessage(winerr))
         exc.winerror = winerr
         raise exc

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1118,7 +1118,7 @@ def grant_winsta_and_desktop(th):
     """
     current_sid = win32security.GetTokenInformation(th, win32security.TokenUser)[0]
     # Add permissions for the sid to the current windows station and thread id.
-    # This prevents windows error 0xC0000142.
+    # This prevents Windows error 0xC0000142.
     winsta = win32process.GetProcessWindowStation()
     set_user_perm(winsta, WINSTA_ALL, current_sid)
     desktop = win32service.GetThreadDesktop(win32api.GetCurrentThreadId())
@@ -1164,8 +1164,8 @@ def CreateProcessWithTokenW(
         ctypes.byref(startupinfo),
         ctypes.byref(process_info),
     )
+    winerr = win32api.GetLastError()
     if ret == 0:
-        winerr = win32api.GetLastError()
         exc = OSError(win32api.FormatMessage(winerr))
         exc.winerror = winerr
         raise exc
@@ -1343,11 +1343,12 @@ def CreateProcessWithLogonW(
 
 def prepend_cmd(win_shell, cmd):
     """
-    Prep cmd when shell is cmd.exe. Always use a command string instead of a list to satisfy
-    both CreateProcess and CreateProcessWithToken.
+    Prep cmd when shell is cmd.exe. Always use a command string instead of a
+    list to satisfy both CreateProcess and CreateProcessWithToken.
 
-    cmd must be double-quoted to ensure proper handling of space characters. The first opening
-    quote and the closing quote are stripped automatically by the Win32 API.
+    cmd must be double-quoted to ensure proper handling of space characters.
+    The first opening quote and the closing quote are stripped automatically by
+    the Win32 API.
     """
     if isinstance(cmd, (list, tuple)):
         args = subprocess.list2cmdline(cmd)

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -19,13 +19,18 @@ import subprocess
 from ctypes import wintypes
 
 # pylint: disable=3rd-party-module-not-gated
-import ntsecuritycon
-import psutil
-import win32api
-import win32con
-import win32process
-import win32security
-import win32service
+try:
+    import ntsecuritycon
+    import psutil
+    import win32api
+    import win32con
+    import win32process
+    import win32security
+    import win32service
+
+    HAS_PYWIN32 = True
+except ImportError:
+    HAS_PYWIN32 = False
 
 # pylint: enable=3rd-party-module-not-gated
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1353,7 +1353,12 @@ def _cmd_exe_cswitch_quoted_argument(payload: str) -> str:
     return '"' + payload.replace('"', '""') + '"'
 
 
-def prepend_cmd(win_shell, cmd, quote_c_payload=True):
+def prepend_cmd(
+    win_shell,
+    cmd,
+    quote_c_payload=True,
+    msvc_quote_bare_path_string=False,
+):
     """
     Prep cmd when shell is cmd.exe. Always use a command string instead of a
     list to satisfy both :class:`subprocess.Popen` and CreateProcess.
@@ -1366,9 +1371,19 @@ def prepend_cmd(win_shell, cmd, quote_c_payload=True):
             in double quotes after ``/c`` and double internal double quotes so
             the whole command is a single argument (required for
             ``CreateProcessWithTokenW`` and :mod:`win_runas <salt.utils.win_runas>`).
-            If ``False``, use ``cmd /c`` plus the raw payload (no outer wrap) so
-            command parsing matches the normal :class:`subprocess` / ``TimedProc``
-            path (e.g. ``set /p`` and special characters).
+            If ``False``, use ``cmd /c`` without the big ``_cmd_exe_cswitch`` wrap
+            (so batch ``%1``/``%2`` match the non-runas path). A *string* without
+            ``&``/``|`` is then either passed raw (so ``echo "a b"`` works with
+            ``python_shell``) or as one :func:`subprocess.list2cmdline` token
+            (see *msvc_quote_bare_path_string*). Compound *strings* use the
+            raw tail so ``cmd`` still parses ``&`` and ``|``. List/tuple payloads
+            use ``list2cmdline`` as above.
+        msvc_quote_bare_path_string: When ``quote_c_payload`` is false and
+            *cmd* is a string, if true and the payload has no ``&``/``|``,
+            wrap the entire string with ``list2cmdline`` so a *single* path
+            with spaces is one token (``runas`` and no ``python_shell``). If
+            false (default), use the string as the raw ``/c`` tail (e.g.
+            ``python_shell`` and ``echo`` with quotes).
 
     Returns:
         A full command line string starting with ``win_shell``.
@@ -1387,7 +1402,16 @@ def prepend_cmd(win_shell, cmd, quote_c_payload=True):
         # and also sidesteps cmd.exe quoting issues with double quotes inside the block.
         args = _maybe_encode_powershell_block(args)
     if not quote_c_payload:
-        return f"{win_shell} /c {args}"
+        if isinstance(cmd, (list, tuple)):
+            c_payload = args
+        else:
+            if ("&" in args) or ("|" in args):
+                c_payload = args
+            elif msvc_quote_bare_path_string:
+                c_payload = subprocess.list2cmdline([args])
+            else:
+                c_payload = args
+        return f"{win_shell} /c {c_payload}"
     return f"{win_shell} /c {_cmd_exe_cswitch_quoted_argument(args)}"
 
 

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -9,7 +9,6 @@ import os
 import subprocess
 import time
 
-import salt.platform.win
 import salt.utils.path
 from salt.exceptions import CommandExecutionError
 

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -1,5 +1,10 @@
 """
-Run processes as a different user in Windows
+Run child processes as another Windows user.
+
+The main entry points are :func:`runas` (starts the child with
+``CreateProcessWithTokenW`` when the minion can obtain a privileged context) and
+:func:`runas_unpriv` (uses ``CreateProcessWithLogonW`` as a fallback). Both are
+used from :mod:`salt.modules.cmdmod` when ``runas`` is set on Windows.
 """
 
 # Import Python Libraries
@@ -35,7 +40,17 @@ log = logging.getLogger(__name__)
 
 
 def _preview_cmd(cmd, max_len=500):
-    """Shorten command lines for log messages (not for execution)."""
+    """
+    Shorten a command line for safe logging (full line is never executed from
+    this helper).
+
+    Args:
+        cmd: Command string; non-strings are formatted with ``repr()``.
+        max_len: Maximum length before truncation; an ellipsis is appended.
+
+    Returns:
+        Truncated string suitable for debug log lines.
+    """
     s = cmd if isinstance(cmd, str) else repr(cmd)
     if len(s) > max_len:
         return s[:max_len] + "…"
@@ -46,7 +61,11 @@ def _preview_cmd(cmd, max_len=500):
 # loader.
 def __virtual__():
     """
-    Only load if Win32 Libraries are installed
+    Load this module only when PyWin32 (and related imports) succeeded.
+
+    Returns:
+        The string ``win_runas`` on success, or ``(False, reason)`` when
+        required imports failed so the loader should skip the module.
     """
     if not HAS_WIN32:
         return False, "This utility requires pywin32"
@@ -56,7 +75,17 @@ def __virtual__():
 
 def split_username(username):
     """
-    Splits out the username from the domain name and returns both.
+    Parse domain-style account names into a plain user name and domain.
+
+    Accepts UPN (``user@domain``), down-level (``DOMAIN\\user``), or a bare
+    name (domain becomes ``.`` for local accounts).
+
+    Args:
+        username: Account string; non-strings are coerced with ``str()`` at the
+            start of this function.
+
+    Returns:
+        A ``(user_name, domain)`` pair suitable for ``LogonUser`` and family.
     """
     domain = "."
     user_name = str(username)
@@ -72,13 +101,28 @@ def split_username(username):
 
 def create_env(user_token, inherit=False, timeout=1):
     """
-    CreateEnvironmentBlock might fail when we close a login session and then
-    try to re-open one very quickly. Run the method multiple times to work
-    around the async nature of logoffs.
+    Build a user environment block for ``CreateProcess*`` using
+    ``CreateEnvironmentBlock``.
 
-    Intentionally does not call LoadUserProfile/UnloadUserProfile: that path
-    can block for a long time (e.g. first logon) and is unnecessary for
-    building an environment block for the token we already hold.
+    Retries for up to ``timeout`` seconds if the call fails (e.g. logon/logoff
+    races). Does not use ``LoadUserProfile`` / ``UnloadUserProfile``: that can
+    block for a long time and is not required when the caller already holds a
+    user token from ``LogonUser`` or similar.
+
+    Args:
+        user_token: Windows access token (handle) for the target user, as used
+            by ``win32profile.CreateEnvironmentBlock`` / ``CreateProcess*``.
+        inherit: Passed through to ``CreateEnvironmentBlock`` (whether to
+            inherit the environment of the process associated with
+            ``user_token``; typically ``False`` for an isolated child env).
+        timeout: If ``CreateEnvironmentBlock`` raises, retry until this many
+            seconds have elapsed since the first attempt, then give up.
+
+    Returns:
+        Environment data for the ``environment`` parameter to ``CreateProcess*``,
+        or ``None`` if no block was produced and there was no exception to
+        re-raise. On repeated failure, the last ``pywintypes.error`` may be
+        raised.
     """
     t0 = time.monotonic()
     log.debug("win_runas.create_env: begin inherit=%s timeout=%ss", inherit, timeout)
@@ -117,11 +161,36 @@ def create_env(user_token, inherit=False, timeout=1):
 
 def runas(cmd, username, password=None, cwd=None):
     """
-    Run a command as another user. If the process is running as an admin or
-    system account, this method does not require a password. Other
-    non-privileged accounts need to provide a password for the user to "runas".
-    Commands are run in with the highest level privileges possible for the
-    account provided.
+    Run ``cmd`` as ``username`` using a logon token and
+    ``CreateProcessWithTokenW``.
+
+    The minion must be able to impersonate ``SYSTEM`` (e.g. admin with
+    ``SeImpersonatePrivilege``) for the primary path. If that fails, this
+    delegates to :func:`runas_unpriv` (logon + ``CreateProcessWithLogonW``) so a
+    password is required for non-service accounts in that case.
+
+    The process is created suspended, the primary thread is resumed with
+    ``ResumeThread``, and stdout/stderr are read on helper threads while waiting
+    so large child output cannot fill the pipe and deadlock the parent.
+
+    Args:
+        cmd: Full process command line (string) or argv sequence; lists are
+            passed through ``subprocess.list2cmdline`` to build
+            ``lpCommandLine``.
+        username: Target account; UPN, ``DOMAIN\\user``, or local name. May be
+            non-string (e.g. numeric local user name) and is coerced to ``str``.
+        password: Password for ``LogonUser`` when required; may be omitted for
+            some service accounts and when S4U logon is used.
+        cwd: Optional working directory for the child (``lpCurrentDirectory``);
+            ``None`` uses the default for the new process.
+
+    Returns:
+        Dict with keys: ``pid``, ``retcode`` (if wait succeeded), ``stdout``,
+        ``stderr`` (empty strings on read failure).
+
+    Raises:
+        salt.exceptions.CommandExecutionError: If the account name cannot be
+            resolved (e.g. ``LookupAccountName`` failure).
     """
     # Sometimes this comes in as an int. LookupAccountName can't handle an int
     # Let's make it a string if it's anything other than a string
@@ -307,6 +376,7 @@ def runas(cmd, username, password=None, cwd=None):
         stderr_buf = []
 
         def _pump_pipecopy(handle, bucket, name):
+            """Read one inherited pipe end into *bucket* (list with one string)."""
             try:
                 fd = msvcrt.open_osfhandle(int(handle), os.O_RDONLY | os.O_TEXT)
                 with os.fdopen(fd, "r") as fh:
@@ -372,7 +442,29 @@ def runas(cmd, username, password=None, cwd=None):
 
 def runas_unpriv(cmd, username, password, cwd=None):
     """
-    Runas that works for non-privileged users
+    Run ``cmd`` as ``username`` using ``CreateProcessWithLogonW`` (with profile).
+
+    Used when :func:`runas` cannot use ``CreateProcessWithTokenW`` (e.g. no
+    SYSTEM impersonation). Requires ``password`` for the target account. Stdin
+    is inherited from the minion; stdout/stderr are collected from anonymous
+    pipes. Output is read after the process exit wait (acceptable for typical
+    output sizes; the privileged :func:`runas` path uses concurrent draining to
+    avoid pipe deadlocks on very large streams).
+
+    Args:
+        cmd: Command line string, or a list/tuple passed to
+            ``subprocess.list2cmdline``.
+        username: Target account; coerced to ``str`` if needed.
+        password: Password for ``CreateProcessWithLogonW`` (required).
+        cwd: Optional working directory for the child; ``None`` for default.
+
+    Returns:
+        Dict with ``pid``, ``retcode`` (if the process handle wait succeeded),
+        ``stdout``, and ``stderr`` strings.
+
+    Raises:
+        salt.exceptions.CommandExecutionError: If the account name cannot be
+            resolved.
     """
     # Sometimes this comes in as an int. LookupAccountName can't handle an int
     # Let's make it a string if it's anything other than a string

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -7,17 +7,10 @@ import ctypes
 import logging
 import os
 import subprocess
+import threading
 import time
 
-import salt.utils.path
 from salt.exceptions import CommandExecutionError
-
-try:
-    import psutil
-
-    HAS_PSUTIL = True
-except ImportError:
-    HAS_PSUTIL = False
 
 try:
     import msvcrt
@@ -41,14 +34,22 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+def _preview_cmd(cmd, max_len=500):
+    """Shorten command lines for log messages (not for execution)."""
+    s = cmd if isinstance(cmd, str) else repr(cmd)
+    if len(s) > max_len:
+        return s[:max_len] + "…"
+    return s
+
+
 # Although utils are often directly imported, it is also possible to use the
 # loader.
 def __virtual__():
     """
     Only load if Win32 Libraries are installed
     """
-    if not HAS_WIN32 or not HAS_PSUTIL:
-        return False, "This utility requires pywin32 and psutil"
+    if not HAS_WIN32:
+        return False, "This utility requires pywin32"
 
     return "win_runas"
 
@@ -69,42 +70,48 @@ def split_username(username):
     return str(user_name), str(domain)
 
 
-def create_env(username, user_token, inherit=False, timeout=1):
+def create_env(user_token, inherit=False, timeout=1):
     """
     CreateEnvironmentBlock might fail when we close a login session and then
     try to re-open one very quickly. Run the method multiple times to work
     around the async nature of logoffs.
+
+    Intentionally does not call LoadUserProfile/UnloadUserProfile: that path
+    can block for a long time (e.g. first logon) and is unnecessary for
+    building an environment block for the token we already hold.
     """
+    t0 = time.monotonic()
+    log.debug("win_runas.create_env: begin inherit=%s timeout=%ss", inherit, timeout)
     start = time.time()
     env = None
     exc = None
-    profile_info_dict = {"UserName": username}
-    try:
-        profile_handle = win32profile.LoadUserProfile(user_token, profile_info_dict)
-        while True:
-            try:
-                env = win32profile.CreateEnvironmentBlock(user_token, inherit)
-                if env is not None:
-                    break
-            except pywintypes.error as exc:
-                pass
-            else:
-                break
-            if time.time() - start > timeout:
-                break
-    except (win32api.error, pywintypes.error) as e:
-        msg = f"Failed to load user profile: {e}"
-        raise CommandExecutionError(msg)
-
-    try:
-        win32profile.UnloadUserProfile(user_token, profile_handle)
-    except (win32api.error, pywintypes.error) as e:
-        msg = f"Failed to unload user profile: {e}"
-        raise CommandExecutionError(msg)
-
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            env = win32profile.CreateEnvironmentBlock(user_token, inherit)
+        except pywintypes.error as exc:
+            log.debug(
+                "win_runas.create_env: CreateEnvironmentBlock attempt %s failed: %s",
+                attempt,
+                exc,
+            )
+        else:
+            break
+        if time.time() - start > timeout:
+            log.debug(
+                "win_runas.create_env: giving up after %s attempts in %.2fs",
+                attempt,
+                time.time() - start,
+            )
+            break
+    elapsed = time.monotonic() - t0
     if env is not None:
+        log.debug("win_runas.create_env: success in %.3fs", elapsed)
         return env
+    log.debug("win_runas.create_env: no environment block after %.3fs", elapsed)
     if exc is not None:
+        log.debug("win_runas.create_env: re-raising last CreateEnvironmentBlock error")
         raise exc
 
 
@@ -154,6 +161,14 @@ def runas(cmd, username, password=None, cwd=None):
         # Since it is called directly and not via the subprocess module,
         # the arguments must be processed manually.
         cmd = subprocess.list2cmdline(cmd)
+
+    log.debug(
+        "win_runas.runas: user=%r domain=%r cwd=%r cmdline=%s",
+        username,
+        domain,
+        cwd,
+        _preview_cmd(cmd),
+    )
 
     # Impersonation of the SYSTEM user failed. Fallback to an un-privileged
     # runas.
@@ -229,33 +244,38 @@ def runas(cmd, username, password=None, cwd=None):
     )
 
     # Create the environment for the user
-    env = create_env(username, user_token, inherit=False)
-    application_name = None
-    # TODO: Maybe it has something to do with applicationname
-    # application_name = salt.utils.path.which("cmd.exe")
-    # application_name = cmd
-    # import salt.utils.args
-    # if salt.utils.args.shlex_split(cmd)[0].endswith((".bat", "cmd", "cmd.exe")):
-    #     application_name = salt.utils.path.which("cmd.exe")
+    log.debug("win_runas.runas: building environment block for user token")
+    env = create_env(user_token, inherit=False)
 
     hProcess = None
     try:
         # Start the process in a suspended state.
+        log.debug("win_runas.runas: calling CreateProcessWithTokenW (suspended)")
+        t0 = time.monotonic()
         process_info = salt.platform.win.CreateProcessWithTokenW(
             int(user_token),
             logonflags=1,
-            applicationname=application_name,
+            applicationname=None,
             commandline=cmd,
             currentdirectory=cwd,
             creationflags=creationflags,
             startupinfo=startup_info,
             environment=env,
         )
+        log.debug(
+            "win_runas.runas: CreateProcessWithTokenW returned in %.3fs",
+            time.monotonic() - t0,
+        )
 
         hProcess = process_info.hProcess
         hThread = process_info.hThread
         dwProcessId = process_info.dwProcessId
         dwThreadId = process_info.dwThreadId
+        log.debug(
+            "win_runas.runas: new process pid=%s main_thread_id=%s",
+            dwProcessId,
+            dwThreadId,
+        )
 
         # We don't use these, so let's close the handle
         salt.platform.win.kernel32.CloseHandle(stdin_write.handle)
@@ -263,28 +283,81 @@ def runas(cmd, username, password=None, cwd=None):
         salt.platform.win.kernel32.CloseHandle(stderr_write.handle)
 
         ret = {"pid": dwProcessId}
-        # Resume the process
-        psutil.Process(dwProcessId).resume()
+        # CREATE_SUSPENDED: the primary thread must be resumed. psutil's
+        # process resume is not as reliable as ResumeThread on the handle
+        # returned in PROCESS_INFORMATION.
+        if hThread:
+            resume_count = win32process.ResumeThread(hThread)
+            log.debug(
+                "win_runas.runas: ResumeThread returned %s (previously-suspended count)",
+                resume_count,
+            )
+            if resume_count in (-1, 0xFFFFFFFF):
+                log.error(
+                    "win_runas.runas: ResumeThread failed; process may never run; "
+                    "if the next line logs an infinite wait, the child is likely still suspended"
+                )
+            win32api.CloseHandle(hThread)
+
+        # Read stdout/stderr in background threads *before* waiting on the
+        # process. If we WaitForSingleObject first then read, the child can
+        # fill the 64k pipe and block in WriteFile (e.g. huge ``dir`` output
+        # when ``cd`` failed) while the parent is stuck in Wait -- deadlock.
+        stdout_buf = []
+        stderr_buf = []
+
+        def _pump_pipecopy(handle, bucket, name):
+            try:
+                fd = msvcrt.open_osfhandle(int(handle), os.O_RDONLY | os.O_TEXT)
+                with os.fdopen(fd, "r") as fh:
+                    bucket.append(fh.read())
+            except OSError as exc:
+                log.debug("win_runas.runas: reading %s pipe: %s", name, exc)
+                bucket.append("")
+
+        t_out = threading.Thread(
+            target=_pump_pipecopy,
+            args=(stdout_read.handle, stdout_buf, "stdout"),
+        )
+        t_err = threading.Thread(
+            target=_pump_pipecopy,
+            args=(stderr_read.handle, stderr_buf, "stderr"),
+        )
+        t_out.start()
+        t_err.start()
+        log.debug(
+            "win_runas.runas: started pipe-drain threads for pid=%s", dwProcessId
+        )
 
         # Wait for the process to exit and get its return code.
+        log.debug(
+            "win_runas.runas: waiting for pid=%s to exit (infinite wait)",
+            dwProcessId,
+        )
+        t_wait = time.monotonic()
         if (
             win32event.WaitForSingleObject(hProcess, win32event.INFINITE)
             == win32con.WAIT_OBJECT_0
         ):
+            log.debug(
+                "win_runas.runas: WaitForSingleObject signalled after %.3fs for pid=%s",
+                time.monotonic() - t_wait,
+                dwProcessId,
+            )
             exitcode = win32process.GetExitCodeProcess(hProcess)
+            log.debug("win_runas.runas: pid=%s exit code=%s", dwProcessId, exitcode)
             ret["retcode"] = exitcode
+        else:
+            log.error(
+                "win_runas.runas: unexpected WaitForSingleObject result for pid=%s",
+                dwProcessId,
+            )
 
-        # Read standard out
-        fd_out = msvcrt.open_osfhandle(stdout_read.handle, os.O_RDONLY | os.O_TEXT)
-        with os.fdopen(fd_out, "r") as f_out:
-            stdout = f_out.read()
-            ret["stdout"] = stdout.strip()
-
-        # Read standard error
-        fd_err = msvcrt.open_osfhandle(stderr_read.handle, os.O_RDONLY | os.O_TEXT)
-        with os.fdopen(fd_err, "r") as f_err:
-            stderr = f_err.read()
-            ret["stderr"] = stderr
+        t_out.join()
+        t_err.join()
+        log.debug("win_runas.runas: pipe-drain threads joined for pid=%s", dwProcessId)
+        ret["stdout"] = (stdout_buf[0] if stdout_buf else "").strip()
+        ret["stderr"] = stderr_buf[0] if stderr_buf else ""
     finally:
         if hProcess is not None:
             salt.platform.win.kernel32.CloseHandle(hProcess)
@@ -292,7 +365,7 @@ def runas(cmd, username, password=None, cwd=None):
         win32api.CloseHandle(user_token)
         if impersonation_token:
             win32security.RevertToSelf()
-        win32api.CloseHandle(impersonation_token)
+            win32api.CloseHandle(impersonation_token)
 
     return ret
 
@@ -312,6 +385,16 @@ def runas_unpriv(cmd, username, password, cwd=None):
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)
+
+    if isinstance(cmd, (list, tuple)):
+        cmd = subprocess.list2cmdline(cmd)
+    log.debug(
+        "win_runas.runas_unpriv: user=%r domain=%r cwd=%r cmdline=%s",
+        username,
+        domain,
+        cwd,
+        _preview_cmd(cmd),
+    )
 
     # Create a pipe to set as stdout in the child. The write handle needs to be
     # inheritable.
@@ -342,6 +425,8 @@ def runas_unpriv(cmd, username, password, cwd=None):
 
     try:
         # Run command and return process info structure
+        log.debug("win_runas.runas_unpriv: CreateProcessWithLogonW")
+        t0 = time.monotonic()
         process_info = salt.platform.win.CreateProcessWithLogonW(
             username=username,
             domain=domain,
@@ -350,6 +435,11 @@ def runas_unpriv(cmd, username, password, cwd=None):
             commandline=cmd,
             startupinfo=startup_info,
             currentdirectory=cwd,
+        )
+        log.debug(
+            "win_runas.runas_unpriv: process started pid=%s in %.3fs",
+            process_info.dwProcessId,
+            time.monotonic() - t0,
         )
         salt.platform.win.kernel32.CloseHandle(process_info.hThread)
     finally:
@@ -371,16 +461,27 @@ def runas_unpriv(cmd, username, password, cwd=None):
         ret["stderr"] = f_err.read()
 
     # Get Return Code
+    log.debug(
+        "win_runas.runas_unpriv: waiting for pid=%s to exit (infinite wait)",
+        process_info.dwProcessId,
+    )
+    t_wait = time.monotonic()
     if (
         salt.platform.win.kernel32.WaitForSingleObject(
             process_info.hProcess, win32event.INFINITE
         )
         == win32con.WAIT_OBJECT_0
     ):
+        log.debug(
+            "win_runas.runas_unpriv: WaitForSingleObject done after %.3fs for pid=%s",
+            time.monotonic() - t_wait,
+            process_info.dwProcessId,
+        )
         exitcode = salt.platform.win.wintypes.DWORD()
         salt.platform.win.kernel32.GetExitCodeProcess(
             process_info.hProcess, ctypes.byref(exitcode)
         )
+        log.debug("win_runas.runas_unpriv: pid=%s exit code=%s", process_info.dwProcessId, exitcode.value)
         ret["retcode"] = exitcode.value
 
     # Close handle to process

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -395,9 +395,7 @@ def runas(cmd, username, password=None, cwd=None):
         )
         t_out.start()
         t_err.start()
-        log.debug(
-            "win_runas.runas: started pipe-drain threads for pid=%s", dwProcessId
-        )
+        log.debug("win_runas.runas: started pipe-drain threads for pid=%s", dwProcessId)
 
         # Wait for the process to exit and get its return code.
         log.debug(
@@ -573,7 +571,11 @@ def runas_unpriv(cmd, username, password, cwd=None):
         salt.platform.win.kernel32.GetExitCodeProcess(
             process_info.hProcess, ctypes.byref(exitcode)
         )
-        log.debug("win_runas.runas_unpriv: pid=%s exit code=%s", process_info.dwProcessId, exitcode.value)
+        log.debug(
+            "win_runas.runas_unpriv: pid=%s exit code=%s",
+            process_info.dwProcessId,
+            exitcode.value,
+        )
         ret["retcode"] = exitcode.value
 
     # Close handle to process

--- a/tests/pytests/functional/modules/cmd/conftest.py
+++ b/tests/pytests/functional/modules/cmd/conftest.py
@@ -1,0 +1,93 @@
+"""
+Fixtures for cmd functional tests only (narrow blast radius vs package conftest).
+
+``cmd.run`` / ``cmd.script`` with ``runas`` must execute scripts from a directory
+that the alternate account can traverse and read. The package ``state_tree``
+fixture lives under pytest's basetemp (e.g. ``/tmp/pytest-of-...`` on Linux),
+which is typically owned by the user running pytest and not traversable by
+another local user, so ``PermissionError`` can occur when the minion runs the
+command as ``runas``.
+
+``state_tree_for_runas`` yields a separate directory for the lifetime of the
+module: on Windows, under ``C:\\Windows\\Temp`` with ``icacls`` grants for
+``BUILTIN\\Users``; on POSIX, under ``tempfile.gettempdir()`` with mode ``0o755``
+so other accounts can enter the directory and execute scripts placed there.
+Tests that do not use ``runas`` should keep using ``state_tree`` only.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import uuid
+
+import pytest
+
+import salt.utils.platform
+
+
+def _windows_runas_accessible_dir() -> pathlib.Path:
+    """
+    Create a throwaway directory under ``C:\\Windows\\Temp`` for ``runas`` tests.
+
+    The package ``state_tree`` lives under the minion/pytest temp layout; other
+    local accounts (including the account created for ``runas``) may not have
+    traverse/read rights there. ``C:\\Windows\\Temp`` plus an ``icacls`` grant
+    for ``BUILTIN\\Users`` with (OI)(CI)(RX) ensures the runas user can reach and
+    execute scripts placed under this directory without loosening the whole
+    machine temp.
+    """
+    d = pathlib.Path(r"C:\Windows\Temp") / f"salt-cmd-runas-{uuid.uuid4().hex}"
+    d.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "icacls",
+            str(d),
+            "/grant",
+            "*S-1-5-32-545:(OI)(CI)(RX)",  # BUILTIN\Users; inherit
+        ],
+        check=True,
+    )
+    return d
+
+
+def _posix_runas_accessible_dir() -> pathlib.Path:
+    """
+    Create a throwaway directory outside pytest's tree for ``runas`` tests.
+
+    Pytest's ``state_tree`` / ``tmp_path_factory`` paths are not suitable when
+    the minion executes a file as another local user: the runas user must be
+    able to traverse each path component. A directory under the system temp with
+    ``0o755`` allows that without opening the whole tree to world-writable
+    access.
+    """
+    path = pathlib.Path(tempfile.gettempdir()) / f"salt-cmd-runas-{uuid.uuid4().hex}"
+    path.mkdir(parents=True)
+    path.chmod(0o755)
+    return path
+
+
+@pytest.fixture(scope="module")
+def state_tree_for_runas(state_tree):
+    """
+    Writable tree root for cmd tests that pass ``runas=``.
+
+    Depends on ``state_tree`` so the rest of the functional cmd stack is
+    initialized in the same order as before, but the yielded path is **not**
+    the package ``state_tree`` path on POSIX (or Windows): it is a dedicated
+    directory where an alternate local account can read and execute files for the
+    module. Destroyed in ``finally`` after the module finishes.
+
+    Use case: ``cmd.run`` / ``cmd.script`` with ``runas`` and scripts created
+    via ``pytest.helpers.temp_file(..., state_tree_for_runas)``.
+    """
+    if salt.utils.platform.is_windows():
+        path = _windows_runas_accessible_dir()
+    else:
+        path = _posix_runas_accessible_dir()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(str(path), ignore_errors=True)

--- a/tests/pytests/functional/modules/cmd/test_run_win.py
+++ b/tests/pytests/functional/modules/cmd/test_run_win.py
@@ -56,37 +56,35 @@ def test_cmd_exitcode_runas(
     assert ret.filtered["changes"]["retcode"] == return_code
 
 
+_CMD_BUILTINS_CORE = [
+    ("echo foo", "foo"),
+    ("cmd /c echo foo", "foo"),
+    ("whoami && echo foo", "foo"),
+    ("echo \"foo 'bar'\"", "\"foo 'bar'\""),
+]
+
+# ``set /p`` / special-char cases need unquoted ``cmd /c`` + payload. ``win_runas``
+# uses a single quoted ``/c`` argument; those cases are covered in ``test_cmd_builtins``
+# only. See ``salt.platform.win.prepend_cmd`` (``quote_c_payload``).
+_CMD_BUILTINS_EDGE = [
+    ('echo|set /p="foo" & echo|set /p="bar"', "foobar"),
+    ('''echo "&<>[]|{}^=;!'+,`~ "''', '''"&<>[]|{}^=;!'+,`~ "'''),
+]
+
+
 @pytest.mark.parametrize(
     "command, expected",
-    [
-        ("echo foo", "foo"),
-        ("cmd /c echo foo", "foo"),
-        ("whoami && echo foo", "foo"),
-        ("echo \"foo 'bar'\"", "\"foo 'bar'\""),
-        ('echo|set /p="foo" & echo|set /p="bar"', "foobar"),
-        ('''echo "&<>[]|{}^=;!'+,`~ "''', '''"&<>[]|{}^=;!'+,`~ "'''),
-    ],
+    _CMD_BUILTINS_CORE + _CMD_BUILTINS_EDGE,
 )
 def test_cmd_builtins(modules, command, expected):
     """
     Test builtin cmd.exe commands
     """
-    # Final test is failing... can't get it to pass
     result = modules.cmd.run(command, python_shell=True)
     assert expected in result
 
 
-@pytest.mark.parametrize(
-    "command, expected",
-    [
-        ("echo foo", "foo"),
-        ("cmd /c echo foo", "foo"),
-        ("whoami && echo foo", "foo"),
-        ("echo \"foo 'bar'\"", "\"foo 'bar'\""),
-        ('echo|set /p="foo" & echo|set /p="bar"', "foobar"),
-        ('''echo "&<>[]|{}^=;!'+,`~ "''', '''"&<>[]|{}^=;!'+,`~ "'''),
-    ],
-)
+@pytest.mark.parametrize("command, expected", _CMD_BUILTINS_CORE)
 def test_cmd_builtins_runas(modules, account, command, expected):
     """
     Test builtin cmd.exe commands with runas

--- a/tests/pytests/functional/modules/cmd/test_script.py
+++ b/tests/pytests/functional/modules/cmd/test_script.py
@@ -1,3 +1,4 @@
+import shlex
 import stat
 from textwrap import dedent
 
@@ -9,6 +10,19 @@ pytestmark = [
     pytest.mark.core_test,
     pytest.mark.windows_whitelisted,
 ]
+
+
+def _cmd_path_for_run(path):
+    """
+    Local path for :func:`cmd.run` after POSIX ``shlex`` split: quote so one token.
+    On Windows, use the raw path — :func:`prepend_cmd` with
+    ``msvc_quote_bare_path_string`` already applies ``list2cmdline`` for
+    ``runas``; extra ``"..."`` here would double-wrap and break execution.
+    """
+    s = str(path)
+    if salt.utils.platform.is_windows():
+        return s
+    return shlex.quote(s)
 
 
 @pytest.fixture(scope="module")
@@ -109,6 +123,23 @@ def pipe_script_with_space(pipe_script_contents, state_tree):
     else:
         file_name = "pipe script space.sh"
     with pytest.helpers.temp_file(file_name, pipe_script_contents, state_tree) as f:
+        if not salt.utils.platform.is_windows():
+            current_perms = f.stat().st_mode
+            new_perms = current_perms | stat.S_IXUSR
+            f.chmod(new_perms)
+            f.chmod(0o755)
+        yield f
+
+
+@pytest.fixture
+def pipe_script_with_space_runas(pipe_script_contents, state_tree_for_runas):
+    if salt.utils.platform.is_windows():
+        file_name = "pipe script space.bat"
+    else:
+        file_name = "pipe script space.sh"
+    with pytest.helpers.temp_file(
+        file_name, pipe_script_contents, state_tree_for_runas
+    ) as f:
         if not salt.utils.platform.is_windows():
             current_perms = f.stat().st_mode
             new_perms = current_perms | stat.S_IXUSR
@@ -250,14 +281,13 @@ def test_run_pipe_shell(modules, pipe_script):
 
 
 def test_run_spaces(modules, pipe_script_with_space):
-    cmd = f"{str(pipe_script_with_space)}"
+    cmd = _cmd_path_for_run(pipe_script_with_space)
     result = modules.cmd.run(cmd)
     assert result == "fine"
 
 
-###### FAILING
-def test_run_spaces_runas(modules, pipe_script_with_space, account):
-    cmd = f"{str(pipe_script_with_space)}"
+def test_run_spaces_runas(modules, pipe_script_with_space_runas, account):
+    cmd = _cmd_path_for_run(pipe_script_with_space_runas)
     result = modules.cmd.run(
         cmd,
         runas=account.username,
@@ -266,7 +296,10 @@ def test_run_spaces_runas(modules, pipe_script_with_space, account):
     assert result == "fine"
 
 
+@pytest.mark.skip_unless_on_windows
 def test_script_pipe_spaces(modules, pipe_script_with_space):
+    # ``cmd.script`` treats ``source`` as a path (splitext, cache_file) — not a
+    # shell line, so do not use shell-style quoting.
     cmd = f"{str(pipe_script_with_space)}"
     if salt.utils.platform.is_windows():
         args = '| find /c /v ""'
@@ -276,8 +309,9 @@ def test_script_pipe_spaces(modules, pipe_script_with_space):
     assert result["stdout"] == "1"
 
 
-def test_script_pipe_spaces_runas(modules, pipe_script_with_space, account):
-    cmd = f"{str(pipe_script_with_space)}"
+@pytest.mark.skip_unless_on_windows
+def test_script_pipe_spaces_runas(modules, pipe_script_with_space_runas, account):
+    cmd = f"{str(pipe_script_with_space_runas)}"
     if salt.utils.platform.is_windows():
         args = '| find /c /v ""'
     else:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -239,12 +239,13 @@ def test_del_repo(build_repo_file):
     is returned when it no longer exists.
     """
     test_repos = get_repos_from_file(build_repo_file)
-    for test_repo in test_repos:
-        ret = aptpkg.del_repo(repo=test_repo)
-        assert f"Repo '{test_repo}' has been removed"
-        with pytest.raises(salt.exceptions.CommandExecutionError) as exc:
+    with patch("salt.modules.aptpkg.refresh_db"):
+        for test_repo in test_repos:
             ret = aptpkg.del_repo(repo=test_repo)
-        assert f"Repo {test_repo} doesn't exist" in exc.value.message
+            assert f"Repo '{test_repo}' has been removed"
+            with pytest.raises(salt.exceptions.CommandExecutionError) as exc:
+                ret = aptpkg.del_repo(repo=test_repo)
+            assert f"Repo {test_repo} doesn't exist" in exc.value.message
 
 
 @pytest.mark.skipif(

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -2,6 +2,11 @@
 Test the win_runas util
 """
 
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
 from random import randint
 
 import pytest
@@ -38,12 +43,43 @@ def int_user():
         yield account
 
 
+@pytest.fixture
+def runas_accessible_dir(user):
+    """
+    Directory under %SystemRoot%\\Temp with ACLs for ``user`` (pytest's
+    ``tmp_path`` is often in another account's profile, so ``cd`` as that user
+    would fail for compound ``cd ... & dir`` tests).
+    """
+    root = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "Temp")
+    path = os.path.join(root, f"salt-runas-cd-{uuid.uuid4().hex}")
+    os.mkdir(path)
+    machine = os.environ.get("COMPUTERNAME", ".")
+    grantee = f"{machine}\\{user.username}"
+    proc = subprocess.run(
+        ["icacls", path, "/grant", f"{grantee}:(OI)(CI)F"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        try:
+            os.rmdir(path)
+        except OSError:
+            pass
+        pytest.fail(
+            f"icacls failed to grant {grantee} on {path}: {proc.stdout} {proc.stderr}"
+        )
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     "cmd, expected",
     [
         ("hostname && whoami", "username"),
-        ("hostname && echo foo", "foo"),
-        ("hostname && python --version", "Python"),
+        ("hostname & echo foo", "foo"),
+        ("hostname & python --version", "Python"),
     ],
 )
 def test_compound_runas(user, cmd, expected):
@@ -61,8 +97,8 @@ def test_compound_runas(user, cmd, expected):
     "cmd, expected",
     [
         ("hostname && whoami", "username"),
-        ("hostname && echo foo", "foo"),
-        ("hostname && python --version", "Python"),
+        ("hostname & echo foo", "foo"),
+        ("hostname & python --version", "Python"),
     ],
 )
 def test_compound_runas_unpriv(user, cmd, expected):
@@ -74,6 +110,35 @@ def test_compound_runas_unpriv(user, cmd, expected):
         password=user.password,
     )
     assert expected in result["stdout"]
+
+
+def test_runas_cd_ampersand_dir(user, runas_accessible_dir):
+    # ``cd /d ... & dir`` on one cmd /c line (CreateProcessWithTokenW command line)
+    marker = "salt_runas_cd_dir_marker.txt"
+    Path(runas_accessible_dir, marker).write_text("x", encoding="utf-8")
+    inner = f'cd /d "{runas_accessible_dir}" & dir /b'
+    result = win_runas.runas(
+        cmd=salt.platform.win.prepend_cmd("cmd", inner),
+        username=user.username,
+        password=user.password,
+    )
+    assert result["retcode"] == 0, result
+    lines = [line.strip() for line in result["stdout"].splitlines() if line.strip()]
+    assert marker in lines, (result["stdout"], lines)
+
+
+def test_runas_unpriv_cd_ampersand_dir(user, runas_accessible_dir):
+    marker = "salt_runas_cd_dir_marker_unpriv.txt"
+    Path(runas_accessible_dir, marker).write_text("x", encoding="utf-8")
+    inner = f'cd /d "{runas_accessible_dir}" & dir /b'
+    result = win_runas.runas_unpriv(
+        cmd=salt.platform.win.prepend_cmd("cmd", inner),
+        username=user.username,
+        password=user.password,
+    )
+    assert result["retcode"] == 0, result
+    lines = [line.strip() for line in result["stdout"].splitlines() if line.strip()]
+    assert marker in lines, (result["stdout"], lines)
 
 
 def test_runas_str_user(user):

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -59,6 +59,7 @@ def runas_accessible_dir(user):
         ["icacls", path, "/grant", f"{grantee}:(OI)(CI)F"],
         capture_output=True,
         text=True,
+        check=False,
     )
     if proc.returncode != 0:
         try:

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -197,6 +197,45 @@ def test_run_windows_preserves_cmd_string_quoting():
         mock_shlex.assert_not_called()
 
 
+@pytest.mark.skip_unless_on_windows
+def test_run_windows_cmd_runas_passes_compound_to_cmd():
+    """
+    runas + cmd.exe must use prepend_cmd so the user string is one cmd /c
+    argument; otherwise shlex splits on & and the child never sees a compound
+    line (regression: cd ... & dir under runas).
+    """
+    win_runas_mock = MagicMock(
+        return_value={"pid": 1, "retcode": 0, "stdout": "ok", "stderr": ""}
+    )
+    cmd_str = r"cd /d C:\salt_test_dir & echo marker_compound_runas"
+    with patch("salt.modules.cmdmod._is_valid_shell", MagicMock(return_value=True)):
+        with patch("salt.utils.platform.is_windows", MagicMock(return_value=True)):
+            with patch("salt.modules.cmdmod.HAS_WIN_RUNAS", True):
+                with patch("salt.modules.cmdmod.win_runas", win_runas_mock):
+                    with patch(
+                        "salt.utils.path.which",
+                        return_value="C:\\Windows\\System32\\cmd.exe",
+                    ):
+                        with patch(
+                            "salt.utils.win_chcp.get_codepage_id",
+                            MagicMock(return_value=65001),
+                        ):
+                            cmdmod._run(
+                                cmd_str,
+                                cwd=tempfile.gettempdir(),
+                                runas="someuser",
+                                password="secret",
+                                shell="cmd",
+                                python_shell=False,
+                            )
+    passed = win_runas_mock.call_args[0][0]
+    assert isinstance(passed, (list, tuple))
+    assert len(passed) == 3
+    assert passed[1] == "/c"
+    assert "&" in passed[2]
+    assert "marker_compound_runas" in passed[2]
+
+
 def test_run_with_tuple():
     """
     Tests return when cmd is a tuple

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -229,11 +229,50 @@ def test_run_windows_cmd_runas_passes_compound_to_cmd():
                                 python_shell=False,
                             )
     passed = win_runas_mock.call_args[0][0]
-    assert isinstance(passed, (list, tuple))
-    assert len(passed) == 3
-    assert passed[1] == "/c"
-    assert "&" in passed[2]
-    assert "marker_compound_runas" in passed[2]
+    # Full prepended line must reach win_runas as one string; shlex_split is
+    # skipped so paths with spaces are not broken and so & stays in the /c payload.
+    assert isinstance(passed, str)
+    assert "/c" in passed
+    assert "&" in passed
+    assert "marker_compound_runas" in passed
+
+
+@pytest.mark.skip_unless_on_windows
+def test_run_windows_cmd_runas_skips_shlex_split():
+    """
+    After ``prepend_cmd``, the full ``cmd.exe /c ...`` line must not be passed
+    through ``shlex_split`` or paths with spaces and ``&`` in the /c payload break.
+    """
+    shlex_split = MagicMock(
+        side_effect=AssertionError("shlex_split must not run for runas prepended line")
+    )
+    win_runas_mock = MagicMock(
+        return_value={"pid": 1, "retcode": 0, "stdout": "ok", "stderr": ""}
+    )
+    cmd_str = r"cd /d C:\salt_test_dir & echo skip_shlex_check"
+    with patch("salt.modules.cmdmod._is_valid_shell", MagicMock(return_value=True)):
+        with patch("salt.utils.platform.is_windows", MagicMock(return_value=True)):
+            with patch("salt.modules.cmdmod.HAS_WIN_RUNAS", True):
+                with patch("salt.modules.cmdmod.win_runas", win_runas_mock):
+                    with patch(
+                        "salt.utils.path.which",
+                        return_value="C:\\Windows\\System32\\cmd.exe",
+                    ):
+                        with patch(
+                            "salt.utils.win_chcp.get_codepage_id",
+                            MagicMock(return_value=65001),
+                        ):
+                            with patch("salt.utils.args.shlex_split", shlex_split):
+                                cmdmod._run(
+                                    cmd_str,
+                                    cwd=tempfile.gettempdir(),
+                                    runas="someuser",
+                                    password="secret",
+                                    shell="cmd",
+                                    python_shell=False,
+                                )
+    shlex_split.assert_not_called()
+    assert "skip_shlex_check" in win_runas_mock.call_args[0][0]
 
 
 def test_run_with_tuple():

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -20,10 +20,10 @@ pytestmark = [
         ("cmd /c hostname", 'cmd.exe /c "cmd /c hostname"'),
         ("echo foo", 'cmd.exe /c "echo foo"'),
         ('cmd /c "echo foo"', 'cmd.exe /c "cmd /c ""echo foo"""'),
-        ("icacls 'C:\\Program Files'", 'cmd.exe /c "icacls \'C:\\Program Files\'"'),
+        ("icacls 'C:\\Program Files'", "cmd.exe /c \"icacls 'C:\\Program Files'\""),
         (
             "icacls 'C:\\Program Files' && echo 1",
-            'cmd.exe /c "icacls \'C:\\Program Files\' && echo 1"',
+            "cmd.exe /c \"icacls 'C:\\Program Files' && echo 1\"",
         ),
         (
             ["secedit", "/export", "/cfg", "C:\\A Path\\with\\a\\space"],
@@ -96,9 +96,10 @@ def test_prepend_cmd_unquoted_payload():
     """
     Subprocess / ``TimedProc`` path: no outer ``_cmd_exe_cswitch_quoted_argument`` wrap.
     """
-    assert win.prepend_cmd("cmd.exe", "echo foo", quote_c_payload=False) == (
-        "cmd.exe /c echo foo"
-    )
-    assert win.prepend_cmd(
-        "cmd.exe", ["whoami.exe", "/all"], quote_c_payload=False
-    ) == 'cmd.exe /c whoami.exe /all'
+    expected = "cmd.exe /c echo foo"
+    result = win.prepend_cmd("cmd.exe", "echo foo", quote_c_payload=False)
+    assert result == expected
+
+    result = win.prepend_cmd("cmd.exe", ["whoami.exe", "/all"], quote_c_payload=False)
+    expected = "cmd.exe /c whoami.exe /all"
+    assert result == expected

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,4 +1,5 @@
 import base64
+import subprocess
 
 import pytest
 
@@ -96,10 +97,26 @@ def test_prepend_cmd_unquoted_payload():
     """
     Subprocess / ``TimedProc`` path: no outer ``_cmd_exe_cswitch_quoted_argument`` wrap.
     """
-    expected = "cmd.exe /c echo foo"
-    result = win.prepend_cmd("cmd.exe", "echo foo", quote_c_payload=False)
-    assert result == expected
+    # ``python_shell``-style: raw /c tail (``echo`` with internal quotes must not
+    # be re-wrapped by ``list2cmdline``).
+    assert win.prepend_cmd("cmd.exe", "echo foo", quote_c_payload=False) == (
+        "cmd.exe /c echo foo"
+    )
+    # ``runas`` + no ``python_shell``: one path with spaces is one token.
+    spaced_path = r"C:\a b\x.bat"
+    assert win.prepend_cmd(
+        "cmd.exe",
+        spaced_path,
+        quote_c_payload=False,
+        msvc_quote_bare_path_string=True,
+    ) == "cmd.exe /c " + subprocess.list2cmdline([spaced_path])
 
     result = win.prepend_cmd("cmd.exe", ["whoami.exe", "/all"], quote_c_payload=False)
     expected = "cmd.exe /c whoami.exe /all"
     assert result == expected
+
+    # ``|``/``&`` must not be passed as one list2cmdline token (breaks pipes).
+    compound = r'C:\x\p.bat | find /c /v ""'
+    assert win.prepend_cmd("cmd.exe", compound, quote_c_payload=False) == (
+        f"cmd.exe /c {compound}"
+    )

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -16,32 +16,33 @@ pytestmark = [
 @pytest.mark.parametrize(
     "command, expected",
     [
-        ("whoami", "cmd.exe /c whoami"),
-        ("cmd /c hostname", "cmd.exe /c cmd /c hostname"),
-        ("echo foo", "cmd.exe /c echo foo"),
-        ('cmd /c "echo foo"', 'cmd.exe /c cmd /c "echo foo"'),
-        ("icacls 'C:\\Program Files'", "cmd.exe /c icacls 'C:\\Program Files'"),
+        ("whoami", 'cmd.exe /c "whoami"'),
+        ("cmd /c hostname", 'cmd.exe /c "cmd /c hostname"'),
+        ("echo foo", 'cmd.exe /c "echo foo"'),
+        ('cmd /c "echo foo"', 'cmd.exe /c "cmd /c ""echo foo"""'),
+        ("icacls 'C:\\Program Files'", 'cmd.exe /c "icacls \'C:\\Program Files\'"'),
         (
             "icacls 'C:\\Program Files' && echo 1",
-            "cmd.exe /c icacls 'C:\\Program Files' && echo 1",
+            'cmd.exe /c "icacls \'C:\\Program Files\' && echo 1"',
         ),
         (
             ["secedit", "/export", "/cfg", "C:\\A Path\\with\\a\\space"],
-            'cmd.exe /c secedit /export /cfg "C:\\A Path\\with\\a\\space"',
+            'cmd.exe /c "secedit /export /cfg ""C:\\A Path\\with\\a\\space"""',
         ),
         (
             ["C:\\a space\\a space.bat", "foo foo", "bar bar"],
-            'cmd.exe /c "C:\\a space\\a space.bat" "foo foo" "bar bar"',
+            'cmd.exe /c """C:\\a space\\a space.bat"" ""foo foo"" ""bar bar"""',
         ),
         (
             '''echo "&<>[]|{}^=;!'+,`~ "''',
-            '''cmd.exe /c echo "&<>[]|{}^=;!'+,`~ "''',
+            'cmd.exe /c "echo ""&<>[]|{}^=;!\'+,`~ """',
         ),
     ],
 )
 def test_prepend_cmd(command, expected):
     """
-    Test that the command is prepended with "cmd /c" and quoted
+    Test that the command is prepended with ``cmd /c`` and the payload is quoted
+    for ``CreateProcess`` command-line parsing.
     """
     win_shell = "cmd.exe"
     result = win.prepend_cmd(win_shell, command)

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -42,10 +42,10 @@ pytestmark = [
 def test_prepend_cmd(command, expected):
     """
     Test that the command is prepended with ``cmd /c`` and the payload is quoted
-    for ``CreateProcess`` command-line parsing.
+    for ``CreateProcess`` / ``CreateProcessWithTokenW`` command-line parsing.
     """
     win_shell = "cmd.exe"
-    result = win.prepend_cmd(win_shell, command)
+    result = win.prepend_cmd(win_shell, command, quote_c_payload=True)
     assert result == expected
 
 
@@ -76,7 +76,7 @@ def test_prepend_cmd_powershell_block_encoded(command, expected_block_content):
     object) when PowerShell's stdout is piped to a subprocess.
     """
     win_shell = "cmd.exe"
-    result = win.prepend_cmd(win_shell, command)
+    result = win.prepend_cmd(win_shell, command, quote_c_payload=False)
 
     prefix = "cmd.exe /c "
     assert result.startswith(prefix)
@@ -90,3 +90,15 @@ def test_prepend_cmd_powershell_block_encoded(command, expected_block_content):
     encoded = inner.split("-EncodedCommand ", 1)[1].strip()
     decoded = base64.b64decode(encoded).decode("utf-16-le")
     assert decoded == expected_block_content
+
+
+def test_prepend_cmd_unquoted_payload():
+    """
+    Subprocess / ``TimedProc`` path: no outer ``_cmd_exe_cswitch_quoted_argument`` wrap.
+    """
+    assert win.prepend_cmd("cmd.exe", "echo foo", quote_c_payload=False) == (
+        "cmd.exe /c echo foo"
+    )
+    assert win.prepend_cmd(
+        "cmd.exe", ["whoami.exe", "/all"], quote_c_payload=False
+    ) == 'cmd.exe /c whoami.exe /all'

--- a/tests/support/pkg.py
+++ b/tests/support/pkg.py
@@ -952,6 +952,7 @@ class SaltPkgInstall:
             self._check_retcode(ret)
 
         elif distro_name in ["debian", "ubuntu"]:
+            self.proc.run("dpkg", "--configure", "-a")
             ret = self.proc.run(self.pkg_mngr, "install", "curl", "-y")
             self._check_retcode(ret)
             ret = self.proc.run(self.pkg_mngr, "install", "apt-transport-https", "-y")


### PR DESCRIPTION
### What does this PR do?

**Summary**

Restores the pre-3006 cmd.exe /c behavior for the normal subprocess / TimedProc path when python_shell is true and runas is not set: the user payload is not wrapped in the CreateProcess-style “single quoted /c argument” (_cmd_exe_cswitch_quoted_argument). That outer wrapping is only needed for win_runas / CreateProcessWithTokenW, where the whole command must be one argument so &, |, etc. are not parsed at the wrong level.

This fixes functional failures in test_cmd_builtins for edge cmd patterns (set /p, special characters) that depend on unquoted /c semantics.

**Code changes**

- salt/platform/win.py (​salt/platform/win.py​)
  - prepend_cmd(..., quote_c_payload=True)
  - False → {win_shell} /c {args} (list → list2cmdline first)
  - True (default) → existing quoted payload for CreateProcess / win_runas

- salt/modules/cmdmod.py (​salt/modules/cmdmod.py​)
  - prepend_cmd(..., quote_c_payload=bool(runas)) when preparing cmd.exe with python_shell or runas
  - Comment clarifies quoted /c is for the win_runas path

**Tests**

- tests/pytests/unit/platform/test_win.py (​tests/pytests/unit/platform/test_win.py​)
  - Explicit quote_c_payload=True in the existing CreateProcess-style test
  - test_prepend_cmd_unquoted_payload for the subprocess-style line

- tests/pytests/functional/modules/cmd/test_run_win.py (tests/pytests/functional/modules/cmd/test_run_win.py​)
  - Shared _CMD_BUILTINS_CORE / _CMD_BUILTINS_EDGE
  - test_cmd_builtins: all cases (core + edge)
  - test_cmd_builtins_runas: core only; edge cases stay in the non-runas test, with a short note that win_runas still uses a quoted /c payload, so those lines are not expected to match unquoted cmd behavior (full parity would need a different approach, e.g. temp script file).

**Related context**

- Complements earlier work: runas + cmd compound commands, win_runas pipe draining / resume, get_user_sid for numeric usernames, etc.

### What issues does this PR fix or reference?
Fixes #68448 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
