### PR TITLE
Update bootstrap script to 2026.05.01

### DIFF
--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -26,7 +26,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2026.01.22"
+__ScriptVersion="2026.05.01"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"
@@ -515,6 +515,7 @@ fi
 
 # What ever is written to the logpipe gets written to the logfile
 tee < "$LOGPIPE" "$LOGFILE" &
+TEE_PID=$!
 
 # Close STDOUT, reopen it directing it to the logpipe
 exec 1>&-
@@ -571,10 +572,10 @@ __exit_cleanup() {
     fi
 
     # Kill tee when exiting, CentOS, at least requires this
-    # shellcheck disable=SC2009
-    TEE_PID=$(ps ax | grep tee | grep "$LOGFILE" | awk '{print $1}')
-
-    [ "$TEE_PID" = "" ] && exit $EXIT_CODE
+    if [ "$TEE_PID" = "" ]; then
+        exec >/dev/null 2>&1
+        exit "$EXIT_CODE"
+    fi
 
     echodebug "Killing logging pipe tee's with pid(s): $TEE_PID"
 
@@ -587,11 +588,13 @@ __exit_cleanup() {
     }
     trap "__trap_errors" INT ABRT QUIT TERM
 
-    # Now we're "good" to kill tee
+    # Detach stdout/stderr from LOGPIPE before killing tee so shell teardown does
+    # not write to a pipe with no reader (SIGPIPE / exit 141 under docker exec -e).
+    exec >/dev/null 2>&1
     kill -s TERM "$TEE_PID"
 
     # In case the 127 errno is not triggered, exit with the "original" exit code
-    exit $EXIT_CODE
+    exit "$EXIT_CODE"
 }
 trap "__exit_cleanup" EXIT INT
 
@@ -6386,6 +6389,15 @@ EOF
 #
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __salt_onedir_filter_ga_version_dirs
+#   DESCRIPTION:  From stdin: keep only GA CalVer-style directory names (digits and dots;
+#                 prerelease dirs like 3008.0rc1 are excluded).
+#----------------------------------------------------------------------------------------------------------------------
+__salt_onedir_filter_ga_version_dirs() {
+    grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)*$'
+}
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __rpm_get_packagesite_onedir_latest
 #   DESCRIPTION:  Set _GENERIC_PKG_VERSION to the latest for RPM or latest for major version input
 #----------------------------------------------------------------------------------------------------------------------
@@ -6393,26 +6405,35 @@ __get_packagesite_onedir_latest() {
 
     echodebug "Find latest rpm release from repository"
 
-    # get dir listing from url, sort and pick highest
     generic_versions_tmpdir=$(mktemp -d)
     curr_pwd=$(pwd)
-    cd  ${generic_versions_tmpdir} || return 1
+    cd "${generic_versions_tmpdir}" || return 1
 
     # leverage the windows directories since release Windows and Linux
     wget -q -r -np -nH --exclude-directories=onedir,relenv,macos -x -l 1 "https://${_REPO_URL}/saltproject-generic/windows/"
     if [ "$#" -gt 0 ] && [ -n "$1" ]; then
         MAJOR_VER="$1"
         # shellcheck disable=SC2010
-        _GENERIC_PKG_VERSION=$(ls artifactory/saltproject-generic/windows/ | grep -v 'index.html' | sort -V -u | grep -E "$MAJOR_VER" | tail -n 1)
+        _GENERIC_PKG_VERSION=$(ls artifactory/saltproject-generic/windows/ | grep -v 'index.html' | __salt_onedir_filter_ga_version_dirs | grep -E "^${MAJOR_VER}\\." | sort -V -u | tail -n 1)
     else
         # shellcheck disable=SC2010
-        _GENERIC_PKG_VERSION=$(ls artifactory/saltproject-generic/windows/ | grep -v 'index.html' | sort -V -u | tail -n 1)
+        _GENERIC_PKG_VERSION=$(ls artifactory/saltproject-generic/windows/ | grep -v 'index.html' | __salt_onedir_filter_ga_version_dirs | sort -V -u | tail -n 1)
     fi
-    cd ${curr_pwd} || return "${_GENERIC_PKG_VERSION}"
-    rm -fR ${generic_versions_tmpdir}
+    cd "${curr_pwd}" || return 1
+    rm -fR "${generic_versions_tmpdir}"
+
+    if [ -z "${_GENERIC_PKG_VERSION}" ]; then
+        if [ "$#" -gt 0 ] && [ -n "$1" ]; then
+            echoerror "No GA Salt onedir version found for major series $1 (prerelease dirs are ignored for this selection)."
+        else
+            echoerror "No GA Salt onedir version found for latest (prerelease dirs are ignored for this selection)."
+        fi
+        return 1
+    fi
 
     echodebug "latest rpm release from repository found ${_GENERIC_PKG_VERSION}"
 
+    return 0
 }
 
 
@@ -6756,7 +6777,7 @@ install_vmware_photon_os_onedir() {
 
     if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
         # Major version Salt, config and repo already setup
-        __get_packagesite_onedir_latest "$STABLE_REV"
+        __get_packagesite_onedir_latest "$STABLE_REV" || return 1
         MINOR_VER_STRG="-$_GENERIC_PKG_VERSION"
     elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
         # Minor version Salt, need to add specific minor version
@@ -6764,7 +6785,7 @@ install_vmware_photon_os_onedir() {
         MINOR_VER_STRG="-$STABLE_REV_DOT"
     else
         # default to latest version Salt, config and repo already setup
-        __get_packagesite_onedir_latest
+        __get_packagesite_onedir_latest || return 1
         MINOR_VER_STRG="-$_GENERIC_PKG_VERSION"
     fi
 
@@ -7838,24 +7859,33 @@ __macosx_get_packagesite_onedir_latest() {
 
     echodebug "Find latest MacOS release from repository"
 
-    # get dir listing from url, sort and pick highest
     macos_versions_tmpdir=$(mktemp -d)
     curr_pwd=$(pwd)
-    cd  ${macos_versions_tmpdir} || return 1
+    cd "${macos_versions_tmpdir}" || return 1
     wget -q -r -np -nH --exclude-directories=onedir,relenv,windows -x -l 1 "$SALT_MACOS_PKGDIR_URL/"
     if [ "$#" -gt 0 ] && [ -n "$1" ]; then
         MAJOR_VER="$1"
         # shellcheck disable=SC2010
-        _PKG_VERSION=$(ls artifactory/saltproject-generic/macos/ | grep -v 'index.html' | sort -V -u | grep -E "$MAJOR_VER" | tail -n 1)
+        _PKG_VERSION=$(ls artifactory/saltproject-generic/macos/ | grep -v 'index.html' | __salt_onedir_filter_ga_version_dirs | grep -E "^${MAJOR_VER}\\." | sort -V -u | tail -n 1)
     else
         # shellcheck disable=SC2010
-        _PKG_VERSION=$(ls artifactory/saltproject-generic/macos/ | grep -v 'index.html' | sort -V -u | tail -n 1)
+        _PKG_VERSION=$(ls artifactory/saltproject-generic/macos/ | grep -v 'index.html' | __salt_onedir_filter_ga_version_dirs | sort -V -u | tail -n 1)
     fi
-    cd ${curr_pwd} || return "${_PKG_VERSION}"
-    rm -fR ${macos_versions_tmpdir}
+    cd "${curr_pwd}" || return 1
+    rm -fR "${macos_versions_tmpdir}"
+
+    if [ -z "${_PKG_VERSION}" ]; then
+        if [ "$#" -gt 0 ] && [ -n "$1" ]; then
+            echoerror "No GA Salt macOS onedir version found for major series $1 (prerelease dirs are ignored for this selection)."
+        else
+            echoerror "No GA Salt macOS onedir version found for latest (prerelease dirs are ignored for this selection)."
+        fi
+        return 1
+    fi
 
     echodebug "latest MacOS release from repository found ${_PKG_VERSION}"
 
+    return 0
 }
 
 
@@ -7874,15 +7904,15 @@ __macosx_get_packagesite_onedir() {
     _ONEDIR_TYPE="saltproject-generic"
     SALT_MACOS_PKGDIR_URL="https://${_REPO_URL}/${_ONEDIR_TYPE}/macos"
     if [ "$(echo "$_ONEDIR_REV" | grep -E '^(latest)$')" != "" ]; then
-        __macosx_get_packagesite_onedir_latest
+        __macosx_get_packagesite_onedir_latest || return 1
     elif [ "$(echo "$_ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
         # need to get latest for major version
-        __macosx_get_packagesite_onedir_latest "$_ONEDIR_REV"
+        __macosx_get_packagesite_onedir_latest "$_ONEDIR_REV" || return 1
     elif [ "$(echo "$_ONEDIR_REV" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
         _PKG_VERSION=$_ONEDIR_REV
     else
         # default to getting latest
-        __macosx_get_packagesite_onedir_latest
+        __macosx_get_packagesite_onedir_latest || return 1
     fi
 
     PKG="salt-${_PKG_VERSION}-py3-${DARWIN_ARCH}.pkg"


### PR DESCRIPTION
### What does this PR do?
Updates the bootstrap scripts used by salt-cloud to the latest version, 2026.05.01. The script wasn't working due to the 3008.0rc1 release. This should fix that.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
