### PR TITLE
Revoke Salt eauth token on salt-api Logout

### DIFF
--- a/changelog/69067.fixed.md
+++ b/changelog/69067.fixed.md
@@ -1,0 +1,12 @@
+Fixed `salt-api`'s `Logout` endpoint not revoking the underlying Salt
+eauth token. `Logout.POST` only expired the CherryPy session cookie
+and regenerated the server-side session id, leaving the Salt token in
+the configured `eauth_tokens` backend (localfs/redis/etc.) valid until
+its `token_expire` (12 hours by default). Anyone who had observed the
+token value could keep using it as a bearer credential through
+`X-Auth-Token: <token>` even after the user thought they had logged
+out. The endpoint now calls `salt.auth.LoadAuth(self.opts).rm_token`
+on the session token before expiring the cookie, so logout actually
+invalidates the bearer credential. If the token backend is
+unreachable the failure is logged and the cookie is still expired,
+so the user-visible logout flow always completes.

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1951,8 +1951,33 @@ class Logout(LowDataAdapter):
 
     def POST(self):  # pylint: disable=arguments-differ
         """
-        Destroy the currently active session and expire the session cookie
+        Destroy the currently active session, expire the session cookie,
+        and revoke the underlying Salt eauth token so the bearer
+        credential cannot be re-used until ``token_expire`` has elapsed.
         """
+        # Revoke the Salt eauth token. ``cherrypy.lib.sessions.expire()``
+        # below only clears the browser cookie and the server-side
+        # CherryPy session; the Salt token in the configured
+        # ``eauth_tokens`` backend (localfs/redis/etc.) outlives both by
+        # ``token_expire`` (12h by default), and any party that has
+        # observed the token value can keep using it as a bearer
+        # credential until then.
+        salt_token = cherrypy.session.get("token")
+        if salt_token:
+            try:
+                salt.auth.LoadAuth(self.opts).rm_token(salt_token)
+            except Exception:  # pylint: disable=broad-except
+                # If the token backend is unreachable (e.g. Redis down)
+                # finish the logout from the client's point of view
+                # anyway -- the cookie still gets expired below. The
+                # operator sees the failure in the master log and can
+                # investigate.
+                logger.exception(
+                    "Logout: failed to revoke Salt eauth token; "
+                    "the cookie has been expired but the token may "
+                    "still be valid in the eauth_tokens backend until "
+                    "its expiry."
+                )
         cherrypy.lib.sessions.expire()  # set client-side to expire
         cherrypy.session.regenerate()  # replace server-side with new
 

--- a/tests/pytests/unit/netapi/cherrypy/test_logout.py
+++ b/tests/pytests/unit/netapi/cherrypy/test_logout.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import pytest
+
+import salt.netapi.rest_cherrypy.app as cherrypy_app
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {cherrypy_app: {}}
+
+
+class _MockNetapiClient:
+    """Stand-in for ``salt.netapi.NetapiClient`` so ``LowDataAdapter``
+    can be instantiated under unit-test conditions without trying to
+    bring up the real client (which expects a populated ``opts`` dict)."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _build_cherrypy_mock(session_token="cafebabe"):
+    """Build a minimal ``cherrypy`` stand-in that records calls so tests
+    can assert on ``cherrypy.lib.sessions.expire()`` and on the value the
+    handler reads from ``cherrypy.session``."""
+    sessions = SimpleNamespace(expire=MagicMock(name="sessions.expire"))
+    session = MagicMock(name="session")
+    session.get = MagicMock(
+        side_effect=lambda key, default=None: {"token": session_token}.get(key, default)
+    )
+    session.regenerate = MagicMock(name="session.regenerate")
+
+    return SimpleNamespace(
+        config={"saltopts": {}, "apiopts": {}},
+        session=session,
+        lib=SimpleNamespace(sessions=sessions),
+    )
+
+
+def test_logout_revokes_salt_token_via_loadauth():
+    """``Logout.POST`` must call ``LoadAuth.rm_token(<session_token>)`` so
+    the underlying eauth bearer credential is invalidated; otherwise the
+    Salt token outlives the cookie by ``token_expire`` (12h default) and
+    can be replayed by anyone who observed it."""
+    cherrypy_mock = _build_cherrypy_mock(session_token="deadbeef")
+    fake_loadauth = MagicMock(name="LoadAuth_instance")
+    fake_loadauth_cls = MagicMock(name="LoadAuth_class", return_value=fake_loadauth)
+
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", cherrypy_mock):
+        with patch("salt.netapi.NetapiClient", _MockNetapiClient):
+            with patch("salt.auth.LoadAuth", fake_loadauth_cls):
+                cherrypy_app.Logout().POST()
+
+    fake_loadauth.rm_token.assert_called_once_with("deadbeef")
+    cherrypy_mock.lib.sessions.expire.assert_called_once()
+    cherrypy_mock.session.regenerate.assert_called_once()
+
+
+def test_logout_skips_rm_token_when_no_session_token():
+    """If the session has no ``token`` key (already-cleared session, or
+    never logged in), Logout must not attempt to revoke -- skip cleanly
+    and expire the cookie regardless."""
+    cherrypy_mock = _build_cherrypy_mock()
+    cherrypy_mock.session.get = MagicMock(return_value=None)
+    fake_loadauth_cls = MagicMock(name="LoadAuth_class")
+
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", cherrypy_mock):
+        with patch("salt.netapi.NetapiClient", _MockNetapiClient):
+            with patch("salt.auth.LoadAuth", fake_loadauth_cls):
+                cherrypy_app.Logout().POST()
+
+    fake_loadauth_cls.assert_not_called()
+    cherrypy_mock.lib.sessions.expire.assert_called_once()
+
+
+def test_logout_completes_when_token_backend_raises():
+    """If the eauth_tokens backend is unreachable (e.g. Redis down) and
+    ``rm_token`` raises, Logout must still expire the cookie and
+    return success -- the backend failure is logged but does not abort
+    the user-visible logout flow."""
+    cherrypy_mock = _build_cherrypy_mock(session_token="cafebabe")
+    fake_loadauth = MagicMock(name="LoadAuth_instance")
+    fake_loadauth.rm_token.side_effect = RuntimeError("redis is down")
+    fake_loadauth_cls = MagicMock(name="LoadAuth_class", return_value=fake_loadauth)
+
+    with patch("salt.netapi.rest_cherrypy.app.cherrypy", cherrypy_mock):
+        with patch("salt.netapi.NetapiClient", _MockNetapiClient):
+            with patch("salt.auth.LoadAuth", fake_loadauth_cls):
+                result = cherrypy_app.Logout().POST()
+
+    fake_loadauth.rm_token.assert_called_once_with("cafebabe")
+    cherrypy_mock.lib.sessions.expire.assert_called_once()
+    assert result == {"return": "Your token has been cleared"}


### PR DESCRIPTION
### What does this PR do?

`POST /logout` on `salt-api` (`rest_cherrypy`) only expires the CherryPy session cookie and regenerates the server-side session id. The underlying Salt eauth token — the value stored in the configured `eauth_tokens` backend (`localfs` / `redis` / `rediscluster`) and the bearer credential clients send via `X-Auth-Token: <token>` — is never revoked. It outlives the cookie by `token_expire` (12 hours by default), so anyone who has observed the token value (access logs, shell history, leaked cookie, browser cache) can keep authenticating as that user until the natural expiry.

This PR reads the session token before expiring the cookie and calls `salt.auth.LoadAuth(self.opts).rm_token(salt_token)` to invalidate it in the backend. If the backend is unreachable (Redis down, NFS hung, etc.), the failure is logged and the cookie is still expired, so the user-visible logout flow always succeeds — operators see the backend failure in the master log and can investigate; the orphaned token will still expire on schedule.

### What issues does this PR fix or reference?

Fixes #69067

### Previous Behavior

```python
def POST(self):
    cherrypy.lib.sessions.expire()  # set client-side to expire
    cherrypy.session.regenerate()   # replace server-side with new
    return {"return": "Your token has been cleared"}
```

After logout, the same `<token>` value still authenticated for up to `token_expire` seconds.

### New Behavior

```python
def POST(self):
    salt_token = cherrypy.session.get("token")
    if salt_token:
        try:
            salt.auth.LoadAuth(self.opts).rm_token(salt_token)
        except Exception:
            logger.exception(...)
    cherrypy.lib.sessions.expire()
    cherrypy.session.regenerate()
    return {"return": "Your token has been cleared"}
```

After logout, the token is removed from the configured `eauth_tokens` backend and any further `X-Auth-Token: <same>` request is rejected.

### Merge requirements satisfied?

- [ ] Docs (no user-facing config or API change; not required)
- [x] Changelog — `changelog/69067.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/netapi/cherrypy/test_logout.py`:
  - `test_logout_revokes_salt_token_via_loadauth` — headline regression.
  - `test_logout_skips_rm_token_when_no_session_token` — no token in session, no rm_token call, no crash.
  - `test_logout_completes_when_token_backend_raises` — cookie still expires and POST returns success when the backend errors.

### Commits signed with GPG?

No.