### PR TITLE
Drop mutable global PG_SAVE_LOAD_SQL in pgjsonb returner

### DIFF
--- a/changelog/69046.fixed.md
+++ b/changelog/69046.fixed.md
@@ -1,0 +1,6 @@
+Fixed `salt.returners.pgjsonb.save_load` silently swallowing all
+`psycopg2.IntegrityError`s. The catch is now narrowed to
+`psycopg2.errors.UniqueViolation` only — the legacy duplicate-jid
+case from #22171 on PostgreSQL < 9.5 — and emits a warning. Other
+integrity errors (foreign-key, NOT NULL, CHECK violations) now
+surface to the caller instead of being dropped.

--- a/changelog/69052.fixed.md
+++ b/changelog/69052.fixed.md
@@ -1,0 +1,7 @@
+Fixed `salt.returners.pgjsonb` mutating a module-global SQL string
+(`PG_SAVE_LOAD_SQL`) inside `_get_serv` on every connection. The
+SQL form is now chosen per-call inside `save_load` from the actual
+connection's `server_version`, so a master that talks to PostgreSQL
+clusters with mixed versions (e.g. through a failover) no longer
+sends UPSERT syntax to a pre-9.5 server after the first 9.5+
+connection.

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -172,6 +172,7 @@ import salt.utils.job
 
 try:
     import psycopg2
+    import psycopg2.errors
     import psycopg2.extras
 
     HAS_PG = True
@@ -345,11 +346,13 @@ def save_load(jid, load, minions=None):
             cur.execute(
                 PG_SAVE_LOAD_SQL, {"jid": jid, "load": psycopg2.extras.Json(load)}
             )
-        except psycopg2.IntegrityError:
-            # https://github.com/saltstack/salt/issues/22171
-            # Without this try/except we get tons of duplicate entry errors
-            # which result in job returns not being stored properly
-            pass
+        except psycopg2.errors.UniqueViolation:
+            # PG >= 9.5 uses ON CONFLICT (see _get_serv) and never reaches
+            # this branch. On PG < 9.5 the same jid may legitimately be
+            # written twice (see #22171); tolerate that one case. Other
+            # integrity errors (FK, NOT NULL, CHECK) are real bugs and are
+            # left to propagate.
+            log.warning("save_load: duplicate jid %s ignored (PG < 9.5)", jid)
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -184,8 +184,6 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = "pgjsonb"
 
-PG_SAVE_LOAD_SQL = """INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s)"""
-
 
 def __virtual__():
     if not HAS_PG:
@@ -262,14 +260,6 @@ def _get_serv(ret=None, commit=False):
             f"pgjsonb returner could not connect to database: {exc}"
         )
 
-    if conn.server_version is not None and conn.server_version >= 90500:
-        global PG_SAVE_LOAD_SQL
-        PG_SAVE_LOAD_SQL = """INSERT INTO jids
-                              (jid, load)
-                              VALUES (%(jid)s, %(load)s)
-                              ON CONFLICT (jid) DO UPDATE
-                              SET load=%(load)s"""
-
     cursor = conn.cursor()
 
     try:
@@ -342,16 +332,24 @@ def save_load(jid, load, minions=None):
     """
     with _get_serv(commit=True) as cur:
         load = salt.utils.data.decode(load)
-        try:
-            cur.execute(
-                PG_SAVE_LOAD_SQL, {"jid": jid, "load": psycopg2.extras.Json(load)}
+        # The SQL form is decided per-call from the actual connection
+        # version: ON CONFLICT is supported from PostgreSQL 9.5 onward;
+        # older servers fall back to a plain INSERT and rely on the
+        # UniqueViolation handler below for duplicate jids (#22171).
+        if cur.connection.server_version >= 90500:
+            sql = (
+                "INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s) "
+                "ON CONFLICT (jid) DO UPDATE SET load=%(load)s"
             )
+        else:
+            sql = "INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s)"
+        try:
+            cur.execute(sql, {"jid": jid, "load": psycopg2.extras.Json(load)})
         except psycopg2.errors.UniqueViolation:
-            # PG >= 9.5 uses ON CONFLICT (see _get_serv) and never reaches
-            # this branch. On PG < 9.5 the same jid may legitimately be
-            # written twice (see #22171); tolerate that one case. Other
-            # integrity errors (FK, NOT NULL, CHECK) are real bugs and are
-            # left to propagate.
+            # PG >= 9.5 takes the ON CONFLICT path and never lands here.
+            # On PG < 9.5 the same jid may legitimately be written twice
+            # (see #22171); tolerate that one case. Other integrity errors
+            # (FK, NOT NULL, CHECK) are real bugs and are left to propagate.
             log.warning("save_load: duplicate jid %s ignored (PG < 9.5)", jid)
 
 

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -79,3 +79,34 @@ def test_save_load_with_bytes():
         with patch.object(psycopg2.extras, "Json") as json_mock:
             pgjsonb.save_load(load["jid"], load)
             json_mock.assert_called_with(decoded_load)
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test_save_load_swallows_duplicate_jid_unique_violation():
+    """A duplicate-jid unique violation on PG < 9.5 is the legacy case
+    from #22171 (PG >= 9.5 uses ON CONFLICT and never reaches here);
+    it must be tolerated silently."""
+    cur = MagicMock()
+    cur.execute.side_effect = psycopg2.errors.UniqueViolation("duplicate jid")
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        # Should not raise.
+        pgjsonb.save_load("20260504000000000001", {"fun": "test.ping"})
+
+    cur.execute.assert_called_once()
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test_save_load_propagates_other_integrity_errors():
+    """Non-unique-violation IntegrityErrors (foreign-key, NOT NULL, CHECK)
+    are real bugs and must surface instead of being silently swallowed."""
+    cur = MagicMock()
+    cur.execute.side_effect = psycopg2.errors.ForeignKeyViolation("fk violation")
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        with pytest.raises(psycopg2.IntegrityError):
+            pgjsonb.save_load("20260504000000000001", {"fun": "test.ping"})

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -75,7 +75,9 @@ def test_save_load_with_bytes():
         "return": "bytes",
         "jid": "20221101172203459989",
     }
-    with patch.object(pgjsonb, "_get_serv"):
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value.connection.server_version = 90500
+    with patch.object(pgjsonb, "_get_serv", serv):
         with patch.object(psycopg2.extras, "Json") as json_mock:
             pgjsonb.save_load(load["jid"], load)
             json_mock.assert_called_with(decoded_load)
@@ -87,6 +89,7 @@ def test_save_load_swallows_duplicate_jid_unique_violation():
     from #22171 (PG >= 9.5 uses ON CONFLICT and never reaches here);
     it must be tolerated silently."""
     cur = MagicMock()
+    cur.connection.server_version = 90400  # PG < 9.5: only path that reaches the catch.
     cur.execute.side_effect = psycopg2.errors.UniqueViolation("duplicate jid")
     serv = MagicMock()
     serv.return_value.__enter__.return_value = cur
@@ -103,6 +106,7 @@ def test_save_load_propagates_other_integrity_errors():
     """Non-unique-violation IntegrityErrors (foreign-key, NOT NULL, CHECK)
     are real bugs and must surface instead of being silently swallowed."""
     cur = MagicMock()
+    cur.connection.server_version = 90500
     cur.execute.side_effect = psycopg2.errors.ForeignKeyViolation("fk violation")
     serv = MagicMock()
     serv.return_value.__enter__.return_value = cur
@@ -110,3 +114,37 @@ def test_save_load_propagates_other_integrity_errors():
     with patch.object(pgjsonb, "_get_serv", serv):
         with pytest.raises(psycopg2.IntegrityError):
             pgjsonb.save_load("20260504000000000001", {"fun": "test.ping"})
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test_save_load_uses_upsert_sql_on_pg_95_or_newer():
+    """On PostgreSQL >= 9.5 ``save_load`` must issue the ON CONFLICT form
+    so a re-publish of the same jid updates the row instead of raising
+    a unique violation."""
+    cur = MagicMock()
+    cur.connection.server_version = 90500
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        pgjsonb.save_load("20260504000000000001", {"fun": "test.ping"})
+
+    sql = cur.execute.call_args.args[0]
+    assert "ON CONFLICT" in sql
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test_save_load_uses_plain_insert_on_pre_pg_95():
+    """On PostgreSQL < 9.5 ``save_load`` falls back to a plain INSERT
+    (ON CONFLICT is unavailable). The UniqueViolation handler covers the
+    duplicate-jid case from #22171."""
+    cur = MagicMock()
+    cur.connection.server_version = 90400
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        pgjsonb.save_load("20260504000000000001", {"fun": "test.ping"})
+
+    sql = cur.execute.call_args.args[0]
+    assert "ON CONFLICT" not in sql


### PR DESCRIPTION
> **Depends on #69047.** This branch is layered on top of that PR; the diff currently shows both commits and will rebase to a single commit once #69047 is merged.

### What does this PR do?

`salt/returners/pgjsonb.py` defines a module-level `PG_SAVE_LOAD_SQL` string with the plain-INSERT form, then `_get_serv` rewrites that global to the `ON CONFLICT` (UPSERT) form on every connect to PostgreSQL >= 9.5:

```python
PG_SAVE_LOAD_SQL = """INSERT INTO jids (jid, load) VALUES (%(jid)s, %(load)s)"""

def _get_serv(...):
    ...
    if conn.server_version is not None and conn.server_version >= 90500:
        global PG_SAVE_LOAD_SQL
        PG_SAVE_LOAD_SQL = """INSERT INTO jids ... ON CONFLICT (jid) DO UPDATE SET load=%(load)s"""
```

`save_load` then reads `PG_SAVE_LOAD_SQL`. This couples two functions through a mutable module-level variable, and the mutation is one-way: once any 9.5+ connection runs, the global is permanently UPSERT for the lifetime of the master process. A master that subsequently talks to a pre-9.5 server — failover to a legacy replica, mixed-version fleet, dev/staging environment — sends UPSERT syntax there and gets a SQL `SyntaxError`.

This PR decides the SQL form per-call inside `save_load` from `cur.connection.server_version`. The module-level global is removed, and the `if conn.server_version >= 90500` mutation block in `_get_serv` is removed.

### What issues does this PR fix or reference?

Fixes #69052

### Previous Behavior

```python
# module level
PG_SAVE_LOAD_SQL = """INSERT INTO jids ..."""

# inside _get_serv, mutated on every 9.5+ connect
global PG_SAVE_LOAD_SQL
PG_SAVE_LOAD_SQL = """INSERT INTO jids ... ON CONFLICT ..."""

# inside save_load
cur.execute(PG_SAVE_LOAD_SQL, ...)
```

The global stayed UPSERT after the first 9.5+ connection. A subsequent connection to a pre-9.5 server saw `INSERT ... ON CONFLICT ...` and crashed.

### New Behavior

```python
# inside save_load
if cur.connection.server_version >= 90500:
    sql = "INSERT INTO jids ... ON CONFLICT ..."
else:
    sql = "INSERT INTO jids ..."
cur.execute(sql, ...)
```

Each call decides the form from the live connection. No shared state, no mutation. Mixed-version deployments work correctly.

### Merge requirements satisfied?

- [ ] Docs (no user-facing change; not required)
- [x] Changelog — `changelog/69052.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test_save_load_uses_upsert_sql_on_pg_95_or_newer`
  - `test_save_load_uses_plain_insert_on_pre_pg_95`
  - existing `save_load` tests updated to set `cur.connection.server_version`.

### Commits signed with GPG?

No.