### PR TITLE
Fix multiline PowerShell -Command { } blocks failing on Windows

### DIFF
--- a/changelog/68397.fixed.md
+++ b/changelog/68397.fixed.md
@@ -1,0 +1,4 @@
+Fixed multiline powershell -Command { } blocks failing with "Missing closing
+'}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+execution and suppressing CLIXML noise from stderr.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -421,6 +421,15 @@ def _run(
             elif any(win_shell_lower.endswith(word) for word in ["cmd.exe"]):
                 if python_shell:
                     cmd = salt.platform.win.prepend_cmd(win_shell, cmd)
+                    # prepend_cmd may have silently converted -Command { } to
+                    # -EncodedCommand; treat that the same as encoded_cmd=True so
+                    # the CLIXML PowerShell emits to stderr is suppressed.
+                    if (
+                        not encoded_cmd
+                        and isinstance(cmd, str)
+                        and "-EncodedCommand" in cmd
+                    ):
+                        encoded_cmd = True
             else:
                 raise CommandExecutionError(f"unsupported shell type: {win_shell}")
         else:

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -9,10 +9,12 @@ Much of what is here was adapted from the following:
     http://stackoverflow.com/questions/29566330
 """
 
+import base64
 import collections
 import ctypes
 import logging
 import os
+import re
 import subprocess
 from ctypes import wintypes
 
@@ -1350,7 +1352,38 @@ def prepend_cmd(win_shell, cmd):
     if isinstance(cmd, (list, tuple)):
         args = subprocess.list2cmdline(cmd)
     else:
-        args = cmd
+        # cmd.exe treats newlines as command separators even within a command-line
+        # string, so a multiline command passed via the command line only executes
+        # its first line. Collapse CRLF/LF to a single space so the entire command
+        # reaches the target process (e.g. a PowerShell -Command script block).
+        args = cmd.replace("\r\n", " ").replace("\n", " ")
+        # When PowerShell's stdout is piped (non-interactive), the -Command { block }
+        # form evaluates the script block as an expression and returns the ScriptBlock
+        # object instead of executing it. Converting to -EncodedCommand avoids this
+        # and also sidesteps cmd.exe quoting issues with double quotes inside the block.
+        args = _maybe_encode_powershell_block(args)
     new_cmd = f"{win_shell} /c {args}"
 
     return new_cmd
+
+
+# Matches: powershell[-Command { block }] when the block is the last argument.
+# The executable name check prevents false positives on non-PowerShell commands.
+_PS_BLOCK_RE = re.compile(r"-Command\s+\{(.*)\}\s*$", re.IGNORECASE | re.DOTALL)
+_PS_EXE_RE = re.compile(r"(?:^|[\\/])(?:powershell|pwsh)(?:\.exe)?\b", re.IGNORECASE)
+
+
+def _maybe_encode_powershell_block(cmd):
+    """
+    If *cmd* is a PowerShell invocation that uses ``-Command { block }`` syntax,
+    replace it with ``-EncodedCommand <base64>`` so the script block is executed
+    rather than returned as a ScriptBlock object when stdout is not a console.
+    """
+    if not _PS_EXE_RE.search(cmd):
+        return cmd
+    m = _PS_BLOCK_RE.search(cmd)
+    if not m:
+        return cmd
+    content = m.group(1)
+    encoded = base64.b64encode(content.encode("utf-16-le")).decode("ascii")
+    return cmd[: m.start()] + f"-EncodedCommand {encoded}"

--- a/tests/pytests/functional/modules/cmd/test_powershell.py
+++ b/tests/pytests/functional/modules/cmd/test_powershell.py
@@ -270,3 +270,35 @@ def test_cmd_run_encoded_cmd_runas(shell, account, cmd, expected, encoded_cmd):
         password=account.password,
     )
     assert ret == expected
+
+
+@pytest.mark.parametrize(
+    "command, expected_stdout",
+    [
+        # LF line endings, as produced by a YAML block scalar (|)
+        (
+            "powershell -NoProfile -ExecutionPolicy Bypass -Command {\n    Write-Output test\n}\n",
+            "test",
+        ),
+        # CRLF line endings
+        (
+            "powershell -NoProfile -ExecutionPolicy Bypass -Command {\r\n    Write-Output test\r\n}\r\n",
+            "test",
+        ),
+    ],
+)
+def test_powershell_multiline_block_no_clixml(command, expected_stdout):
+    """
+    A multiline ``powershell -Command { }`` block run via cmd.run_all with
+    python_shell=True must execute correctly and must not leave CLIXML noise
+    in stderr.
+
+    Without special handling, cmd.exe treats newlines as command separators so
+    only the first line reaches PowerShell, producing a 'Missing closing }'
+    error. Salt collapses the newlines and converts ``-Command { block }`` to
+    ``-EncodedCommand`` so the script block executes and stderr is clean.
+    """
+    result = cmdmod.run_all(command, python_shell=True)
+    assert result["retcode"] == 0
+    assert result["stdout"] == expected_stdout
+    assert "CLIXML" not in result["stderr"]

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 
 import salt.utils.platform
@@ -44,3 +46,46 @@ def test_prepend_cmd(command, expected):
     win_shell = "cmd.exe"
     result = win.prepend_cmd(win_shell, command)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "command, expected_block_content",
+    [
+        # LF line endings
+        (
+            "powershell -Command {\n    Write-Host 'test'\n}\n",
+            "     Write-Host 'test' ",
+        ),
+        # CRLF line endings
+        (
+            "powershell -Command {\r\n    Write-Host 'test'\r\n}\r\n",
+            "     Write-Host 'test' ",
+        ),
+        # Flags before -Command
+        (
+            "powershell -NoProfile -ExecutionPolicy Bypass -Command {\n    Write-Host 'test'\n}\n",
+            "     Write-Host 'test' ",
+        ),
+    ],
+)
+def test_prepend_cmd_powershell_block_encoded(command, expected_block_content):
+    """
+    Multiline PowerShell -Command { } blocks must be converted to -EncodedCommand
+    so that the script block executes (rather than being returned as a ScriptBlock
+    object) when PowerShell's stdout is piped to a subprocess.
+    """
+    win_shell = "cmd.exe"
+    result = win.prepend_cmd(win_shell, command)
+
+    prefix = "cmd.exe /c "
+    assert result.startswith(prefix)
+    inner = result[len(prefix) :]
+
+    # The -EncodedCommand flag must be present and -Command must not be
+    assert "-EncodedCommand " in inner
+    assert "-Command" not in inner
+
+    # Decode and verify the script block content
+    encoded = inner.split("-EncodedCommand ", 1)[1].strip()
+    decoded = base64.b64decode(encoded).decode("utf-16-le")
+    assert decoded == expected_block_content


### PR DESCRIPTION
### What does this PR do?

When a Salt state uses a YAML block scalar (|) to define a multiline powershell -Command { block } command, cmd.exe treats the embedded newlines as command separators, causing only the first line to reach PowerShell and producing a "Missing closing '}'" error.

Fix by:
- Collapsing CRLF/LF to spaces in prepend_cmd (salt/platform/win.py) so the full command reaches PowerShell via cmd.exe /c
- Converting -Command { block } to -EncodedCommand <base64> via a new _maybe_encode_powershell_block helper, which also ensures the script block is executed rather than evaluated as a ScriptBlock object when stdout is piped (non-interactive)
- Detecting the implicit -EncodedCommand conversion in cmdmod._run() and setting encoded_cmd=True so the existing CLIXML suppression logic strips PowerShell's structured stderr noise
 
Adds unit tests for prepend_cmd / _maybe_encode_powershell_block and a functional test asserting correct stdout and clean stderr for both LF and CRLF multiline blocks.

### What issues does this PR fix or reference?
Fixes #68397 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
