### PR TITLE
Fix AttributeError on closed IPCClient (#68993)

### DIFF
--- a/changelog/68993.fixed.md
+++ b/changelog/68993.fixed.md
@@ -1,0 +1,1 @@
+Avoid AttributeError on a closed IPCClient when the connect coroutine resolves after close().

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -330,7 +330,8 @@ class IPCClient:
             try:
                 log.trace("IPCClient: Connecting to socket: %s", self.socket_path)
                 yield self.stream.connect(sock_addr)
-                self._connecting_future.set_result(True)
+                if self._connecting_future is not None:
+                    self._connecting_future.set_result(True)
                 break
             except Exception as e:  # pylint: disable=broad-except
                 if self.stream.closed():
@@ -340,7 +341,8 @@ class IPCClient:
                     if self.stream is not None:
                         self.stream.close()
                         self.stream = None
-                    self._connecting_future.set_exception(e)
+                    if self._connecting_future is not None:
+                        self._connecting_future.set_exception(e)
                     break
 
                 yield salt.ext.tornado.gen.sleep(1)

--- a/tests/pytests/unit/transport/test_ipc.py
+++ b/tests/pytests/unit/transport/test_ipc.py
@@ -34,3 +34,25 @@ async def test_ipc_connect_sync_wrapped(io_loop, tmp_path):
     with pytest.raises(salt.ext.tornado.iostream.StreamClosedError):
         # Don't `await subscriber.connect()`, that's the purpose of the SyncWrapper
         subscriber.connect()
+
+
+async def test_ipc_client_connect_after_close_no_attribute_error(io_loop, tmp_path):
+    """
+    Regression for #68993.
+
+    When IPCClient.close() runs while _connect() is still pending, the
+    coroutine eventually resumes and used to call set_result/set_exception
+    on self._connecting_future after close() had cleared it to None,
+    raising AttributeError. _connect() must tolerate a cleared
+    _connecting_future.
+    """
+    if salt.utils.platform.is_windows():
+        socket_path = ports.get_unused_localhost_port()
+    else:
+        socket_path = str(tmp_path / "noexist.ipc")
+    client = salt.transport.ipc.IPCClient(socket_path, io_loop=io_loop)
+    # Simulate the race: _connecting_future has already been cleared by
+    # close() by the time _connect() reaches its set_result/set_exception
+    # call sites. timeout=0 forces the failure branch on the first attempt.
+    client._connecting_future = None
+    await client._connect(timeout=0)


### PR DESCRIPTION
Fixes #68993.

When `IPCClient.close()` runs while `_connect()` is still pending, the coroutine reaches `set_result`/`set_exception` after `_connecting_future` has been cleared to `None`, raising `AttributeError`. Guard both call sites with a None-check.