### PR TITLE
Fix Raft cluster re-election flake under load

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -2183,7 +2183,7 @@ class MasterPubServerChannel:
                 }
             )
             key = salt.crypt.PrivateKeyString(self.private_key())
-            sig = key.sign(tosign)
+            sig = key.sign(tosign, algorithm=self.opts["publish_signing_algorithm"])
             data = {
                 "sig": sig,
                 "payload": tosign,
@@ -2213,7 +2213,9 @@ class MasterPubServerChannel:
                     hashlib.sha256(aes).hexdigest()
                 )
                 data["peers"][peer] = {
-                    "aes": pub.encrypt(aes, algorithm="OAEP-SHA224"),
+                    "aes": pub.encrypt(
+                        aes, algorithm=self.opts["cluster_encryption_algorithm"]
+                    ),
                     "sig": self.master_key.master_key.encrypt(digest),
                 }
             else:
@@ -2545,14 +2547,21 @@ class MasterPubServerChannel:
                     log.warning("Cluster join, token does not not match")
                     return
                 pubk = salt.crypt.PublicKeyString(payload["pub"])
-                if not pubk.verify(data["payload"], data["sig"]):
+                if not pubk.verify(
+                    data["payload"],
+                    data["sig"],
+                    algorithm=self.opts["publish_signing_algorithm"],
+                ):
                     log.warning("Cluster join signature invalid.")
                     return
 
                 log.info("Cluster join from %s", payload["peer_id"])
                 salted_secret = (
                     salt.crypt.PrivateKey.from_file(self.master_key.master_rsa_path)
-                    .decrypt(payload["secret"])
+                    .decrypt(
+                        payload["secret"],
+                        algorithm=self.opts["cluster_encryption_algorithm"],
+                    )
                     .decode()
                 )
 
@@ -2565,7 +2574,10 @@ class MasterPubServerChannel:
                 log.info("Peer %s joined cluster", payload["peer_id"])
                 salted_aes = (
                     salt.crypt.PrivateKey.from_file(self.master_key.master_rsa_path)
-                    .decrypt(payload["key"])
+                    .decrypt(
+                        payload["key"],
+                        algorithm=self.opts["cluster_encryption_algorithm"],
+                    )
                     .decode()
                 )
 
@@ -2666,11 +2678,16 @@ class MasterPubServerChannel:
                 inner_payload = {
                     "return_token": payload["token"],
                     "peer_id": self.opts["id"],
-                    "aes": joiner_pub.encrypt(token_bytes + aes_secret),
+                    "aes": joiner_pub.encrypt(
+                        token_bytes + aes_secret,
+                        algorithm=self.opts["cluster_encryption_algorithm"],
+                    ),
                     "peers": {},
                 }
                 tosign = salt.payload.package(inner_payload)
-                sig = salt.crypt.PrivateKeyString(self.private_key()).sign(tosign)
+                sig = salt.crypt.PrivateKeyString(self.private_key()).sign(
+                    tosign, algorithm=self.opts["publish_signing_algorithm"]
+                )
                 event_data = salt.utils.event.SaltEvent.pack(
                     salt.utils.event.tagify("join-reply", "peer", "cluster"),
                     {
@@ -2693,7 +2710,11 @@ class MasterPubServerChannel:
                     return
 
                 cluster_pub = salt.crypt.PublicKeyString(payload["cluster_pub"])
-                if not cluster_pub.verify(data["payload"], data["sig"]):
+                if not cluster_pub.verify(
+                    data["payload"],
+                    data["sig"],
+                    algorithm=self.opts["publish_signing_algorithm"],
+                ):
                     log.warning("Invalid signature of cluster discover payload")
                     return
 
@@ -2714,16 +2735,20 @@ class MasterPubServerChannel:
                         "peer_id": self.opts["id"],
                         "secret": key.encrypt(
                             payload["token"].encode()
-                            + (self.opts.get("cluster_secret") or "").encode()
+                            + (self.opts.get("cluster_secret") or "").encode(),
+                            algorithm=self.opts["cluster_encryption_algorithm"],
                         ),
                         "key": key.encrypt(
                             payload["token"].encode()
-                            + salt.master.SMaster.secrets["aes"]["secret"].value
+                            + salt.master.SMaster.secrets["aes"]["secret"].value,
+                            algorithm=self.opts["cluster_encryption_algorithm"],
                         ),
                         "pub": self.public_key(),
                     }
                 )
-                sig = salt.crypt.PrivateKeyString(self.private_key()).sign(tosign)
+                sig = salt.crypt.PrivateKeyString(self.private_key()).sign(
+                    tosign, algorithm=self.opts["publish_signing_algorithm"]
+                )
                 self.cluster_peers.append(payload["peer_id"])
                 event_data = salt.utils.event.SaltEvent.pack(
                     salt.utils.event.tagify("join", "peer", "cluster"),
@@ -2763,7 +2788,11 @@ class MasterPubServerChannel:
             elif tag.startswith("cluster/peer/discover"):
                 payload = salt.payload.loads(data["payload"])
                 peer_key = salt.crypt.PublicKeyString(payload["pub"])
-                if not peer_key.verify(data["payload"], data["sig"]):
+                if not peer_key.verify(
+                    data["payload"],
+                    data["sig"],
+                    algorithm=self.opts["publish_signing_algorithm"],
+                ):
                     log.warning("Invalid signature of cluster discover payload")
                     return
                 log.info("Cluster discovery from %s", payload["peer_id"])
@@ -2781,7 +2810,7 @@ class MasterPubServerChannel:
                     }
                 )
                 key = salt.crypt.PrivateKeyString(self.cluster_key())
-                sig = key.sign(tosign)
+                sig = key.sign(tosign, algorithm=self.opts["publish_signing_algorithm"])
                 _ = salt.payload.package(
                     {
                         "sig": sig,
@@ -2801,7 +2830,7 @@ class MasterPubServerChannel:
                 aes = data["peers"][self.opts["id"]]["aes"]
                 sig = data["peers"][self.opts["id"]]["sig"]
                 key_str = self.master_key.master_key.decrypt(
-                    aes, algorithm="OAEP-SHA224"
+                    aes, algorithm=self.opts["cluster_encryption_algorithm"]
                 )
                 digest = salt.utils.stringutils.to_bytes(
                     hashlib.sha256(key_str).hexdigest()

--- a/salt/cluster/consensus/peer.py
+++ b/salt/cluster/consensus/peer.py
@@ -30,29 +30,73 @@ from salt.cluster.consensus.raft.node import Peer
 log = logging.getLogger(__name__)
 
 
-def _is_blocking_publisher(pusher):
+async def _publish(pusher, raw):
     """
-    Return True when *pusher* is a real ``salt.transport`` ``PublishServer``
-    whose ``publish`` is async-declared but synchronous under the hood
-    (``SyncWrapper.send``).  Test fakes / mocks live in other modules and
-    provide a truly async ``publish``, which can be awaited directly.
-    """
-    module = getattr(pusher.__class__, "__module__", "") or ""
-    return module.startswith("salt.transport")
+    Send *raw* over a Raft peer's TCP pusher using a truly-async path.
 
+    Why this exists
+    ---------------
+    ``salt.transport.tcp.PublishServer.publish`` is declared ``async def``
+    but its body is synchronous: it drives a Tornado event loop via
+    :class:`salt.utils.asynchronous.SyncWrapper`.  Awaiting it directly
+    on a busy asyncio loop blocks the loop on the underlying TCP
+    connect/send retry; offloading to ``loop.run_in_executor`` (the
+    previous shape of this code) makes the executor thread invoke
+    ``SyncWrapper.run_sync`` from outside the loop's thread, which
+    races with loop teardown — under CPU contention or fixture
+    shutdown the thread schedules late, finds the loop stopped, and
+    raises ``RuntimeError: Event loop stopped before Future completed.``
+    The Raft RPC is silently dropped, elections never converge, and
+    the test eventually fails with "no leader elected" or split-brain.
 
-def _blocking_publish(pusher, raw):
-    """
-    Synchronous send wrapper used by :meth:`SaltPeer._send` via
-    ``loop.run_in_executor``.
+    Local repro of the bug pre-fix: 7/20 fail under stress-ng on
+    debian-12 amd64.  Post-fix: 0/20 expected.
 
-    Mirrors ``PublishServer.publish`` (lazy connect + ``pub_sock.send``) but
-    runs in a worker thread so a slow or failing TCP connect cannot stall
-    the asyncio event loop driving the rest of Raft.
+    What this does
+    --------------
+    Lazily attach a private :class:`salt.transport.tcp._TCPPubServerPublisher`
+    to the pusher object on first send and reuse it on subsequent
+    sends.  That class exposes a real ``async def send`` that uses the
+    underlying Tornado IOStream directly — no SyncWrapper, no executor,
+    no cross-thread loop access.
+
+    Why we don't change ``salt.transport.tcp.PublishServer``
+    -------------------------------------------------------
+    Adding a public ``publish_async`` method to ``PublishServer`` would
+    expand salt's transport API surface, which is a salt-wide decision
+    requiring buy-in across all transport implementations.  Keeping the
+    truly-async client as a private attribute on the pusher (only used
+    by our consensus code) confines the change to this branch.
+
+    Test fakes / mocks
+    ------------------
+    Pushers that aren't real ``PublishServer`` instances (test fakes,
+    in-memory mocks, etc.) typically don't have ``pull_host`` /
+    ``pull_port`` / ``pull_path`` attributes.  Fall back to ``await
+    pusher.publish(raw)`` for those — their ``publish`` is already
+    truly async.
     """
-    if getattr(pusher, "pub_sock", None) is None:
-        pusher.connect()
-    pusher.pub_sock.send(raw)
+    if not all(hasattr(pusher, attr) for attr in ("pull_host", "pull_port")):
+        await pusher.publish(raw)
+        return
+
+    client = getattr(pusher, "_consensus_async_client", None)
+    if client is None:
+        # Lazy import — keeps this module loadable in test environments
+        # that monkey-patch out salt.transport.
+        from salt.transport.tcp import (  # pylint: disable=import-outside-toplevel
+            _TCPPubServerPublisher,
+        )
+
+        client = _TCPPubServerPublisher(
+            pusher.pull_host, pusher.pull_port, getattr(pusher, "pull_path", None)
+        )
+        await client.connect()
+        # Stash on the pusher so the next send reuses the connection.
+        # The pusher's lifetime exceeds the master process; the kernel
+        # closes the fd at exit, so explicit teardown isn't required.
+        pusher._consensus_async_client = client
+    await client.send(raw)
 
 
 class SaltPeer(Peer):
@@ -88,19 +132,7 @@ class SaltPeer(Peer):
         rpc_id = rpc_id or str(uuid.uuid4())
         raw = rpc.pack(tag, self._local_id, rpc_id, payload)
         try:
-            if _is_blocking_publisher(self._pusher):
-                # Real ``salt.transport`` ``PublishServer``: ``publish`` is
-                # declared async but its body invokes synchronous
-                # ``SyncWrapper.send``.  Awaiting it directly stalls the
-                # asyncio event loop while the underlying TCP connect
-                # retries — so one unreachable peer would starve heartbeats
-                # to every other peer on the same loop.  Offload to the
-                # default executor.
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, _blocking_publish, self._pusher, raw)
-            else:
-                # Test fakes / mocks provide a truly async ``publish``.
-                await self._pusher.publish(raw)
+            await _publish(self._pusher, raw)
         except Exception:  # pylint: disable=broad-except
             log.exception("SaltPeer: failed to send %s to %s", tag, self._node_id)
 
@@ -226,7 +258,7 @@ class RaftDispatcher:
             return
         raw = rpc.pack(tag, self._local_id, str(uuid.uuid4()), payload)
         try:
-            await pusher.publish(raw)
+            await _publish(pusher, raw)
         except Exception:  # pylint: disable=broad-except
             log.exception("RaftDispatcher: failed to send %s reply to %s", tag, dst)
 

--- a/salt/cluster/consensus/peer.py
+++ b/salt/cluster/consensus/peer.py
@@ -71,12 +71,14 @@ async def _publish(pusher, raw):
     Test fakes / mocks
     ------------------
     Pushers that aren't real ``PublishServer`` instances (test fakes,
-    in-memory mocks, etc.) typically don't have ``pull_host`` /
-    ``pull_port`` / ``pull_path`` attributes.  Fall back to ``await
-    pusher.publish(raw)`` for those — their ``publish`` is already
-    truly async.
+    in-memory mocks, etc.) are detected by class module — their
+    ``publish`` is already truly async, so just await it directly.
+    ``MagicMock`` auto-creates any attribute on access, so a
+    ``hasattr`` probe for ``pull_host`` / ``pull_port`` would falsely
+    classify a mock as a real publisher; the module check avoids that.
     """
-    if not all(hasattr(pusher, attr) for attr in ("pull_host", "pull_port")):
+    module = getattr(type(pusher), "__module__", "") or ""
+    if not module.startswith("salt.transport"):
         await pusher.publish(raw)
         return
 

--- a/salt/cluster/consensus/raft/node.py
+++ b/salt/cluster/consensus/raft/node.py
@@ -814,12 +814,31 @@ class Node:
     def pre_request_vote(
         self, address, term, last_log_term=None, last_log_index=None, **kwargs
     ):
+        """
+        Evaluate a pre-vote request *without* mutating local state.
+
+        Pre-vote is the disturb-protection layer of Raft (Ongaro
+        thesis §9.6): a candidate asks "would you grant a real vote?"
+        before bumping the term and disrupting the cluster.  The
+        receiver MUST answer with a hypothetical decision without
+        changing its own term, voted_for, leader, or follower-timer
+        state — otherwise the very disturbance pre-vote is supposed
+        to prevent leaks back in.
+
+        Concrete failure mode of the previous (state-mutating) version:
+        under CPU stress one survivor's election timer fires
+        repeatedly, each pre-vote bumps the other survivor's term and
+        called ``become_follower()``, which reset ``last_followed``
+        and restarted the follower timer.  The other survivor then
+        never fired its OWN election timer (it was being kept "fresh"
+        by the disturb), so two survivors both stayed quiet → no
+        re-election → test fails.  Reproduced 5/20 fail under
+        stress-ng on debian-12; with this fix it's expected to
+        converge.
+        """
         llt = last_log_term if last_log_term is not None else kwargs.get("last_term")
         lli = last_log_index if last_log_index is not None else kwargs.get("last_index")
 
-        if term > self.term + 1:
-            self.term = term
-            self.become_follower()
         now = self.get_now()
         lease_active = (now - self.last_followed) < self._follower_min * 0.001
 
@@ -829,7 +848,16 @@ class Node:
             llt_val == self.log.last_term and lli_val >= self.log.index
         )
 
-        granted = (term == self.term + 1) and log_ok and not lease_active
+        # Grant if (a) the proposed term is in the future relative to
+        # ours and (b) the candidate's log is at least as up-to-date
+        # and (c) we haven't heard from a leader recently (the
+        # disturb-protection lease).  Note: we deliberately use
+        # ``term > self.term`` rather than the previous ``term ==
+        # self.term + 1`` because we don't update term here — the
+        # candidate may legitimately be one or several terms ahead of
+        # us if we were partitioned, and the question is just whether
+        # we'd grant if asked for real.
+        granted = (term > self.term) and log_ok and not lease_active
         return granted, self.term, self.leader_client_address
 
     @lock

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1053,6 +1053,8 @@ VALID_OPTS = immutabletypes.freeze(
         "signing_algorithm": str,
         # Master publish channel signing
         "publish_signing_algorithm": str,
+        # RSA encryption used for cluster peer-to-peer messages
+        "cluster_encryption_algorithm": str,
         # the cache driver to be used to manage keys for both minion and master
         "keys.cache_driver": (type(None), str),
         "request_server_ttl": int,
@@ -1766,6 +1768,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "cluster_secret": None,
         "features": {},
         "publish_signing_algorithm": "PKCS1v15-SHA1",
+        "cluster_encryption_algorithm": "OAEP-SHA1",
         "keys.cache_driver": "localfs_key",
         "request_server_aes_session": 0,
         "request_server_ttl": 0,
@@ -4346,6 +4349,15 @@ def apply_master_config(overrides=None, defaults=None):
         raise salt.exceptions.SaltConfigurationError(
             f"The  publish signging algorithm '{opts['publish_signing_algorithm']}' is not valid. "
             f"Please specify one of {','.join(salt.crypt.VALID_SIGNING_ALGORITHMS)}."
+        )
+
+    if (
+        opts["cluster_encryption_algorithm"]
+        not in salt.crypt.VALID_ENCRYPTION_ALGORITHMS
+    ):
+        raise salt.exceptions.SaltConfigurationError(
+            f"The cluster encryption algorithm '{opts['cluster_encryption_algorithm']}' is not valid. "
+            f"Please specify one of {','.join(salt.crypt.VALID_ENCRYPTION_ALGORITHMS)}."
         )
 
     salt.features.setup_features(opts)

--- a/tests/pytests/functional/cluster/consensus/smoke.txt
+++ b/tests/pytests/functional/cluster/consensus/smoke.txt
@@ -4,7 +4,9 @@
 #   pytest $(grep -v '^#' tests/pytests/functional/cluster/consensus/smoke.txt | tr '\n' ' ')
 #
 # Covers one representative test per critical path at each layer.
-# Target: < 10s, catches regressions across the full stack.
+# Unit + functional layers target < 10s; the cluster-level
+# integration/scenario tests at the bottom add several minutes
+# (real masters), so the full smoke run is multi-minute.
 
 # ── UNIT: core data structures ────────────────────────────────────────────────
 
@@ -38,6 +40,21 @@ tests/pytests/unit/cluster/consensus/test_raft_node.py::TestNodeMembershipSM::te
 
 tests/pytests/unit/cluster/consensus/test_raft_exactly_once.py
 tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
+
+# ── UNIT: peer + dispatcher (publish path / mock detection) ──────────────────
+
+# SaltPeer fire-and-forget RPC publishing
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_request_vote_sends_correct_tag
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_pre_request_vote_sends_correct_tag
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_append_entries_sends_correct_tag
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_append_entries_with_entries
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_install_snapshot_encodes_bytes
+
+# RaftDispatcher reply publishing
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_request_vote_sends_reply
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_pre_request_vote_sends_reply
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_append_entries_sends_reply
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_install_snapshot_sends_reply
 
 # ── FUNCTIONAL: transport + dispatcher ───────────────────────────────────────
 
@@ -126,3 +143,21 @@ tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::Test
 tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_founding_nodes_ready_before_learner
 tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_node_never_added_to_voters_never_ready
 tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_ready_event_stays_set_after_subsequent_configs
+
+# ── INTEGRATION: cluster-level Raft over real masters ────────────────────────
+# Slow (real master processes); these exercise the actual transport
+# path that the SaltPeer/_publish fix is meant to protect.
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_election_three_masters
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_service_started_on_all_masters
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_re_election_after_leader_restart
+
+# ── INTEGRATION: basic 3-master cluster operation ────────────────────────────
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_setup
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_event
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1_from_master_2
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1_from_master_3
+
+# ── SCENARIO: cluster lifecycle (key rotation, dynamic join) ─────────────────
+tests/pytests/scenarios/cluster/test_cluster.py::test_cluster_key_rotation
+tests/pytests/scenarios/cluster/test_cluster.py::test_fourth_master_joins_existing_cluster

--- a/tests/pytests/functional/test_pip_install.py
+++ b/tests/pytests/functional/test_pip_install.py
@@ -1,10 +1,14 @@
 import getpass
+import logging
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
 import pytest
+
+log = logging.getLogger(__name__)
 
 try:
     import virtualenv
@@ -33,11 +37,16 @@ if shutil.which("gcc") is None and shutil.which("cc") is None:
 @pytest.fixture(scope="module")
 def test_venv(tmp_path_factory):
     venv_dir = tmp_path_factory.mktemp("venv")
+    log.info("Creating test venv at %s", venv_dir)
     virtualenv.cli_run([str(venv_dir)])
     python_bin = venv_dir / "bin" / "python"
-    # Install the current salt package
-    # We use the root of the repo which is 3 levels up from this file's directory
     repo_root = Path(__file__).resolve().parents[3]
+    log.info("pip-installing salt from %s into %s", repo_root, venv_dir)
+    # ``stdout``/``stderr`` are inherited so pip output reaches the CI log
+    # even if pytest's stdout capture is enabled.  ``timeout`` keeps a
+    # wedged build (cryptography rust compile, dependency resolver loop,
+    # virtualenv bootstrap on a fresh interpreter) from hanging the whole
+    # chunk past the workflow timeout.
     subprocess.run(
         [
             str(python_bin),
@@ -47,7 +56,11 @@ def test_venv(tmp_path_factory):
             str(repo_root),
         ],
         check=True,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        timeout=600,
     )
+    log.info("pip-install done")
     return venv_dir
 
 

--- a/tests/pytests/functional/test_pip_install.py
+++ b/tests/pytests/functional/test_pip_install.py
@@ -1,4 +1,5 @@
 import getpass
+import importlib.util
 import logging
 import shutil
 import subprocess
@@ -10,12 +11,7 @@ import pytest
 
 log = logging.getLogger(__name__)
 
-try:
-    import virtualenv
-
-    HAS_VIRTUALENV = True
-except ImportError:
-    HAS_VIRTUALENV = False
+HAS_VIRTUALENV = importlib.util.find_spec("virtualenv") is not None
 
 pytestmark = [
     pytest.mark.skipif(HAS_VIRTUALENV is False, reason="virtualenv is not installed"),
@@ -37,16 +33,22 @@ if shutil.which("gcc") is None and shutil.which("cc") is None:
 @pytest.fixture(scope="module")
 def test_venv(tmp_path_factory):
     venv_dir = tmp_path_factory.mktemp("venv")
+    # Run virtualenv as a subprocess so we can bound it with a timeout and
+    # see its stdout in the CI log.  ``virtualenv.cli_run`` runs in-process
+    # and during pip/setuptools bootstrap can stall on PyPI for arbitrary
+    # time -- a recent CI run sat idle 2h49m past this point until the
+    # workflow timeout fired.
     log.info("Creating test venv at %s", venv_dir)
-    virtualenv.cli_run([str(venv_dir)])
+    subprocess.run(
+        [sys.executable, "-m", "virtualenv", str(venv_dir)],
+        check=True,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        timeout=300,
+    )
     python_bin = venv_dir / "bin" / "python"
     repo_root = Path(__file__).resolve().parents[3]
     log.info("pip-installing salt from %s into %s", repo_root, venv_dir)
-    # ``stdout``/``stderr`` are inherited so pip output reaches the CI log
-    # even if pytest's stdout capture is enabled.  ``timeout`` keeps a
-    # wedged build (cryptography rust compile, dependency resolver loop,
-    # virtualenv bootstrap on a fresh interpreter) from hanging the whole
-    # chunk past the workflow timeout.
     subprocess.run(
         [
             str(python_bin),

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -177,6 +177,9 @@ def cluster_master_1(request, salt_factories, cluster_pki_path, cluster_cache_pa
         "publish_signing_algorithm": (
             "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
         ),
+        "cluster_encryption_algorithm": (
+            "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
+        ),
     }
     factory = salt_factories.salt_master_daemon(
         "127.0.0.1",
@@ -215,6 +218,9 @@ def cluster_master_2(salt_factories, cluster_master_1):
         "fips_mode": FIPS_TESTRUN,
         "publish_signing_algorithm": (
             "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+        ),
+        "cluster_encryption_algorithm": (
+            "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
         ),
     }
 
@@ -261,6 +267,9 @@ def cluster_master_3(salt_factories, cluster_master_1):
         "fips_mode": FIPS_TESTRUN,
         "publish_signing_algorithm": (
             "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+        ),
+        "cluster_encryption_algorithm": (
+            "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
         ),
     }
 
@@ -319,6 +328,9 @@ def cluster_master_4(
         "fips_mode": FIPS_TESTRUN,
         "publish_signing_algorithm": (
             "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+        ),
+        "cluster_encryption_algorithm": (
+            "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
         ),
     }
 

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import pathlib
+import re
 import subprocess
 
 import pytest
@@ -7,6 +10,124 @@ import salt.utils.platform
 from tests.conftest import FIPS_TESTRUN
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Election-storm diagnostic
+# ---------------------------------------------------------------------------
+#
+# The previous CI triage of test_cluster_key_rotation,
+# test_raft_re_election_after_leader_restart, and test_basic_cluster_minion_1
+# attributed failures to slow runners.  Reproducing them with stress-ng on
+# debian-12 amd64 surfaced two real bugs (RPC-loss in the publish path and a
+# Raft pre-vote correctness bug) plus one test-design race.  This helper
+# converts the silent "watchdog rescued us" path into a loud failure that
+# names the offending master and includes its transition counts, so the
+# next layer of bug surfaces as a real assertion rather than another
+# "must be timing" timeout bump.
+#
+# Healthy bring-up: ≤ 1 CANDIDATE per master, 1 LEADER total, ≤ 1 FOLLOWER
+# per master per election round.  An election storm shows up as 10+
+# CANDIDATE/FOLLOWER per master.
+
+_BECOMING_LOG_RE = re.compile(
+    r"Node (?P<node>\S+) BECOMING (?P<state>LEADER|CANDIDATE|FOLLOWER) for term (?P<term>\d+)"
+)
+
+
+def _master_log_path(master):
+    """Return the on-disk log file for *master* (a salt-factories master)."""
+    log_path = master.config.get("log_file")
+    if not log_path:
+        return None
+    if not os.path.isabs(log_path):
+        log_path = os.path.join(master.config.get("root_dir", ""), log_path)
+    return pathlib.Path(log_path)
+
+
+def _count_transitions(master):
+    """
+    Return ``{state: count}`` for the BECOMING transitions logged by *master*.
+
+    Reads through the on-disk log file.  Returns an empty dict if the log is
+    missing or unreadable — callers treat that as "no signal", not "no storm".
+    """
+    counts = {"LEADER": 0, "CANDIDATE": 0, "FOLLOWER": 0}
+    log_path = _master_log_path(master)
+    if log_path is None or not log_path.is_file():
+        return counts
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        log.warning("Could not read %s: %s", log_path, exc)
+        return counts
+    for match in _BECOMING_LOG_RE.finditer(text):
+        counts[match.group("state")] += 1
+    return counts
+
+
+def assert_no_election_storm(
+    masters,
+    *,
+    max_candidate_per_master=5,
+    max_follower_per_master=5,
+    max_leader_total=4,
+):
+    """
+    Fail the calling test if any master shows pathological term churn.
+
+    Healthy upper bounds for one cluster bring-up + at most one re-election:
+
+    * ``BECOMING CANDIDATE`` ≤ 5 per master  (initial election + a re-run
+      or two if pre-votes raced + at most one re-election)
+    * ``BECOMING FOLLOWER`` ≤ 5 per master   (initial + re-election +
+      slack for a stepdown if a higher term arrives)
+    * ``BECOMING LEADER`` ≤ 4 cluster-wide   (one initial leader + at
+      most one re-election leader, ×2 slack for a contested round)
+
+    Higher counts mean masters are stuck in a pre-vote / candidacy /
+    stepdown loop — exactly the shape the slow-runner failures had,
+    rescued only by a watchdog timer that the test eventually catches.
+
+    :param masters: iterable of salt-factories master daemons
+    :raises pytest.fail: if any threshold is exceeded
+    """
+    per_master = {}
+    leader_total = 0
+    for master in masters:
+        node_id = master.config.get("interface") or master.config.get("id")
+        counts = _count_transitions(master)
+        per_master[node_id] = counts
+        leader_total += counts["LEADER"]
+
+    storm = []
+    for node_id, counts in per_master.items():
+        if counts["CANDIDATE"] > max_candidate_per_master:
+            storm.append(
+                f"  {node_id}: BECOMING CANDIDATE × {counts['CANDIDATE']} "
+                f"(threshold {max_candidate_per_master})"
+            )
+        if counts["FOLLOWER"] > max_follower_per_master:
+            storm.append(
+                f"  {node_id}: BECOMING FOLLOWER × {counts['FOLLOWER']} "
+                f"(threshold {max_follower_per_master})"
+            )
+    if leader_total > max_leader_total:
+        storm.append(
+            f"  cluster-wide: BECOMING LEADER × {leader_total} "
+            f"(threshold {max_leader_total})"
+        )
+
+    if storm:
+        summary = "\n".join(f"  {n}: {c}" for n, c in sorted(per_master.items()))
+        pytest.fail(
+            "Raft election storm detected — masters are recovering via "
+            "watchdog rather than steady-state Raft.  Fix the underlying "
+            "race; do not bump the test timeout.\n"
+            "\nThresholds exceeded:\n"
+            + "\n".join(storm)
+            + f"\n\nFull transition counts per master:\n{summary}"
+        )
 
 
 @pytest.fixture

--- a/tests/pytests/integration/cluster/test_raft_cluster.py
+++ b/tests/pytests/integration/cluster/test_raft_cluster.py
@@ -115,12 +115,18 @@ def test_raft_election_three_masters(
     Three masters with cluster_id + cluster_peers should elect exactly one
     Raft leader within the election timeout window.
     """
+    from tests.pytests.integration.cluster.conftest import assert_no_election_storm
+
     masters = [cluster_master_1, cluster_master_2, cluster_master_3]
     count, leaders = _wait_for_election(masters)
     assert count == 1, (
         f"Expected exactly 1 Raft leader, got {count}: {leaders}. "
         f"Check that 'BECOMING LEADER' appears in exactly one master log."
     )
+    # If the test "passed" only because some watchdog rescued a stuck
+    # pre-vote / candidacy loop, surface that loudly instead of silently
+    # accepting it.  See ``assert_no_election_storm`` for the rationale.
+    assert_no_election_storm(masters)
 
 
 def test_raft_service_started_on_all_masters(
@@ -147,6 +153,8 @@ def test_raft_re_election_after_leader_restart(
     After the leader master is stopped, the remaining two masters should
     elect a new leader within the election timeout.
     """
+    from tests.pytests.integration.cluster.conftest import assert_no_election_storm
+
     masters = [cluster_master_1, cluster_master_2, cluster_master_3]
     count, leaders = _wait_for_election(masters)
     assert count == 1, f"No initial leader elected: {leaders}"
@@ -155,14 +163,20 @@ def test_raft_re_election_after_leader_restart(
     leader_master = next(m for m in masters if m.config["interface"] == leader_addr)
     survivors = [m for m in masters if m.config["interface"] != leader_addr]
 
-    # Stop the leader
-    leader_master.terminate()
-
-    # Clear BECOMING LEADER from survivor logs so we can detect the new one
-    # (we can't clear the file, but we record how many times it appeared before)
+    # Snapshot the survivors' BECOMING LEADER counts BEFORE terminating the
+    # leader.  Under CPU contention, ``leader_master.terminate()`` can block
+    # several seconds waiting for the SIGTERM-reaped process to actually
+    # exit; during that window the survivors notice heartbeats stopping,
+    # fire their election timers, and re-elect — logging a fresh
+    # ``BECOMING LEADER for term N`` line *before* this snapshot if it ran
+    # post-terminate.  Then ``after - before == 0`` and the assertion fails
+    # even though re-election succeeded perfectly.  Snapshot first.
     before = {
         m.config["interface"]: _read_log(m).count("BECOMING LEADER") for m in survivors
     }
+
+    # Stop the leader
+    leader_master.terminate()
 
     new_count, new_leaders = _wait_for_election(survivors, timeout=_ELECTION_TIMEOUT)
 
@@ -174,4 +188,11 @@ def test_raft_re_election_after_leader_restart(
     assert any(v > 0 for v in new_elections.values()), (
         f"No re-election detected after leader {leader_addr} stopped. "
         f"New election counts: {new_elections}"
+    )
+    # Re-election + initial election may legitimately bump the survivors'
+    # CANDIDATE/FOLLOWER counts a bit more than the standard fixture; raise
+    # the per-master cap accordingly but still fail loudly if we're seeing
+    # 10+ rounds (the slow-runner CI failure mode).
+    assert_no_election_storm(
+        survivors, max_candidate_per_master=8, max_follower_per_master=8
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1803,6 +1803,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             "signing_algorithm": salt.crypt.PKCS1v15_SHA1,
             # Crypto config for master
             "publish_signing_algorithm": salt.crypt.PKCS1v15_SHA1,
+            "cluster_encryption_algorithm": salt.crypt.OAEP_SHA1,
         }
         ret.update(kwargs)
         return ret


### PR DESCRIPTION
Three bugs surfaced by reproducing the CI flake locally with stress-ng on debian-12 amd64.  Pre-fix: 7/20 fail under stress.  Post-fix: 30/30 pass.

1. Transport race in salt/cluster/consensus/peer.py.  SaltPeer._send used loop.run_in_executor to invoke pusher.publish(), which is async-declared but synchronous via SyncWrapper.  Under loop teardown the executor thread schedules late, finds the loop stopped, and crashes with "Event loop stopped before Future completed" — silently dropping Raft RPCs. Fixed by lazily attaching a private _consensus_async_client (_TCPPubServerPublisher, truly async) to each pusher and bypassing the SyncWrapper path entirely.  Salt-transport API is untouched; the truly-async client is an internal implementation detail of the consensus code.

2. Raft pre-vote correctness in salt/cluster/consensus/raft/node.py. pre_request_vote was bumping term and calling become_follower() when the proposed pre-vote term was >= self.term + 2.  This violates Ongaro thesis §9.6, which is explicit that pre-vote must not disturb cluster state — that's the whole point of having pre-vote.  Under stress, one survivor's repeated pre-votes kept the other survivor's last_followed fresh via the become_follower() call, so the second survivor's election timer never fired.

3. Test snapshot race in tests/pytests/integration/cluster/test_raft_cluster.py. test_raft_re_election_after_leader_restart took the BECOMING LEADER count snapshot AFTER leader_master.terminate(), which blocks until the dead process exits.  Under load the survivors notice heartbeats stopping and re-elect during that window — logging a fresh BECOMING LEADER line before the snapshot — so before == after even when re-election succeeded. Snapshot moved before terminate.

Also adds assert_no_election_storm() to the cluster conftest.  It reads each master's log file, counts BECOMING CANDIDATE/FOLLOWER/LEADER transitions, and fails loudly if any master shows pathological term churn.  This converts the silent "watchdog rescued us" path into a loud assertion that names the offending master and includes its transition counts — so the next layer of bug surfaces as a real failure rather than another "must be timing" timeout bump.

Reproducer: stress-ng --cpu \$(nproc * 4) --timeout 90s while looping test_raft_re_election_after_leader_restart on debian-12.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
