### PR TITLE
Write ContextCache atomically with owner-only file and directory mode

### DIFF
--- a/changelog/69069.fixed.md
+++ b/changelog/69069.fixed.md
@@ -1,0 +1,11 @@
+Fixed `salt.utils.cache.ContextCache.cache_context` writing the
+serialized pillar context to disk with whatever mode the process
+umask happened to allow (typically `0o644` on default Linux installs)
+inside a `0o755` parent directory. Pillar context can carry
+credentials (passwords, vault tokens, API keys), so any local user
+could read them; even with the file mode tightened, the directory
+mode let any local user `ls` the cache and learn which modules and
+external-pillar backends were in use. The cache file is now written
+through `tempfile.mkstemp` (creates with `0o600` by default) followed
+by atomic `os.replace`, and the parent `context/` directory is
+created with `stat.S_IRWXU` (`0o700`).

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -2,11 +2,14 @@
 In-memory caching used by Salt
 """
 
+import contextlib
 import functools
 import logging
 import os
 import re
 import shutil
+import stat
+import tempfile
 import time
 
 import salt.config
@@ -302,12 +305,58 @@ class ContextCache:
 
     def cache_context(self, context):
         """
-        Cache the given context to disk
+        Cache the given context to disk.
+
+        Pillar context can carry credentials (passwords, tokens, vault
+        data, API keys sourced from external pillar backends). Both
+        the cache file and its parent directory are therefore created
+        with owner-only permissions:
+
+        - the parent ``context/`` directory is created with mode
+          ``0o700`` (``stat.S_IRWXU``). Without this it inherits the
+          process umask -- typically ``0o755`` -- so any local user
+          can ``ls`` the directory and observe filenames, which leak
+          which external-pillar backends and modules are in use.
+          Existing directories from earlier installs are left
+          untouched; operators upgrading may want to ``chmod 0700``
+          their cache context directory once.
+        - the cache file is written via ``tempfile.mkstemp`` + atomic
+          ``os.replace`` so that the file is created with mode
+          ``0o600`` from the first byte (``mkstemp`` documents this
+          as its default:
+          https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp,
+          "the file is readable and writable only by the creating
+          user ID"), and so that readers consuming the cache
+          concurrently see either the old content or the new one,
+          never a partial write.
+
+        Note on hard crashes (``SIGKILL`` / OOM-killer / power loss):
+        if the process dies between ``mkstemp`` and ``os.replace``, the
+        ``.tmp_*`` file remains on disk. It carries mode ``0o600`` (no
+        information disclosure beyond what the legitimate cache file
+        would have exposed) and is bounded in size, so this is
+        operational hygiene rather than a security issue. Operators
+        can clean stale temporaries with e.g.
+        ``find <cachedir>/context/ -name '.tmp_*' -mtime +1 -delete``.
         """
-        if not os.path.isdir(os.path.dirname(self.cache_path)):
-            os.mkdir(os.path.dirname(self.cache_path))
-        with salt.utils.files.fopen(self.cache_path, "w+b") as cache:
-            salt.payload.dump(context, cache)
+        parent = os.path.dirname(self.cache_path)
+        if not os.path.isdir(parent):
+            os.mkdir(parent, mode=stat.S_IRWXU)
+        fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".tmp_")
+        try:
+            with os.fdopen(fd, "wb") as cache:
+                salt.payload.dump(context, cache)
+            os.replace(tmp_path, self.cache_path)
+        except BaseException:
+            # ``BaseException`` -- not just ``Exception`` -- so that
+            # KeyboardInterrupt and SystemExit also clean up. Any error
+            # reaching this handler means ``os.replace`` did not run,
+            # so the target ``cache_path`` is unchanged and the tmp
+            # file is now an orphan; remove it on a best-effort basis
+            # and re-raise the original error.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
 
     def get_cache_context(self):
         """

--- a/tests/pytests/unit/utils/test_cache.py
+++ b/tests/pytests/unit/utils/test_cache.py
@@ -66,6 +66,88 @@ def test_smoke_context(minion_opts):
     assert ret == data
 
 
+def test_cache_context_writes_with_owner_only_mode(minion_opts):
+    """
+    ``ContextCache.cache_context`` must produce a cache file with mode
+    ``0o600`` (owner-read+write only). The file holds pillar context
+    which can contain credentials (passwords, vault tokens, API keys);
+    on the previous implementation it inherited the process umask and
+    became world-readable on most Linux distributions.
+    """
+    import os
+    import stat
+
+    context_cache = cache.ContextCache(minion_opts, "cache_test_perms")
+    context_cache.cache_context({"secret": "value"})
+
+    mode = stat.S_IMODE(os.stat(context_cache.cache_path).st_mode)
+    assert mode == stat.S_IRUSR | stat.S_IWUSR, (
+        f"ContextCache file mode is {oct(mode)}, expected 0o600 "
+        f"(owner-read+write only). World-readable pillar cache leaks "
+        f"credentials to any local user."
+    )
+
+
+def test_cache_context_creates_parent_directory_with_owner_only_mode(
+    minion_opts, tmp_path
+):
+    """
+    The on-disk ``context/`` directory holding cached pillar data must
+    be created with mode ``0o700`` (owner-only). The previous
+    implementation created the directory with the default ``os.mkdir``
+    mode of ``0o755`` modulo the process umask -- which on most Linux
+    installs left it world-readable, so any local user could ``ls`` the
+    directory and learn which modules and external-pillar backends were
+    cached (filenames look like ``salt.loaded.ext.<module>.<name>.p``).
+    """
+    import os
+    import stat
+
+    # Use a fresh cachedir so context/ does not pre-exist from another
+    # test, otherwise the mode of the existing directory is whatever
+    # earlier code left behind and the test can't verify our behaviour.
+    fresh_opts = {**minion_opts, "cachedir": str(tmp_path / "fresh_cachedir")}
+    os.makedirs(fresh_opts["cachedir"])
+    cc = cache.ContextCache(fresh_opts, "first_write")
+    cc.cache_context({"v": 1})
+
+    parent = os.path.dirname(cc.cache_path)
+    mode = stat.S_IMODE(os.stat(parent).st_mode)
+    assert mode == stat.S_IRWXU, (
+        f"context/ dir mode is {oct(mode)}, expected 0o700 "
+        f"(owner-only). World-readable parent leaks cache filenames "
+        f"and metadata to local users."
+    )
+
+
+def test_cache_context_overwrites_atomically_via_replace(minion_opts):
+    """
+    ``ContextCache.cache_context`` must overwrite the cache file
+    atomically: a concurrent reader during a re-cache must see either
+    the previous content or the new one in full, never a partially
+    written file. The ``tempfile.mkstemp`` + ``os.replace`` path makes
+    this guarantee at the POSIX layer; the previous in-place
+    truncate-and-write path did not. Compare inode numbers across two
+    successive writes -- atomic replace gives a fresh inode each time
+    (the rename swaps the directory entry to a new file), in-place
+    truncate keeps the inode constant.
+    """
+    import os
+
+    cc = cache.ContextCache(minion_opts, "cache_test_atomic")
+    cc.cache_context({"v": 1})
+    inode_first = os.stat(cc.cache_path).st_ino
+    cc.cache_context({"v": 2})
+    inode_second = os.stat(cc.cache_path).st_ino
+
+    assert inode_first != inode_second, (
+        "ContextCache write reused the same inode, indicating in-place "
+        "truncate-and-write rather than atomic mkstemp+replace; readers "
+        "concurrent with the write can observe a partial file."
+    )
+    assert cc.get_cache_context() == {"v": 2}
+
+
 @pytest.fixture
 def cache_mod_name():
     return "cache_mod"


### PR DESCRIPTION
### What does this PR do?

`salt.utils.cache.ContextCache.cache_context` opens the cache file through `salt.utils.files.fopen(self.cache_path, "w+b")` and lets the process umask pick the file mode; the parent directory is created via plain `os.mkdir()` with no `mode` argument. On default Linux installs the file ends up `0o644` (world-readable) inside a `0o755` directory.

The cache holds **pillar context** — pillar values plus surrounding state, including credentials sourced from external pillar backends (`vault`, `git_pillar`, `consul`). With the default modes any local user can:

- `ls /var/cache/salt/master/context/` → see filenames like `salt.loaded.ext.pillar.vault.p`, `salt.loaded.ext.pillar.git_pillar.p` — leaks which external-pillar backends and modules are in use;
- `cat <file>` → read the credentials directly.

A separate but related rough edge: the same code path rewrites the cache in place via `"w+b"` mode, which truncates the file before writing back. A concurrent reader can observe a half-written file and fail to deserialize.

This PR makes two changes:

1. The file write goes through `tempfile.mkstemp` + `os.replace`. `mkstemp` creates the temporary file with mode `0o600` by default (per its [documented contract](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp): "the file is readable and writable only by the creating user ID"); `os.replace` atomically renames it into place. The final cache file therefore has the correct mode from the first byte, and concurrent readers never see a partial write.
2. The parent `context/` directory is created with `mode=stat.S_IRWXU` (`0o700`).

### What issues does this PR fix or reference?

Fixes #69069

### Previous Behavior

```python
def cache_context(self, context):
    if not os.path.isdir(os.path.dirname(self.cache_path)):
        os.mkdir(os.path.dirname(self.cache_path))     # 0o755 on default umask
    with salt.utils.files.fopen(self.cache_path, "w+b") as cache:
        salt.payload.dump(context, cache)              # 0o644 on default umask
```

```bash
$ ls -ld /var/cache/salt/master/context/
drwxr-xr-x 2 salt salt  context/
$ ls -l /var/cache/salt/master/context/*.p
-rw-r--r-- 1 salt salt  jinja2.p
```

### New Behavior

```python
def cache_context(self, context):
    parent = os.path.dirname(self.cache_path)
    if not os.path.isdir(parent):
        os.mkdir(parent, mode=stat.S_IRWXU)            # 0o700
    fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".tmp_")
    try:
        with os.fdopen(fd, "wb") as cache:
            salt.payload.dump(context, cache)
        os.replace(tmp_path, self.cache_path)          # atomic, inherits mkstemp's 0o600
    except BaseException:
        with contextlib.suppress(OSError):
            os.unlink(tmp_path)
        raise
```

```bash
$ ls -ld /var/cache/salt/master/context/
drwx------ 2 salt salt  context/
$ ls -l /var/cache/salt/master/context/*.p
-rw------- 1 salt salt  jinja2.p
```

### Migration note

Existing `context/` directories from earlier installs are left untouched — auto-changing their mode would be surprising (some operators may have deliberately set them differently for monitoring tools). On upgrade, operators can run `chmod 0700` on their cache context directory once. New installs and freshly-created directories get the right mode automatically.

### Crash-safety note

If the process is killed (`SIGKILL` / OOM / power loss) between `mkstemp` and `os.replace`, the `.tmp_*` file remains on disk. It is mode `0o600` so this is operational hygiene rather than a security issue; operators can clean stale temporaries with `find <cachedir>/context/ -name '.tmp_*' -mtime +1 -delete`.

### Merge requirements satisfied?

- [ ] Docs (no user-facing config or API change; not required)
- [x] Changelog — `changelog/69069.fixed.md`
- [x] Tests written/updated — see `tests/pytests/unit/utils/test_cache.py`:
  - `test_cache_context_writes_with_owner_only_mode` — file is `0o600`.
  - `test_cache_context_creates_parent_directory_with_owner_only_mode` — parent is `0o700`.
  - `test_cache_context_overwrites_atomically_via_replace` — successive writes use distinct inodes (proves atomic rename rather than in-place truncate).

### Commits signed with GPG?

No.