### PR TITLE
Calculate UUID grain for Xen PV guests

### DIFF
--- a/changelog/69036.added.md
+++ b/changelog/69036.added.md
@@ -1,0 +1,1 @@
+Added UUID detection for Xen paravirtualized guests

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3260,15 +3260,18 @@ def _hw_data(osdata):
 
     grains = {}
 
-    # For Xen para-virtualized guests read UUID from /sys/hypervisor/uuid
+    # For Xen para-virtualized guests read UUID from /sys/hypervisor/uuid.
+    # This file also exists on Xen Dom0 but contains all-zeros; skip that
+    # sentinel value so the real DMI/smbios UUID is used on Dom0 hosts.
     if osdata["kernel"] == "Linux" and os.path.exists("/sys/hypervisor/uuid"):
         try:
             with salt.utils.files.fopen("/sys/hypervisor/uuid", "rb") as ifile:
                 hypervisor_uuid = salt.utils.stringutils.to_unicode(
                     ifile.read().strip(), errors="replace"
-                )
-                if hypervisor_uuid:
-                    grains["uuid"] = hypervisor_uuid.lower()
+                ).lower()
+                # All-zero UUID is the Dom0 sentinel; ignore it.
+                if hypervisor_uuid and hypervisor_uuid.strip("0-"):
+                    grains["uuid"] = hypervisor_uuid
                     log.debug(
                         "Read UUID from /sys/hypervisor/uuid for para-virtualized guest: %s",
                         grains["uuid"],

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3323,18 +3323,20 @@ def _hw_data(osdata):
     ):
         # On SmartOS (possibly SunOS also) smbios only works in the global zone
         # smbios is also not compatible with linux's smbios (smbios -s = print summarized)
+        uuid = __salt__["smbios.get"]("system-uuid")
+        if uuid is not None:
+            uuid = uuid.lower()
+        else:
+            uuid = grains.get("uuid")
         grains = {
             "biosversion": __salt__["smbios.get"]("bios-version"),
             "biosvendor": __salt__["smbios.get"]("bios-vendor"),
             "productname": __salt__["smbios.get"]("system-product-name"),
             "manufacturer": __salt__["smbios.get"]("system-manufacturer"),
             "biosreleasedate": __salt__["smbios.get"]("bios-release-date"),
-            "uuid": __salt__["smbios.get"]("system-uuid"),
+            "uuid": uuid,
         }
         grains = {key: val for key, val in grains.items() if val is not None}
-        uuid = __salt__["smbios.get"]("system-uuid")
-        if uuid is not None:
-            grains["uuid"] = uuid.lower()
         for serial in (
             "system-serial-number",
             "chassis-serial-number",

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3263,16 +3263,16 @@ def _hw_data(osdata):
     # For Xen para-virtualized guests read UUID from /sys/hypervisor/uuid
     if osdata["kernel"] == "Linux" and os.path.exists("/sys/hypervisor/uuid"):
         try:
-            with salt.utils.files.fopen("/sys/hypervisor/uuid", "r") as ifile:
+            with salt.utils.files.fopen("/sys/hypervisor/uuid", "rb") as ifile:
                 hypervisor_uuid = salt.utils.stringutils.to_unicode(
                     ifile.read().strip(), errors="replace"
                 )
-                # Normalize to lowercase to match DMI format
-                grains["uuid"] = hypervisor_uuid.lower()
-                log.debug(
-                    "Read UUID from /sys/hypervisor/uuid for para-virtualized guest: %s",
-                    grains["uuid"],
-                )
+                if hypervisor_uuid:
+                    grains["uuid"] = hypervisor_uuid.lower()
+                    log.debug(
+                        "Read UUID from /sys/hypervisor/uuid for para-virtualized guest: %s",
+                        grains["uuid"],
+                    )
         except OSError as err:
             log.debug("Unable to read /sys/hypervisor/uuid: %s", err)
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3259,6 +3259,23 @@ def _hw_data(osdata):
         return {}
 
     grains = {}
+
+    # For Xen para-virtualized guests read UUID from /sys/hypervisor/uuid
+    if osdata["kernel"] == "Linux" and os.path.exists("/sys/hypervisor/uuid"):
+        try:
+            with salt.utils.files.fopen("/sys/hypervisor/uuid", "r") as ifile:
+                hypervisor_uuid = salt.utils.stringutils.to_unicode(
+                    ifile.read().strip(), errors="replace"
+                )
+                # Normalize to lowercase to match DMI format
+                grains["uuid"] = hypervisor_uuid.lower()
+                log.debug(
+                    "Read UUID from /sys/hypervisor/uuid for para-virtualized guest: %s",
+                    grains["uuid"],
+                )
+        except OSError as err:
+            log.debug("Unable to read /sys/hypervisor/uuid: %s", err)
+
     if osdata["kernel"] == "Linux" and os.path.exists("/sys/class/dmi/id"):
         # On many Linux distributions basic firmware information is available via sysfs
         # requires CONFIG_DMIID to be enabled in the Linux kernel configuration
@@ -3273,6 +3290,9 @@ def _hw_data(osdata):
             "serialnumber": "product_serial",
         }
         for key, fw_file in sysfs_firmware_info.items():
+            # Skip UUID if already read from /sys/hypervisor/uuid (Xen PV guests)
+            if key == "uuid" and "uuid" in grains:
+                continue
             contents_file = os.path.join("/sys/class/dmi/id", fw_file)
             if os.path.exists(contents_file):
                 try:

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3580,6 +3580,30 @@ def test__hw_data_xen_pv_uuid():
         assert result.get("uuid") == expected_uuid
 
 
+@pytest.mark.skip_unless_on_linux
+def test__hw_data_xen_dom0_uuid_ignored():
+    """
+    On Xen Dom0, /sys/hypervisor/uuid contains an all-zero sentinel value.
+    The grain should not be set from that value so the real DMI UUID can
+    be used instead.
+    """
+    dom0_uuid = b"00000000-0000-0000-0000-000000000000"
+
+    def _exists_side_effect(path):
+        if path == "/sys/hypervisor/uuid":
+            return True
+        return False
+
+    with patch("os.path.exists", side_effect=_exists_side_effect), patch(
+        "salt.utils.platform.is_proxy", return_value=False
+    ), patch("salt.utils.path.which_bin", return_value=None), patch(
+        "salt.utils.files.fopen",
+        mock_open(read_data=dom0_uuid),
+    ):
+        result = core._hw_data({"kernel": "Linux"})
+        assert result.get("uuid") is None
+
+
 @pytest.mark.skip_unless_on_windows
 def test_kernelparams_return_windows():
     """

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3562,7 +3562,7 @@ def test__hw_data_linux_unicode_error():
 
 @pytest.mark.skip_unless_on_linux
 def test__hw_data_xen_pv_uuid():
-    hypervisor_uuid = "12345678-1234-1234-1234-123456789ABC"
+    hypervisor_uuid = b"12345678-1234-1234-1234-123456789ABC"
     expected_uuid = "12345678-1234-1234-1234-123456789abc"
 
     def _exists_side_effect(path):

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3560,6 +3560,26 @@ def test__hw_data_linux_unicode_error():
         assert core._hw_data({"kernel": "Linux"}) == {}
 
 
+@pytest.mark.skip_unless_on_linux
+def test__hw_data_xen_pv_uuid():
+    hypervisor_uuid = "12345678-1234-1234-1234-123456789ABC"
+    expected_uuid = "12345678-1234-1234-1234-123456789abc"
+
+    def _exists_side_effect(path):
+        if path == "/sys/hypervisor/uuid":
+            return True
+        return False
+
+    with patch("os.path.exists", side_effect=_exists_side_effect), patch(
+        "salt.utils.platform.is_proxy", return_value=False
+    ), patch("salt.utils.path.which_bin", return_value=None), patch(
+        "salt.utils.files.fopen",
+        mock_open(read_data=hypervisor_uuid),
+    ):
+        result = core._hw_data({"kernel": "Linux"})
+        assert result.get("uuid") == expected_uuid
+
+
 @pytest.mark.skip_unless_on_windows
 def test_kernelparams_return_windows():
     """


### PR DESCRIPTION
### What does this PR do?

On Linux systems running as Xen paravirtualized (PV) guests, standard DMI/SMBIOS tools (like dmidecode) may not be available or may not provide the correct hardware UUID. Instead, Xen provides this information via /sys/hypervisor/uuid.

This PR updates the core grains to prioritize reading the UUID from the Xen hypervisor path when it exists.

### What issues does this PR fix or reference?
Tracks https://github.com/SUSE/spacewalk/issues/29298

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
