### PR TITLE
Fix pgjsonb returner referencing salt.utils.jid without importing it

### DIFF
--- a/changelog/69042.fixed.md
+++ b/changelog/69042.fixed.md
@@ -1,0 +1,4 @@
+Fixed `salt.returners.pgjsonb.prep_jid` and `get_jids` raising
+`AttributeError` when the `salt.utils.jid` submodule was not loaded
+transitively by another import. The pgjsonb module now imports
+`salt.utils.jid` explicitly.

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -167,6 +167,7 @@ from contextlib import contextmanager
 import salt.exceptions
 import salt.returners
 import salt.utils.data
+import salt.utils.jid
 import salt.utils.job
 
 try:

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -317,3 +317,53 @@ def test_event_return_logs_on_database_error_without_raising(caplog):
         "failed to store" in r.message and "3 event" in r.message
         for r in caplog.records
     )
+
+
+def test_prep_jid_returns_passed_jid_unchanged():
+    """``prep_jid(passed_jid=X)`` returns X verbatim."""
+    assert pgjsonb.prep_jid(passed_jid="20260504000000000001") == "20260504000000000001"
+
+
+def test_prep_jid_generates_a_valid_jid_when_none_passed():
+    """With no ``passed_jid``, ``prep_jid`` returns Salt's default
+    20-character all-digit jid."""
+    out = pgjsonb.prep_jid()
+    assert isinstance(out, str)
+    assert out.isdigit()
+    assert len(out) == 20
+
+
+def test_get_jids_returns_one_formatted_entry_per_row():
+    """``get_jids`` reads ``(jid, load)`` rows from the ``jids`` table
+    and returns ``{jid: format_jid_instance(jid, load)}``."""
+    rows = [
+        (
+            "20260504000000000001",
+            {"fun": "test.ping", "tgt": "*", "user": "root", "arg": []},
+        ),
+        (
+            "20260504000000000002",
+            {
+                "fun": "state.apply",
+                "tgt": "minion-1",
+                "user": "salt",
+                "arg": ["highstate"],
+            },
+        ),
+    ]
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        result = pgjsonb.get_jids()
+
+    assert set(result) == {"20260504000000000001", "20260504000000000002"}
+    assert result["20260504000000000001"]["Function"] == "test.ping"
+    assert result["20260504000000000001"]["Target"] == "*"
+    assert result["20260504000000000001"]["User"] == "root"
+    assert result["20260504000000000002"]["Function"] == "state.apply"
+    assert result["20260504000000000002"]["Target"] == "minion-1"
+    assert result["20260504000000000002"]["Arguments"] == ["highstate"]
+    assert result["20260504000000000002"]["User"] == "salt"


### PR DESCRIPTION
### What does this PR do?

Restores the explicit `import salt.utils.jid` in
`salt/returners/pgjsonb.py`. The module uses `salt.utils.jid.gen_jid()`
in `prep_jid()` and `salt.utils.jid.format_jid_instance()` in
`get_jids()`, but does not import the submodule. Today this works
only because `salt.utils.args` (transitively pulled in via
`salt.utils.data`, which the module does import) loads
`salt.utils.jid` as a side effect.

Adds behavioural unit tests for `prep_jid()` and `get_jids()` (none
existed before): the `passed_jid` pass-through, the default jid
format, and end-to-end formatting of `jids`-table rows through the
real `salt.utils.jid.format_jid_instance()`.

### What issues does this PR fix or reference?

Fixes #69042

### Previous Behavior

`prep_jid()` and `get_jids()` work only when `salt.utils.jid` has
been loaded by some other code path before pgjsonb is exercised. In
a process where it has not been (or where a future refactor of
`salt.utils.args` removes the side effect), both raise:

    AttributeError: module 'salt.utils' has no attribute 'jid'

`master.py:_prep_jid()` only handles `KeyError, TypeError`, so an
`AttributeError` there propagates up and prevents job publish.

### New Behavior

`pgjsonb` imports `salt.utils.jid` explicitly. The functions work
regardless of import order in the surrounding process.

### Merge requirements satisfied?

- [ ] Docs (no user-facing change; not required)
- [x] Changelog — `changelog/69042.fixed.md`
- [x] Tests written/updated — see
  `tests/pytests/unit/returners/test_pgjsonb.py`

### Commits signed with GPG?

No.