### PR TITLE
fix: add valid content-type header for slack_webhook

### DIFF
--- a/changelog/69006.fixed.md
+++ b/changelog/69006.fixed.md
@@ -1,0 +1,1 @@
+Fix `slack_webhook` returner sending requests without a `Content-Type` header, causing Slack to return `400 invalid_payload`.

--- a/salt/returners/slack_webhook_return.py
+++ b/salt/returners/slack_webhook_return.py
@@ -345,7 +345,12 @@ def _post_message(webhook, author_icon, title, report, **kwargs):
     data = urllib.parse.urlencode({"payload": json.dumps(payload, ensure_ascii=False)})
 
     webhook_url = urllib.parse.urljoin("https://hooks.slack.com/services/", webhook)
-    query_result = salt.utils.http.query(webhook_url, "POST", data=data)
+    query_result = salt.utils.http.query(
+        webhook_url,
+        "POST",
+        data=data,
+        header_dict={"Content-Type": "application/x-www-form-urlencoded"},
+    )
 
     # Sometimes the status is not available, so status 200 is assumed when it is not present
     if (

--- a/tests/pytests/unit/returners/test_slack_webhook_return.py
+++ b/tests/pytests/unit/returners/test_slack_webhook_return.py
@@ -7,7 +7,7 @@
 import pytest
 
 import salt.returners.slack_webhook_return as slack_webhook
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -250,6 +250,23 @@ def test_event_return(evnt_ret):
     query_ret = {"body": "ok", "status": 200}
     with patch("salt.utils.http.query", return_value=query_ret):
         assert slack_webhook.event_return(evnt_ret)
+
+
+def test_returner_sends_content_type_header(ret):
+    """
+    Regression test: _post_message must include Content-Type:
+    application/x-www-form-urlencoded so Slack's webhook endpoint accepts
+    the request instead of returning 400 invalid_payload.
+    """
+    query_ret = {"body": "ok", "status": 200}
+    mock_query = MagicMock(return_value=query_ret)
+    with patch("salt.utils.http.query", mock_query):
+        slack_webhook.returner(ret)
+    assert mock_query.called
+    _args, kwargs = mock_query.call_args
+    header_dict = kwargs.get("header_dict", {})
+    assert "Content-Type" in header_dict
+    assert header_dict["Content-Type"] == "application/x-www-form-urlencoded"
 
 
 def test_generate_payload_for_state_apply(


### PR DESCRIPTION
### What does this PR do?
Adds Content-Type header to slack_webhook_returner.  This header is required for the returner to work.


### What issues does this PR fix or reference?
Fixes

### Previous Behavior
slack_webhook would get a 400 invalid_payload from slack when posting

### New Behavior
slack_webhook actually works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
