### PR TITLE
Stop pgjsonb purge / archive from orphaning recent salt_returns rows

### DIFF
--- a/changelog/69060.fixed.md
+++ b/changelog/69060.fixed.md
@@ -1,0 +1,8 @@
+Fixed `salt.returners.pgjsonb._purge_jobs` and `_archive_jobs` deleting
+or archiving the parent `jids` row as soon as a single `salt_returns`
+row for that jid was older than the cutoff, even when newer rows for
+the same jid existed. For long-running jobs whose minions answer at
+staggered times, this orphaned the recent `salt_returns` rows in the
+source table and produced an inconsistent archive. The predicate now
+keeps the parent until every `salt_returns` row for the jid is older
+than the cutoff (`EXISTS ... AND NOT EXISTS ...` antijoin).

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -497,9 +497,21 @@ def _purge_jobs(timestamp):
     """
     with _get_serv() as cursor:
         try:
+            # Purge a jids row only when every salt_returns row for that jid
+            # is older than the cutoff. The previous predicate
+            # ("delete from jids where jid in (select distinct jid from
+            # salt_returns where alter_time < %s)") fired as soon as ONE
+            # old return existed, leaving recent returns from the same jid
+            # orphaned in salt_returns once the parent was deleted -- a
+            # data-integrity bug for any long-running job whose minions
+            # answer at staggered times.
             sql = (
-                "delete from jids where jid in (select distinct jid from salt_returns"
-                " where alter_time < %s)"
+                "delete from jids j where exists ("
+                "  select 1 from salt_returns r where r.jid = j.jid"
+                ") and not exists ("
+                "  select 1 from salt_returns r"
+                "  where r.jid = j.jid and r.alter_time >= %s"
+                ")"
             )
             cursor.execute(sql, (timestamp,))
             cursor.execute("COMMIT")
@@ -556,11 +568,18 @@ def _archive_jobs(timestamp):
                 raise
 
         try:
+            # Mirror the predicate used in _purge_jobs: archive a jids row
+            # only when every salt_returns row for that jid is older than
+            # the cutoff. Otherwise the archive ends up holding parent
+            # rows whose recent salt_returns rows were left behind in the
+            # source table.
             sql = (
-                "insert into {} select * from {} where jid in (select distinct jid from"
-                " salt_returns where alter_time < %s)".format(
-                    target_tables["jids"], "jids"
-                )
+                "insert into {target} select * from jids j where exists ("
+                "  select 1 from salt_returns r where r.jid = j.jid"
+                ") and not exists ("
+                "  select 1 from salt_returns r"
+                "  where r.jid = j.jid and r.alter_time >= %s"
+                ")".format(target=target_tables["jids"])
             )
             cursor.execute(sql, (timestamp,))
             cursor.execute("COMMIT")

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -414,3 +414,59 @@ def test__get_options_coerces_string_connect_timeout_to_int():
         opts = pgjsonb._get_options()
     assert opts["connect_timeout"] == 5
     assert isinstance(opts["connect_timeout"], int)
+
+
+def _capture_jids_predicate(executed_calls, marker):
+    """Return the parameterised SQL string from the first call whose text
+    contains ``marker`` (e.g. ``"delete from jids"`` or ``"insert into"``)."""
+    for call_ in executed_calls:
+        if not call_.args:
+            continue
+        sql = call_.args[0]
+        if isinstance(sql, str) and marker in sql:
+            return sql
+    raise AssertionError(
+        f"no execute call contained {marker!r}; "
+        f"saw: {[c.args for c in executed_calls]}"
+    )
+
+
+def test__purge_jobs_keeps_jids_with_any_recent_salt_returns_row():
+    """Regression for the orphan-returns bug: ``_purge_jobs`` must delete
+    a jids row only when every salt_returns row for that jid is older
+    than the cutoff. The previous predicate fired as soon as one old
+    return existed, which left recent returns from the same jid orphaned
+    in salt_returns once the parent was deleted."""
+    cursor = MagicMock()
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cursor
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        pgjsonb._purge_jobs("2026-01-01")
+
+    sql = _capture_jids_predicate(cursor.execute.call_args_list, "delete from jids")
+    # Antijoin: keep the row if any recent salt_returns row exists for it.
+    assert "not exists" in sql.lower()
+    assert "alter_time >= %s" in sql
+    # Defence against regressing to the old predicate.
+    assert "alter_time < %s" not in sql
+
+
+def test__archive_jobs_keeps_jids_with_any_recent_salt_returns_row():
+    """Mirror of the purge test for the archive path. The archive INSERT
+    into ``jids_archive`` must use the same antijoin predicate so that it
+    does not pick up parent rows whose recent returns were left behind in
+    the source table."""
+    cursor = MagicMock()
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cursor
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        pgjsonb._archive_jobs("2026-01-01")
+
+    sql = _capture_jids_predicate(
+        cursor.execute.call_args_list, "insert into jids_archive"
+    )
+    assert "not exists" in sql.lower()
+    assert "alter_time >= %s" in sql
+    assert "alter_time < %s" not in sql


### PR DESCRIPTION
> **Depends on #69049.** This branch is layered on top of that PR; the diff currently shows both commits and will rebase to a single commit once #69049 is merged.

### What does this PR do?

`_purge_jobs` and `_archive_jobs` decided which `jids` rows to handle with this predicate:

```sql
delete from jids where jid in (
    select distinct jid from salt_returns where alter_time < %s
)
```

The subquery returned a jid as soon as **any single** `salt_returns` row for that jid was older than the cutoff. For long-running jobs whose minions answer at staggered times — slow orchestrate runs, SSH commands that take hours, syndic batches — the predicate fired on the first old return and deleted the parent `jids` row, but the recent `salt_returns` rows for the same jid stayed behind. They became orphans: `salt-run jobs.lookup_jid` could no longer rebuild the load, the archive held parent rows without their recent returns, and any code joining `salt_returns` to `jids` saw a broken parent edge.

This PR rewrites both predicates as an `EXISTS` / `NOT EXISTS` antijoin so a `jids` row is removed only when **every** `salt_returns` row for that jid is older than the cutoff:

```sql
delete from jids j where exists (
    select 1 from salt_returns r where r.jid = j.jid
) and not exists (
    select 1 from salt_returns r
    where r.jid = j.jid and r.alter_time >= %s
)
```

`EXISTS` is preferred over `IN (SELECT distinct ...)`: it short-circuits on the first hit, uses `idx_salt_returns_jid` for per-row probes, and avoids `NOT IN`'s NULL gotcha. Since `jids` is typically much smaller than `salt_returns`, the planner picks an antijoin via the jid index — at least as fast as the original seq scan under the old predicate.

### What issues does this PR fix or reference?

Fixes #69060

### Previous Behavior

A long-running job whose first minion answers at `t0` and last minion answers at `t0 + keep_jobs_seconds + ε` loses its `jids` row at the first maintenance tick after `t0 + keep_jobs_seconds`, while the late return is still being inserted into `salt_returns`. Subsequent `jobs.lookup_jid` calls cannot reconstruct the load.

### New Behavior

The parent `jids` row is kept while any recent `salt_returns` row for that jid exists. Once every return is older than the cutoff, the parent and the returns are purged together, and the archive captures both consistently.

### Scope of this PR

Fixes orphan **returns** only. There is a related but separate slower leak: jobs published against an offline target leave a `jids` row with no `salt_returns` rows at all, which the maintenance loop never touches because the subquery cannot match on missing data. Closing that needs either a `jids.created_at` schema migration with backwards-compat detection in the code, or jid-format parsing in Python. Both warrant their own discussion and will be tracked as a follow-up.

### Merge requirements satisfied?

- [ ] Docs (no schema or user-facing config change; not required)
- [x] Changelog — `changelog/69060.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test__purge_jobs_keeps_jids_with_any_recent_salt_returns_row`
  - `test__archive_jobs_keeps_jids_with_any_recent_salt_returns_row`

### Commits signed with GPG?

No.