### PR TITLE
Fix circular reference issues with OptsDict/NamedLoaderContext

### DIFF
--- a/salt/utils/optsdict.py
+++ b/salt/utils/optsdict.py
@@ -37,6 +37,8 @@ import traceback
 import weakref
 from typing import Any
 
+NamedLoaderContext = None
+
 log = logging.getLogger(__name__)
 
 
@@ -1226,6 +1228,13 @@ def safe_opts_copy(opts: Any, name: str | None = None) -> OptsDict:
         from salt.utils.optsdict import safe_opts_copy
         opts = safe_opts_copy(opts, name="loader:states")
     """
+    global NamedLoaderContext
+    if NamedLoaderContext is None:
+        from salt.loader.context import NamedLoaderContext
+
+    if isinstance(opts, NamedLoaderContext):
+        opts = opts.value()
+
     if isinstance(opts, OptsDict):
         # Create child from current opts, not root
         # This ensures the child can see all values in the current opts,

--- a/tests/pytests/functional/loader/test_dunder.py
+++ b/tests/pytests/functional/loader/test_dunder.py
@@ -1,4 +1,7 @@
+import shutil
 from collections.abc import MutableMapping
+
+import pytest
 
 import salt.loader.context
 import salt.loader.lazy
@@ -51,3 +54,55 @@ def test_opts_dunder_opts_with_import(tmp_path):
     loader = salt.loader.lazy.LazyLoader([tmp_path], opts)
     assert loader["mymod.optstype"]() == salt.loader.context.NamedLoaderContext
     assert loader["mymod.opts"]() == opts
+
+
+@pytest.fixture
+def child_mod(tmp_path_factory):
+    mod_contents = tests.support.helpers.dedent(
+        """
+    def run():
+        return "foo" in __opts__
+    """
+    )
+    tmp = tmp_path_factory.mktemp("child")
+    with salt.utils.files.fopen(tmp / "child.py", "w") as fp:
+        fp.write(mod_contents)
+    try:
+        yield tmp
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture
+def parent_mod(child_mod, tmp_path_factory):
+    mod_contents = tests.support.helpers.dedent(
+        f"""
+    import salt.loader.lazy
+    from salt.loader.dunder import __opts__
+
+    def run():
+        loader = salt.loader.lazy.LazyLoader([{salt.utils.json.dumps(str(child_mod))}], __opts__)
+        return loader["child.run"]()
+    """
+    )
+    tmp = tmp_path_factory.mktemp("parent")
+    with salt.utils.files.fopen(tmp / "parent.py", "w") as fp:
+        fp.write(mod_contents)
+    try:
+        yield tmp
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_opts_dunder_optsdict(parent_mod):
+    """
+    The introduction of the copy-on-write OptsDict did not correctly account for a module having
+    a NamedLoaderContext reference to __opts__, which resulted in an OptsDict having itself
+    as its base (transitively via the NamedLoaderContext).
+    This caused circular reference issues, such as when its __contains__ was called.
+
+    Issue #68973.
+    """
+    opts = {"foo": True}
+    loader = salt.loader.lazy.LazyLoader([parent_mod], opts)
+    assert loader["parent.run"]() is True


### PR DESCRIPTION
### What does this PR do?
Makes `safe_opts_copy` account for being passed a `NamedLoaderContext` instance by unwrapping its current value before returning the derivative dict.

Note:
* I hope this fix is correct, please review it carefully.
* No changelog because this issue is not present in any stable release.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/68973

### Previous Behavior
Possible circular references because an OptsDict could become its own base transitively via a `NamedLoaderContext` instance returning it.

### New Behavior
`NamedLoaderContext` instances are resolved before creating a derivative dict.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes