### PR TITLE
Fix editable installs for troubleshooting

### DIFF
--- a/changelog/69101.fixed.md
+++ b/changelog/69101.fixed.md
@@ -1,0 +1,1 @@
+Fix pip install -e salt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=62.0",
+    "setuptools>=64.0",
     "wheel",
     "looseversion",
     "packaging",

--- a/tests/pytests/scenarios/setup/conftest.py
+++ b/tests/pytests/scenarios/setup/conftest.py
@@ -66,7 +66,18 @@ def src_dir(setup_tests_path):
         RUNTIME_VARS.CODE_DIR,
         str(_src_dir),
         ignore=shutil.ignore_patterns(
-            "__pycache__", "*.pyc", "*.pyo", ".coverage.*", ".nox"
+            "__pycache__",
+            "*.pyc",
+            "*.pyo",
+            ".coverage.*",
+            ".nox",
+            ".venvs",
+            ".tools-venvs",
+            "artifacts",
+            ".git",
+            ".pytest_cache",
+            ".mypy_cache",
         ),
+        ignore_dangling_symlinks=True,
     )
     return str(_src_dir)

--- a/tests/pytests/scenarios/setup/conftest.py
+++ b/tests/pytests/scenarios/setup/conftest.py
@@ -26,8 +26,15 @@ def setup_tests_path(tmp_path_factory):
 @pytest.fixture
 def virtualenv(setup_tests_path, pip_temp_dir):
     venv_dir = setup_tests_path / ".venv"
+    pip_req = "pip>=22.3"
+    setuptools_req = "setuptools>=64.0"
     try:
-        yield VirtualEnv(venv_dir=venv_dir, env={"TMPDIR": str(pip_temp_dir)})
+        yield VirtualEnv(
+            venv_dir=venv_dir,
+            env={"TMPDIR": str(pip_temp_dir)},
+            pip_requirement=pip_req,
+            setuptools_requirement=setuptools_req,
+        )
     finally:
         shutil.rmtree(str(venv_dir), ignore_errors=True)
 

--- a/tests/pytests/scenarios/setup/conftest.py
+++ b/tests/pytests/scenarios/setup/conftest.py
@@ -28,10 +28,11 @@ def virtualenv(setup_tests_path, pip_temp_dir):
     venv_dir = setup_tests_path / ".venv"
     pip_req = "pip>=22.3"
     setuptools_req = "setuptools>=64.0"
+    venv_env = {"TMPDIR": str(pip_temp_dir)}
     try:
         yield VirtualEnv(
             venv_dir=venv_dir,
-            env={"TMPDIR": str(pip_temp_dir)},
+            env=venv_env,
             pip_requirement=pip_req,
             setuptools_requirement=setuptools_req,
         )

--- a/tests/pytests/scenarios/setup/test_editable.py
+++ b/tests/pytests/scenarios/setup/test_editable.py
@@ -26,31 +26,11 @@ def use_static_requirements(request):
 
 
 @pytest.fixture
-def venv(setup_tests_path, pip_temp_dir, use_static_requirements):
-    from tests.support.helpers import VirtualEnv
-
-    venv_dir = setup_tests_path / ".venv"
-    # Python 3.12+ needs newer pip and setuptools
-    # But AL2 and others might have older python, so we keep it as low as possible
-    # while still supporting PEP 660.
-    pip_req = "pip>=22.3"
-    setuptools_req = "setuptools>=64.0"
-
-    v = VirtualEnv(
-        venv_dir=venv_dir,
-        env={
-            "TMPDIR": str(pip_temp_dir),
-            "USE_STATIC_REQUIREMENTS": "1" if use_static_requirements else "0",
-        },
-        pip_requirement=pip_req,
-        setuptools_requirement=setuptools_req,
+def venv(virtualenv, use_static_requirements):
+    virtualenv.environ["USE_STATIC_REQUIREMENTS"] = (
+        "1" if use_static_requirements else "0"
     )
-    try:
-        yield v
-    finally:
-        import shutil
-
-        shutil.rmtree(str(venv_dir), ignore_errors=True)
+    return virtualenv
 
 
 def test_editable_install(venv, src_dir):

--- a/tests/pytests/scenarios/setup/test_editable.py
+++ b/tests/pytests/scenarios/setup/test_editable.py
@@ -1,0 +1,102 @@
+"""
+Tests for editable installation of salt
+"""
+
+import json
+import logging
+import pathlib
+
+import pytest
+
+import salt.utils.platform
+import salt.version
+
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.core_test,
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture(params=[True, False], ids=["static-reqs", "pypi-reqs"])
+def use_static_requirements(request):
+    return request.param
+
+
+@pytest.fixture
+def venv(setup_tests_path, pip_temp_dir, use_static_requirements):
+    from tests.support.helpers import VirtualEnv
+
+    venv_dir = setup_tests_path / ".venv"
+    # Python 3.12+ needs newer pip and setuptools
+    pip_req = "pip>=24.0"
+    setuptools_req = "setuptools>=69.0"
+
+    v = VirtualEnv(
+        venv_dir=venv_dir,
+        env={
+            "TMPDIR": str(pip_temp_dir),
+            "USE_STATIC_REQUIREMENTS": "1" if use_static_requirements else "0",
+        },
+        pip_requirement=pip_req,
+        setuptools_requirement=setuptools_req,
+    )
+    try:
+        yield v
+    finally:
+        import shutil
+
+        shutil.rmtree(str(venv_dir), ignore_errors=True)
+
+
+def test_editable_install(venv, src_dir):
+    """
+    test installing salt in editable mode
+    """
+    with venv as v:
+        # Run pip install -e .
+        # We use --no-cache-dir to ensure we are actually hitting PyPI when requested
+        v.run(
+            v.venv_python, "-m", "pip", "install", "--no-cache-dir", "-e", str(src_dir)
+        )
+
+        # Let's ensure the version is correct
+        cmd = v.run(v.venv_python, "-m", "pip", "list", "--format", "json")
+        for details in json.loads(cmd.stdout):
+            if details["name"] != "salt":
+                continue
+            installed_version = details["version"]
+            break
+        else:
+            pytest.fail("Salt was not found installed")
+
+        # Let's compare the installed version with the version salt reports
+        # The version might have a '+' or other PEP440 suffix in editable mode
+        assert installed_version.startswith(salt.version.__version__.split("+")[0])
+
+        # Verify we can import salt and it's coming from the src_dir
+        cmd = v.run(v.venv_python, "-c", "import salt; print(salt.__file__)")
+        import_path = pathlib.Path(cmd.stdout.strip()).resolve()
+
+        # In editable mode with some setuptools versions, it might be a redirecting
+        # script or point directly to the source.
+        # But for Salt, it should eventually be in the src_dir
+        expected_path_parent = pathlib.Path(src_dir).resolve() / "salt"
+        assert (
+            expected_path_parent in import_path.parents
+            or import_path.parent == expected_path_parent
+        )
+
+        # Verify dependencies are installed by trying to import a common one
+        # 'requests' or 'yaml' or 'jinja2' should be installed as they are base deps
+        v.run(v.venv_python, "-c", "import requests; import yaml; import jinja2")
+
+        # Verify entry points work
+        if salt.utils.platform.is_windows():
+            salt_call = pathlib.Path(v.venv_dir) / "Scripts" / "salt-call.exe"
+        else:
+            salt_call = pathlib.Path(v.venv_dir) / "bin" / "salt-call"
+
+        ret = v.run(str(salt_call), "--version")
+        assert salt.version.__version__ in ret.stdout

--- a/tests/pytests/scenarios/setup/test_editable.py
+++ b/tests/pytests/scenarios/setup/test_editable.py
@@ -10,6 +10,7 @@ import pytest
 
 import salt.utils.platform
 import salt.version
+from salt.version import SaltStackVersion
 
 log = logging.getLogger(__name__)
 
@@ -30,8 +31,10 @@ def venv(setup_tests_path, pip_temp_dir, use_static_requirements):
 
     venv_dir = setup_tests_path / ".venv"
     # Python 3.12+ needs newer pip and setuptools
-    pip_req = "pip>=24.0"
-    setuptools_req = "setuptools>=69.0"
+    # But AL2 and others might have older python, so we keep it as low as possible
+    # while still supporting PEP 660.
+    pip_req = "pip>=22.3"
+    setuptools_req = "setuptools>=64.0"
 
     v = VirtualEnv(
         venv_dir=venv_dir,
@@ -73,7 +76,11 @@ def test_editable_install(venv, src_dir):
 
         # Let's compare the installed version with the version salt reports
         # The version might have a '+' or other PEP440 suffix in editable mode
-        assert installed_version.startswith(salt.version.__version__.split("+")[0])
+        # We compare the major and minor versions to be safe
+        assert (
+            SaltStackVersion.parse(installed_version).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        )
 
         # Verify we can import salt and it's coming from the src_dir
         cmd = v.run(v.venv_python, "-c", "import salt; print(salt.__file__)")
@@ -99,4 +106,8 @@ def test_editable_install(venv, src_dir):
             salt_call = pathlib.Path(v.venv_dir) / "bin" / "salt-call"
 
         ret = v.run(str(salt_call), "--version")
-        assert salt.version.__version__ in ret.stdout
+        # Ensure the reported version is what we expect
+        assert (
+            SaltStackVersion.parse(ret.stdout).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        )

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -44,29 +44,11 @@ def use_static_requirements(request):
 
 
 @pytest.fixture
-def virtualenv(setup_tests_path, pip_temp_dir, use_static_requirements):
-    from tests.support.helpers import VirtualEnv
-
-    venv_dir = setup_tests_path / ".venv"
-    # Python 3.12+ needs newer pip and setuptools
-    pip_req = "pip>=22.3"
-    setuptools_req = "setuptools>=64.0"
-
-    v = VirtualEnv(
-        venv_dir=venv_dir,
-        env={
-            "TMPDIR": str(pip_temp_dir),
-            "USE_STATIC_REQUIREMENTS": "1" if use_static_requirements else "0",
-        },
-        pip_requirement=pip_req,
-        setuptools_requirement=setuptools_req,
+def virtualenv(virtualenv, use_static_requirements):
+    virtualenv.environ["USE_STATIC_REQUIREMENTS"] = (
+        "1" if use_static_requirements else "0"
     )
-    try:
-        yield v
-    finally:
-        import shutil
-
-        shutil.rmtree(str(venv_dir), ignore_errors=True)
+    return virtualenv
 
 
 @pytest.mark.skip_initial_gh_actions_failure(skip=_check_skip)
@@ -480,10 +462,17 @@ def test_setup_install(virtualenv, cache_dir, use_static_requirements, src_dir):
         site_packages_dir = pathlib.Path(venv.venv_dir)
         site_packages_dir = site_packages_dir.joinpath(*subdir)
         assert site_packages_dir.is_dir()
+
+        # Depending on setuptools version, it might be an egg or a direct install
         installed_salt_path = list(site_packages_dir.glob("salt*.egg"))
-        if not installed_salt_path:
+        if installed_salt_path:
+            installed_salt_path = installed_salt_path[0] / "salt"
+        else:
+            installed_salt_path = site_packages_dir / "salt"
+
+        if not installed_salt_path.is_dir():
             pytest.fail("Failed to find the installed salt path")
-        installed_salt_path = installed_salt_path[0] / "salt"
+
         salt_generated_version_file_path = installed_salt_path / "_version.txt"
         assert salt_generated_version_file_path.is_file()
 

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -16,6 +16,7 @@ import salt.utils.path
 import salt.utils.platform
 import salt.version
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
+from salt.version import SaltStackVersion
 
 log = logging.getLogger(__name__)
 
@@ -43,11 +44,29 @@ def use_static_requirements(request):
 
 
 @pytest.fixture
-def virtualenv(virtualenv, use_static_requirements):
-    virtualenv.environ["USE_STATIC_REQUIREMENTS"] = (
-        "1" if use_static_requirements else "0"
+def virtualenv(setup_tests_path, pip_temp_dir, use_static_requirements):
+    from tests.support.helpers import VirtualEnv
+
+    venv_dir = setup_tests_path / ".venv"
+    # Python 3.12+ needs newer pip and setuptools
+    pip_req = "pip>=22.3"
+    setuptools_req = "setuptools>=64.0"
+
+    v = VirtualEnv(
+        venv_dir=venv_dir,
+        env={
+            "TMPDIR": str(pip_temp_dir),
+            "USE_STATIC_REQUIREMENTS": "1" if use_static_requirements else "0",
+        },
+        pip_requirement=pip_req,
+        setuptools_requirement=setuptools_req,
     )
-    return virtualenv
+    try:
+        yield v
+    finally:
+        import shutil
+
+        shutil.rmtree(str(venv_dir), ignore_errors=True)
 
 
 @pytest.mark.skip_initial_gh_actions_failure(skip=_check_skip)
@@ -80,9 +99,10 @@ def test_wheel(virtualenv, cache_dir, use_static_requirements, src_dir):
             if re.search(r"^\d.\d*", x)
         ][0]
         whl_ver_cmp = whl_ver.replace("_", "-")
-        assert whl_ver_cmp == salt.version.__version__, "{} != {}".format(
-            whl_ver_cmp, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(whl_ver_cmp).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{whl_ver_cmp}[:2] != {salt.version.__version__}[:2]"
 
         # Because bdist_wheel supports pep517, we don't have to pre-install Salt's
         # dependencies before installing the wheel package
@@ -104,9 +124,10 @@ def test_wheel(virtualenv, cache_dir, use_static_requirements, src_dir):
             pytest.fail("Salt was not found installed")
 
         # Let's compare the installed version with the version salt reports
-        assert installed_version == salt.version.__version__, "{} != {}".format(
-            installed_version, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(installed_version).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{installed_version}[:2] != {salt.version.__version__}[:2]"
 
         # Let's also ensure we have a salt/_version.txt from the installed salt wheel
         subdir = [
@@ -221,9 +242,10 @@ def test_egg(virtualenv, cache_dir, use_static_requirements, src_dir):
             if re.search(r"^\d.\d*", x)
         ][0]
         egg_ver_cmp = egg_ver.replace("_", "-")
-        assert egg_ver_cmp == salt.version.__version__, "{} != {}".format(
-            egg_ver_cmp, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(egg_ver_cmp).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{egg_ver_cmp}[:2] != {salt.version.__version__}[:2]"
 
         # We cannot pip install an egg file, let's go old school
         venv.run(venv.venv_python, "-m", "easy_install", str(salt_generated_package))
@@ -239,9 +261,10 @@ def test_egg(virtualenv, cache_dir, use_static_requirements, src_dir):
             pytest.fail("Salt was not found installed")
 
         # Let's compare the installed version with the version salt reports
-        assert installed_version == salt.version.__version__, "{} != {}".format(
-            installed_version, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(installed_version).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{installed_version}[:2] != {salt.version.__version__}[:2]"
 
         # Let's also ensure we have a salt/_version.txt from the installed salt egg
         subdir = [
@@ -332,9 +355,10 @@ def test_sdist(virtualenv, cache_dir, use_static_requirements, src_dir):
         sdist_ver_cmp = salt_generated_package.name.split(".tar.gz")[0].split("salt-")[
             -1
         ]
-        assert sdist_ver_cmp == salt.version.__version__, "{} != {}".format(
-            sdist_ver_cmp, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(sdist_ver_cmp).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{sdist_ver_cmp}[:2] != {salt.version.__version__}[:2]"
 
         venv.install(str(salt_generated_package))
 
@@ -367,9 +391,10 @@ def test_sdist(virtualenv, cache_dir, use_static_requirements, src_dir):
             pytest.fail("Salt was not found installed")
 
         # Let's compare the installed version with the version salt reports
-        assert installed_version == salt.version.__version__, "{} != {}".format(
-            installed_version, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(installed_version).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{installed_version}[:2] != {salt.version.__version__}[:2]"
 
 
 @pytest.mark.skip_initial_gh_actions_failure(skip=_check_skip)
@@ -439,9 +464,10 @@ def test_setup_install(virtualenv, cache_dir, use_static_requirements, src_dir):
             pytest.fail("Salt was not found installed")
 
         # Let's compare the installed version with the version salt reports
-        assert installed_version == salt.version.__version__, "{} != {}".format(
-            installed_version, salt.version.__version__
-        )
+        assert (
+            SaltStackVersion.parse(installed_version).info[:2]
+            == SaltStackVersion.parse(salt.version.__version__).info[:2]
+        ), f"{installed_version}[:2] != {salt.version.__version__}[:2]"
 
         # Let's also ensure we have a salt/_version.txt from the installed salt
         subdir = [

--- a/tests/pytests/scenarios/setup/test_man.py
+++ b/tests/pytests/scenarios/setup/test_man.py
@@ -3,6 +3,7 @@ Tests for existence of manpages
 """
 
 import os
+import pathlib
 import pprint
 
 import pytest
@@ -23,6 +24,9 @@ def test_man_pages(virtualenv, src_dir):
     """
     Make sure that man pages are installed
     """
+    if not (pathlib.Path(src_dir) / "doc" / "man").is_dir():
+        pytest.skip("Man pages are not generated in the source tree")
+
     # Map filenames to search strings which should be in the manpage
     manpages = {
         "salt-cp.1": ["salt-cp Documentation", "copies files from the master"],

--- a/tests/pytests/unit/test_salt_build_backend.py
+++ b/tests/pytests/unit/test_salt_build_backend.py
@@ -1,0 +1,128 @@
+"""
+    tests.pytests.unit.test_salt_build_backend
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for Salt's custom build backend tools/pkg/salt_build_backend.py
+"""
+
+import sys
+
+import pytest
+
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def salt_build_backend():
+    with patch("sys.path", ["tools/pkg"] + sys.path):
+        import salt_build_backend
+
+        yield salt_build_backend
+        if "salt_build_backend" in sys.modules:
+            del sys.modules["salt_build_backend"]
+
+
+def test_build_editable(salt_build_backend):
+    with patch(
+        "salt_build_backend.setuptools_build_editable", return_value="wheel.whl"
+    ) as mock_setuptools_build_editable:
+        ret = salt_build_backend.build_editable("wheel_dir")
+        assert ret == "wheel.whl"
+        mock_setuptools_build_editable.assert_called_once_with("wheel_dir", None, None)
+
+
+def test_prepare_metadata_for_build_editable(salt_build_backend):
+    with patch(
+        "salt_build_backend.setuptools_prepare_metadata", return_value="metadata_dir"
+    ) as mock_setuptools_prepare_metadata:
+        ret = salt_build_backend.prepare_metadata_for_build_editable("metadata_dir")
+        assert ret == "metadata_dir"
+        mock_setuptools_prepare_metadata.assert_called_once_with("metadata_dir", None)
+
+
+def test_prepare_metadata_for_build_wheel(salt_build_backend):
+    from setuptools import build_meta as _orig
+
+    assert (
+        salt_build_backend.prepare_metadata_for_build_wheel
+        is _orig.prepare_metadata_for_build_wheel
+    )
+
+
+def test_build_wheel(salt_build_backend):
+    from setuptools import build_meta as _orig
+
+    assert salt_build_backend.build_wheel is _orig.build_wheel
+
+
+def test_build_sdist(salt_build_backend):
+    from setuptools import build_meta as _orig
+
+    assert salt_build_backend.build_sdist is _orig.build_sdist
+
+
+def test_get_requires_for_build_wheel(salt_build_backend):
+    from setuptools import build_meta as _orig
+
+    assert (
+        salt_build_backend.get_requires_for_build_wheel
+        is _orig.get_requires_for_build_wheel
+    )
+
+
+def test_get_requires_for_build_sdist(salt_build_backend):
+    from setuptools import build_meta as _orig
+
+    assert (
+        salt_build_backend.get_requires_for_build_sdist
+        is _orig.get_requires_for_build_sdist
+    )
+
+
+def test_get_salt_version(salt_build_backend):
+    with patch("salt_build_backend.PROJECT_ROOT", "."), patch(
+        "salt_build_backend.open",
+        MagicMock(
+            return_value=MagicMock(
+                __enter__=lambda x: x,
+                __exit__=lambda x, y, z, w: None,
+                read=lambda: "__saltstack_version__ = '3006.0'",
+            )
+        ),
+    ):
+        assert salt_build_backend.get_salt_version() == "3006.0"
+
+
+def test_get_install_requires(salt_build_backend):
+    with patch("salt_build_backend.PROJECT_ROOT", "."), patch(
+        "salt_build_backend._parse_requirements_file", return_value=["salt-req"]
+    ):
+        reqs = salt_build_backend.get_install_requires()
+        assert "salt-req" in reqs
+
+
+def test_get_extras_require(salt_build_backend):
+    with patch("salt_build_backend.PROJECT_ROOT", "."), patch(
+        "os.path.exists", return_value=True
+    ), patch(
+        "salt_build_backend._parse_requirements_file", return_value=["crypto-req"]
+    ):
+        extras = salt_build_backend.get_extras_require()
+        assert extras["crypto"] == ["crypto-req"]
+
+
+def test_get_entry_points(salt_build_backend):
+    with patch("salt_build_backend.PROJECT_ROOT", "."), patch(
+        "os.path.exists", return_value=True
+    ):
+        entry_points = salt_build_backend.get_entry_points()
+        assert "console_scripts" in entry_points
+        assert any("salt-call =" in s for s in entry_points["console_scripts"])
+
+
+def test_get_scripts(salt_build_backend):
+    with patch("salt_build_backend.PROJECT_ROOT", "."), patch(
+        "os.path.exists", return_value=True
+    ):
+        scripts = salt_build_backend.get_scripts()
+        assert "scripts/salt-call" in scripts

--- a/tests/pytests/unit/test_salt_build_backend.py
+++ b/tests/pytests/unit/test_salt_build_backend.py
@@ -5,6 +5,7 @@
     Tests for Salt's custom build backend tools/pkg/salt_build_backend.py
 """
 
+import os
 import sys
 
 import pytest
@@ -15,11 +16,22 @@ from tests.support.mock import MagicMock, patch
 @pytest.fixture
 def salt_build_backend():
     with patch("sys.path", ["tools/pkg"] + sys.path):
-        import salt_build_backend
+        # Onedir test interpreters bundle stdlib ``distutils`` on ``sys.path`` before
+        # setuptools finishes its ``_distutils_hack`` shim, which can raise
+        # ``AssertionError`` when importing ``setuptools.build_meta``. Prefer stdlib
+        # distutils for this import only; evict any cached ``distutils`` tree so the
+        # env var is honored from a clean state.
+        with patch.dict(
+            os.environ, {"SETUPTOOLS_USE_DISTUTILS": "stdlib"}, clear=False
+        ):
+            for modname in list(sys.modules):
+                if modname == "distutils" or modname.startswith("distutils."):
+                    sys.modules.pop(modname, None)
+            import salt_build_backend
 
-        yield salt_build_backend
-        if "salt_build_backend" in sys.modules:
-            del sys.modules["salt_build_backend"]
+            yield salt_build_backend
+            if "salt_build_backend" in sys.modules:
+                del sys.modules["salt_build_backend"]
 
 
 def test_build_editable(salt_build_backend):

--- a/tests/pytests/unit/test_salt_build_backend.py
+++ b/tests/pytests/unit/test_salt_build_backend.py
@@ -23,6 +23,8 @@ def salt_build_backend():
 
 
 def test_build_editable(salt_build_backend):
+    if salt_build_backend.setuptools_build_editable is None:
+        pytest.skip("setuptools does not support build_editable")
     with patch(
         "salt_build_backend.setuptools_build_editable", return_value="wheel.whl"
     ) as mock_setuptools_build_editable:
@@ -31,13 +33,27 @@ def test_build_editable(salt_build_backend):
         mock_setuptools_build_editable.assert_called_once_with("wheel_dir", None, None)
 
 
+def test_build_editable_unsupported(salt_build_backend):
+    with patch("salt_build_backend.setuptools_build_editable", None):
+        with pytest.raises(NotImplementedError):
+            salt_build_backend.build_editable("wheel_dir")
+
+
 def test_prepare_metadata_for_build_editable(salt_build_backend):
+    if salt_build_backend.setuptools_prepare_metadata is None:
+        pytest.skip("setuptools does not support prepare_metadata_for_build_editable")
     with patch(
         "salt_build_backend.setuptools_prepare_metadata", return_value="metadata_dir"
     ) as mock_setuptools_prepare_metadata:
         ret = salt_build_backend.prepare_metadata_for_build_editable("metadata_dir")
         assert ret == "metadata_dir"
         mock_setuptools_prepare_metadata.assert_called_once_with("metadata_dir", None)
+
+
+def test_prepare_metadata_for_build_editable_unsupported(salt_build_backend):
+    with patch("salt_build_backend.setuptools_prepare_metadata", None):
+        with pytest.raises(NotImplementedError):
+            salt_build_backend.prepare_metadata_for_build_editable("metadata_dir")
 
 
 def test_prepare_metadata_for_build_wheel(salt_build_backend):

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1632,6 +1632,15 @@ class VirtualEnv:
         environ = os.environ.copy()
         if self.env:
             environ.update(self.env)
+        # Onedir interpreters embed relenv toolchain paths under $HOME; CI may lack that
+        # tree when building sdists (e.g. timelib). Prefer host compilers when available.
+        if os.environ.get("ONEDIR_TESTRUN") == "1" and sys.platform != "win32":
+            cc = shutil.which("gcc")
+            cxx = shutil.which("g++")
+            if cc and "CC" not in environ:
+                environ["CC"] = cc
+            if cxx and "CXX" not in environ:
+                environ["CXX"] = cxx
         return environ
 
     @venv_python.default
@@ -1674,11 +1683,10 @@ class VirtualEnv:
         kwargs.setdefault("stderr", subprocess.PIPE)
         kwargs.setdefault("universal_newlines", True)
         env = kwargs.pop("env", None)
+        merged = dict(self.environ)
         if env:
-            env = self.environ.copy().update(env)
-        else:
-            env = self.environ
-        proc = subprocess.run(args, check=False, env=env, **kwargs)
+            merged.update(env)
+        proc = subprocess.run(args, check=False, env=merged, **kwargs)
         ret = ProcessResult(
             returncode=proc.returncode,
             stdout=proc.stdout,

--- a/tools/pkg/salt_build_backend.py
+++ b/tools/pkg/salt_build_backend.py
@@ -7,6 +7,10 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from setuptools import build_meta as _orig
+from setuptools.build_meta import build_editable as setuptools_build_editable
+from setuptools.build_meta import (
+    prepare_metadata_for_build_editable as setuptools_prepare_metadata,
+)
 
 # PEP 517 hooks
 prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
@@ -14,6 +18,18 @@ build_wheel = _orig.build_wheel
 build_sdist = _orig.build_sdist
 get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
 get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+
+def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    # Delegate to the actual setuptools implementation
+    return setuptools_build_editable(
+        wheel_directory, config_settings, metadata_directory
+    )
+
+
+def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    # Delegate to setuptools to get the metadata
+    return setuptools_prepare_metadata(metadata_directory, config_settings)
 
 
 def _parse_requirements_file(requirements_file):

--- a/tools/pkg/salt_build_backend.py
+++ b/tools/pkg/salt_build_backend.py
@@ -7,10 +7,18 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from setuptools import build_meta as _orig
-from setuptools.build_meta import build_editable as setuptools_build_editable
-from setuptools.build_meta import (
-    prepare_metadata_for_build_editable as setuptools_prepare_metadata,
-)
+
+try:
+    from setuptools.build_meta import build_editable as setuptools_build_editable
+except ImportError:
+    setuptools_build_editable = None
+
+try:
+    from setuptools.build_meta import (
+        prepare_metadata_for_build_editable as setuptools_prepare_metadata,
+    )
+except ImportError:
+    setuptools_prepare_metadata = None
 
 # PEP 517 hooks
 prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
@@ -21,6 +29,8 @@ get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
 
 
 def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    if setuptools_build_editable is None:
+        raise NotImplementedError("setuptools does not support build_editable")
     # Delegate to the actual setuptools implementation
     return setuptools_build_editable(
         wheel_directory, config_settings, metadata_directory
@@ -28,6 +38,10 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
 
 
 def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    if setuptools_prepare_metadata is None:
+        raise NotImplementedError(
+            "setuptools does not support prepare_metadata_for_build_editable"
+        )
     # Delegate to setuptools to get the metadata
     return setuptools_prepare_metadata(metadata_directory, config_settings)
 


### PR DESCRIPTION
### What does this PR do?
Something broke editable installs at some point. This fixes that

Fixes: #69101

### Previous Behavior
Could not `pip install -e .` salt

### New Behavior
`pip install -e .` now creates an editable install

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes