### PR TITLE
Pick latest pgjsonb get_fun return by alter_time, not by MAX(jid)

### DIFF
--- a/changelog/69062.fixed.md
+++ b/changelog/69062.fixed.md
@@ -1,0 +1,4 @@
+Fixed `salt.returners.pgjsonb.get_fun` raising a SQL syntax error on
+PostgreSQL because of MySQL-style backtick quoting (`` MAX(`jid`) ``)
+left over from a copy-paste of the `mysql` returner. The query now
+uses unquoted identifiers, which is valid on PostgreSQL.

--- a/changelog/69064.fixed.md
+++ b/changelog/69064.fixed.md
@@ -1,0 +1,12 @@
+Fixed `salt.returners.pgjsonb.get_fun` returning the wrong row per
+minion when jids are not lexicographically sortable as timestamps.
+The previous SQL used `MAX(jid)` to pick the "latest" return, which
+was correct only for Salt's default jid format
+(`YYYYMMDDHHMMSSffffff` and the `nano` variant). Deployments that
+override `master_job_cache.gen_jid` (custom prep_jid emitting UUIDs,
+snowflake ids, or any non-sortable scheme) -- or that hold rows
+written under different jid formats from a past config change --
+got a silently wrong answer. The query now orders by
+`alter_time DESC` and picks one row per minion via `DISTINCT ON`,
+so "latest" is determined from the timestamp Postgres populates via
+`DEFAULT NOW()`.

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -430,13 +430,13 @@ def get_fun(fun):
     """
     with _get_serv(ret=None, commit=True) as cur:
 
-        sql = """SELECT s.id,s.jid, s.full_ret
-                FROM salt_returns s
-                JOIN ( SELECT MAX(`jid`) as jid
-                    from salt_returns GROUP BY fun, id) max
-                ON s.jid = max.jid
-                WHERE s.fun = %s
-                """
+        sql = """SELECT s.id, s.jid, s.full_ret
+                 FROM salt_returns s
+                 JOIN (SELECT MAX(jid) AS jid
+                       FROM salt_returns GROUP BY fun, id) max
+                 ON s.jid = max.jid
+                 WHERE s.fun = %s
+                 """
 
         cur.execute(sql, (fun,))
         data = cur.fetchall()

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -430,12 +430,21 @@ def get_fun(fun):
     """
     with _get_serv(ret=None, commit=True) as cur:
 
-        sql = """SELECT s.id, s.jid, s.full_ret
-                 FROM salt_returns s
-                 JOIN (SELECT MAX(jid) AS jid
-                       FROM salt_returns GROUP BY fun, id) max
-                 ON s.jid = max.jid
-                 WHERE s.fun = %s
+        # The previous query picked the latest return per minion with
+        # ``MAX(jid)``. That assumed jids are lexicographically sortable
+        # as timestamps (the default ``YYYYMMDDHHMMSSffffff`` format and
+        # the ``nano`` variant), which silently returns the wrong row
+        # for any deployment that overrides ``master_job_cache.gen_jid``
+        # or that has a mix of jid formats in ``salt_returns`` from a
+        # past config change. Use ``alter_time`` -- which Postgres
+        # populates from ``DEFAULT NOW()`` -- as the source of truth
+        # for "latest" instead, and pick one row per minion with
+        # ``DISTINCT ON``.
+        sql = """SELECT DISTINCT ON (id)
+                        id, jid, full_ret
+                 FROM salt_returns
+                 WHERE fun = %s
+                 ORDER BY id, alter_time DESC
                  """
 
         cur.execute(sql, (fun,))

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -470,3 +470,35 @@ def test__archive_jobs_keeps_jids_with_any_recent_salt_returns_row():
     assert "not exists" in sql.lower()
     assert "alter_time >= %s" in sql
     assert "alter_time < %s" not in sql
+
+
+@pytest.mark.skipif(not pgjsonb.HAS_PG, reason="psycopg2 not installed")
+def test_get_fun_returns_one_full_ret_per_minion_with_postgres_compatible_sql():
+    """``get_fun`` builds a per-minion last-execution dict.
+
+    The previous SQL used MySQL-style backtick quoting (``MAX(`jid`)``),
+    which raises a syntax error on PostgreSQL where the function lives.
+    Verify both the produced mapping and that the issued SQL is free of
+    backticks so the fix does not regress through future copy-paste from
+    the mysql returner.
+    """
+    rows = [
+        ("minion-1", "20260505000000000001", {"return": "ok-1", "fun": "test.ping"}),
+        ("minion-2", "20260505000000000002", {"return": "ok-2", "fun": "test.ping"}),
+    ]
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        result = pgjsonb.get_fun("test.ping")
+
+    assert result == {
+        "minion-1": {"return": "ok-1", "fun": "test.ping"},
+        "minion-2": {"return": "ok-2", "fun": "test.ping"},
+    }
+    issued_sql = cur.execute.call_args.args[0]
+    assert (
+        "`" not in issued_sql
+    ), "MySQL-style backtick quoting in pgjsonb SQL — invalid on PostgreSQL"

--- a/tests/pytests/unit/returners/test_pgjsonb.py
+++ b/tests/pytests/unit/returners/test_pgjsonb.py
@@ -502,3 +502,35 @@ def test_get_fun_returns_one_full_ret_per_minion_with_postgres_compatible_sql():
     assert (
         "`" not in issued_sql
     ), "MySQL-style backtick quoting in pgjsonb SQL — invalid on PostgreSQL"
+
+
+def test_get_fun_orders_by_alter_time_desc_not_max_jid():
+    """``get_fun`` must determine "latest execution per minion" from
+    ``alter_time`` rather than from a lexicographic ordering of jids.
+
+    The previous SQL used ``MAX(jid)``, which works only when jids are
+    timestamp-formatted strings of equal length (Salt's default
+    ``YYYYMMDDHHMMSSffffff`` and the ``nano`` variant). Deployments that
+    override ``master_job_cache.gen_jid`` (custom prep_jid emitting UUIDs,
+    snowflake ids, or any non-sortable scheme), or that hold rows written
+    under different jid formats from a past config change, get a
+    silently wrong answer with ``MAX(jid)`` -- the lexicographic max is
+    not the time-latest.
+
+    Pin the algorithm: order by ``alter_time DESC`` (which Postgres
+    populates via ``DEFAULT NOW()``), and guard against regression to
+    the ``MAX(jid)`` form.
+    """
+    cur = MagicMock()
+    cur.fetchall.return_value = []
+    serv = MagicMock()
+    serv.return_value.__enter__.return_value = cur
+
+    with patch.object(pgjsonb, "_get_serv", serv):
+        pgjsonb.get_fun("test.ping")
+
+    sql = cur.execute.call_args.args[0].lower()
+    assert "alter_time" in sql
+    assert "order by" in sql
+    assert "desc" in sql
+    assert "max(jid)" not in sql


### PR DESCRIPTION
> **Depends on #69063.** This branch is layered on top of that PR; the diff currently shows both commits and will rebase to a single commit once #69063 is merged.

### What does this PR do?

`salt/returners/pgjsonb.py:get_fun` chose the latest return per minion with `MAX(jid)`. That is the lexicographic maximum of the `jid` column, not the time-latest return. It happens to coincide for Salt's default jid format (`YYYYMMDDHHMMSSffffff`) and the `nano` variant — both are timestamp-formatted strings of equal length, so lex order matches chronological. It silently breaks for any deployment where that assumption does not hold:

* `master_job_cache.gen_jid` is overridden with a custom scheme — UUIDs, snowflake ids, hash-based identifiers — none lexicographically sortable as timestamps.
* External publishers (salt-api, salt-ssh, orchestrate runners) call `prep_jid(passed_jid="...")` with a custom jid string.
* A master spans a `jid_format` config change and ends up with rows of different formats in the same `salt_returns`.

In all those cases `MAX(jid)` returns a row that is not the time-latest, and `get_fun` reports the wrong `full_ret` per minion. No exception, no warning — just a silently wrong answer.

This PR replaces the lex-max algorithm with `ORDER BY alter_time DESC` and `DISTINCT ON (id)`. `alter_time` is populated by Postgres via `DEFAULT NOW()`, so "latest" reflects actual insertion order regardless of jid format.

### What issues does this PR fix or reference?

Fixes #69064

### Previous Behavior

```python
sql = """SELECT s.id, s.jid, s.full_ret
         FROM salt_returns s
         JOIN (SELECT MAX(jid) AS jid
               FROM salt_returns GROUP BY fun, id) max
         ON s.jid = max.jid
         WHERE s.fun = %s
         """
```

For two returns of the same fun on the same minion with custom jids `"abc-001"` and `"000-002"` (chronologically the second is newer), `MAX(jid)` picks `"abc-001"` — wrong.

### New Behavior

```python
sql = """SELECT DISTINCT ON (id)
                id, jid, full_ret
         FROM salt_returns
         WHERE fun = %s
         ORDER BY id, alter_time DESC
         """
```

`alter_time DESC` orders by Postgres-managed insertion timestamp; `DISTINCT ON (id)` keeps the first row per minion. The chronologically newest return wins regardless of jid format.

### Performance

There is no index on `salt_returns.alter_time` in the documented schema, so this query remains a sequential scan — same as the previous `MAX(jid) GROUP BY` form. Adding an `alter_time` index, alongside several other schema observations (`jids.created_at`, redundant GIN indexes, `salt_returns.success` typing), will be tracked as a separate follow-up RFC.

### Merge requirements satisfied?

- [ ] Docs (no user-facing change; not required)
- [x] Changelog — `changelog/69064.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/returners/test_pgjsonb.py`:
  - `test_get_fun_orders_by_alter_time_desc_not_max_jid` — pins the algorithm: SQL must order by `alter_time DESC` and must not contain `MAX(jid)`.

### Commits signed with GPG?

No.