### PR TITLE
Fix pgjsonb get_fun raising SQL syntax error on PostgreSQL

### DIFF
--- a/changelog/69062.fixed.md
+++ b/changelog/69062.fixed.md
@@ -1,0 +1,4 @@
+Fixed `salt.returners.pgjsonb.get_fun` raising a SQL syntax error on
+PostgreSQL because of MySQL-style backtick quoting (`` MAX(`jid`) ``)
+left over from a copy-paste of the `mysql` returner. The query now
+uses unquoted identifiers, which is valid on PostgreSQL.

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -397,13 +397,13 @@ def get_fun(fun):
     """
     with _get_serv(ret=None, commit=True) as cur:
 
-        sql = """SELECT s.id,s.jid, s.full_ret
-                FROM salt_returns s
-                JOIN ( SELECT MAX(`jid`) as jid
-                    from salt_returns GROUP BY fun, id) max
-                ON s.jid = max.jid
-                WHERE s.fun = %s
-                """
+        sql = """SELECT s.id, s.jid, s.full_ret
+                 FROM salt_returns s
+                 JOIN (SELECT MAX(jid) AS jid
+                       FROM salt_returns GROUP BY fun, id) max
+                 ON s.jid = max.jid
+                 WHERE s.fun = %s
+                 """
 
         cur.execute(sql, (fun,))
         data = cur.fetchall()

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -148,3 +148,34 @@ def test_save_load_uses_plain_insert_on_pre_pg_95():
 
     sql = cur.execute.call_args.args[0]
     assert "ON CONFLICT" not in sql
+
+
+def test_get_fun_returns_one_full_ret_per_minion_with_postgres_compatible_sql():
+    """``get_fun`` builds a per-minion last-execution dict.
+
+    The previous SQL used MySQL-style backtick quoting (``MAX(`jid`)``),
+    which raises a syntax error on PostgreSQL where the function lives.
+    Verify both the produced mapping and that the issued SQL is free of
+    backticks so the fix does not regress through future copy-paste from
+    the mysql returner.
+    """
+    rows = [
+        ("minion-1", "20260505000000000001", {"return": "ok-1", "fun": "test.ping"}),
+        ("minion-2", "20260505000000000002", {"return": "ok-2", "fun": "test.ping"}),
+    ]
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        result = pgjsonb.get_fun("test.ping")
+
+    assert result == {
+        "minion-1": {"return": "ok-1", "fun": "test.ping"},
+        "minion-2": {"return": "ok-2", "fun": "test.ping"},
+    }
+    issued_sql = cur.execute.call_args.args[0]
+    assert (
+        "`" not in issued_sql
+    ), "MySQL-style backtick quoting in pgjsonb SQL — invalid on PostgreSQL"


### PR DESCRIPTION
### What does this PR do?

`salt/returners/pgjsonb.py:get_fun` issued a SQL query with MySQL-style backtick identifier quoting (`` MAX(`jid`) ``), copy-pasted from `salt/returners/mysql.py`. PostgreSQL — the only server pgjsonb talks to — rejects backticks at parse time with `syntax error at or near "\`"`. The bug is dormant in typical deployments because stock `master_job_cache: pgjsonb` operation does not exercise `get_fun`; it surfaces only when an operator or extension explicitly calls `pgjsonb.get_fun`.

This PR drops the backticks (`jid` is not a reserved word in PostgreSQL, so no quoting is needed) and normalises the indentation of the SQL string. Behaviour is otherwise unchanged.

### What issues does this PR fix or reference?

Fixes #69062

### Previous Behavior

```python
sql = """SELECT s.id,s.jid, s.full_ret
        FROM salt_returns s
        JOIN ( SELECT MAX(`jid`) as jid
            from salt_returns GROUP BY fun, id) max
        ON s.jid = max.jid
        WHERE s.fun = %s
        """
```

PostgreSQL parser rejected this with a syntax error.

### New Behavior

```python
sql = """SELECT s.id, s.jid, s.full_ret
         FROM salt_returns s
         JOIN (SELECT MAX(jid) AS jid
               FROM salt_returns GROUP BY fun, id) max
         ON s.jid = max.jid
         WHERE s.fun = %s
         """
```

The query parses and runs against PostgreSQL.

### Merge requirements satisfied?

- [ ] Docs (no user-facing change; not required)
- [x] Changelog — `changelog/69062.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test_get_fun_returns_one_full_ret_per_minion_with_postgres_compatible_sql` — asserts the per-minion mapping is built correctly and guards against backticks creeping back into the issued SQL through future copy-paste from the mysql returner.

### Commits signed with GPG?

No.