### PR TITLE
Fix win_pkg msiexec quoting regression (issue #68950)

### DIFF
--- a/changelog/68950.fixed.md
+++ b/changelog/68950.fixed.md
@@ -1,0 +1,6 @@
+Fixed a regression in win_pkg where msiexec install flags containing
+Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+Restored the pre-regression behaviour where ``shlex_split`` is not applied
+to command strings on Windows, preserving Windows-style argument quoting
+when the command is passed directly to ``CreateProcess``.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -738,7 +738,7 @@ def _run(
     if (
         python_shell is not True
         and shell is not None
-        # and not salt.utils.platform.is_windows()
+        and not salt.utils.platform.is_windows()
         and not isinstance(cmd, list)
     ):
         cmd = salt.utils.args.shlex_split(cmd)

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -169,6 +169,34 @@ def test_run_runas_with_windows():
                         cmdmod._run("foo", "bar", runas="baz")
 
 
+def test_run_windows_preserves_cmd_string_quoting():
+    """
+    On Windows, shlex_split must NOT be called on the command string so that
+    Windows-style argument quoting (e.g. MYPROPERTY="C:\\path with space") is
+    preserved when the string is handed directly to CreateProcess.
+    Regression test for issue #68950.
+    """
+    mock_proc = MockTimedProc(stdout=b"", stderr=b"")
+    with patch("salt.utils.platform.is_windows", MagicMock(return_value=True)), patch(
+        "salt.utils.path.which",
+        MagicMock(return_value="C:\\Windows\\system32\\cmd.exe"),
+    ), patch(
+        "salt.utils.timed_subprocess.TimedProc", MagicMock(return_value=mock_proc)
+    ), patch(
+        "salt.utils.args.shlex_split"
+    ) as mock_shlex:
+        try:
+            cmdmod._run(
+                '"msiexec" /I "C:\\pkg.msi" MYPROPERTY="C:\\some file.txt"',
+                cwd="C:\\",
+                shell="C:\\Windows\\system32\\cmd.exe",
+                python_shell=False,
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass
+        mock_shlex.assert_not_called()
+
+
 def test_run_with_tuple():
     """
     Tests return when cmd is a tuple

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -301,6 +301,58 @@ def test_pkg_install_existing_with_version():
         assert expected == result
 
 
+def test_pkg_install_msiexec_quoted_property():
+    """
+    Test that msiexec extra_install_flags with Windows-style property=value quoting
+    (e.g. MYPROPERTY="C:\\path with space") are preserved as-is when passed to
+    cmd.run_all (regression test for issue #68950).
+    """
+    ret__get_package_info = {
+        "0.11.29": {
+            "uninstaller": "{GUID}",
+            "reboot": False,
+            "msiexec": True,
+            "installer": "https://example.com/pkg.msi",
+            "uninstall_flags": "/X {GUID} /qn",
+            "locale": "en_US",
+            "install_flags": "/qn /norestart",
+            "full_name": "NSClient++ (x64)",
+        }
+    }
+
+    mock_cmd_run_all = MagicMock(return_value={"retcode": 0})
+    with patch.object(
+        salt.utils.data, "is_true", MagicMock(return_value=True)
+    ), patch.object(
+        win_pkg, "_get_package_info", MagicMock(return_value=ret__get_package_info)
+    ), patch.dict(
+        win_pkg.__salt__,
+        {
+            "pkg_resource.parse_targets": MagicMock(
+                return_value=[{"nsclient": "0.11.29"}, None]
+            ),
+            "cp.is_cached": MagicMock(
+                return_value="C:\\ProgramData\\Salt\\cache\\pkg.msi"
+            ),
+            "cmd.run_all": mock_cmd_run_all,
+        },
+    ):
+        win_pkg.install(
+            name="nsclient",
+            version="0.11.29",
+            extra_install_flags='MYPROPERTY="C:\\some file.txt"',
+        )
+        call_cmd = mock_cmd_run_all.call_args[0][0]
+        # The property=value pair must keep its inner quotes so msiexec can parse it
+        assert (
+            'MYPROPERTY="C:\\some file.txt"' in call_cmd
+        ), f"Expected inner-quoted property in cmd, got: {call_cmd!r}"
+        # Outer-quoted form produced by shlex_split + list2cmdline must not appear
+        assert (
+            '"MYPROPERTY=C:\\some file.txt"' not in call_cmd
+        ), f"Outer-quoted property found in cmd (shlex_split regression): {call_cmd!r}"
+
+
 def test_pkg_install_name():
     """
     test pkg.install name extra_install_flags


### PR DESCRIPTION
### What does this PR do?
Restore the `and not salt.utils.platform.is_windows()` guard that was commented out during the cc32817a4b refactor. Without it, shlex_split was called on Windows command strings inside cmdmod._run, stripping inner quotes from MSI property values such as
MYPROPERTY="C:\some file.txt". subprocess.list2cmdline then re-wrapped the space-containing token as "MYPROPERTY=C:\some file.txt", which msiexec cannot parse, causing it to hang on its help dialog.

On Windows, command strings are passed directly to CreateProcess and must not be split via shlex. This restores the pre-3006.17 behaviour.

### What issues does this PR fix or reference?
Fixes #68950 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
