### PR TITLE
Route pgjsonb database errors through Salt's logger instead of stderr

### DIFF
--- a/changelog/69048.fixed.md
+++ b/changelog/69048.fixed.md
@@ -1,0 +1,5 @@
+Fixed `salt.returners.pgjsonb` writing database errors to `sys.stderr`
+instead of Salt's logger. Errors from `_get_serv`, `_purge_jobs` and
+`_archive_jobs` are now reported via `log.exception`, so they reach
+the configured `log_file` / syslog destination on a daemonized master,
+including a full traceback. The unused `import sys` is also dropped.


### PR DESCRIPTION
### What does this PR do?

`salt/returners/pgjsonb.py` has eight error-handling sites in `_get_serv`, `_purge_jobs` and `_archive_jobs` that write `psycopg2.DatabaseError` messages directly to `sys.stderr` and re-raise. On a daemonized master `sys.stderr` ends up in systemd's journal at best (or `/dev/null` at worst) — never in the configured `log_file` / syslog destination. Operators that scrape Salt's log file have no idea those database errors happened.

This PR replaces every `sys.stderr.write` with `log.exception(...)` carrying a description of the operation that failed, so the message and a full traceback reach Salt's configured log destination. The dead `error = err.args` assignment is removed, the now-unused `import sys` is dropped, and `raise err` is normalised to bare `raise` to preserve the original traceback. Behaviour (rollback, re-raise) is unchanged — only the visibility of the error changes.

The asymmetric `except Exception` block on `_archive_jobs` jids-insert is updated to use `log.exception` for consistency, but it is left in place for the same scope reason — sorting that asymmetry out belongs in a separate PR.

### What issues does this PR fix or reference?

Fixes #69048

### Previous Behavior

```python
except psycopg2.DatabaseError as err:
    error = err.args
    sys.stderr.write(str(error))
    cursor.execute("ROLLBACK")
    raise err
```

The error message went to stderr (journal / /dev/null) and never to the configured Salt log. The exception still propagated, but with a synthetic traceback (because of `raise err` instead of bare `raise`).

### New Behavior

```python
except psycopg2.DatabaseError:
    log.exception("pgjsonb: failed to purge salt_returns")
    cursor.execute("ROLLBACK")
    raise
```

The error message and the full traceback are routed through `log.exception` to Salt's configured logger. The original traceback is preserved.

### Merge requirements satisfied?

- [ ] Docs (no user-facing change; not required)
- [x] Changelog — `changelog/69048.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test__purge_jobs_logs_via_salt_logger_and_reraises_on_db_error`
  - `test__archive_jobs_logs_via_salt_logger_and_reraises_on_db_error`
  - `test__get_serv_logs_via_salt_logger_and_reraises_on_yield_error`

### Commits signed with GPG?

No.