### PR TITLE
Add configurable connect_timeout to pgjsonb returner

### DIFF
--- a/changelog/69050.added.md
+++ b/changelog/69050.added.md
@@ -1,0 +1,6 @@
+Added an optional `returner.pgjsonb.connect_timeout` configuration
+option (in seconds) for the pgjsonb returner. When set, the value is
+forwarded to `psycopg2.connect(connect_timeout=...)` so a stalled
+PostgreSQL connect attempt cannot block the master event loop. The
+option has no default and the existing connect behaviour is preserved
+for deployments that do not set it.

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -29,6 +29,16 @@ config. These are the defaults:
     returner.pgjsonb.db: 'salt'
     returner.pgjsonb.port: 5432
 
+An optional ``connect_timeout`` (in seconds) caps how long ``psycopg2.connect``
+will wait for a database connection. When unset, ``libpq``'s default applies
+(no application-level timeout, only the system TCP timeout). Setting it is
+recommended on masters that talk to PostgreSQL through HAProxy or Sentinel
+to keep a stalled connect attempt from blocking the master event loop.
+
+.. code-block:: yaml
+
+    returner.pgjsonb.connect_timeout: 5
+
 SSL is optional. The defaults are set to None. If you do not want to use SSL,
 either exclude these options or set them to None.
 
@@ -212,6 +222,7 @@ def _get_options(ret=None):
         "pass": "pass",
         "db": "db",
         "port": "port",
+        "connect_timeout": "connect_timeout",
         "sslmode": "sslmode",
         "sslcert": "sslcert",
         "sslkey": "sslkey",
@@ -230,6 +241,9 @@ def _get_options(ret=None):
     # Ensure port is an int
     if "port" in _options:
         _options["port"] = int(_options["port"])
+    # Coerce connect_timeout when set: pillar / env may deliver it as a string.
+    if _options.get("connect_timeout") is not None:
+        _options["connect_timeout"] = int(_options["connect_timeout"])
     return _options
 
 
@@ -247,14 +261,19 @@ def _get_serv(ret=None, commit=False):
             for k, v in _options.items()
             if k in ["sslmode", "sslcert", "sslkey", "sslrootcert", "sslcrl"]
         }
-        conn = psycopg2.connect(
-            host=_options.get("host"),
-            port=_options.get("port"),
-            dbname=_options.get("db"),
-            user=_options.get("user"),
-            password=_options.get("pass"),
+        connect_kwargs = {
+            "host": _options.get("host"),
+            "port": _options.get("port"),
+            "dbname": _options.get("db"),
+            "user": _options.get("user"),
+            "password": _options.get("pass"),
             **ssl_options,
-        )
+        }
+        # Only pass connect_timeout when configured; omitting it preserves
+        # libpq's default behaviour for existing deployments.
+        if _options.get("connect_timeout") is not None:
+            connect_kwargs["connect_timeout"] = _options["connect_timeout"]
+        conn = psycopg2.connect(**connect_kwargs)
     except psycopg2.OperationalError as exc:
         raise salt.exceptions.SaltMasterError(
             f"pgjsonb returner could not connect to database: {exc}"

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -367,3 +367,50 @@ def test_get_jids_returns_one_formatted_entry_per_row():
     assert result["20260504000000000002"]["Target"] == "minion-1"
     assert result["20260504000000000002"]["Arguments"] == ["highstate"]
     assert result["20260504000000000002"]["User"] == "salt"
+
+
+def _enter_get_serv(connect_mock):
+    """Enter ``_get_serv`` once with a mocked ``psycopg2.connect`` and a
+    minimal fake connection, so the body opens the connection and we can
+    inspect the kwargs the caller passed to ``connect``."""
+    fake_conn = MagicMock()
+    fake_conn.server_version = 90500
+    connect_mock.return_value = fake_conn
+    with patch("psycopg2.connect", connect_mock):
+        with pgjsonb._get_serv():
+            pass
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test__get_serv_omits_connect_timeout_when_not_configured():
+    """Existing deployments must keep their current connect behaviour:
+    when no ``connect_timeout`` is configured, the kwarg is not passed to
+    ``psycopg2.connect`` at all so libpq's default (no app-level timeout)
+    still applies."""
+    connect = MagicMock()
+    with patch.object(pgjsonb, "_get_options", return_value={}):
+        _enter_get_serv(connect)
+    assert "connect_timeout" not in connect.call_args.kwargs
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test__get_serv_passes_connect_timeout_when_configured():
+    """When ``connect_timeout`` is configured, it is forwarded to
+    ``psycopg2.connect`` verbatim."""
+    connect = MagicMock()
+    with patch.object(pgjsonb, "_get_options", return_value={"connect_timeout": 5}):
+        _enter_get_serv(connect)
+    assert connect.call_args.kwargs["connect_timeout"] == 5
+
+
+def test__get_options_coerces_string_connect_timeout_to_int():
+    """A string ``connect_timeout`` (as it can arrive from pillar or env)
+    is coerced to int so ``psycopg2.connect`` does not get a string."""
+    with patch.object(
+        pgjsonb.salt.returners,
+        "get_returner_options",
+        return_value={"connect_timeout": "5", "port": "5432"},
+    ):
+        opts = pgjsonb._get_options()
+    assert opts["connect_timeout"] == 5
+    assert isinstance(opts["connect_timeout"], int)


### PR DESCRIPTION
### What does this PR do?

`salt/returners/pgjsonb.py` calls `psycopg2.connect()` without `connect_timeout`. When the database is reachable on the network but does not respond — stalled standby, firewall drop, HAProxy or Sentinel mid-failover — the connect call blocks for tens of seconds on the system TCP timeout. Both `event_return` and `clean_old_jobs` run inside the master event loop, so one stalled connect cascades into delayed events and slow returners across the whole master.

This PR adds an optional `returner.pgjsonb.connect_timeout` (seconds) that is forwarded to `psycopg2.connect(connect_timeout=...)` only when set. With no default, the kwarg is omitted entirely, so libpq's default behaviour stays in force for existing deployments — operators opt in.

```yaml
returner.pgjsonb.connect_timeout: 5
```

`_get_options` also coerces a string-valued timeout (which can arrive via pillar or environment) to int, mirroring the existing treatment of `port`.

### What issues does this PR fix or reference?

Fixes #69050

### Previous Behavior

```python
conn = psycopg2.connect(
    host=_options.get("host"),
    port=_options.get("port"),
    dbname=_options.get("db"),
    user=_options.get("user"),
    password=_options.get("pass"),
    **ssl_options,
)
```

No `connect_timeout`, no way for an operator to bound the wait short of patching Salt.

### New Behavior

```python
connect_kwargs = {
    "host": _options.get("host"),
    "port": _options.get("port"),
    "dbname": _options.get("db"),
    "user": _options.get("user"),
    "password": _options.get("pass"),
    **ssl_options,
}
if _options.get("connect_timeout") is not None:
    connect_kwargs["connect_timeout"] = _options["connect_timeout"]
conn = psycopg2.connect(**connect_kwargs)
```

The kwarg is forwarded only when configured. Backwards-compatible for every existing deployment; opt-in for operators that need it.

### Merge requirements satisfied?

- [x] Docs — module docstring extended with the new option and a usage example.
- [x] Changelog — `changelog/69050.added.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test__get_serv_omits_connect_timeout_when_not_configured` (backwards-compat guard)
  - `test__get_serv_passes_connect_timeout_when_configured`
  - `test__get_options_coerces_string_connect_timeout_to_int`

### Commits signed with GPG?

No.