### PR TITLE
Replicate cluster state over the wire and harden Raft elections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,20 @@ repos:
           - check
 
       - id: tools
+        alias: check-cp1252-docstrings
+        name: Check docstrings encode in cp1252 (Windows stdout)
+        files: salt/.*\.py$
+        exclude: >
+            (?x)^(
+                templates/.*|
+                salt/ext/.*|
+            )$
+        args:
+          - pre-commit
+          - docstrings
+          - check-cp1252
+
+      - id: tools
         alias: check-known-missing-docstrings
         name: Check Known Missing Docstrings
         stages: [manual]

--- a/doc/ref/runners/all/index.rst
+++ b/doc/ref/runners/all/index.rst
@@ -13,6 +13,7 @@ runner modules
     auth
     batch
     cache
+    cluster
     config
     doc
     error

--- a/doc/ref/runners/all/salt.runners.cluster.rst
+++ b/doc/ref/runners/all/salt.runners.cluster.rst
@@ -1,0 +1,5 @@
+salt.runners.cluster
+====================
+
+.. automodule:: salt.runners.cluster
+    :members:

--- a/salt/cache/mmap_cache.py
+++ b/salt/cache/mmap_cache.py
@@ -54,7 +54,7 @@ log = logging.getLogger(__name__)
 
 __func_alias__ = {"list_": "list", "flush_": "flush"}
 
-# Module-level registry: (cachedir, bank) → (tuning_tuple, MmapCache).
+# Module-level registry: (cachedir, bank) -> (tuning_tuple, MmapCache).
 # When ``__opts__`` mmap tuning changes (e.g. tests patch opts after an early
 # cache miss vs hit), evict and rebuild so we never reuse an ``MmapCache``
 # sized for stale configuration over the same bank directory.

--- a/salt/cache/mmap_cache.py
+++ b/salt/cache/mmap_cache.py
@@ -162,11 +162,22 @@ def _get_cache(bank, cachedir):
     index_path = os.path.join(bank_dir, ".mmap_cache.idx")
 
     size, slot_size, key_size = tuning
+    # Heap segment cap controls "how big can a single .heap-N file get
+    # before the next append rolls a new segment".  Pulled from opts
+    # rather than hardcoded so operators can tune for filesystems or
+    # backup tools that struggle past a given size.  Not part of the
+    # ``tuning`` tuple because changing it does not invalidate
+    # already-written segments — it only affects future appends.
+    max_segment_bytes = __opts__.get(
+        "mmap_cache_max_segment_bytes",
+        salt.utils.mmap_cache.DEFAULT_MAX_SEGMENT_BYTES,
+    )
     cache_obj = salt.utils.mmap_cache.MmapCache(
         path=index_path,
         size=size,
         slot_size=slot_size,
         key_size=key_size,
+        max_segment_bytes=max_segment_bytes,
     )
     _caches[key] = (tuning, cache_obj)
     return cache_obj

--- a/salt/cache/mmap_key.py
+++ b/salt/cache/mmap_key.py
@@ -116,11 +116,25 @@ def _get_cache(bank, cachedir):
         size = __opts__.get("mmap_key_size", _DEFAULT_SIZE)
         slot_size = __opts__.get("mmap_key_slot_size", _DEFAULT_SLOT_SIZE)
         id_size = __opts__.get("mmap_key_id_size", _DEFAULT_ID_SIZE)
+        # Heap segment cap — how big a single .heap-N file may grow
+        # before the next append rolls a new segment.  Read from opts
+        # so operators can tune below 1 GiB on filesystems or backup
+        # tools that don't like multi-GiB single files.  Falls back to
+        # ``mmap_cache_max_segment_bytes`` so an operator who already
+        # set it for the generic backend doesn't need to set it twice.
+        max_segment_bytes = __opts__.get(
+            "mmap_key_max_segment_bytes",
+            __opts__.get(
+                "mmap_cache_max_segment_bytes",
+                salt.utils.mmap_cache.DEFAULT_MAX_SEGMENT_BYTES,
+            ),
+        )
         _caches[key] = salt.utils.mmap_cache.MmapCache(
             path=index_path,
             size=size,
             slot_size=slot_size,
             key_size=id_size,
+            max_segment_bytes=max_segment_bytes,
         )
     return _caches[key]
 

--- a/salt/cache/mmap_key.py
+++ b/salt/cache/mmap_key.py
@@ -78,7 +78,7 @@ _DEFAULT_SIZE = 1_000_000
 _DEFAULT_SLOT_SIZE = 96
 _DEFAULT_ID_SIZE = 64
 
-# Module-level registry: (cachedir, bank) → MmapCache
+# Module-level registry: (cachedir, bank) -> MmapCache
 _caches: dict = {}
 
 

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -2293,7 +2293,10 @@ class MasterPubServerChannel:
                     try:
                         salted = salt.crypt.PrivateKey.from_file(
                             self.master_key.master_rsa_path
-                        ).decrypt(inner["cluster_aes"])
+                        ).decrypt(
+                            inner["cluster_aes"],
+                            algorithm=self.opts["cluster_encryption_algorithm"],
+                        )
                         new_cluster_aes = salted[len(token) :]
                         with salt.master.SMaster.secrets["cluster_aes"][
                             "secret"
@@ -2321,7 +2324,10 @@ class MasterPubServerChannel:
                     try:
                         salted_session = salt.crypt.PrivateKey.from_file(
                             self.master_key.master_rsa_path
-                        ).decrypt(inner["cluster_key_session"])
+                        ).decrypt(
+                            inner["cluster_key_session"],
+                            algorithm=self.opts["cluster_encryption_algorithm"],
+                        )
                         session_key_str = salted_session[len(token) :].decode()
                         cluster_key_crypt = salt.crypt.Crypticle(
                             self.opts, session_key_str

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -2138,13 +2138,18 @@ class MasterPubServerChannel:
 
         Called exactly once by ``RaftService._on_membership_change`` when the
         founding or promotion CONFIG entry commits with this node in the voter set.
+
+        Also writes the Kubernetes readiness sentinel so an exec probe
+        can route traffic to this master.
         """
+        import salt.cluster.healthchecks  # pylint: disable=import-outside-toplevel
         import salt.master  # pylint: disable=import-outside-toplevel
 
         entry = salt.master.SMaster.secrets.get("cluster_ready")
         if entry is not None:
             log.info("MasterPubServerChannel: cluster ready — opening request gate")
             entry["event"].set()
+        salt.cluster.healthchecks.mark_cluster_ready(self.opts)
 
     def private_key(self):
         """

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -634,14 +634,14 @@ class PoolRoutingChannel:
 
     Architecture::
 
-        External Transport → PoolRoutingChannel → RequestClient (IPC) →
-        Pool RequestServer (IPC) → MWorkers
+        External Transport -> PoolRoutingChannel -> RequestClient (IPC) ->
+        Pool RequestServer (IPC) -> MWorkers
 
     ``_auth`` handling
     ------------------
     Under a fully started master, ``_auth`` is looked up in the routing table
     and forwarded to the mapped pool's IPC RequestServer, then handled in a
-    worker by :meth:`~salt.master.MWorker._handle_clear` →
+    worker by :meth:`~salt.master.MWorker._handle_clear` ->
     :meth:`~salt.master.ClearFuncs._auth`.
 
     If the pool's IPC client is not connected yet (e.g. tests calling
@@ -1667,7 +1667,7 @@ class MasterPubServerChannel:
         async def send_channel(channel, chunk_iter):
             chunks = list(chunk_iter)
             if not chunks:
-                # Defensive: every iter_*_chunks must yield ≥ 1 (empty
+                # Defensive: every iter_*_chunks must yield >= 1 (empty
                 # for empty data).  Synthesize an eof-only chunk so the
                 # receiver doesn't hang on a missing channel.
                 chunks = [[]]

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1639,6 +1639,233 @@ class MasterPubServerChannel:
     def gen_token(self):
         return "".join(random.choices(string.ascii_letters + string.digits, k=32))
 
+    async def _send_state_sync_chunks(self, session_id, peer_id):
+        """
+        Stream the four state-sync channels (keys, denied_keys,
+        file_roots, pillar_roots) to a freshly joined peer.
+
+        Each channel runs to completion independently and emits at least
+        one chunk (an empty chunk with ``eof=True`` if the channel has
+        no data).  All chunks are encrypted with the cluster session AES
+        key — the joiner has it from the join-reply we just sent.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            DENIED_CHANNEL,
+            FILE_ROOTS_CHANNEL,
+            KEYS_CHANNEL,
+            PILLAR_ROOTS_CHANNEL,
+            iter_keys_chunks,
+            iter_root_chunks,
+        )
+
+        pusher = self.pusher(peer_id)
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+
+        async def send_channel(channel, chunk_iter):
+            chunks = list(chunk_iter)
+            if not chunks:
+                # Defensive: every iter_*_chunks must yield ≥ 1 (empty
+                # for empty data).  Synthesize an eof-only chunk so the
+                # receiver doesn't hang on a missing channel.
+                chunks = [[]]
+            total = len(chunks)
+            for seq, items in enumerate(chunks):
+                payload = {
+                    "session": session_id,
+                    "channel": channel,
+                    "seq": seq,
+                    "total": total,
+                    "eof": seq == total - 1,
+                    "items": items,
+                }
+                event_data = salt.utils.event.SaltEvent.pack(
+                    salt.utils.event.tagify("state-sync-chunk", "peer", "cluster"),
+                    crypticle.dumps(payload),
+                )
+                try:
+                    await pusher.publish(event_data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception(
+                        "state-sync %s/%s seq=%d publish failed to %s",
+                        session_id,
+                        channel,
+                        seq,
+                        peer_id,
+                    )
+                    return
+            log.info(
+                "state-sync %s/%s sent %d chunks (%d items total) to %s",
+                session_id,
+                channel,
+                total,
+                sum(len(c) for c in chunks),
+                peer_id,
+            )
+
+        # Run the four channels concurrently — each finishes when it
+        # finishes, and a slow file_roots stream does not block keys.
+        try:
+            await asyncio.gather(
+                send_channel(KEYS_CHANNEL, iter_keys_chunks(self.opts, KEYS_CHANNEL)),
+                send_channel(
+                    DENIED_CHANNEL, iter_keys_chunks(self.opts, DENIED_CHANNEL)
+                ),
+                send_channel(
+                    FILE_ROOTS_CHANNEL,
+                    iter_root_chunks(self.opts.get("file_roots")),
+                ),
+                send_channel(
+                    PILLAR_ROOTS_CHANNEL,
+                    iter_root_chunks(self.opts.get("pillar_roots")),
+                ),
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception("state-sync session %s aborted unexpectedly", session_id)
+
+    def _apply_state_sync_chunk(self, chunk):
+        """
+        Install one ``cluster/peer/state-sync-chunk`` payload locally.
+
+        The chunk has already been Crypticle-decrypted by the caller.
+        We dispatch to the right install helper by ``chunk["channel"]``,
+        then ping the matching :class:`StateSyncSession` so
+        :meth:`_start_raft_as_learner` fires once all four channels eof.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            DENIED_CHANNEL,
+            FILE_ROOTS_CHANNEL,
+            KEYS_CHANNEL,
+            PILLAR_ROOTS_CHANNEL,
+            install_keys_chunk,
+            install_root_chunk,
+        )
+
+        if not isinstance(chunk, dict):
+            log.warning("state-sync chunk is not a dict: %r", type(chunk).__name__)
+            return
+        session_id = chunk.get("session")
+        channel = chunk.get("channel")
+        seq = chunk.get("seq", -1)
+        eof = bool(chunk.get("eof"))
+        items = chunk.get("items") or []
+        sessions = getattr(self, "_state_sync_sessions", None) or {}
+        session = sessions.get(session_id)
+        if session is None:
+            log.warning(
+                "state-sync chunk for unknown session %r (channel=%s seq=%s); dropping",
+                session_id,
+                channel,
+                seq,
+            )
+            return
+
+        installed = 0
+        try:
+            if channel in (KEYS_CHANNEL, DENIED_CHANNEL):
+                installed = install_keys_chunk(self.opts, channel, items)
+            elif channel == FILE_ROOTS_CHANNEL:
+                installed = install_root_chunk(self.opts.get("file_roots"), items)
+            elif channel == PILLAR_ROOTS_CHANNEL:
+                installed = install_root_chunk(self.opts.get("pillar_roots"), items)
+            else:
+                log.warning(
+                    "state-sync chunk for unknown channel %r (session=%s seq=%s)",
+                    channel,
+                    session_id,
+                    seq,
+                )
+                return
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "state-sync %s/%s seq=%s install failed",
+                session_id,
+                channel,
+                seq,
+            )
+
+        log.info(
+            "state-sync %s/%s seq=%s installed %d items%s",
+            session_id,
+            channel,
+            seq,
+            installed,
+            " (eof)" if eof else "",
+        )
+        session.record_chunk(channel, seq, eof, installed)
+
+    def _begin_state_sync_session(self, session_id, known_peers, discover_event):
+        """
+        Register a state-sync session and arm its watchdog timer.
+
+        Called from the join-reply handler once we know the responder is
+        running with ``cluster_isolated_filesystem=True`` and intends to
+        push the four chunked channels at us.  The session's
+        ``on_complete`` callback fires
+        :meth:`_start_raft_as_learner` exactly once, either when all four
+        channels report eof or when the deadline expires.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            DEFAULT_RECEIVE_TIMEOUT,
+            StateSyncSession,
+        )
+
+        if not hasattr(self, "_state_sync_sessions"):
+            self._state_sync_sessions = {}
+
+        if session_id in self._state_sync_sessions:
+            log.warning(
+                "Duplicate state-sync session id %s; ignoring second join-reply",
+                session_id,
+            )
+            return
+
+        completed_holder = {"done": False}
+
+        def _on_complete():
+            if completed_holder["done"]:
+                return
+            completed_holder["done"] = True
+            try:
+                self._start_raft_as_learner(known_peers)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "state-sync %s: _start_raft_as_learner failed", session_id
+                )
+            if discover_event is not None:
+                discover_event.set()
+            # Cancel the watchdog if it hasn't fired yet.
+            handle = session.watchdog_handle
+            if handle is not None:
+                try:
+                    handle.cancel()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            # Drop the session from the registry — keep memory bounded.
+            self._state_sync_sessions.pop(session_id, None)
+
+        session = StateSyncSession(session_id, _on_complete)
+        # Stash the watchdog handle on the session so on_complete can
+        # cancel it; created below.
+        session.watchdog_handle = None
+        self._state_sync_sessions[session_id] = session
+
+        try:
+            loop = asyncio.get_event_loop()
+            session.watchdog_handle = loop.call_later(
+                DEFAULT_RECEIVE_TIMEOUT, session.force_complete
+            )
+        except RuntimeError:
+            # No running event loop in this context (defensive — the
+            # join-reply handler runs inside ``_publish_daemon``'s loop,
+            # so this branch should not execute in production).
+            log.warning(
+                "state-sync %s: no event loop for watchdog; running without timeout",
+                session_id,
+            )
+
     def _join_sentinel_path(self):
         """
         Return the path to the per-master join sentinel file.
@@ -1987,6 +2214,23 @@ class MasterPubServerChannel:
                     )
                 return
             log.debug("Incomming from peer %s %r", tag, data)
+            if tag.startswith("cluster/peer/state-sync-chunk"):
+                # Encrypted with the shared cluster_aes the joiner just
+                # installed in the matching join-reply.  Each chunk
+                # belongs to one of four channels; install items
+                # in-order, mark eof when announced, and let the
+                # session's ``on_complete`` fire ``_start_raft_as_learner``.
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    chunk = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt state-sync-chunk")
+                    return
+                self._apply_state_sync_chunk(chunk)
+                return
             if tag.startswith("cluster/peer/join-notify"):
                 # join-notify is encrypted with the shared cluster AES key.
                 try:
@@ -2031,21 +2275,106 @@ class MasterPubServerChannel:
                 # The join-reply carries a signed, packed inner payload.
                 inner = salt.payload.loads(data["payload"])
                 log.info("Cluster join reply from %s", inner.get("peer_id", "unknown"))
-                # cluster_key is NOT sent over the wire; both sides have access to
-                # it via the shared cluster_pki_dir.  Only the AES session key is
-                # encrypted and delivered here so the joiner can adopt the cluster
-                # session without a restart.
+                # ``cluster_aes`` (the cluster's shared session AES key) is
+                # encrypted to our master pub here so a joiner without access
+                # to a shared ``cluster_pki_dir/.aes`` can adopt the cluster
+                # session.  ``cluster.pem`` (cluster RSA private) is still
+                # expected to be present locally — wire delivery for it is
+                # tracked separately.
+                token = self._discover_token or ""
+                if isinstance(token, str):
+                    token = token.encode()
+                if "cluster_aes" in inner:
+                    try:
+                        salted = salt.crypt.PrivateKey.from_file(
+                            self.master_key.master_rsa_path
+                        ).decrypt(inner["cluster_aes"])
+                        new_cluster_aes = salted[len(token) :]
+                        with salt.master.SMaster.secrets["cluster_aes"][
+                            "secret"
+                        ].get_lock():
+                            salt.master.SMaster.secrets["cluster_aes"][
+                                "secret"
+                            ].value = new_cluster_aes
+                        # Persist locally so the joiner survives restart
+                        # without re-running the join handshake.
+                        aes_path = pathlib.Path(self.opts["cluster_pki_dir"]) / ".aes"
+                        aes_path.parent.mkdir(parents=True, exist_ok=True)
+                        with salt.utils.files.set_umask(0o177):
+                            with salt.utils.files.fopen(aes_path, "wb") as fp:
+                                fp.write(new_cluster_aes)
+                        log.info(
+                            "Installed cluster_aes from join-reply (%d bytes)",
+                            len(new_cluster_aes),
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        log.exception("Failed to install cluster_aes from join-reply")
+                # Install the cluster RSA key pair (private + public) from
+                # the wire so a joiner without shared ``cluster_pki_dir``
+                # can sign cluster events and serve discover-reply.
+                if "cluster_key_session" in inner and "cluster_pem" in inner:
+                    try:
+                        salted_session = salt.crypt.PrivateKey.from_file(
+                            self.master_key.master_rsa_path
+                        ).decrypt(inner["cluster_key_session"])
+                        session_key_str = salted_session[len(token) :].decode()
+                        cluster_key_crypt = salt.crypt.Crypticle(
+                            self.opts, session_key_str
+                        )
+                        pem_bytes = cluster_key_crypt.decrypt(inner["cluster_pem"])
+                        pub_pem = inner.get("cluster_pub") or ""
+                        if isinstance(pub_pem, bytes):
+                            pub_pem = pub_pem.decode()
+                        cluster_pki = pathlib.Path(self.opts["cluster_pki_dir"])
+                        cluster_pki.mkdir(parents=True, exist_ok=True)
+                        # ``find_or_create_keys`` may have already written a
+                        # locally-generated cluster.pem at mode 0400; unlink
+                        # before writing so the wire-delivered version wins.
+                        pem_path = cluster_pki / "cluster.pem"
+                        pub_path = cluster_pki / "cluster.pub"
+                        for p in (pem_path, pub_path):
+                            try:
+                                p.unlink()
+                            except FileNotFoundError:
+                                pass
+                        with salt.utils.files.set_umask(0o277):
+                            with salt.utils.files.fopen(pem_path, "wb") as fp:
+                                fp.write(pem_bytes)
+                        if pub_pem:
+                            with salt.utils.files.fopen(pub_path, "w") as fp:
+                                fp.write(pub_pem)
+                        log.info(
+                            "Installed cluster.pem (%d bytes) and cluster.pub from join-reply",
+                            len(pem_bytes),
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        log.exception(
+                            "Failed to install cluster RSA key pair from join-reply"
+                        )
                 event = self._discover_event
                 self._discover_event = None
                 # Write the join sentinel so future restarts skip discover/join.
                 self._mark_joined_cluster()
-                # Start Raft as a non-voting learner now that we have peer keys.
+                # Paged bulk state-sync: the join-reply names a session id
+                # and the responder follows up with chunked
+                # ``cluster/peer/state-sync-chunk`` events, four channels
+                # in parallel (keys, denied_keys, file_roots, pillar_roots).
+                # Defer the Raft-learner start until all four channels eof
+                # (or the per-session deadline elapses).
                 known_peers = {p: inner["peers"][p] for p in inner.get("peers", {})}
-                self._start_raft_as_learner(known_peers)
-                # Signal the main master process to start the rest of the
-                # master service processeses.
-                if event is not None:
-                    event.set()
+                state_sync_session = inner.get("state_sync_session")
+                if state_sync_session and self.opts.get("cluster_isolated_filesystem"):
+                    self._begin_state_sync_session(
+                        state_sync_session, known_peers, event
+                    )
+                else:
+                    # Either the responder isn't running with isolated-FS
+                    # mode or the session announcement is missing.  Fall
+                    # back to immediate learner start; event-driven
+                    # replication will fill any gaps.
+                    self._start_raft_as_learner(known_peers)
+                    if event is not None:
+                        event.set()
             elif tag.startswith("cluster/peer/join"):
 
                 payload = salt.payload.loads(data["payload"])
@@ -2180,13 +2509,32 @@ class MasterPubServerChannel:
                 aes_secret = salt.master.SMaster.secrets["aes"]["secret"].value
                 if isinstance(aes_secret, str):
                     aes_secret = aes_secret.encode()
-                # XXX No-shared-filesystem topology is not yet supported: the
-                # join-reply payload still needs to carry the other peers'
-                # public keys and the minion keys so a joiner without access
-                # to a shared cluster_pki_dir can populate it from the wire.
-                # The cluster private key PEM is too large for direct RSA
-                # encryption; for now we rely on the shared cluster_pki_dir so
-                # the joiner already has the cluster key before this reply lands.
+                cluster_aes_secret = salt.master.SMaster.secrets["cluster_aes"][
+                    "secret"
+                ].value
+                if isinstance(cluster_aes_secret, str):
+                    cluster_aes_secret = cluster_aes_secret.encode()
+                # No-shared-filesystem support: the join-reply carries
+                # ``cluster_aes`` and the cluster RSA key pair so a joiner
+                # without access to a shared ``cluster_pki_dir`` can adopt
+                # the cluster identity from the wire alone.
+                #
+                # ``cluster.pem`` is too large for direct RSA encryption, so
+                # it travels under a fresh Crypticle session key wrapped to
+                # the joiner's RSA pub.  ``cluster.pub`` is not secret so it
+                # rides in the inner payload unencrypted (and the inner
+                # payload is signed with this master's private key).
+                cluster_pem_pem = self.cluster_key() or ""
+                cluster_pub_pem = self.cluster_public_key() or ""
+                cluster_key_session = salt.crypt.Crypticle.generate_key_string()
+                cluster_key_crypt = salt.crypt.Crypticle(self.opts, cluster_key_session)
+                cluster_pem_ciphertext = cluster_key_crypt.encrypt(
+                    cluster_pem_pem.encode()
+                )
+                wrapped_session = joiner_pub.encrypt(
+                    token_bytes + cluster_key_session.encode(),
+                    algorithm=self.opts["cluster_encryption_algorithm"],
+                )
                 inner_payload = {
                     "return_token": payload["token"],
                     "peer_id": self.opts["id"],
@@ -2194,8 +2542,28 @@ class MasterPubServerChannel:
                         token_bytes + aes_secret,
                         algorithm=self.opts["cluster_encryption_algorithm"],
                     ),
+                    "cluster_aes": joiner_pub.encrypt(
+                        token_bytes + cluster_aes_secret,
+                        algorithm=self.opts["cluster_encryption_algorithm"],
+                    ),
+                    "cluster_key_session": wrapped_session,
+                    "cluster_pem": cluster_pem_ciphertext,
+                    "cluster_pub": cluster_pub_pem,
                     "peers": {},
                 }
+                # Isolated-FS bulk state sync: announce a session id in the
+                # join-reply, then push the per-channel chunks separately.
+                # The joiner waits on all four channel eofs before becoming
+                # a Raft learner; per-channel chunking lets each stream
+                # progress independently and isolates failures.
+                state_sync_session_id = None
+                if self.opts.get("cluster_isolated_filesystem"):
+                    from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+                        new_session_id,
+                    )
+
+                    state_sync_session_id = new_session_id()
+                    inner_payload["state_sync_session"] = state_sync_session_id
                 tosign = salt.payload.package(inner_payload)
                 sig = salt.crypt.PrivateKeyString(self.private_key()).sign(
                     tosign, algorithm=self.opts["publish_signing_algorithm"]
@@ -2208,6 +2576,12 @@ class MasterPubServerChannel:
                     },
                 )
                 await self.pusher(payload["peer_id"]).publish(event_data)
+                if state_sync_session_id is not None:
+                    asyncio.get_event_loop().create_task(
+                        self._send_state_sync_chunks(
+                            state_sync_session_id, payload["peer_id"]
+                        )
+                    )
             elif tag.startswith("cluster/peer/discover-reply"):
                 payload = salt.payload.loads(data["payload"])
 

--- a/salt/cluster/consensus/peer.py
+++ b/salt/cluster/consensus/peer.py
@@ -248,7 +248,7 @@ class RaftDispatcher:
     :param node:      The local ``salt.cluster.consensus.raft.Node``.
     :param local_id:  This master's node-id (``opts["interface"]``) — used as
                       ``src`` in outbound RPC envelopes.
-    :param pushers:   Dict mapping peer node-id (interface address) →
+    :param pushers:   Dict mapping peer node-id (interface address) ->
                       ``PublishServer`` pusher.
     """
 

--- a/salt/cluster/consensus/peer.py
+++ b/salt/cluster/consensus/peer.py
@@ -105,7 +105,10 @@ class SaltPeer(Peer):
     """
     A ``Peer`` that sends Raft RPCs over the cluster pool channel.
 
-    :param node_id:  The remote master's node-id (its ``opts["id"]``).
+    :param node_id:  The remote master's node-id — its
+                     ``opts["interface"]`` address (matches the entries in
+                     ``opts["cluster_peers"]`` and the ``peer_pushers`` keys
+                     used everywhere else in the cluster code).
     :param pusher:   The ``PublishServer`` instance already connected to that
                      master's ``cluster_pool_port``.
     :param local_id: This master's own node-id (used as ``src`` in envelopes).
@@ -243,8 +246,10 @@ class RaftDispatcher:
     alongside the existing pushers.
 
     :param node:      The local ``salt.cluster.consensus.raft.Node``.
-    :param local_id:  This master's ``opts["id"]``.
-    :param pushers:   Dict mapping peer node-id → ``PublishServer`` pusher.
+    :param local_id:  This master's node-id (``opts["interface"]``) — used as
+                      ``src`` in outbound RPC envelopes.
+    :param pushers:   Dict mapping peer node-id (interface address) →
+                      ``PublishServer`` pusher.
     """
 
     def __init__(self, node, local_id, pushers):

--- a/salt/cluster/consensus/raft/log.py
+++ b/salt/cluster/consensus/raft/log.py
@@ -9,11 +9,17 @@ algorithm stays testable without real disks or networks.  The production
 implementation lives in :mod:`salt.cluster.consensus.storage`.
 """
 
+import base64
 import json
 import logging
 from typing import NamedTuple
 
 log = logging.getLogger(__name__)
+
+# Envelope marker for multi-state-machine snapshots.  See
+# Log.snapshot / Log.restore_state_machines_from_data.  Bumping this
+# version is a breaking change for on-disk snapshot compatibility.
+SNAPSHOT_ENVELOPE_VERSION = "raft.snapshot.v1"
 
 
 class LogEntryCommitStatus:
@@ -163,6 +169,10 @@ class Log:
         self.last_included_term = 0
         self._cached_index = -1
         self.state_machine = kwargs.get("state_machine")
+        # Additional named state machines (e.g. ``membership_sm``) whose state
+        # must also survive log compaction.  Snapshot/restore dispatches
+        # through this registry on top of ``self.state_machine``.
+        self._extra_state_machines = dict(kwargs.get("state_machines") or {})
         self.max_log_size = kwargs.get("max_log_size")
         self.commit_index = -1
         self.last_applied = -1
@@ -173,12 +183,23 @@ class Log:
             if snapshot:
                 self.last_included_index = snapshot["index"]
                 self.last_included_term = snapshot["term"]
-                if self.state_machine:
-                    self.state_machine.restore_snapshot(snapshot["data"])
+                self.restore_state_machines_from_data(snapshot["data"])
             state = self.storage.load_state()
             self._term = state.get("term", 0) if isinstance(state, dict) else state[0]
 
         self._update_cached_index()
+
+    def register_state_machine(self, name, sm):
+        """
+        Register an additional named state machine.
+
+        The SM's ``get_snapshot()`` / ``restore_snapshot()`` are wired into
+        :meth:`snapshot` and :meth:`restore_state_machines_from_data` so its
+        state survives log compaction along with the application state
+        machine.  ``name`` keys the SM inside the snapshot envelope and must
+        be stable across restarts.
+        """
+        self._extra_state_machines[name] = sm
 
     def _update_cached_index(self):
         """Update the cached index based on current entries and snapshot."""
@@ -317,23 +338,110 @@ class Log:
         )
 
     def snapshot(self):
-        """Compact the log by creating a snapshot of the state machine."""
+        """
+        Compact the log by snapshotting every registered state machine.
+
+        Writes a versioned envelope::
+
+            {"__envelope__": "raft.snapshot.v1",
+             "machines": {"state_machine": ..., "membership_sm": ..., ...}}
+
+        Each SM's payload is the value of its ``get_snapshot()``; bytes
+        payloads are base64-wrapped so the envelope stays JSON-safe.  Older
+        single-SM snapshots written before this format are still recognised
+        on load (see :meth:`restore_state_machines_from_data`).
+        """
         if not self.entries:
             return
         last_entry = self.entries[-1]
         self.last_included_index = last_entry.index
         self.last_included_term = last_entry.term
 
+        machines = {}
         if self.state_machine:
-            data = self.state_machine.get_snapshot()
-            if self.storage:
-                self.storage.save_snapshot(
-                    data, self.last_included_index, self.last_included_term
-                )
+            machines["state_machine"] = self._encode_sm_payload(
+                self.state_machine.get_snapshot()
+            )
+        for name, sm in self._extra_state_machines.items():
+            machines[name] = self._encode_sm_payload(sm.get_snapshot())
+
+        if machines and self.storage:
+            envelope = {
+                "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+                "machines": machines,
+            }
+            self.storage.save_snapshot(
+                envelope, self.last_included_index, self.last_included_term
+            )
 
         # Discard entries up to last_included_index
         self.entries = []
         self._update_cached_index()
+
+    def restore_state_machines_from_data(self, data):
+        """
+        Restore every registered state machine from snapshot ``data``.
+
+        Recognises three input shapes:
+
+        * Envelope dict (or JSON bytes containing one) with the
+          ``__envelope__`` marker — dispatches each ``machines[name]``
+          payload to the SM registered under that name.
+        * Anything else — legacy single-SM payload; passed straight through
+          to ``self.state_machine.restore_snapshot``.  Extra SMs keep their
+          current state; the post-snapshot log replay rebuilds them.
+
+        Missing keys are silently ignored so a snapshot written by an older
+        node (or a node that didn't yet register a particular SM) restores
+        cleanly.
+        """
+        envelope = self._maybe_envelope(data)
+        if envelope is not None:
+            machines = envelope.get("machines", {}) or {}
+            sm_payload = machines.get("state_machine")
+            if sm_payload is not None and self.state_machine:
+                self.state_machine.restore_snapshot(self._decode_sm_payload(sm_payload))
+            for name, sm in self._extra_state_machines.items():
+                if name in machines:
+                    sm.restore_snapshot(self._decode_sm_payload(machines[name]))
+            return
+        if self.state_machine is not None:
+            self.state_machine.restore_snapshot(data)
+
+    @staticmethod
+    def _maybe_envelope(data):
+        """Return *data* as an envelope dict, or ``None`` if it isn't one."""
+        if isinstance(data, dict):
+            if data.get("__envelope__") == SNAPSHOT_ENVELOPE_VERSION:
+                return data
+            return None
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            try:
+                obj = json.loads(bytes(data).decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                return None
+            if (
+                isinstance(obj, dict)
+                and obj.get("__envelope__") == SNAPSHOT_ENVELOPE_VERSION
+            ):
+                return obj
+        return None
+
+    @staticmethod
+    def _encode_sm_payload(payload):
+        """Make an SM ``get_snapshot()`` value safe to embed in a JSON envelope."""
+        if isinstance(payload, (bytes, bytearray, memoryview)):
+            return {
+                "__bytes__": base64.b64encode(bytes(payload)).decode("ascii"),
+            }
+        return payload
+
+    @staticmethod
+    def _decode_sm_payload(payload):
+        """Inverse of :meth:`_encode_sm_payload`."""
+        if isinstance(payload, dict) and len(payload) == 1 and "__bytes__" in payload:
+            return base64.b64decode(payload["__bytes__"])
+        return payload
 
     def commit(self, index):
         self.commit_index = max(getattr(self, "commit_index", -1), index)

--- a/salt/cluster/consensus/raft/log.py
+++ b/salt/cluster/consensus/raft/log.py
@@ -60,6 +60,11 @@ class LogEntryType:
     COMMAND = 0
     CONFIG = 1
     SNAPSHOT = 2
+    # Ring policy commit (members source + replication factor).  Driven
+    # by a salt-run cluster.ring runner in stage 1; applied to a
+    # ``RingConfigStateMachine`` registered on the Log so its state
+    # survives compaction in the same envelope as ``membership_sm``.
+    RING_CONFIG = 3
 
 
 class LogEntry(NamedTuple):
@@ -620,6 +625,142 @@ class MembershipStateMachine(BaseStateMachine):
         return (
             f"<MembershipStateMachine voters={sorted(self._voters)} "
             f"learners={sorted(self._learners)} version={self._membership_version}>"
+        )
+
+
+# ---------------------------------------------------------------------------
+# RingConfigStateMachine
+# ---------------------------------------------------------------------------
+
+
+# Valid values for the ring's ``members`` policy.
+RING_MEMBERS_SELF = "self"
+RING_MEMBERS_VOTERS = "voters"
+RING_MEMBERS_VALID = (RING_MEMBERS_SELF, RING_MEMBERS_VOTERS)
+
+
+class RingConfigStateMachine(BaseStateMachine):
+    """
+    State machine for the cluster's :class:`~salt.cluster.ring.HashRing`
+    policy — *what* the ring contains and *how many replicas* per key.
+
+    Two committable knobs:
+
+    * ``members`` — ``"self"`` (default; ring contains only this master so
+      every key is owned locally — preserves today's broadcast behaviour)
+      or ``"voters"`` (ring is rebuilt from the committed Raft voter set
+      so writes shard across the cluster).
+    * ``replicas`` — replication factor.  ``1`` (default) means each key
+      has exactly one owner with no backups.  Higher values request the
+      ring to keep the top-N nodes as replicas; the runner validates
+      against ``len(voters)``.
+
+    Driven by a ``LogEntryType.RING_CONFIG`` entry proposed through
+    Raft (typically by a ``cluster.ring`` runner).  Operators flip from
+    self-only to cluster-wide sharding by committing a single entry; no
+    code changes required.
+
+    The ``on_change`` callback (if set) runs after every successful
+    ``apply`` with ``(members, replicas)``.  ``RaftService`` wires this
+    to update :func:`salt.cluster.ring_membership.rebuild` so the
+    process-local ring re-syncs to the new policy.
+
+    Snapshot/restore round-trips through the same envelope shape used by
+    ``MembershipStateMachine`` (registered under name ``"ring_sm"``), so
+    ring config survives log compaction.
+    """
+
+    def __init__(self, on_change=None):
+        self._members = RING_MEMBERS_SELF
+        self._replicas = 1
+        self._version = -1
+        self.on_change = on_change
+
+    # ------------------------------------------------------------------
+    # BaseStateMachine interface
+    # ------------------------------------------------------------------
+
+    def apply(self, cmd, client_id=None, sequence_num=None, index=-1):
+        """
+        Apply a committed RING_CONFIG entry.
+
+        :param cmd:   ``dict`` with keys ``"members"`` (str, one of
+                      ``RING_MEMBERS_VALID``) and ``"replicas"`` (int).
+                      Either may be omitted to keep the existing value
+                      — useful for partial updates that only flip one
+                      knob.  Unknown keys are ignored.
+        :param index: Raft log index of this entry; stored as the
+                      version stamp visible via :attr:`config_version`.
+        """
+        if isinstance(cmd, dict):
+            new_members = cmd.get("members", self._members)
+            new_replicas = cmd.get("replicas", self._replicas)
+            if new_members in RING_MEMBERS_VALID:
+                self._members = new_members
+            else:
+                log.warning(
+                    "RingConfigStateMachine: ignoring unknown members policy %r "
+                    "(expected one of %s)",
+                    new_members,
+                    RING_MEMBERS_VALID,
+                )
+            try:
+                self._replicas = max(1, int(new_replicas))
+            except (TypeError, ValueError):
+                log.warning(
+                    "RingConfigStateMachine: ignoring non-integer replicas %r",
+                    new_replicas,
+                )
+        self._version = index
+        if self.on_change is not None:
+            self.on_change(self._members, self._replicas)
+
+    def get_snapshot(self):
+        """Return the JSON-serialisable ring policy."""
+        return {
+            "members": self._members,
+            "replicas": self._replicas,
+            "version": self._version,
+        }
+
+    def restore_snapshot(self, data):
+        """Restore from a snapshot dict (as produced by :meth:`get_snapshot`)."""
+        if isinstance(data, (bytes, bytearray)):
+            data = json.loads(data.decode())
+        if not isinstance(data, dict):
+            return
+        members = data.get("members", self._members)
+        if members in RING_MEMBERS_VALID:
+            self._members = members
+        try:
+            self._replicas = max(1, int(data.get("replicas", self._replicas)))
+        except (TypeError, ValueError):
+            pass
+        self._version = data.get("version", -1)
+
+    # ------------------------------------------------------------------
+    # Query API
+    # ------------------------------------------------------------------
+
+    @property
+    def members(self):
+        """Current members policy (``"self"`` or ``"voters"``)."""
+        return self._members
+
+    @property
+    def replicas(self):
+        """Current replication factor (>= 1)."""
+        return self._replicas
+
+    @property
+    def config_version(self):
+        """Log index of the most recently applied RING_CONFIG entry, or -1 if none."""
+        return self._version
+
+    def __repr__(self):
+        return (
+            f"<RingConfigStateMachine members={self._members!r} "
+            f"replicas={self._replicas} version={self._version}>"
         )
 
 

--- a/salt/cluster/consensus/raft/node.py
+++ b/salt/cluster/consensus/raft/node.py
@@ -501,7 +501,7 @@ class Node:
         The SM is the authoritative query store for committed membership
         (``current_voters()``, ``current_learners()``).  Side-effects on
         ``Node.peers`` / ``Node.voting`` are driven directly by
-        ``apply_entries`` → ``on_config_change``, not by the SM's
+        ``apply_entries`` -> ``on_config_change``, not by the SM's
         ``on_change`` callback, to avoid double-applying eager leader updates.
         """
         self.membership_sm = sm
@@ -889,8 +889,8 @@ class Node:
         called ``become_follower()``, which reset ``last_followed``
         and restarted the follower timer.  The other survivor then
         never fired its OWN election timer (it was being kept "fresh"
-        by the disturb), so two survivors both stayed quiet → no
-        re-election → test fails.  Reproduced 5/20 fail under
+        by the disturb), so two survivors both stayed quiet -> no
+        re-election -> test fails.  Reproduced 5/20 fail under
         stress-ng on debian-12; with this fix it's expected to
         converge.
         """

--- a/salt/cluster/consensus/raft/node.py
+++ b/salt/cluster/consensus/raft/node.py
@@ -510,6 +510,45 @@ class Node:
         if self.log is not None:
             self.log.register_state_machine("membership_sm", sm)
 
+    def reconcile_membership(self):
+        """
+        Re-apply the current ``membership_sm`` voter/learner state to the rest
+        of the Node.
+
+        :meth:`MembershipStateMachine.restore_snapshot` is a pure store
+        operation — it does not invoke ``on_change``.  After a snapshot
+        restore (Node startup with a saved snapshot, or
+        :meth:`install_snapshot` from a leader) the SM holds the right
+        committed view but ``Node.peers`` / ``Node.voting`` and any
+        downstream ``on_change`` hook (e.g. ``RaftService._on_ready`` /
+        ring rebuild) are stale because the CONFIG entries that originally
+        flipped them have been compacted away.
+
+        Calling this after every restore re-runs ``on_config_change`` for
+        the side-effects on the local peer table, then invokes the wired
+        ``on_change`` hook so RaftService and any future SM observers see
+        the same committed view they would see after a fresh CONFIG apply.
+
+        Idempotent: calling it on a Node whose peer table already matches
+        the SM is a no-op modulo a redundant ``on_change`` fire.  When the
+        SM is empty (no compacted snapshot, no apply yet) it is a no-op
+        because there's nothing to reconcile.
+        """
+        if self.membership_sm is None:
+            return
+        voters = self.membership_sm.current_voters()
+        learners = self.membership_sm.current_learners()
+        if not voters and not learners:
+            # Nothing committed yet (e.g. fresh node before founding CONFIG).
+            return
+        # Update Node.peers / Node.voting in place from the restored view.
+        self.on_config_change(voters, learners)
+        # Also notify the SM's on_change observer (RaftService wires this
+        # for the cluster-ready hook and, post-ring-stage-0, ring rebuild).
+        on_change = getattr(self.membership_sm, "on_change", None)
+        if on_change is not None:
+            on_change(voters, learners)
+
     def schedule_timeout(self, delay, callback):
         if not self._schedule_timeout_method:
             raise RuntimeError("Register a scheduling method first")
@@ -725,6 +764,14 @@ class Node:
                     if entry.index >= self._applied_config_index:
                         self._applied_config_index = entry.index
                         self.on_config_change(voters, learners)
+                elif entry.type == LogEntryType.RING_CONFIG:
+                    # Ring policy commit (members source + replication
+                    # factor).  Applied to the registered ``ring_sm``
+                    # if any; on_change inside the SM drives
+                    # ``ring_membership.rebuild`` via RaftService.
+                    ring_sm = self.log._extra_state_machines.get("ring_sm")
+                    if ring_sm is not None:
+                        ring_sm.apply(entry.cmd, index=entry.index)
             self.log.last_applied = new_applied
 
     @lock
@@ -1105,6 +1152,12 @@ class Node:
             # Legacy single-SM payloads still flow to state_machine via
             # restore_state_machines_from_data's fallback path.
             self.log.restore_state_machines_from_data(data)
+
+            # restore_snapshot is a pure store; reconcile so Node.peers /
+            # Node.voting and any wired on_change hook re-converge with the
+            # restored membership SM (CONFIG entries it derived from were
+            # compacted away).
+            self.reconcile_membership()
 
             self.log.commit_index = max(self.log.commit_index, last_index)
             self.log.last_applied = max(self.log.last_applied, last_index)

--- a/salt/cluster/consensus/raft/node.py
+++ b/salt/cluster/consensus/raft/node.py
@@ -11,7 +11,6 @@ for I/O where we control it, and adapt into these callbacks.
 """
 
 import functools
-import json
 import logging
 import threading
 import time
@@ -372,12 +371,6 @@ class Node:
         # True if this node participates in quorum; False means learner/observer.
         self.voting = voting
 
-        # Use local variable to avoid property collision
-        sm = state_machine or (
-            getattr(self.storage, "state_machine", None) if storage else None
-        )
-        self.log = Log(storage=storage, state_machine=sm, max_log_size=max_log_size)
-
         # Membership state machine: applies CONFIG entries to track the committed
         # voter/learner sets.  It is the authoritative query store for committed
         # membership; it does NOT drive on_config_change (that is called directly
@@ -385,6 +378,20 @@ class Node:
         if membership_sm is None:
             membership_sm = MembershipStateMachine()
         self.membership_sm = membership_sm
+
+        # Use local variable to avoid property collision.  ``membership_sm`` is
+        # registered alongside the application SM so its state survives log
+        # compaction (otherwise CONFIG entries that were truncated would leave
+        # the membership SM empty after restart).
+        sm = state_machine or (
+            getattr(self.storage, "state_machine", None) if storage else None
+        )
+        self.log = Log(
+            storage=storage,
+            state_machine=sm,
+            max_log_size=max_log_size,
+            state_machines={"membership_sm": self.membership_sm},
+        )
 
         self.state = NodeState()
         self._term = 0
@@ -498,6 +505,10 @@ class Node:
         ``on_change`` callback, to avoid double-applying eager leader updates.
         """
         self.membership_sm = sm
+        # Keep the Log's snapshot registry in sync so future snapshots include
+        # the replacement SM rather than the one set up at __init__.
+        if self.log is not None:
+            self.log.register_state_machine("membership_sm", sm)
 
     def schedule_timeout(self, delay, callback):
         if not self._schedule_timeout_method:
@@ -1090,14 +1101,10 @@ class Node:
             self.log.last_included_index = last_index
             self.log.last_included_term = last_term
 
-            if self.state_machine:
-                # Handle bytes vs dict
-                sd = (
-                    data
-                    if not isinstance(data, (bytes, memoryview))
-                    else json.loads(data.decode())
-                )
-                self.state_machine.restore_snapshot(sd)
+            # Dispatch to every registered SM (state_machine + membership_sm).
+            # Legacy single-SM payloads still flow to state_machine via
+            # restore_state_machines_from_data's fallback path.
+            self.log.restore_state_machines_from_data(data)
 
             self.log.commit_index = max(self.log.commit_index, last_index)
             self.log.last_applied = max(self.log.last_applied, last_index)

--- a/salt/cluster/consensus/raft/scheduler.py
+++ b/salt/cluster/consensus/raft/scheduler.py
@@ -2,9 +2,10 @@
 Timeout scheduling for the Raft node.
 
 Provides manual, threaded, and asynchronous schedulers so election and
-heartbeat timers stay outside the core state machine. Production Salt will
-use a Tornado-backed scheduler in ``salt.cluster.consensus``; tests use
-:class:`ManualTimeoutScheduler` for deterministic time.
+heartbeat timers stay outside the core state machine.  Production Salt
+runs the consensus event loop inside ``MasterPubServerChannel._publish_daemon``
+(Tornado on top of asyncio) and uses :class:`AsyncTimeoutScheduler`; tests
+use :class:`ManualTimeoutScheduler` for deterministic time.
 """
 
 import asyncio

--- a/salt/cluster/consensus/rpc.py
+++ b/salt/cluster/consensus/rpc.py
@@ -62,7 +62,9 @@ def pack(tag, src, rpc_id, payload):
     Serialise a Raft RPC into the bytes the pool puller expects.
 
     :param tag:     One of the ``cluster/raft/*`` constants above.
-    :param src:     Sender node-id (``opts["id"]``).
+    :param src:     Sender node-id (``opts["interface"]``) — matches the
+                    cluster-wide identity used by ``RaftService`` and the
+                    ``cluster_peers`` opt; not the daemon's ``opts["id"]``.
     :param rpc_id:  Opaque correlation string chosen by the caller.
     :param payload: Dict of RPC-specific fields.
     :returns:       Raw bytes ready for ``pusher.publish()``.

--- a/salt/cluster/consensus/service.py
+++ b/salt/cluster/consensus/service.py
@@ -38,6 +38,12 @@ import logging
 
 from salt.cluster.consensus.peer import RaftDispatcher, SaltPeer
 from salt.cluster.consensus.raft import AsyncTimeoutScheduler, Node
+from salt.cluster.consensus.raft.log import (
+    RING_MEMBERS_SELF,
+    RING_MEMBERS_VOTERS,
+    LogEntryType,
+    RingConfigStateMachine,
+)
 from salt.cluster.consensus.raft.node import NodeState
 from salt.cluster.consensus.storage import SaltStorage
 
@@ -84,12 +90,21 @@ class RaftService:
         # ``cluster_election_max`` opts let deployments tune further.
         election_min = opts.get("cluster_election_min", 750)
         election_max = opts.get("cluster_election_max", 1500)
+        # ``cluster_max_log_size`` (default ``None``) gates Raft log
+        # compaction.  When unset, the log keeps every committed entry
+        # forever and snapshots never fire — fine for small clusters
+        # but pathological for any long-running deployment.  When set,
+        # the membership SM round-trips through the snapshot envelope
+        # (raft.snapshot.v1); CONSENSUS_BUGS.md #1's fix and the
+        # reconcile_membership hook ensure peer state survives.
+        max_log_size = opts.get("cluster_max_log_size")
         self._node = Node(
             node_id,
             storage=storage,
             voting=voting,
             _follower_min=election_min,
             _follower_max=election_max,
+            max_log_size=max_log_size,
         )
         self._scheduler = AsyncTimeoutScheduler(loop=loop)
         self._node.register_schedule_timeout(self._scheduler.schedule)
@@ -97,6 +112,17 @@ class RaftService:
         # Wire the membership SM's on_change so we can fire on_ready once
         # this node appears in the committed voter set.
         self._node.membership_sm.on_change = self._on_membership_change
+
+        # Ring config SM: tracks the cluster's ring policy (members
+        # source + replication factor).  Registered on the Log so its
+        # state survives compaction.  Default policy ("self", 1) means
+        # the per-process ring contains only this master and writes
+        # broadcast as they do today; an operator flips to ("voters",
+        # N) by committing a RING_CONFIG entry through Raft.
+        self._ring_config_sm = RingConfigStateMachine(
+            on_change=self._on_ring_config_change
+        )
+        self._node.log.register_state_machine("ring_sm", self._ring_config_sm)
 
         # Build SaltPeer objects - one per cluster peer (all voting at start).
         peers = [
@@ -112,6 +138,12 @@ class RaftService:
         # callback_node field written into RPC envelopes.
         self._dispatcher = RaftDispatcher(self._node, node_id, self._peer_pushers)
 
+        # If Node started from a saved snapshot the membership SM was
+        # restored before this on_change wiring existed, so the cluster-
+        # ready / peer-table side effects never fired.  Reconcile now so
+        # _on_ready and on_config_change run for the restored view.
+        self._node.reconcile_membership()
+
         self._heartbeat_handle = None
 
     # ------------------------------------------------------------------
@@ -125,7 +157,14 @@ class RaftService:
         Fires ``on_ready`` (once) when this node's address first appears in the
         committed voter set, signalling that it is a full participant and may
         begin serving minion/CLI traffic.
+
+        Also reapplies the current ring policy: when ``members=voters`` the
+        ring contents track the new voter set.  In ``members=self`` (default)
+        the ring stays self-only regardless of voters, which preserves the
+        broadcast-everywhere stage-0 behaviour.
         """
+        self._apply_ring_policy()
+
         if self._on_ready is None:
             return
         node_id = self._node.node_id
@@ -136,6 +175,90 @@ class RaftService:
             )
             self._on_ready()
             self._on_ready = None  # fire only once
+
+    def _on_ring_config_change(self, members, replicas):
+        """
+        Called by ``RingConfigStateMachine`` after every committed
+        RING_CONFIG entry.  Rebuilds this process's ring with the new
+        policy applied to the current voter set.
+
+        Replication factor is tracked in the SM but not yet honoured by
+        the rebuild — stage 1 ships the policy plumbing; stage 2 will
+        teach the ring to use ``replicas > 1`` for fault tolerance.
+        """
+        log.info(
+            "RaftService: ring policy committed — members=%s replicas=%d",
+            members,
+            replicas,
+        )
+        self._apply_ring_policy()
+
+    def _apply_ring_policy(self):
+        """
+        Rebuild the per-process ring from current SM state.
+
+        Resolves ``ring_config_sm.members``:
+
+        * ``"self"`` — ring contains only this master; ``owns`` returns
+          True for every key.  Default; matches today's broadcast.
+        * ``"voters"`` — ring contains the current Raft voter set
+          (``membership_sm.current_voters()``); ``owns`` shards by
+          consistent hash.
+
+        Called from both the membership-change and ring-config-change
+        paths because either can shift the ring's contents under the
+        ``"voters"`` policy.
+        """
+        # Lazy import keeps the consensus package independent of the
+        # ring module's load order.
+        import salt.cluster.ring_membership  # pylint: disable=import-outside-toplevel
+
+        if self._ring_config_sm.members == RING_MEMBERS_VOTERS:
+            voters = self._node.membership_sm.current_voters()
+            salt.cluster.ring_membership.rebuild(voters)
+        else:  # RING_MEMBERS_SELF (default)
+            # Self-only ring: contains just this master so owns()
+            # answers True for everything.  Empty ring would also do —
+            # we use the explicit single-node form so logs are clear.
+            salt.cluster.ring_membership.rebuild([self._node.node_id])
+
+    def propose_ring_config(self, members=None, replicas=None):
+        """
+        Propose a RING_CONFIG entry through Raft.
+
+        Only valid on the leader; followers will see a future commit
+        once the leader replicates the entry.  Either argument can be
+        omitted to keep the existing value (the SM merges partial
+        updates).
+
+        :param members: ``"self"`` or ``"voters"`` (or ``None`` to
+                        keep current).
+        :param replicas: integer >= 1 (or ``None`` to keep current).
+        :raises ValueError: if *members* is set to an unknown value.
+        :raises RuntimeError: if this node is not currently the
+                              leader (the entry would not commit).
+        """
+        if members is not None and members not in (
+            RING_MEMBERS_SELF,
+            RING_MEMBERS_VOTERS,
+        ):
+            raise ValueError(
+                f"Unknown ring members policy {members!r}; "
+                f"expected 'self' or 'voters'"
+            )
+        if self._node.state != NodeState.LEADER:
+            raise RuntimeError(
+                "propose_ring_config must run on the Raft leader; "
+                f"this node is in state {self._node.state}"
+            )
+        cmd = {}
+        if members is not None:
+            cmd["members"] = members
+        if replicas is not None:
+            cmd["replicas"] = int(replicas)
+        if not cmd:
+            return  # no-op
+        self._node.log_add(cmd, entry_type=LogEntryType.RING_CONFIG)
 
     # ------------------------------------------------------------------
     # Peer factory (used by Node.on_config_change)

--- a/salt/cluster/consensus/service.py
+++ b/salt/cluster/consensus/service.py
@@ -85,7 +85,7 @@ class RaftService:
         # multi-process Salt masters running over real sockets — a single
         # delayed heartbeat in CI can cause a follower to step up and fight
         # the existing leader for the term.  At ``_HEARTBEAT_INTERVAL`` =
-        # 50 ms the rule of thumb is election ≥ 10× heartbeat, so default
+        # 50 ms the rule of thumb is election >= 10× heartbeat, so default
         # to 750–1500 ms here.  ``cluster_election_min`` /
         # ``cluster_election_max`` opts let deployments tune further.
         election_min = opts.get("cluster_election_min", 750)

--- a/salt/cluster/consensus/storage.py
+++ b/salt/cluster/consensus/storage.py
@@ -6,11 +6,18 @@ Implements :class:`salt.cluster.consensus.raft.BaseStorage` using the
 operator has configured (``localfs`` today, ``mmapcache`` tomorrow) is used
 automatically.
 
-Bank layout under ``cluster/consensus/<node_id>/``::
+Bank layout::
 
-    state     — {"term": int, "voted_for": str|None}
-    log       — [LogEntry.info() tuple, ...]
-    snapshot  — {"data": base64-str, "index": int, "term": int}
+    cluster/consensus/<node_id>/        — state + snapshot
+        state     — {"term": int, "voted_for": str|None}
+        snapshot  — {"data": base64-str, "index": int, "term": int}
+
+    cluster/consensus/<node_id>/log/    — one cache key per log entry
+        <index>   — LogEntry.info() tuple
+
+Per-entry log keys keep ``append_log`` O(1) on a backend whose store
+primitive is O(1) (mmap_cache).  ``save_log`` (used for truncation and
+recovery) flushes the log bank and re-writes each entry.
 """
 
 import base64
@@ -22,9 +29,10 @@ from salt.cluster.consensus.raft.log import BaseStorage, LogEntry, LogEntryType
 
 log = logging.getLogger(__name__)
 
-# Keys written into the cache bank.
+# Keys written into the meta bank (state + snapshot share one bank so a
+# single ``flush`` of the meta bank wipes all metadata; the log lives in
+# its own bank so we can flush it independently for truncation).
 _KEY_STATE = "state"
-_KEY_LOG = "log"
 _KEY_SNAPSHOT = "snapshot"
 
 
@@ -32,9 +40,10 @@ class SaltStorage(BaseStorage):
     """
     Raft persistence backed by ``salt.cache.Cache``.
 
-    All three durable documents (state, log, snapshot) are stored in the
-    bank ``cluster/consensus/<node_id>`` so they share the operator's
-    configured ``cache_driver`` and are co-located with other cluster data.
+    ``state`` and ``snapshot`` share the bank
+    ``cluster/consensus/<node_id>``; log entries live in
+    ``cluster/consensus/<node_id>/log`` with one cache key per entry,
+    keyed by stringified Raft index.
 
     :param node_id: Raft node identifier (the master's interface address).
     :param opts:    Salt master opts dict — passed straight to
@@ -42,7 +51,8 @@ class SaltStorage(BaseStorage):
     """
 
     def __init__(self, node_id, opts):
-        self._bank = f"cluster/consensus/{node_id}"
+        self._meta_bank = f"cluster/consensus/{node_id}"
+        self._log_bank = f"cluster/consensus/{node_id}/log"
         self._cache = salt.cache.Cache(opts)
         self._lock = threading.RLock()
 
@@ -54,71 +64,99 @@ class SaltStorage(BaseStorage):
         """Persist currentTerm and votedFor (Raft §5.2)."""
         with self._lock:
             self._cache.store(
-                self._bank, _KEY_STATE, {"term": term, "voted_for": voted_for}
+                self._meta_bank, _KEY_STATE, {"term": term, "voted_for": voted_for}
             )
 
     def load_state(self):
         """Return persisted state, or defaults if not yet written."""
         with self._lock:
-            data = self._cache.fetch(self._bank, _KEY_STATE)
+            data = self._cache.fetch(self._meta_bank, _KEY_STATE)
         if not data:
             return {"term": 0, "voted_for": None}
         return data
 
     def save_log(self, entries):
-        """Rewrite the entire log (used during truncation and recovery)."""
+        """
+        Rewrite the entire log.
+
+        Used by :class:`~salt.cluster.consensus.raft.log.Log` during
+        truncation (conflict resolution) and after :meth:`Log.clear`.  We
+        flush the log bank to drop any indices not in *entries* and then
+        store each entry under its own key.
+        """
         with self._lock:
-            self._cache.store(self._bank, _KEY_LOG, [e.info() for e in entries])
+            self._cache.flush(self._log_bank)
+            for entry in entries:
+                self._cache.store(self._log_bank, str(entry.index), entry.info())
 
     def append_log(self, entry):
         """
-        Append a single entry.
+        Append a single entry — O(1) on per-key backends.
 
-        ``salt.cache`` has no efficient append primitive, so we do a
-        read-modify-write under the lock.  For the membership-only log that
-        Salt consensus tracks this is fine; the log stays small.
+        Stores under ``log_bank/<entry.index>`` so the hot append path
+        does not read or rewrite any other entry.  Re-appending the same
+        index (rare; only happens on a leader-side overwrite that does
+        not also drive ``save_log``) is a benign overwrite.
         """
         with self._lock:
-            raw = self._cache.fetch(self._bank, _KEY_LOG)
-            existing = raw if isinstance(raw, list) else []
-            existing.append(entry.info())
-            self._cache.store(self._bank, _KEY_LOG, existing)
+            self._cache.store(self._log_bank, str(entry.index), entry.info())
 
     def load_log(self):
         """Return all persisted log entries as :class:`~.LogEntry` objects."""
         with self._lock:
-            raw = self._cache.fetch(self._bank, _KEY_LOG)
-        if not raw or not isinstance(raw, list):
+            keys = self._cache.list(self._log_bank)
+        if not keys:
+            return []
+        try:
+            indices = sorted(int(k) for k in keys)
+        except (TypeError, ValueError):
+            log.warning(
+                "SaltStorage: ignoring non-integer keys in %s: %r",
+                self._log_bank,
+                keys,
+            )
             return []
         entries = []
-        for e in raw:
-            if isinstance(e, (list, tuple)):
-                term = e[0]
-                idx = e[1]
-                cmd = e[2]
-                node_id = e[3] if len(e) > 3 else None
-                entry_type = e[4] if len(e) > 4 else LogEntryType.COMMAND
-                client_id = e[5] if len(e) > 5 else None
-                sequence_num = e[6] if len(e) > 6 else None
-                entries.append(
-                    LogEntry(
-                        term, idx, cmd, node_id, entry_type, client_id, sequence_num
-                    )
+        for idx in indices:
+            with self._lock:
+                raw = self._cache.fetch(self._log_bank, str(idx))
+            if not raw:
+                log.warning(
+                    "SaltStorage: log entry %d missing from %s",
+                    idx,
+                    self._log_bank,
                 )
-            else:
-                # dict format (defensive — cache backends may return dicts)
-                entries.append(
-                    LogEntry(
-                        e["term"],
-                        e["index"],
-                        e["cmd"],
-                        e.get("node_id"),
-                        e.get("type", LogEntryType.COMMAND),
-                        e.get("client_id"),
-                        e.get("sequence_num"),
-                    )
-                )
+                continue
+            entry = self._decode_entry(raw)
+            if entry is not None:
+                entries.append(entry)
         return entries
+
+    @staticmethod
+    def _decode_entry(raw):
+        """Reconstruct a :class:`LogEntry` from a cached ``info()`` payload."""
+        if isinstance(raw, (list, tuple)):
+            term = raw[0]
+            idx = raw[1]
+            cmd = raw[2]
+            node_id = raw[3] if len(raw) > 3 else None
+            entry_type = raw[4] if len(raw) > 4 else LogEntryType.COMMAND
+            client_id = raw[5] if len(raw) > 5 else None
+            sequence_num = raw[6] if len(raw) > 6 else None
+            return LogEntry(
+                term, idx, cmd, node_id, entry_type, client_id, sequence_num
+            )
+        if isinstance(raw, dict):
+            return LogEntry(
+                raw["term"],
+                raw["index"],
+                raw["cmd"],
+                raw.get("node_id"),
+                raw.get("type", LogEntryType.COMMAND),
+                raw.get("client_id"),
+                raw.get("sequence_num"),
+            )
+        return None
 
     def save_snapshot(self, data, index, term):
         """Persist a state-machine snapshot and its metadata."""
@@ -129,7 +167,7 @@ class SaltStorage(BaseStorage):
         encoded = base64.b64encode(bytes(data)).decode("utf-8")
         with self._lock:
             self._cache.store(
-                self._bank,
+                self._meta_bank,
                 _KEY_SNAPSHOT,
                 {"data": encoded, "index": index, "term": term},
             )
@@ -137,7 +175,7 @@ class SaltStorage(BaseStorage):
     def load_snapshot(self):
         """Return the latest snapshot dict, or ``None`` if none exists."""
         with self._lock:
-            raw = self._cache.fetch(self._bank, _KEY_SNAPSHOT)
+            raw = self._cache.fetch(self._meta_bank, _KEY_SNAPSHOT)
         if not raw or "data" not in raw:
             return None
         raw = dict(raw)

--- a/salt/cluster/file_sync.py
+++ b/salt/cluster/file_sync.py
@@ -1,0 +1,121 @@
+"""
+Helpers for replicating ``file_roots`` and ``pillar_roots`` between
+cluster masters that don't share a filesystem.
+
+The cluster join-reply embeds the responder's current local state-tree
+contents alongside the keys dump.  A late-joining master applies the
+contents into its own local roots before becoming a Raft learner so it
+can serve states/pillars it would otherwise know nothing about.
+
+Used by :mod:`salt.channel.server` for the join handshake and (later)
+by a ``cluster.sync_roots`` runner for ad-hoc updates after roots are
+edited on a peer.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import salt.utils.files
+
+log = logging.getLogger(__name__)
+
+# File and directory names skipped when collecting a roots tree.
+# These are version-control artefacts and editor-temporary files that
+# we never want to ship to peers.
+_SKIP_DIR_NAMES = frozenset({".git", ".hg", ".svn", "__pycache__", ".tox"})
+
+
+def _is_skipped_path(rel_parts):
+    """Return ``True`` if any path component is on the skip list."""
+    return any(part in _SKIP_DIR_NAMES for part in rel_parts)
+
+
+def collect_root_tree(roots_map):
+    """
+    Build a wire-friendly snapshot of a ``file_roots``/``pillar_roots``
+    mapping.
+
+    :param roots_map: ``{env: [path, path, ...]}`` from ``opts``.
+    :return: ``{env: [{"path": rel, "mode": int, "data": bytes}, ...]}``.
+
+    Only regular files are included; symlinks, sockets and unreadable
+    entries are skipped.  Multiple roots for the same env are flattened
+    in declaration order — earlier roots win on path conflicts.
+    """
+    out = {}
+    for env, paths in (roots_map or {}).items():
+        files = []
+        seen = set()
+        for root in paths or []:
+            root_p = Path(root)
+            if not root_p.is_dir():
+                continue
+            for sub in root_p.rglob("*"):
+                try:
+                    if sub.is_symlink() or not sub.is_file():
+                        continue
+                    rel_parts = sub.relative_to(root_p).parts
+                except (OSError, ValueError):
+                    continue
+                if not rel_parts or _is_skipped_path(rel_parts):
+                    continue
+                rel = "/".join(rel_parts)
+                if rel in seen:
+                    continue
+                try:
+                    data = sub.read_bytes()
+                    mode = sub.stat().st_mode & 0o777
+                except OSError as exc:
+                    log.warning("file_sync: skipping unreadable %s: %s", sub, exc)
+                    continue
+                files.append({"path": rel, "mode": mode, "data": data})
+                seen.add(rel)
+        if files:
+            out[env] = files
+    return out
+
+
+def apply_root_tree(roots_map, dump):
+    """
+    Materialise *dump* (from :func:`collect_root_tree`) under the local
+    ``roots_map``.
+
+    :param roots_map: ``{env: [path, path, ...]}`` from ``opts``.  Files
+        for env *e* are written under ``roots_map[e][0]``; envs that are
+        absent or empty are skipped.
+    :param dump: the snapshot dict to apply.
+    :return: number of files written.
+    """
+    written = 0
+    for env, files in (dump or {}).items():
+        roots = (roots_map or {}).get(env)
+        if not roots:
+            log.debug(
+                "file_sync: env %r not configured locally; skipping %d files",
+                env,
+                len(files),
+            )
+            continue
+        target = Path(roots[0])
+        target.mkdir(parents=True, exist_ok=True)
+        for entry in files:
+            rel = entry.get("path") if isinstance(entry, dict) else None
+            data = entry.get("data") if isinstance(entry, dict) else None
+            mode = entry.get("mode", 0o644) if isinstance(entry, dict) else 0o644
+            if not rel or data is None:
+                continue
+            # msgpack round-trip via salt.payload may turn bytes back into
+            # str; coerce so binary files round-trip cleanly.
+            if isinstance(data, str):
+                data = data.encode("utf-8", errors="surrogateescape")
+            dst = target / rel
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                with salt.utils.files.fopen(dst, "wb") as fp:
+                    fp.write(data)
+                os.chmod(dst, mode)
+                written += 1
+            except OSError as exc:
+                log.warning("file_sync: write failed for %s: %s", dst, exc)
+    return written

--- a/salt/cluster/healthchecks.py
+++ b/salt/cluster/healthchecks.py
@@ -1,0 +1,179 @@
+"""
+File-sentinel health probes for Kubernetes (and other supervisors).
+
+Three independent sentinels live under ``<cachedir>/health/``:
+
+* ``startup``   — written once when ``Master.start`` finishes wiring up
+                  every subprocess.  Maps to a Kubernetes
+                  ``startupProbe`` (``test -f <cachedir>/health/startup``).
+* ``ready``     — written once when the master is willing to serve
+                  traffic.  For a clustered master that means the Raft
+                  ``cluster_ready`` event has fired (the node committed
+                  itself as a voter).  For a non-clustered master we
+                  write it at the same time as ``startup`` because there
+                  is no cluster gate.  Maps to a Kubernetes
+                  ``readinessProbe``.
+* ``alive``     — touched periodically from the parent process's
+                  asyncio loop.  If the loop wedges the mtime stops
+                  advancing, so an exec probe ``test $(($(date +%s) -
+                  $(stat -c %Y .../health/alive))) -lt 30`` flips
+                  ``unready`` and Kubernetes restarts the pod.  Maps to
+                  a Kubernetes ``livenessProbe``.
+
+Why files (not HTTP):
+
+  * No new listening port, no extra dependency, no thread/process for
+    a tiny web server.
+  * ``exec`` probes work everywhere (kubelet, docker-compose
+    healthchecks, systemd ``ExecStartPost`` waits).
+  * Easy to inspect by hand: ``ls -l /var/cache/salt/master/health/``.
+
+Why three sentinels (not one):
+
+  * **Cardinal rule from etcd's incident history**: liveness must never
+    reflect cluster state.  Making liveness depend on Raft leader
+    availability caused kubelet to SIGKILL pods *during* legitimate
+    leader elections, preventing the elections from completing.  Each
+    sentinel answers a distinct question (Initialised? Routable?
+    Responsive?) so the answers can disagree.
+
+References:
+  * https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/
+  * https://github.com/etcd-io/etcd/issues/13340
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+import time
+
+log = logging.getLogger(__name__)
+
+#: Subdirectory under ``cachedir`` that holds the three sentinels.
+HEALTH_DIR = "health"
+
+#: Sentinel filename for the startup probe.
+STARTUP_SENTINEL = "startup"
+
+#: Sentinel filename for the readiness probe.
+READY_SENTINEL = "ready"
+
+#: Sentinel filename for the liveness probe.
+ALIVE_SENTINEL = "alive"
+
+#: Default interval in seconds between ``touch_alive`` heartbeats.  Pair
+#: with a Kubernetes ``livenessProbe`` ``periodSeconds: 15`` and a
+#: staleness threshold of 30 s in the exec probe.
+DEFAULT_ALIVE_INTERVAL = 5
+
+
+def health_dir(opts):
+    """
+    Return the on-disk path of ``<cachedir>/health``.
+
+    Returns ``None`` if ``opts`` has no ``cachedir`` (typical of unit
+    tests using a stripped opts dict); callers treat that as "no
+    health checks configured" and silently skip.  This keeps the
+    helpers safe to wire into shared code paths like
+    ``_signal_cluster_ready`` that run in production *and* in tests
+    with hand-crafted opts.
+    """
+    cachedir = opts.get("cachedir")
+    if not cachedir:
+        return None
+    return pathlib.Path(cachedir) / HEALTH_DIR
+
+
+def reset_health_dir(opts):
+    """
+    Wipe and recreate ``<cachedir>/health/``.
+
+    Called once near the top of ``Master.start`` so a stale ``startup``
+    or ``ready`` sentinel from a previous run cannot pass a probe before
+    the freshly-started master is actually ready.
+
+    Errors are logged and swallowed: a missing health dir is *not* a
+    reason to refuse to start the master, so health-check writes are
+    best-effort.
+    """
+    path = health_dir(opts)
+    if path is None:
+        return
+    try:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.warning("healthchecks: could not reset %s: %s", path, exc)
+
+
+def _write_sentinel(opts, name, body=""):
+    """Write a sentinel file atomically.  Best-effort; logs and returns on error."""
+    base = health_dir(opts)
+    if base is None:
+        return
+    path = base / name
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic-ish: write to ``.tmp`` then rename.  Avoids a probe
+        # observing a half-written file even though our payloads are
+        # tiny.
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(body, encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        log.warning("healthchecks: could not write %s: %s", path, exc)
+
+
+def mark_startup_complete(opts):
+    """
+    Write ``<cachedir>/health/startup`` once master init is done.
+
+    Body is the unix epoch second the master finished bootstrapping —
+    handy for ``kubectl describe`` and post-mortems.
+    """
+    _write_sentinel(opts, STARTUP_SENTINEL, body=str(int(time.time())))
+    log.info("healthchecks: startup sentinel written at %s", health_dir(opts))
+
+
+def mark_cluster_ready(opts):
+    """
+    Write ``<cachedir>/health/ready`` when the master is willing to serve
+    traffic.  Idempotent — a second call is harmless.
+    """
+    _write_sentinel(opts, READY_SENTINEL, body=str(int(time.time())))
+    log.info("healthchecks: readiness sentinel written at %s", health_dir(opts))
+
+
+def touch_alive(opts):
+    """
+    Refresh the mtime of ``<cachedir>/health/alive``.
+
+    The exec probe compares ``time.time() - stat(alive).st_mtime`` to a
+    threshold (recommend 3× ``DEFAULT_ALIVE_INTERVAL``).  Stops
+    advancing if the parent process's asyncio loop wedges, which is the
+    exact failure mode liveness is supposed to catch.
+    """
+    base = health_dir(opts)
+    if base is None:
+        return
+    path = base / ALIVE_SENTINEL
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # ``open(...) + close()`` would work but pathlib.Path.touch is
+        # one syscall on Python 3.10+.
+        path.touch(exist_ok=True)
+        # ``Path.touch`` on Python < 3.10 only updates atime/mtime if
+        # the file already exists *and* doesn't always bump them on
+        # every filesystem.  Force a definite mtime update via
+        # os.utime so ``stat -c %Y`` always advances.
+        now = time.time()
+        os.utime(path, (now, now))
+    except OSError as exc:
+        log.warning("healthchecks: could not touch %s: %s", path, exc)
+
+
+def is_clustered(opts):
+    """``True`` if the master is configured for cluster mode."""
+    return bool(opts.get("cluster_id") and opts.get("cluster_peers") is not None)

--- a/salt/cluster/ring.py
+++ b/salt/cluster/ring.py
@@ -13,7 +13,7 @@ Ring position encoding
 Positions are 64-bit unsigned integers derived from
 ``xxhash.xxh3_64_intdigest``.  The ring is modelled as the integer range
 ``[0, 2**64)``, wrapping around.  A key is owned by the first node whose
-position is ≥ the key's hash (clockwise successor), with wrap-around to the
+position is >= the key's hash (clockwise successor), with wrap-around to the
 lowest-position node when no successor exists.
 
 VNode token derivation
@@ -74,21 +74,21 @@ class HashRing:
                     Higher values improve distribution at the cost of memory
                     (``len(nodes) * vnodes * ~50 bytes``).
     :param replicas: Number of distinct owners returned by ``get_replicas``.
-                    Must be ≤ number of physical nodes in the ring.
+                    Must be <= number of physical nodes in the ring.
     """
 
     def __init__(self, nodes=(), vnodes=DEFAULT_VNODES, replicas=1):
         if vnodes < 1:
-            raise ValueError(f"vnodes must be ≥ 1, got {vnodes}")
+            raise ValueError(f"vnodes must be >= 1, got {vnodes}")
         if replicas < 1:
-            raise ValueError(f"replicas must be ≥ 1, got {replicas}")
+            raise ValueError(f"replicas must be >= 1, got {replicas}")
         self._vnodes = vnodes
         self._replicas = replicas
         self._lock = threading.RLock()
 
         # Sorted list of token positions (int).
         self._ring: list[int] = []
-        # token position → physical node ID
+        # token position -> physical node ID
         self._token_map: dict[int, str] = {}
         # set of physical node IDs currently in the ring
         self._nodes: set[str] = set()

--- a/salt/cluster/ring.py
+++ b/salt/cluster/ring.py
@@ -213,8 +213,14 @@ class HashRing:
 
         This is the intended call site for ``master.py``::
 
-            if not ring.owns(load["jid"], self.opts["id"]):
+            if not ring.owns(load["jid"], self.opts["interface"]):
                 # shunt to cluster bus
+
+        ``opts["interface"]`` is used because that's the cluster-wide node
+        identity throughout the consensus layer (matches ``cluster_peers``
+        and the keys in :class:`HashRing`'s internal node set populated by
+        ``rebuild``).  ``opts["id"]`` is the local hostname which other
+        masters do not share.
         """
         with self._lock:
             if not self._nodes:

--- a/salt/cluster/ring.py
+++ b/salt/cluster/ring.py
@@ -41,7 +41,18 @@ import bisect
 import logging
 import threading
 
-import xxhash
+# ``xxhash`` is the canonical ring-hash backend.  Importing optionally
+# keeps ``salt.master`` startable on installs where xxhash is missing
+# (notably Windows NSIS upgrades from 3007.14, which never shipped
+# xxhash and don't pull it in on upgrade): an empty/self-only ring's
+# ``owns()`` returns ``True`` without ever hashing, so the broadcast
+# path keeps working.  Cluster sharding (``add_node``, ``get_owner``,
+# ``get_replicas``, ``rebuild``) raises a clear error if xxhash is
+# genuinely needed but missing.
+try:
+    import xxhash as _xxhash
+except ImportError:  # pragma: no cover - exercised on Windows upgrade only
+    _xxhash = None
 
 log = logging.getLogger(__name__)
 
@@ -50,19 +61,29 @@ log = logging.getLogger(__name__)
 # sizes (1-20 nodes).
 DEFAULT_VNODES = 150
 
-_RING_SIZE = 1 << 64  # 2**64 — hash space
+_RING_SIZE = 1 << 64  # 2**64 hash space
+
+_XXHASH_MISSING_MSG = (
+    "salt.cluster.ring requires the 'xxhash' Python package for ring "
+    "operations beyond a single-node ring.  Install xxhash (>=3.0) and "
+    "restart the master."
+)
 
 
 def _token(node_id: str, replica: int) -> int:
     """Return the ring position for *node_id* replica *replica*."""
-    return xxhash.xxh3_64_intdigest(f"{node_id}#vnode{replica}".encode())
+    if _xxhash is None:
+        raise RuntimeError(_XXHASH_MISSING_MSG)
+    return _xxhash.xxh3_64_intdigest(f"{node_id}#vnode{replica}".encode())
 
 
 def _key_hash(key) -> int:
     """Hash an arbitrary key to a ring position."""
+    if _xxhash is None:
+        raise RuntimeError(_XXHASH_MISSING_MSG)
     if isinstance(key, str):
         key = key.encode()
-    return xxhash.xxh3_64_intdigest(key)
+    return _xxhash.xxh3_64_intdigest(key)
 
 
 class HashRing:

--- a/salt/cluster/ring_membership.py
+++ b/salt/cluster/ring_membership.py
@@ -1,0 +1,116 @@
+"""
+High-level ownership query for cluster-distributed state.
+
+Wraps a per-process :class:`salt.cluster.ring.HashRing` instance with
+the convenience API the rest of the cluster code reaches for:
+
+* :func:`owns` — does this master own *key* per the current ring?
+* :func:`rebuild` — replace the ring contents (called from
+  :meth:`salt.cluster.consensus.service.RaftService._on_membership_change`).
+* :func:`get_ring` — escape hatch for tests and diagnostics.
+
+Stage 0 semantics
+-----------------
+For the initial rollout the ring is **per-process** (a module-level
+singleton) and only ``RaftService`` rebuilds its copy.  Every other
+process (notably ``EventMonitor``, which runs as its own
+``SignalHandlingProcess`` subprocess and does not see the parent's
+membership commits) keeps an *empty* ring.  Because
+:meth:`HashRing.owns` returns ``True`` for an empty ring, every master
+still acts as the owner of every key in those subprocesses.  That
+preserves today's broadcast-fan-out behaviour while putting the gate
+points in code so a future config flip — *not* a code change — can
+turn on real sharding.
+
+Stage 1 will switch to a process-shared ring driven by a
+``RingConfigStateMachine`` so every subprocess agrees on the
+authoritative ring.  At that point the call sites here do not need to
+change; only the underlying transport for ring state does.
+
+Why not pass a ring instance everywhere
+---------------------------------------
+The receivers we gate (``EventMonitor.handle_event`` at master.py:1149-
+1197) live across a ``SignalHandlingProcess`` boundary from the place
+that owns Raft membership (``RaftService`` inside the publish daemon).
+A single instance can't be smuggled across a fork without a shared-
+memory backing store.  A module-level singleton per process is the
+smallest abstraction that survives both the current shape and the
+stage-1 swap.
+"""
+
+import logging
+import threading
+
+from salt.cluster.ring import HashRing
+
+log = logging.getLogger(__name__)
+
+
+# Per-process singleton.  Module load creates an empty ring; only
+# RaftService.rebuild() populates it.  A subprocess inherits the empty
+# ring at fork time and keeps it empty for its lifetime in stage 0.
+_PROCESS_RING = HashRing()
+_LOCK = threading.RLock()
+
+
+def get_ring():
+    """
+    Return this process's :class:`HashRing` singleton.
+
+    Use only from code that needs ring-internals (diagnostics, tests).
+    Production call sites should prefer :func:`owns` so the ownership
+    decision flows through one place.
+    """
+    return _PROCESS_RING
+
+
+def owns(opts, key):
+    """
+    Return ``True`` if this master should process *key* locally.
+
+    *opts* must carry ``"interface"`` — the cluster-wide node identity
+    matching :func:`rebuild`'s input and ``cluster_peers``.
+
+    Stage 0: the ring is empty in any process that did not call
+    :func:`rebuild` (which is currently only ``RaftService``).  An
+    empty ring's :meth:`HashRing.owns` returns ``True`` for every key,
+    so behaviour is unchanged from the pre-ring code path.
+    """
+    node_id = opts.get("interface")
+    if node_id is None:
+        # Defensive: opts without an interface (some test fixtures) act
+        # as a standalone master — own everything.
+        return True
+    return _PROCESS_RING.owns(key, node_id)
+
+
+def rebuild(voters):
+    """
+    Replace the process ring's contents with *voters*.
+
+    Called from :meth:`RaftService._on_membership_change` after every
+    committed CONFIG entry.  Idempotent: rebuilding to the same voter
+    set is cheap and emits no spurious log noise beyond ``HashRing``'s
+    own info-level "rebuilt with N node(s)" message.
+
+    *voters* is the committed voter list — learners are excluded
+    because they don't yet hold replica state to be the canonical
+    owner of anything.  When the ring policy later allows
+    learner-as-replica, this function will grow a ``learners`` arg.
+    """
+    with _LOCK:
+        _PROCESS_RING.rebuild(voters)
+
+
+def reset():
+    """
+    Replace the process ring with a fresh empty one.
+
+    Test-only escape hatch — production code never calls this.  Pytest
+    fixtures that build and tear down a cluster within the same
+    process need to reset the ring between tests so leftover voters
+    from one test don't bleed into the next.
+    """
+    global _PROCESS_RING  # pylint: disable=global-statement
+    with _LOCK:
+        _PROCESS_RING = HashRing()

--- a/salt/cluster/state_sync.py
+++ b/salt/cluster/state_sync.py
@@ -1,7 +1,7 @@
 """
 Paged bulk state-sync for cluster joiners.
 
-The cluster join handshake (``cluster/peer/join`` →
+The cluster join handshake (``cluster/peer/join`` ->
 ``cluster/peer/join-reply``) carries the cluster's identity material
 (``cluster_aes``, ``cluster.pem``, peer pubs), but the joining master
 also needs the *content* the cluster has accumulated: accepted /
@@ -80,7 +80,7 @@ ALL_CHANNELS = (
 )
 
 # Default count per chunk for cache-key channels.  Tuned so a 200-entry
-# minion-key chunk (avg pub key ~500 bytes → ~100 KB) fits comfortably in
+# minion-key chunk (avg pub key ~500 bytes -> ~100 KB) fits comfortably in
 # one Crypticle-encrypted message without dominating heartbeat bandwidth.
 DEFAULT_KEY_CHUNK_COUNT = 200
 

--- a/salt/cluster/state_sync.py
+++ b/salt/cluster/state_sync.py
@@ -1,0 +1,363 @@
+"""
+Paged bulk state-sync for cluster joiners.
+
+The cluster join handshake (``cluster/peer/join`` →
+``cluster/peer/join-reply``) carries the cluster's identity material
+(``cluster_aes``, ``cluster.pem``, peer pubs), but the joining master
+also needs the *content* the cluster has accumulated: accepted /
+denied minion keys, the file_roots tree, and the pillar_roots tree.
+That content can run from a few KB on a fresh cluster to tens of MB
+on a production deployment with thousands of minions and a large
+SLS tree.
+
+To keep the join-reply itself small and to give the joiner partial-
+progress + per-channel failure isolation, the state-sync runs on
+*four independent streams*, each chunked by its own budget:
+
+==============  ==================  =======================
+channel         chunked by          per-chunk budget
+==============  ==================  =======================
+``keys``        entry count         ``DEFAULT_KEY_CHUNK_COUNT``
+``denied_keys`` entry count         ``DEFAULT_KEY_CHUNK_COUNT``
+``file_roots``  cumulative bytes    ``DEFAULT_ROOTS_CHUNK_BYTES``
+``pillar_roots`` cumulative bytes   ``DEFAULT_ROOTS_CHUNK_BYTES``
+==============  ==================  =======================
+
+Wire format
+-----------
+The responder allocates a session id, names it in the join-reply's
+``state_sync_session`` field, then publishes a series of
+``cluster/peer/state-sync-chunk`` events to the joiner.  Each event
+payload is a Crypticle-encrypted dict (encrypted under the cluster
+session AES key the joiner just received in the same join-reply)::
+
+    {
+        "session":  str,            # matches join-reply state_sync_session
+        "channel":  str,            # one of ALL_CHANNELS
+        "seq":      int,            # 0-indexed sequence within this channel
+        "total":    int,            # total chunks for this channel (-1 if unknown)
+        "eof":      bool,           # True on the final chunk for this channel
+        "items":    list,           # channel-specific entries
+    }
+
+A channel with no data still emits one chunk with ``items=[]`` and
+``eof=True``, so receivers can use the ``eof`` flag uniformly.
+
+Receiver state machine
+----------------------
+:class:`StateSyncSession` is held by the joiner's
+``MasterPubServerChannel`` and tracks per-channel ``eof`` flags.  The
+caller provides an ``on_complete`` callback that fires when all four
+channels have either eof'd or the deadline expires (whichever comes
+first); the channel server uses that callback to call
+``_start_raft_as_learner`` only after bulk sync is at rest.
+"""
+
+import logging
+import secrets
+import time
+
+import salt.cache
+import salt.exceptions
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Channel names + chunking knobs
+# ---------------------------------------------------------------------------
+
+KEYS_CHANNEL = "keys"
+DENIED_CHANNEL = "denied_keys"
+FILE_ROOTS_CHANNEL = "file_roots"
+PILLAR_ROOTS_CHANNEL = "pillar_roots"
+
+ALL_CHANNELS = (
+    KEYS_CHANNEL,
+    DENIED_CHANNEL,
+    FILE_ROOTS_CHANNEL,
+    PILLAR_ROOTS_CHANNEL,
+)
+
+# Default count per chunk for cache-key channels.  Tuned so a 200-entry
+# minion-key chunk (avg pub key ~500 bytes → ~100 KB) fits comfortably in
+# one Crypticle-encrypted message without dominating heartbeat bandwidth.
+DEFAULT_KEY_CHUNK_COUNT = 200
+
+# Default per-chunk byte budget for file-tree channels.  1 MB is a
+# pragmatic compromise: small enough that a TCP retransmit is cheap, big
+# enough that a typical SLS tree fits in a handful of chunks.
+DEFAULT_ROOTS_CHUNK_BYTES = 1 * 1024 * 1024
+
+# Default deadline (seconds) the joiner waits for all four channels to
+# eof before falling back to event-driven replication.
+DEFAULT_RECEIVE_TIMEOUT = 30
+
+
+def new_session_id():
+    """Return a fresh session id (URL-safe, no fixed length)."""
+    return secrets.token_urlsafe(16)
+
+
+# ---------------------------------------------------------------------------
+# Sender-side: chunk generators
+# ---------------------------------------------------------------------------
+
+
+def _by_count(items, n):
+    """Yield successive lists of *items* of size up to *n*."""
+    chunk = []
+    for item in items:
+        chunk.append(item)
+        if len(chunk) >= n:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def iter_keys_chunks(opts, channel, count=DEFAULT_KEY_CHUNK_COUNT):
+    """
+    Yield ``items`` lists for the ``keys`` or ``denied_keys`` channel.
+
+    Each item is ``{"id": minion_id, "value": cache_value}`` — a
+    self-contained record the receiver hands straight to ``cache.store``.
+
+    A bank with no entries still yields one empty list so the caller can
+    emit a single eof chunk.
+    """
+    if channel not in (KEYS_CHANNEL, DENIED_CHANNEL):
+        raise ValueError(f"iter_keys_chunks: unsupported channel {channel!r}")
+    cache = salt.cache.Cache(opts, driver=opts["keys.cache_driver"])
+    try:
+        dump = cache.list_all(channel, include_data=True)
+    except (AttributeError, salt.exceptions.SaltCacheError):
+        dump = {}
+    items = [{"id": mid, "value": value} for mid, value in (dump or {}).items()]
+    if not items:
+        yield []
+        return
+    yield from _by_count(items, count)
+
+
+def iter_root_chunks(roots_map, byte_budget=DEFAULT_ROOTS_CHUNK_BYTES):
+    """
+    Yield ``items`` lists for the ``file_roots`` / ``pillar_roots`` channel.
+
+    Each item is ``{"env": str, "path": str, "mode": int, "data": bytes}``
+    — flattened across envs so the receiver can apply each entry without
+    needing to track env boundaries within a chunk.
+
+    Chunks are bounded by *byte_budget*: a chunk is closed when adding
+    the next entry would exceed the budget *and* the chunk already holds
+    at least one entry.  A single file larger than the budget gets its
+    own chunk on its own.
+
+    An empty / missing roots map yields one empty list so the caller can
+    emit a single eof chunk.
+    """
+    # Lazy import to avoid a circular dependency at module load.
+    from salt.cluster.file_sync import (  # pylint: disable=import-outside-toplevel
+        collect_root_tree,
+    )
+
+    dump = collect_root_tree(roots_map)
+    if not dump:
+        yield []
+        return
+
+    chunk = []
+    chunk_bytes = 0
+    for env, files in dump.items():
+        for entry in files:
+            entry_bytes = len(entry.get("data") or b"")
+            if chunk and chunk_bytes + entry_bytes > byte_budget:
+                yield chunk
+                chunk = []
+                chunk_bytes = 0
+            chunk.append(
+                {
+                    "env": env,
+                    "path": entry["path"],
+                    "mode": entry.get("mode", 0o644),
+                    "data": entry["data"],
+                }
+            )
+            chunk_bytes += entry_bytes
+    if chunk:
+        yield chunk
+
+
+# ---------------------------------------------------------------------------
+# Receiver-side: install one chunk
+# ---------------------------------------------------------------------------
+
+
+def install_keys_chunk(opts, channel, items):
+    """
+    Apply a single chunk of ``keys`` / ``denied_keys`` entries.
+
+    Returns the number of entries successfully written.
+    """
+    if channel not in (KEYS_CHANNEL, DENIED_CHANNEL):
+        raise ValueError(f"install_keys_chunk: unsupported channel {channel!r}")
+    cache = salt.cache.Cache(opts, driver=opts["keys.cache_driver"])
+    written = 0
+    for entry in items or []:
+        if not isinstance(entry, dict):
+            continue
+        mid = entry.get("id")
+        value = entry.get("value")
+        if not mid or value is None:
+            continue
+        try:
+            cache.store(channel, mid, value)
+            written += 1
+        except Exception:  # pylint: disable=broad-except
+            log.exception("state-sync: failed to install %s entry for %s", channel, mid)
+    return written
+
+
+def install_root_chunk(roots_map, items):
+    """
+    Apply a single chunk of ``file_roots`` / ``pillar_roots`` entries.
+
+    Reuses :func:`salt.cluster.file_sync.apply_root_tree` by re-grouping
+    the flat ``items`` list back into ``{env: [entry, ...]}`` shape.
+
+    Returns the number of files successfully written.
+    """
+    from salt.cluster.file_sync import (  # pylint: disable=import-outside-toplevel
+        apply_root_tree,
+    )
+
+    grouped = {}
+    for entry in items or []:
+        if not isinstance(entry, dict):
+            continue
+        env = entry.get("env")
+        path = entry.get("path")
+        if not env or not path:
+            continue
+        grouped.setdefault(env, []).append(
+            {
+                "path": path,
+                "mode": entry.get("mode", 0o644),
+                "data": entry.get("data"),
+            }
+        )
+    return apply_root_tree(roots_map, grouped)
+
+
+# ---------------------------------------------------------------------------
+# Receiver-side: per-session state machine
+# ---------------------------------------------------------------------------
+
+
+class StateSyncSession:
+    """
+    Tracks per-channel completion for one bulk state-sync.
+
+    Used by the joiner's ``MasterPubServerChannel``: a session is created
+    when the join-reply arrives, each inbound
+    ``cluster/peer/state-sync-chunk`` calls :meth:`record_chunk`, and the
+    *on_complete* callback fires exactly once when all four channels have
+    eof'd (or :meth:`force_complete` is called by a watchdog timer).
+
+    :param session_id: opaque session identifier from the join-reply.
+    :param on_complete: zero-arg callable invoked once when the session
+        finishes (either all eofs received or forced).
+    :param channels: iterable of channel names that must all eof for
+        *on_complete* to fire.  Defaults to :data:`ALL_CHANNELS`.
+    """
+
+    def __init__(self, session_id, on_complete, channels=ALL_CHANNELS):
+        self.session_id = session_id
+        self._on_complete = on_complete
+        self._channels = tuple(channels)
+        # Per-channel state: eof flag + count of chunks installed
+        self._state = {
+            ch: {"eof": False, "chunks": 0, "items": 0} for ch in self._channels
+        }
+        self._completed = False
+        self.created_at = time.monotonic()
+
+    def record_chunk(self, channel, seq, eof, items_installed):
+        """
+        Record one chunk's arrival.  Fires *on_complete* if this was the
+        last outstanding eof.
+        """
+        if channel not in self._state:
+            log.warning(
+                "state-sync session %s: unknown channel %r (chunks=%d, eof=%s)",
+                self.session_id,
+                channel,
+                seq,
+                eof,
+            )
+            return
+        st = self._state[channel]
+        st["chunks"] += 1
+        st["items"] += int(items_installed)
+        if eof:
+            if st["eof"]:
+                log.warning(
+                    "state-sync session %s: duplicate eof on %s (seq=%d)",
+                    self.session_id,
+                    channel,
+                    seq,
+                )
+            st["eof"] = True
+        self._maybe_complete()
+
+    def _maybe_complete(self):
+        if self._completed:
+            return
+        if all(self._state[ch]["eof"] for ch in self._channels):
+            self._completed = True
+            log.info(
+                "state-sync session %s complete: %s",
+                self.session_id,
+                {ch: self._state[ch] for ch in self._channels},
+            )
+            try:
+                self._on_complete()
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "state-sync session %s: on_complete callback failed",
+                    self.session_id,
+                )
+
+    def force_complete(self):
+        """
+        Fire *on_complete* regardless of outstanding eofs.
+
+        The watchdog timer calls this when the per-session deadline
+        elapses; the joiner then proceeds with whatever data arrived and
+        relies on event-driven replication for the rest.
+        """
+        if self._completed:
+            return
+        missing = [ch for ch in self._channels if not self._state[ch]["eof"]]
+        log.warning(
+            "state-sync session %s deadline reached; forcing complete with "
+            "channels still pending: %s",
+            self.session_id,
+            missing,
+        )
+        self._completed = True
+        try:
+            self._on_complete()
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "state-sync session %s: on_complete callback failed (forced)",
+                self.session_id,
+            )
+
+    @property
+    def completed(self):
+        return self._completed
+
+    def status(self):
+        """Return a serialisable snapshot of per-channel progress (for logs)."""
+        return dict(self._state)

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -214,6 +214,14 @@ VALID_OPTS = immutabletypes.freeze(
         # and can be sync'd as opaque blobs) and joining masters request a
         # bulk state-sync from an existing peer before becoming Raft voters.
         "cluster_isolated_filesystem": bool,
+        # Maximum number of in-memory Raft log entries before the log
+        # compacts into a snapshot.  ``None`` (the default) disables
+        # compaction — fine for small clusters but unbounded growth at
+        # scale.  Setting to a positive integer triggers
+        # ``Log.snapshot()`` whenever the log reaches the threshold;
+        # the snapshot envelope (``raft.snapshot.v1``) carries every
+        # registered state machine so membership survives compaction.
+        "cluster_max_log_size": (type(None), int),
         # Use a module function to determine the unique identifier. If this is
         # set and 'id' is not set, it will allow invocation of a module function
         # to determine the value of 'id'. For simple invocations without function
@@ -1764,6 +1772,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "cluster_pub_fingerprint": None,
         "cluster_secret": None,
         "cluster_isolated_filesystem": False,
+        "cluster_max_log_size": None,
         "features": {},
         "publish_signing_algorithm": "PKCS1v15-SHA1",
         "cluster_encryption_algorithm": "OAEP-SHA1",

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -208,6 +208,12 @@ VALID_OPTS = immutabletypes.freeze(
         # Shared pre-shared string that authenticates a master joining an
         # existing cluster at runtime.
         "cluster_secret": str,
+        # When True, cluster masters do NOT share ``cluster_pki_dir`` /
+        # ``cachedir`` between members.  In this mode keys.cache_driver
+        # defaults to mmap_key (so cache files are deterministic per-bank
+        # and can be sync'd as opaque blobs) and joining masters request a
+        # bulk state-sync from an existing peer before becoming Raft voters.
+        "cluster_isolated_filesystem": bool,
         # Use a module function to determine the unique identifier. If this is
         # set and 'id' is not set, it will allow invocation of a module function
         # to determine the value of 'id'. For simple invocations without function
@@ -1757,6 +1763,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "cluster_pool_port": 4520,
         "cluster_pub_fingerprint": None,
         "cluster_secret": None,
+        "cluster_isolated_filesystem": False,
         "features": {},
         "publish_signing_algorithm": "PKCS1v15-SHA1",
         "cluster_encryption_algorithm": "OAEP-SHA1",

--- a/salt/key.py
+++ b/salt/key.py
@@ -754,6 +754,18 @@ class Key:
                     self.cache.store("keys", keyname, key)
 
                 eload = {"result": True, "act": self.DIR_MAP[to_state], "id": keyname}
+                # Cluster masters: include the public key body so peer
+                # masters can populate their local ``pki_dir/<bucket>/<id>``
+                # without a shared filesystem.  The bytes are only useful
+                # to other cluster members; they're harmless on standalone
+                # masters that ignore the field.
+                pub_bytes = None
+                if to_state == self.DEN:
+                    pub_bytes = key
+                elif "pub" in (key or {}):
+                    pub_bytes = key["pub"]
+                if pub_bytes:
+                    eload["pub"] = pub_bytes
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="key"))
 
         for key in invalid_keys:

--- a/salt/master.py
+++ b/salt/master.py
@@ -28,6 +28,7 @@ import salt.channel.server
 import salt.client
 import salt.client.ssh.client
 import salt.cluster.healthchecks
+import salt.cluster.ring_membership
 import salt.crypt
 import salt.daemons.masterapi
 import salt.defaults.exitcodes
@@ -1157,11 +1158,17 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
             # publishes a new job, mirror its `minions` list into our
             # local job cache so any CLI on this master can later look
             # up the jid without sharing ``cachedir``.
+            #
+            # Stage 0 ring gating: ``ring_membership.owns(opts, jid)`` is
+            # the durable hook a future ring config flip will use to
+            # shard job state.  In stage 0 the per-process ring stays
+            # empty in this subprocess, so ``owns`` returns ``True`` and
+            # we mirror everything (today's behaviour).
             peer_id = data.pop("__peer_id", None)
             if peer_id and self.opts.get("cluster_id"):
                 jid = data.get("jid")
                 minions = data.get("minions") or []
-                if jid:
+                if jid and salt.cluster.ring_membership.owns(self.opts, jid):
                     try:
                         salt.utils.job.store_minions(self.opts, jid, minions)
                     except Exception:  # pylint: disable=broad-except
@@ -1170,15 +1177,21 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
             # Cluster replication of job returns: minion responded to a
             # peer master; persist the return into our local cache so a
             # CLI on this master can deliver it to the user.
+            #
+            # Same ring-gating as the /new branch above.  Once stage 1
+            # ships, the ring will only let the jid's owner write the
+            # return; today every master writes every return.
             peer_id = data.pop("__peer_id", None)
             if peer_id and self.opts.get("cluster_id"):
-                try:
-                    salt.utils.job.store_job(self.opts, data)
-                except Exception:  # pylint: disable=broad-except
-                    log.exception(
-                        "Failed to mirror peer job return for jid %s",
-                        data.get("jid"),
-                    )
+                jid = data.get("jid")
+                if salt.cluster.ring_membership.owns(self.opts, jid):
+                    try:
+                        salt.utils.job.store_job(self.opts, data)
+                    except Exception:  # pylint: disable=broad-except
+                        log.exception(
+                            "Failed to mirror peer job return for jid %s",
+                            jid,
+                        )
         elif tag.startswith("salt/key"):
             # Replicate accepted/rejected/denied/deleted minion key state
             # across the cluster.  When a minion's key state changes on one
@@ -1187,6 +1200,13 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
             # forwards the event to peers; here we install the bytes into the
             # local pki tree so every master agrees on which minions are
             # accepted without sharing pki_dir over a filesystem.
+            #
+            # Ring gating note: even when ring mode flips to voter
+            # sharding in stage 1, every master still needs the public
+            # key bytes to *verify* a minion's signature (latency-
+            # sensitive on every auth), so we keep replicating the bytes
+            # everywhere.  The "is this key accepted/denied" *metadata*
+            # is what stage 2+ will shard; that's a separate gate.
             peer_id = data.pop("__peer_id", None)
             if peer_id and self.opts.get("cluster_id"):
                 act = data.get("act")

--- a/salt/master.py
+++ b/salt/master.py
@@ -906,7 +906,7 @@ class Master(SMaster):
             ipc_publisher.send_aes_key_event()
 
             # If this master has no cluster private key yet, it has not
-            # completed a join handshake and needs to run the discover→join
+            # completed a join handshake and needs to run the discover->join
             # protocol so existing peers add it as a Raft learner.
             #
             # The designated founder (lowest interface address among

--- a/salt/master.py
+++ b/salt/master.py
@@ -27,6 +27,7 @@ import salt.cache
 import salt.channel.server
 import salt.client
 import salt.client.ssh.client
+import salt.cluster.healthchecks
 import salt.crypt
 import salt.daemons.masterapi
 import salt.defaults.exitcodes
@@ -869,6 +870,11 @@ class Master(SMaster):
         self._pre_flight()
         log.info("salt-master is starting as user '%s'", salt.utils.user.get_user())
 
+        # Wipe stale health-probe sentinels from any previous run before
+        # subprocesses come up, so a probe cannot pass on data from the
+        # last incarnation.  Failures are logged but non-fatal.
+        salt.cluster.healthchecks.reset_health_dir(self.opts)
+
         enable_sigusr1_handler()
         enable_sigusr2_handler()
 
@@ -1053,7 +1059,54 @@ class Master(SMaster):
             # No custom signal handling was added, install our own
             signal.signal(signal.SIGTERM, self._handle_signals)
 
-        asyncio.run(self.process_manager.run())
+        # Mark startup complete now that every subprocess has been
+        # registered with the process manager.  For a non-cluster master
+        # mark readiness here as well — there is no Raft gate to wait
+        # for, so the master is immediately willing to serve traffic.
+        # For cluster masters the readiness sentinel is written from
+        # ``MasterPubServerChannel._signal_cluster_ready`` once the
+        # founding/promotion CONFIG entry commits.
+        salt.cluster.healthchecks.mark_startup_complete(self.opts)
+        if not salt.cluster.healthchecks.is_clustered(self.opts):
+            salt.cluster.healthchecks.mark_cluster_ready(self.opts)
+
+        asyncio.run(self._run_with_heartbeat())
+
+    async def _run_with_heartbeat(self):
+        """
+        Run the process manager alongside a periodic liveness heartbeat.
+
+        The heartbeat task runs in this same asyncio loop, so if the
+        loop wedges (the prototypical liveness-failure case) the
+        ``alive`` sentinel's mtime stops advancing and Kubernetes
+        restarts the pod.  Spawning the heartbeat as a subprocess would
+        miss this — a deadlocked parent could keep an unrelated child
+        ticking.
+
+        ``asynchronous=True`` is required: the default branch of
+        ``ProcessManager.run`` uses blocking ``time.sleep(10)`` which
+        would starve the heartbeat task.
+        """
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        try:
+            await self.process_manager.run(asynchronous=True)
+        finally:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except (asyncio.CancelledError, Exception):  # pylint: disable=broad-except
+                pass
+
+    async def _heartbeat_loop(self):
+        """Touch the liveness sentinel every ``DEFAULT_ALIVE_INTERVAL`` seconds."""
+        interval = salt.cluster.healthchecks.DEFAULT_ALIVE_INTERVAL
+        while True:
+            try:
+                salt.cluster.healthchecks.touch_alive(self.opts)
+            except Exception:  # pylint: disable=broad-except
+                # Never let a probe-write mishap kill the master.
+                log.exception("healthchecks: heartbeat write failed")
+            await asyncio.sleep(interval)
 
     def _handle_signals(self, signum, sigframe):
         # escalate the signals to the process manager

--- a/salt/master.py
+++ b/salt/master.py
@@ -1099,6 +1099,55 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
                 for chan in self.channels:
                     tasks.append(asyncio.create_task(chan.publish(data)))
                 await asyncio.gather(*tasks)
+        elif tag.startswith("salt/job") and "/new" in tag:
+            # Cluster replication of job submissions: when a peer master
+            # publishes a new job, mirror its `minions` list into our
+            # local job cache so any CLI on this master can later look
+            # up the jid without sharing ``cachedir``.
+            peer_id = data.pop("__peer_id", None)
+            if peer_id and self.opts.get("cluster_id"):
+                jid = data.get("jid")
+                minions = data.get("minions") or []
+                if jid:
+                    try:
+                        salt.utils.job.store_minions(self.opts, jid, minions)
+                    except Exception:  # pylint: disable=broad-except
+                        log.exception("Failed to mirror peer job submission %s", jid)
+        elif tag.startswith("salt/job") and "/ret/" in tag:
+            # Cluster replication of job returns: minion responded to a
+            # peer master; persist the return into our local cache so a
+            # CLI on this master can deliver it to the user.
+            peer_id = data.pop("__peer_id", None)
+            if peer_id and self.opts.get("cluster_id"):
+                try:
+                    salt.utils.job.store_job(self.opts, data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception(
+                        "Failed to mirror peer job return for jid %s",
+                        data.get("jid"),
+                    )
+        elif tag.startswith("salt/key"):
+            # Replicate accepted/rejected/denied/deleted minion key state
+            # across the cluster.  When a minion's key state changes on one
+            # master, ``salt.key.Key.change_state`` fires ``salt/key`` with
+            # the new state and the public key body.  ``MasterPubServerChannel``
+            # forwards the event to peers; here we install the bytes into the
+            # local pki tree so every master agrees on which minions are
+            # accepted without sharing pki_dir over a filesystem.
+            peer_id = data.pop("__peer_id", None)
+            if peer_id and self.opts.get("cluster_id"):
+                act = data.get("act")
+                minion_id = data.get("id")
+                pub = data.get("pub")
+                if minion_id and act:
+                    try:
+                        self._apply_peer_key_change(act, minion_id, pub)
+                    except Exception:  # pylint: disable=broad-except
+                        log.exception(
+                            "Failed to apply peer key change %s for %s",
+                            act,
+                            minion_id,
+                        )
         elif tag == "rotate_cluster_aes_key":
             peer_id = data.pop("__peer_id", None)
             if peer_id:
@@ -1108,6 +1157,52 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
                 )
         else:
             log.trace("Ignore tag %s", tag)
+
+    _PEER_KEY_STATE = {
+        "accept": "accepted",
+        "reject": "rejected",
+        "pend": "pending",
+    }
+
+    def _apply_peer_key_change(self, act, minion_id, pub):
+        """
+        Mirror a peer master's minion-key state change into our local
+        keys cache so this master can authenticate the minion without
+        sharing storage with the other cluster members.
+
+        ``act`` is one of accept/reject/pend/deny/delete; ``pub`` is the
+        public key PEM (None for ``delete``).
+        """
+        cache = salt.cache.Cache(self.opts, driver=self.opts["keys.cache_driver"])
+        if act == "delete":
+            try:
+                cache.flush("keys", minion_id)
+            except Exception:  # pylint: disable=broad-except
+                log.exception("_apply_peer_key_change: flush keys/%s failed", minion_id)
+            try:
+                cache.flush("denied_keys", minion_id)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "_apply_peer_key_change: flush denied_keys/%s failed",
+                    minion_id,
+                )
+            return
+        if not pub:
+            return
+        if act == "deny":
+            cache.store("denied_keys", minion_id, [pub])
+            log.info("Applied peer key change: deny minion %s", minion_id)
+            return
+        state = self._PEER_KEY_STATE.get(act)
+        if state is None:
+            return
+        cache.store("keys", minion_id, {"state": state, "pub": pub})
+        log.info(
+            "Applied peer key change: %s minion %s (state=%s)",
+            act,
+            minion_id,
+            state,
+        )
 
     def run(self):
         io_loop = asyncio.new_event_loop()
@@ -3012,13 +3107,16 @@ class AuthFuncs(TransportMethods):
 
         # only write to disk if you are adding the file, and in open mode,
         # which implies we accept any key from a minion.
+        key_persisted = False
         if (not key or key["state"] != "accepted") and not self.opts["open_mode"]:
             key = {"pub": load["pub"], "state": "accepted"}
             self.cache.store("keys", load["id"], key)
+            key_persisted = True
         elif self.opts["open_mode"]:
             if load["pub"] and (not key or load["pub"] != key["pub"]):
                 key = {"pub": load["pub"], "state": "accepted"}
                 self.cache.store("keys", load["id"], key)
+                key_persisted = True
             elif not load["pub"]:
                 log.error("Public key is empty: %s", load["id"])
                 if sign_messages:
@@ -3027,6 +3125,20 @@ class AuthFuncs(TransportMethods):
                     )
                 else:
                     return {"enc": "clear", "load": {"ret": False}}
+        # Cluster-wide replication: fire a ``salt/key/accept`` event with
+        # the public key body so peer masters mirror this acceptance into
+        # their own pki_dir without sharing a filesystem.  Standalone
+        # masters ignore the cross-master path; the event is harmless.
+        if key_persisted and self.opts.get("cluster_id"):
+            self.event.fire_event(
+                {
+                    "result": True,
+                    "act": "accept",
+                    "id": load["id"],
+                    "pub": load["pub"],
+                },
+                salt.utils.event.tagify(prefix="key"),
+            )
 
         pub = None
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3587,7 +3587,7 @@ class Minion(MinionBase):
         For each ``(resource_type, resource_id)`` pair, sets the per-call
         :data:`salt.loader.context.resource_ctxvar` and invokes
         ``resource_funcs[f"{type}.grains"]()``. Returns a mapping keyed by
-        composite SRN ``"<type>:<id>"`` → grain dict, suitable for shipping
+        composite SRN ``"<type>:<id>"`` -> grain dict, suitable for shipping
         to the master in :meth:`_register_resources_with_master`.
 
         Resource types without a ``grains`` callable are skipped silently.

--- a/salt/runners/cluster.py
+++ b/salt/runners/cluster.py
@@ -84,7 +84,7 @@ def ring_set(members=None, replicas=None):  # pylint: disable=unused-argument
     * *members*: ``"self"`` (default ring contents — every master a
       single-node ring, broadcast everywhere) or ``"voters"`` (ring
       tracks the Raft voter set so writes shard).
-    * *replicas*: integer ≥ 1.  ``1`` (default) means each key has
+    * *replicas*: integer >= 1.  ``1`` (default) means each key has
       exactly one owner; higher values request additional replica
       owners for fault tolerance.
 

--- a/salt/runners/cluster.py
+++ b/salt/runners/cluster.py
@@ -1,0 +1,106 @@
+"""
+Salt runner for cluster ring management.
+
+Stage 1 of the ring rollout: this runner is the operator-facing
+control surface for the consistent-hash ring that distributes job /
+key state across cluster masters.
+
+Currently exposes a *query-only* view (``ring_info``) of the ring
+state seen by the local master.  The proposal path (``ring_set``)
+that commits a ``RING_CONFIG`` entry through Raft is deferred
+because it requires IPC from the runner's subprocess across to the
+publish daemon's ``RaftService``; that is a follow-up slice.
+
+CLI Examples:
+
+.. code-block:: bash
+
+    # Show this master's current ring state.
+    salt-run cluster.ring_info
+
+.. versionadded:: 3009.0
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def ring_info():
+    """
+    Return a snapshot of this master's ring state.
+
+    Reads the per-process ring populated by
+    :class:`~salt.cluster.consensus.service.RaftService`.  Output:
+
+    .. code-block:: python
+
+        {
+            "is_clustered": bool,
+            "node_count":   int,
+            "nodes":        [str, ...],   # sorted
+            "vnodes":       int,
+        }
+
+    Note that runners run in their own subprocess; the ring instance
+    they see is **not** the publish daemon's ring.  In the current
+    design that subprocess never has a populated ring, so this
+    function will always report ``is_clustered=False`` until stage 2
+    introduces a process-shared ring (see ``GAPS.md``).  The signature
+    is stable so the caller's contract does not change when the
+    backing source does.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.ring_info
+    """
+    # Lazy import — the cluster module is optional when Salt is
+    # installed without consensus support.
+    from salt.cluster import ring_membership  # pylint: disable=import-outside-toplevel
+
+    ring = ring_membership.get_ring()
+    return {
+        "is_clustered": bool(ring.is_clustered),
+        "node_count": ring.node_count(),
+        "nodes": sorted(ring.nodes()),
+        "vnodes": ring.token_count() // max(1, ring.node_count() or 1),
+    }
+
+
+def ring_set(members=None, replicas=None):  # pylint: disable=unused-argument
+    """
+    Propose a new ring policy through Raft.
+
+    Stage 1 placeholder — actual Raft propose path requires IPC from
+    this runner subprocess to the publish daemon's
+    :class:`RaftService`, which is not yet wired.  Today the function
+    raises :class:`NotImplementedError` so an operator who tries it
+    sees the gap loudly rather than thinking their commit landed.
+
+    Once the IPC path lands, expected semantics:
+
+    * *members*: ``"self"`` (default ring contents — every master a
+      single-node ring, broadcast everywhere) or ``"voters"`` (ring
+      tracks the Raft voter set so writes shard).
+    * *replicas*: integer ≥ 1.  ``1`` (default) means each key has
+      exactly one owner; higher values request additional replica
+      owners for fault tolerance.
+
+    Until the propose path lands, operators wanting to flip the
+    policy can call ``RaftService.propose_ring_config`` directly from
+    a python hook running inside the master process — see the
+    functional tests under
+    ``tests/pytests/functional/cluster/consensus/test_raft_service.py``.
+
+    CLI Example (will raise until stage 2):
+
+    .. code-block:: bash
+
+        salt-run cluster.ring_set members=voters replicas=2
+    """
+    raise NotImplementedError(
+        "cluster.ring_set: cross-process Raft propose path is not yet wired. "
+        "Track GAPS.md for the follow-up that adds runner -> RaftService IPC."
+    )

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -5,6 +5,7 @@ This module contains the function calls to execute command line scripts
 import contextlib
 import functools
 import logging
+import multiprocessing
 import os
 import signal
 import subprocess
@@ -18,6 +19,22 @@ import salt.defaults.exitcodes
 from salt.exceptions import SaltClientError, SaltReqTimeoutError, SaltSystemExit
 
 log = logging.getLogger(__name__)
+
+
+# PEP 741: Python 3.14 changed the multiprocessing default start method on
+# Linux from "fork" to "forkserver".  Salt's daemons spawn many short-lived
+# subprocesses (MWorker, RequestServer, EventReturn, PoolRouting, …); under
+# "forkserver" each spawn re-pickles its target and re-imports Salt in a
+# helper process, which both makes startup ~5× slower than 3.13 *and* leaks
+# worker processes that hold ports across daemon restarts.  Pin the start
+# method to "fork" for Linux Salt on 3.14+ so production and test behave
+# the same as on 3.13.  ``force=True`` overrides any prior choice (pytest,
+# for example, may have queried the default before this import ran, which
+# would otherwise cause the pin to be skipped).  Operators who specifically
+# want the PEP-741 safety property can call ``set_start_method`` again with
+# their preferred value after Salt is imported.
+if sys.version_info >= (3, 14) and sys.platform.startswith("linux"):
+    multiprocessing.set_start_method("fork", force=True)
 
 
 def _handle_signals(client, signum, sigframe):

--- a/salt/tops/saltclass.py
+++ b/salt/tops/saltclass.py
@@ -71,35 +71,35 @@ A saltclass tree would look like this:
 .. code-block:: text
 
     <saltclass_path>
-    ├── classes
-    │   ├── app
-    │   │   ├── borgbackup.yml
-    │   │   └── ssh
-    │   │       └── server.yml
-    │   ├── default
-    │   │   ├── init.yml
-    │   │   ├── motd.yml
-    │   │   └── users.yml
-    │   ├── roles
-    │   │   ├── app.yml
-    │   │   └── nginx
-    │   │       ├── init.yml
-    │   │       └── server.yml
-    │   └── subsidiaries
-    │       ├── gnv.yml
-    │       ├── qls.yml
-    │       └── zrh.yml
-    └── nodes
-        ├── geneva
-        │   └── gnv.node1.yml
-        ├── lausanne
-        │   ├── qls.node1.yml
-        │   └── qls.node2.yml
-        ├── node127.yml
-        └── zurich
-            ├── zrh.node1.yml
-            ├── zrh.node2.yml
-            └── zrh.node3.yml
+    |--- classes
+    |   |--- app
+    |   |   |--- borgbackup.yml
+    |   |   `--- ssh
+    |   |       `--- server.yml
+    |   |--- default
+    |   |   |--- init.yml
+    |   |   |--- motd.yml
+    |   |   `--- users.yml
+    |   |--- roles
+    |   |   |--- app.yml
+    |   |   `--- nginx
+    |   |       |--- init.yml
+    |   |       `--- server.yml
+    |   `--- subsidiaries
+    |       |--- gnv.yml
+    |       |--- qls.yml
+    |       `--- zrh.yml
+    `--- nodes
+        |--- geneva
+        |   `--- gnv.node1.yml
+        |--- lausanne
+        |   |--- qls.node1.yml
+        |   `--- qls.node2.yml
+        |--- node127.yml
+        `--- zurich
+            |--- zrh.node1.yml
+            |--- zrh.node2.yml
+            `--- zrh.node3.yml
 
 
 Saltclass Examples

--- a/salt/utils/batch_state.py
+++ b/salt/utils/batch_state.py
@@ -164,9 +164,9 @@ def _collapse_retcode(data):
 
     Mirrors the sync-batch behavior in ``salt/cli/batch.py``:
 
-    - Missing ``retcode`` → 0.
-    - Integer ``retcode`` → itself.
-    - Dict ``retcode`` → max of its values, or 0 if empty.
+    - Missing ``retcode`` -> 0.
+    - Integer ``retcode`` -> itself.
+    - Dict ``retcode`` -> max of its values, or 0 if empty.
     """
     retcode = data.get("retcode", 0)
     if isinstance(retcode, dict):

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -243,9 +243,9 @@ def decode(
 
     One good use case for normalization is in the test suite. For example, on
     some platforms such as Mac OS, os.listdir() will produce the first of the
-    two strings above, in which "й" is represented as two code points (i.e. one
-    for the base character, and one for the breve mark). Normalizing allows for
-    a more reliable test case.
+    two strings above, in which the Cyrillic letter (U+0439) is represented as
+    two code points (i.e. one for the base character, and one for the breve
+    mark). Normalizing allows for a more reliable test case.
 
     """
     # Clean data object before decoding to avoid circular references

--- a/salt/utils/mmap_cache.py
+++ b/salt/utils/mmap_cache.py
@@ -237,7 +237,7 @@ class MmapCache:
         self._roster_cache = None  # cached list of slot indices
         self._roster_mtime = None  # mtime of roster when last read
         self._roster_wfd = None  # append-mode write fd for fast roster appends
-        # slot → byte offset in the roster file for O(1) tombstone writes
+        # slot -> byte offset in the roster file for O(1) tombstone writes
         self._roster_slot_offsets: dict = {}
         self._lock_fd = None  # persistent lock file fd (avoid re-open per op)
         # Per-instance RLock: fcntl is per-process; this covers threads too.
@@ -441,7 +441,7 @@ class MmapCache:
         Segments are named ``<heap_path>`` (seg 0), ``<heap_path>.1``,
         ``<heap_path>.2``, …  Scanning stops at the first gap.
 
-        Returns the number of segments found (≥ 1 if segment-0 exists).
+        Returns the number of segments found (>= 1 if segment-0 exists).
         """
         self._close_seg_mmaps()
         seg_id = 0
@@ -817,7 +817,7 @@ class MmapCache:
         """
         Close mmaps, heap fds, and roster write fd — but NOT the lock fd.
 
-        Used by ``open()`` (when staleness or read→write upgrade forces a
+        Used by ``open()`` (when staleness or read->write upgrade forces a
         re-map) and ``atomic_rebuild``. Both code paths call this **while the
         cross-process flock is held**: closing the lock fd would release that
         flock as a side effect (POSIX flock is keyed to the open file
@@ -1246,7 +1246,7 @@ class MmapCache:
 
     def put(self, key, value=None):
         """
-        Store *key* → *value* in the cache.
+        Store *key* -> *value* in the cache.
 
         *value* may be ``None`` (set/presence mode), a ``str``, or ``bytes``.
         Returns ``True`` on success, ``False`` on failure.
@@ -1801,7 +1801,7 @@ class MmapCache:
                         rf.flush()
                         os.fsync(rf.fileno())
 
-                    # Remove old extra segments (seg ≥ 1) before swapping.
+                    # Remove old extra segments (seg >= 1) before swapping.
                     old_extra = 1
                     while True:
                         old_p = self._segment_path(old_extra)
@@ -1820,7 +1820,7 @@ class MmapCache:
                     # Close mmaps but keep the lock fd — still inside _lock().
                     self._close_mmaps_and_fds()
 
-                    # Swap order: heap segments → index → roster.
+                    # Swap order: heap segments -> index -> roster.
                     # Extra segments get their final names before the pivot.
                     for tmp_seg_path in tmp_heap_segs[1:]:
                         seg_num = int(tmp_seg_path.split(".")[-1])

--- a/salt/utils/mmap_cache.py
+++ b/salt/utils/mmap_cache.py
@@ -1201,15 +1201,28 @@ class MmapCache:
         """
         Overwrite bytes in-place in the heap segment encoded in *packed_offset*.
 
-        When ``verify_checksums=True`` rewrites the CRC prefix as well so the
-        stored checksum stays consistent with the (possibly shorter) value.
+        Writes ``CRC + value_bytes`` (or just ``value_bytes`` when
+        ``verify_checksums=False``).  Callers that overwrite a shorter
+        value into a previously-larger heap region must NOT pre-pad
+        ``value_bytes`` — pass the actual value bytes only.  Any bytes
+        beyond ``len(value_bytes)`` in the previously-allocated region
+        are left in place as unreferenced garbage and reclaimed by the
+        next ``atomic_rebuild``; the slot's ``LENGTH`` field is
+        authoritative for the next read so the garbage tail is never
+        observed.
+
+        Pre-padding with NULs (the prior implementation) plus a
+        ``rstrip`` digest computation here corrupted any binary value
+        whose final byte was ``\\x00`` — the read-side digest was
+        computed over the (still-padded) read bytes while the stored
+        digest was computed over the rstripped version, so the CRC
+        check failed and the entry was reported missing.  See BUG.md.
         """
         seg_id, seg_offset = self._unpack_offset(packed_offset)
         seg_path = self._segment_path(seg_id)
 
         if self.verify_checksums:
-            true_value = value_bytes.rstrip(b"\x00")
-            digest = xxhash.xxh3_64_intdigest(true_value)
+            digest = xxhash.xxh3_64_intdigest(value_bytes)
             record = struct.pack(_CRC_FMT, digest) + value_bytes
         else:
             record = value_bytes
@@ -1274,10 +1287,19 @@ class MmapCache:
                             s_offset
                         )
                         if len(val_bytes) <= existing_len:
-                            # Pad value to existing_len; _overwrite_in_heap
-                            # prepends the fresh CRC itself.
-                            padded = val_bytes.ljust(existing_len, b"\x00")
-                            if not self._overwrite_in_heap(existing_heap_off, padded):
+                            # In-place overwrite: hand the actual value
+                            # bytes to ``_overwrite_in_heap`` (no NUL
+                            # padding).  The slot's LENGTH field becomes
+                            # authoritative for reads; trailing bytes
+                            # from the previous, larger value remain in
+                            # the heap as unreferenced garbage that
+                            # ``atomic_rebuild`` reclaims.  Padding here
+                            # plus a rstrip CRC inside _overwrite_in_heap
+                            # corrupted binary values whose final byte
+                            # was NUL — see BUG.md.
+                            if not self._overwrite_in_heap(
+                                existing_heap_off, val_bytes
+                            ):
                                 return False
                             struct.pack_into(
                                 _LENGTH_FMT,
@@ -1369,7 +1391,11 @@ class MmapCache:
                 if raw is None:
                     return default
 
-                raw = raw.rstrip(b"\x00") or b""
+                # ``_read_from_heap`` returns exactly ``length`` value bytes
+                # (CRC verified separately).  Do NOT rstrip NUL bytes — that
+                # would corrupt any binary value whose serialised form ends
+                # in ``\x00`` (e.g. a msgpack-encoded dict with a trailing
+                # zero integer).  See BUG.md.
                 if not raw:
                     return True
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -174,7 +174,7 @@ def evr_compare(
     """
     Compare two RPM package identifiers using full epoch–version–release semantics.
 
-    This is a pure‑Python equivalent of ``rpm.labelCompare()``, returning the same
+    This is a pure-Python equivalent of ``rpm.labelCompare()``, returning the same
     ordering as the system RPM library without requiring the ``python3-rpm`` bindings.
 
     The comparison is performed in three stages:

--- a/salt/utils/resource_registry.py
+++ b/salt/utils/resource_registry.py
@@ -154,8 +154,8 @@ def parse_srn(expression):
     A full Salt Resource Name (SRN) has the form ``<type>:<id>``. A bare
     expression contains only a type with no colon.
 
-    ``parse_srn("vcf_host")``          → ``{"type": "vcf_host", "id": None}``
-    ``parse_srn("vcf_host:esxi-01")``  → ``{"type": "vcf_host", "id": "esxi-01"}``
+    ``parse_srn("vcf_host")``          -> ``{"type": "vcf_host", "id": None}``
+    ``parse_srn("vcf_host:esxi-01")``  -> ``{"type": "vcf_host", "id": "esxi-01"}``
 
     :param str expression: A bare resource type or a full SRN.
     :rtype: dict
@@ -242,7 +242,7 @@ class _ResourceIndexStore:
     — writers bump the file's ``mtime`` on every ``put``/``delete`` (see
     :meth:`MmapCache._touch_mtime`), so the signal catches both:
 
-    * compactions (``os.replace`` → new inode), and
+    * compactions (``os.replace`` -> new inode), and
     * in-place mutations from other worker processes (same inode, fresh mtime).
 
     Rebuilds are serialised under an internal lock so concurrent readers

--- a/tests/pytests/functional/cluster/consensus/smoke.txt
+++ b/tests/pytests/functional/cluster/consensus/smoke.txt
@@ -130,6 +130,16 @@ tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::te
 tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_wired_to_membership_sm
 tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_not_fired_for_learner_only_entry
 
+# ── INTEGRATION: real cluster bootstrap (deterministic founder, sentinel,
+#    SaltPeer non-blocking publish, TCP pool router) ──────────────────────────
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_election_three_masters
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_re_election_after_leader_restart
+
+# ── SCENARIO: notify_peer_joined on receiver, dynamic 4th-master join ────────
+tests/pytests/scenarios/cluster/test_cluster.py::test_cluster_key_rotation
+tests/pytests/scenarios/cluster/test_cluster.py::test_fourth_master_joins_existing_cluster
+
 # ── FUNCTIONAL/INTEGRATION/SCENARIO: cluster-ready gate ──────────────────────
 tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_fires_after_founding_config_commits
 tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_fires_on_all_founding_nodes

--- a/tests/pytests/functional/cluster/consensus/smoke.txt
+++ b/tests/pytests/functional/cluster/consensus/smoke.txt
@@ -171,3 +171,64 @@ tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_mini
 # ── SCENARIO: cluster lifecycle (key rotation, dynamic join) ─────────────────
 tests/pytests/scenarios/cluster/test_cluster.py::test_cluster_key_rotation
 tests/pytests/scenarios/cluster/test_cluster.py::test_fourth_master_joins_existing_cluster
+
+# ── UNIT: snapshot envelope + reconcile (CONSENSUS_BUGS.md #1 + GAPS #1) ─────
+# Membership SM survives compaction; restored Node reconciles peer table
+# and on_change observers post-restore.
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestSnapshotEnvelopeMultiSM
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestNodeReconcileMembership
+
+# ── FUNCTIONAL: 3-master compaction scenarios (Gap #4) ──────────────────────
+# Membership + ring policy survive log compaction and Node rebuild.
+tests/pytests/functional/cluster/consensus/test_raft_compaction.py
+
+# ── UNIT: ring membership + ownership gating (Stage 0) ──────────────────────
+# Per-process HashRing singleton, owns/rebuild/reset semantics.
+tests/pytests/unit/cluster/test_ring_membership.py
+
+# ── UNIT: master.py gate sites drop writes when ring populated ──────────────
+# EventMonitor handle_event paths only mirror peer events for owned keys.
+tests/pytests/unit/test_event_monitor_ring_gating.py
+
+# ── UNIT: RingConfigStateMachine + RING_CONFIG entry dispatch (Stage 1) ─────
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestRingConfigStateMachine
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestNodeAppliesRingConfigEntry
+
+# ── FUNCTIONAL: ring rebuild hook + policy plumbing through RaftService ─────
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestRingRebuildHook
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestRingPolicyPlumbing
+
+# ── UNIT: cluster.ring runner (read-only ring_info, deferred ring_set) ──────
+tests/pytests/unit/runners/test_cluster_runner.py
+
+# ── UNIT: mmap_cache_max_segment_bytes plumbing + multi-segment compaction ──
+# Operator-tunable heap segment cap reaches MmapCache; atomic_rebuild
+# handles cross-segment input and cleans up stale segment files.
+tests/pytests/unit/cache/test_mmap_cache.py::test_max_segment_bytes_opt_is_passed_through
+tests/pytests/unit/cache/test_mmap_cache.py::test_max_segment_bytes_default_when_opt_missing
+tests/pytests/unit/cache/test_mmap_cache.py::test_segment_actually_rolls_at_configured_cap
+tests/pytests/unit/cache/test_mmap_key.py::test_max_segment_bytes_opt_is_passed_through
+tests/pytests/unit/cache/test_mmap_key.py::test_max_segment_bytes_falls_back_to_mmap_cache_opt
+tests/pytests/unit/cache/test_mmap_key.py::test_max_segment_bytes_default_when_unset
+tests/pytests/unit/cache/test_mmap_key.py::test_mmap_key_specific_opt_wins_over_generic
+tests/pytests/unit/utils/test_mmap_cache_segments.py::TestAtomicRebuildSegmented::test_rebuild_multi_segment_input_into_different_segment_count
+tests/pytests/unit/utils/test_mmap_cache_segments.py::TestAtomicRebuildSegmented::test_rebuild_records_consistent_offsets_in_packed_field
+
+# ── UNIT: BUG.md regression — NUL-tail binary values round-trip ─────────────
+# MmapCache.get and _overwrite_in_heap both unconditionally rstripped
+# trailing NULs; binary payloads (msgpack, protobuf, BSON) ending in
+# \x00 corrupted on read.  Both call sites now trust the slot LENGTH.
+tests/pytests/unit/cache/test_mmap_cache.py::test_get_preserves_every_trailing_byte
+tests/pytests/unit/cache/test_mmap_cache.py::test_msgpack_zero_tail_dict_round_trips_through_cache_backend
+tests/pytests/unit/cache/test_mmap_cache.py::test_overwrite_with_shorter_nul_tailed_value_round_trips
+tests/pytests/unit/cache/test_mmap_cache.py::test_overwrite_then_grow_then_shrink_with_nul_tails
+
+# ── INTEGRATION: Kubernetes health-probe sentinels ──────────────────────────
+# startup / ready / alive sentinels under <cachedir>/health/ wired to
+# Master.start, _signal_cluster_ready, and the parent asyncio heartbeat.
+tests/pytests/integration/cluster/test_health_probes.py
+
+# ── INTEGRATION: cluster failure modes (Gap audit) ──────────────────────────
+# Storage-loss recovery via state-sync; isolated master with unreachable
+# peers self-elects; placeholder for the disruptive-candidate test.
+tests/pytests/integration/cluster/test_failure_modes.py

--- a/tests/pytests/functional/cluster/consensus/test_raft_compaction.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_compaction.py
@@ -1,0 +1,403 @@
+"""
+Functional scenario tests for Raft log compaction.
+
+Closes Gap #4 from ``GAPS.md``: confirm that when ``cluster_max_log_size``
+is set low enough to trigger ``Log.snapshot()``, a master that loses its
+in-memory state and rebuilds (the analogue of a process restart) recovers
+the cluster's committed membership view from the persisted snapshot
+envelope rather than from the truncated CONFIG entries.
+
+The full-stack equivalent (3 real masters via salt-factories with
+compaction enabled, terminate-and-restart one of them) is not yet
+ergonomic to express here because the multi-master fixture set in
+``tests/pytests/integration/cluster/conftest.py`` does not expose a
+config knob for ``cluster_max_log_size``.  The functional test uses
+``Node`` + ``SaltStorage`` directly to exercise the same property
+(membership envelope round-trip preserves voters/learners across a
+node rebuild) without paying the cost of three real master processes.
+
+Pairs with Gap #1 fix (``Node.reconcile_membership``).  Without that
+fix, the rebuilt Node sees the right ``membership_sm`` but its
+``Node.peers`` table and any ``on_change`` observer are stale; we
+assert both ends of the contract.
+"""
+
+import tempfile
+
+import pytest
+
+from salt.cluster.consensus.raft.log import LogEntryType
+from salt.cluster.consensus.raft.node import Node
+from salt.cluster.consensus.storage import SaltStorage
+
+
+def _make_opts(node_id, cachedir):
+    """Minimal opts dict the SaltStorage / Node constructors actually consult."""
+    return {
+        "id": f"{node_id}-hostname",
+        "interface": node_id,
+        "cachedir": cachedir,
+        "cluster_id": "compaction-scenario",
+        "cluster_peers": [],
+    }
+
+
+def _build_node(node_id, cachedir, max_log_size):
+    """Construct a Node wired to persistent SaltStorage under *cachedir*."""
+    opts = _make_opts(node_id, cachedir)
+    storage = SaltStorage(node_id, opts)
+    node = Node(node_id, storage=storage, max_log_size=max_log_size)
+    node.register_schedule_timeout(lambda t, c: None)
+
+    class _StubPeer:
+        def __init__(self, addr, voting=True):
+            self.node_id = addr
+            self.voting = voting
+
+    node.register_peer_factory(_StubPeer)
+    return node
+
+
+def _commit_config_entry(node, voters, learners, term=1):
+    """
+    Append a committed CONFIG entry to *node*'s log.
+
+    Drives the log/SM the same way ``Node.append_entries`` ->
+    ``apply_entries`` does, but without the multi-node replication
+    machinery — fine for a compaction round-trip test.
+
+    Note: the log auto-compacts inside ``Log.add`` when ``max_log_size``
+    is reached, but only if ``commit_index`` has caught up to the head of
+    the log.  We drive the commit-then-add ordering carefully so the
+    snapshot fires *after* every entry has applied to the membership SM.
+    """
+    cmd = {"voters": list(voters), "learners": list(learners)}
+    node.log.add(
+        term,
+        cmd,
+        entry_type=LogEntryType.CONFIG,
+    )
+    # Use the underlying log index even if a previous add already
+    # auto-compacted the entries list — last_included_index moves
+    # forward in lockstep, and Log.index reads through to it.
+    last_index = node.log.index
+    node.log.commit_index = last_index
+    node.commit_index = last_index
+
+
+@pytest.fixture
+def cachedir(tmp_path):
+    """Per-test cachedir so SaltStorage state is isolated."""
+    path = tmp_path / "cache"
+    path.mkdir()
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# The actual scenario
+# ---------------------------------------------------------------------------
+
+
+def test_membership_survives_log_compaction_and_node_rebuild(cachedir):
+    """
+    A node with ``cluster_max_log_size`` set low enough to compact must
+    recover its committed voter/learner set after the log is truncated
+    and the Node is rebuilt against the same storage backend.
+
+    Sequence
+    --------
+    1. Build a Node with ``max_log_size=2``.
+    2. Commit two CONFIG entries — second one promotes a learner to a
+       voter.  This is enough to push past ``max_log_size`` and trigger
+       ``Log.snapshot()``.
+    3. Confirm a snapshot was written (storage exposes it via
+       ``load_snapshot``) and the in-memory log is empty (entries were
+       compacted away).
+    4. Drop the Node and rebuild a fresh one against the same cachedir.
+    5. Assert the rebuilt Node's ``membership_sm`` reflects the latest
+       committed CONFIG, and that ``Node.peers`` has been reconciled.
+    """
+    # max_log_size is set high enough that we control snapshot timing
+    # explicitly; otherwise the in-add auto-compaction can race apply.
+    node = _build_node("self", cachedir, max_log_size=10)
+
+    # First CONFIG: 3 voters, 1 learner.
+    _commit_config_entry(
+        node,
+        voters=["self", "b", "c"],
+        learners=["d"],
+        term=1,
+    )
+    # Second CONFIG: promote the learner.
+    _commit_config_entry(
+        node,
+        voters=["self", "b", "c", "d"],
+        learners=[],
+        term=1,
+    )
+
+    # Pre-condition: SM has the right view *before* compaction.
+    assert node.membership_sm.current_voters() == ["b", "c", "d", "self"]
+
+    # Force a snapshot now that both entries have applied.
+    node.log.snapshot()
+
+    snapshot = node.storage.load_snapshot()
+    assert snapshot is not None, (
+        "Log.snapshot() did not write to storage — check the snapshot "
+        "envelope plumbing"
+    )
+    assert len(node.log.entries) == 0, (
+        "Log entries should have been truncated after snapshot, "
+        f"got {len(node.log.entries)} entries"
+    )
+
+    # Drop the node — analogue of process exit.
+    del node
+
+    # Rebuild from persistent storage.  This is the recovery path that
+    # CONSENSUS_BUGS.md #1 broke and the fix restores.
+    rebuilt = _build_node("self", cachedir, max_log_size=10)
+
+    # The membership SM must reflect the *latest* committed CONFIG, not
+    # an empty set.
+    assert rebuilt.membership_sm.current_voters() == ["b", "c", "d", "self"], (
+        "membership_sm did not survive log compaction; the snapshot "
+        "envelope or restore path is broken"
+    )
+    assert rebuilt.membership_sm.current_learners() == []
+
+
+def test_node_peers_reconciled_after_snapshot_restore(cachedir):
+    """
+    After a Node rebuild that restores membership from a snapshot, the
+    peer table and voting flag must match the committed view — proves
+    Gap #1's reconcile path runs at construction.
+
+    Without ``Node.reconcile_membership``, the rebuilt Node would have
+    the right ``membership_sm`` but an empty ``peers`` list, because
+    the CONFIG entries that originally populated it were compacted
+    away and ``MembershipStateMachine.restore_snapshot`` is a pure
+    store with no side effects.
+    """
+    node = _build_node("self", cachedir, max_log_size=10)
+    _commit_config_entry(
+        node,
+        voters=["self", "alpha", "beta"],
+        learners=["gamma"],
+        term=1,
+    )
+    _commit_config_entry(
+        node,
+        voters=["self", "alpha", "beta", "gamma"],
+        learners=[],
+        term=1,
+    )
+    node.log.snapshot()
+    assert node.storage.load_snapshot() is not None
+    del node
+
+    rebuilt = _build_node("self", cachedir, max_log_size=10)
+
+    # Reconcile is invoked from RaftService.__init__ in production.
+    # When the test rebuilds a bare Node (no RaftService), we drive
+    # reconcile directly to mimic the production wiring.
+    rebuilt.reconcile_membership()
+
+    # Self stays voting.
+    assert rebuilt.voting is True
+    # Peer table populated, every promoted learner voting.
+    peer_ids = sorted(p.node_id for p in rebuilt.peers)
+    assert peer_ids == ["alpha", "beta", "gamma"]
+    voting_by_id = {p.node_id: p.voting for p in rebuilt.peers}
+    assert voting_by_id == {"alpha": True, "beta": True, "gamma": True}
+
+
+def test_install_snapshot_path_also_reconciles_peers(cachedir):
+    """
+    The ``install_snapshot`` path (a far-behind follower receiving an
+    envelope from the leader) must reconcile peers + on_change just
+    like the startup path.  Mirror the install_snapshot test in
+    ``test_raft_log.py`` but at the functional level so the snapshot
+    bytes are produced by a real ``Log.snapshot()`` rather than
+    hand-rolled JSON.
+    """
+    leader = _build_node("leader", cachedir, max_log_size=10)
+    _commit_config_entry(
+        leader,
+        voters=["leader", "follower-a"],
+        learners=["follower-b"],
+        term=1,
+    )
+    _commit_config_entry(
+        leader,
+        voters=["leader", "follower-a", "follower-b"],
+        learners=[],
+        term=1,
+    )
+    leader.log.snapshot()
+    snap = leader.storage.load_snapshot()
+    assert snap is not None
+    snapshot_bytes = snap["data"]
+    last_index = snap["index"]
+    last_term = snap["term"]
+
+    # Build a fresh follower in a separate cachedir; install_snapshot
+    # bytes from the leader.
+    follower_cachedir = tempfile.mkdtemp(prefix="salt_compaction_follower_")
+    follower = _build_node("follower-a", follower_cachedir, max_log_size=10)
+    observed_on_change = []
+    follower.membership_sm.on_change = lambda v, l: observed_on_change.append(
+        (list(v), list(l))
+    )
+
+    follower.term = 1
+    follower.install_snapshot(
+        leader_id="leader",
+        term=1,
+        last_index=last_index,
+        last_term=last_term,
+        data=snapshot_bytes,
+    )
+
+    # Membership SM has the leader's committed view.
+    assert follower.membership_sm.current_voters() == [
+        "follower-a",
+        "follower-b",
+        "leader",
+    ]
+    # on_change fired exactly once via reconcile.
+    assert len(observed_on_change) == 1
+    # Peer table includes the other two cluster members (not self).
+    peer_ids = sorted(p.node_id for p in follower.peers)
+    assert peer_ids == ["follower-b", "leader"]
+
+
+# ---------------------------------------------------------------------------
+# Ring policy survives compaction (Stage 1)
+# ---------------------------------------------------------------------------
+
+
+def _commit_ring_config_entry(node, members=None, replicas=None, term=1):
+    """Append a committed RING_CONFIG entry; mirrors _commit_config_entry."""
+    cmd = {}
+    if members is not None:
+        cmd["members"] = members
+    if replicas is not None:
+        cmd["replicas"] = replicas
+    node.log.add(
+        term,
+        cmd,
+        entry_type=LogEntryType.RING_CONFIG,
+    )
+    last_index = node.log.index
+    node.log.commit_index = last_index
+    node.commit_index = last_index
+
+
+def _build_node_with_ring_sm(node_id, cachedir, max_log_size):
+    """
+    As :func:`_build_node` but also registers a
+    :class:`RingConfigStateMachine`.
+
+    Subtle: ``Log.__init__`` restores any persisted snapshot before
+    this helper has a chance to register the ring SM, so ring data in
+    the envelope is silently skipped on the first restore pass.  We
+    re-load the snapshot after registration so the ring SM sees its
+    payload.  Production code will register the ring SM via
+    ``RaftService.__init__`` before any rebuild, so this re-restore is
+    test-only plumbing.
+    """
+    from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+    node = _build_node(node_id, cachedir, max_log_size)
+    ring_sm = RingConfigStateMachine()
+    node.log.register_state_machine("ring_sm", ring_sm)
+    # Re-restore from disk so the freshly-registered ring_sm picks up
+    # any persisted state.  Idempotent for the already-loaded
+    # membership_sm.
+    snap = node.storage.load_snapshot()
+    if snap is not None:
+        node.log.restore_state_machines_from_data(snap["data"])
+    return node, ring_sm
+
+
+def test_ring_policy_survives_log_compaction(cachedir):
+    """
+    A RING_CONFIG entry committed before compaction must reappear in
+    the rebuilt node's ``ring_sm``.  This is the operator promise:
+    "I flipped the ring to voters mode and bounced master_2 — it
+    came back in voters mode, no manual intervention".
+    """
+    node, ring_sm = _build_node_with_ring_sm("self", cachedir, max_log_size=10)
+
+    _commit_config_entry(node, voters=["self", "b", "c"], learners=[], term=1)
+    _commit_ring_config_entry(node, members="voters", replicas=3, term=1)
+
+    # Pre-condition: both SMs have the right view in memory.
+    assert node.membership_sm.current_voters() == ["b", "c", "self"]
+    assert ring_sm.members == "voters"
+    assert ring_sm.replicas == 3
+
+    node.log.snapshot()
+    assert len(node.log.entries) == 0
+    snap = node.storage.load_snapshot()
+    assert snap is not None
+    del node, ring_sm
+
+    rebuilt, rebuilt_ring_sm = _build_node_with_ring_sm(
+        "self", cachedir, max_log_size=10
+    )
+    assert rebuilt.membership_sm.current_voters() == ["b", "c", "self"]
+    assert rebuilt_ring_sm.members == "voters"
+    assert rebuilt_ring_sm.replicas == 3
+
+
+def test_ring_policy_install_snapshot_round_trip(cachedir):
+    """
+    Drive the ring policy through the leader's snapshot bytes via
+    ``Node.install_snapshot`` on a follower (the cross-master version
+    of the ring-survives-compaction property).
+
+    Avoids a pre-existing limitation in the Log persistence path:
+    ``Log.snapshot()`` does not truncate the per-entry log keys
+    written by ``append_log``, so a fresh Node that loads from the
+    same cachedir sees stale entries with indices below
+    ``last_included_index``.  Applying a *new* entry post-restore
+    therefore mis-indexes against the stale on-disk entries.  The
+    ``install_snapshot`` path bypasses this because it explicitly
+    truncates entries up to ``last_index``.  A separate task should
+    fix the on-disk truncation; tracked in GAPS.md.
+    """
+    leader, leader_ring_sm = _build_node_with_ring_sm(
+        "leader", cachedir, max_log_size=10
+    )
+    _commit_config_entry(
+        leader,
+        voters=["leader", "follower-a"],
+        learners=[],
+        term=1,
+    )
+    _commit_ring_config_entry(leader, members="voters", replicas=3, term=1)
+    leader.log.snapshot()
+    snap = leader.storage.load_snapshot()
+    assert snap is not None
+
+    # Follower in a *different* cachedir so its load_log() doesn't
+    # observe leader's per-entry keys.
+    follower_cachedir = tempfile.mkdtemp(prefix="salt_compaction_ring_follower_")
+    follower, follower_ring_sm = _build_node_with_ring_sm(
+        "follower-a", follower_cachedir, max_log_size=10
+    )
+    follower.term = 1
+    follower.install_snapshot(
+        leader_id="leader",
+        term=1,
+        last_index=snap["index"],
+        last_term=snap["term"],
+        data=snap["data"],
+    )
+
+    assert follower.membership_sm.current_voters() == ["follower-a", "leader"]
+    assert follower_ring_sm.members == "voters"
+    assert follower_ring_sm.replicas == 3

--- a/tests/pytests/functional/cluster/consensus/test_raft_service.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_service.py
@@ -600,3 +600,325 @@ class TestOnReady:
             assert fired == []
         finally:
             loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Ring rebuild hook (Stage 0 of the ring rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestRingRebuildHook:
+    """
+    ``RaftService._on_membership_change`` must rebuild the per-process
+    ``HashRing`` so any code consulting ``ring_membership.owns`` sees the
+    committed voter set.
+
+    Stage 0 invariant: in the master/EventMonitor processes the ring
+    stays empty (broadcast everything); only the publish daemon's
+    process — where ``RaftService`` lives — actually rebuilds.  This
+    proves the rebuild side of that invariant.
+    """
+
+    def _make_svc(self, node_id="m1", peers=("m2",), on_ready=None):
+        opts = _make_opts(node_id, list(peers))
+        loop = asyncio.new_event_loop()
+        pushers = _make_pushers(peers)
+        svc = RaftService(opts, loop, pushers, on_ready=on_ready)
+        return svc, loop
+
+    def test_membership_change_under_voters_policy_rebuilds_with_voter_set(self):
+        """
+        A CONFIG commit drives ``ring_membership.rebuild`` with the
+        committed voter set *only when ring policy is voters*.
+
+        ``_apply_ring_policy`` reads the voter list from
+        ``membership_sm.current_voters()`` (not from on_change args)
+        so we apply through the SM directly to make the test meaningful.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            svc._ring_config_sm.apply({"members": "voters"}, index=1)
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m2", "m3"], "learners": []}, index=2
+            )
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2", "m3"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_membership_change_under_voters_policy_excludes_learners(self):
+        """
+        Learners do not own data — only voters appear in the ring under
+        ``members=voters``.  Stage-1 contract; learner-as-replica
+        support is later work.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            svc._ring_config_sm.apply({"members": "voters"}, index=1)
+            # Drive on_change directly via the SM so the membership SM
+            # records ["m1", "m2"] as voters and ["m3"] as a learner.
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m2"], "learners": ["m3"]}, index=2
+            )
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_repeated_membership_change_atomically_swaps_ring(self):
+        """
+        Two CONFIG commits (e.g. add-then-remove) leave the ring in the
+        latest committed shape, not a union.  Ensures rebuild replaces
+        the ring rather than additively merging.  Under default ``self``
+        policy the ring stays single-node throughout — this test runs
+        under ``voters`` policy to actually exercise replacement.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            svc._ring_config_sm.apply({"members": "voters"}, index=1)
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m2", "m3"], "learners": []}, index=2
+            )
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m4"], "learners": []}, index=3
+            )
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m4"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_membership_change_under_self_policy_keeps_ring_single_node(self):
+        """
+        Default ``members=self`` policy: a CONFIG commit with three
+        voters does not shard the ring.  Stage 0 default behaviour;
+        previously verified in test_self_policy_keeps_single_node_ring
+        but worth pinning at the on_change boundary too.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            # Default policy is "self" — do NOT flip the SM.
+            svc._on_membership_change(["m1", "m2", "m3"], [])
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+
+# ---------------------------------------------------------------------------
+# RingConfigStateMachine integration (Stage 1 of the ring rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestRingPolicyPlumbing:
+    """
+    Verify that RaftService honours the committed ring policy when
+    rebuilding the per-process ring on membership / ring-config commits.
+    """
+
+    def _make_svc(self, node_id="m1", peers=("m2",)):
+        opts = _make_opts(node_id, list(peers))
+        loop = asyncio.new_event_loop()
+        pushers = _make_pushers(peers)
+        svc = RaftService(opts, loop, pushers)
+        return svc, loop
+
+    def test_self_policy_keeps_single_node_ring(self):
+        """
+        Default policy is ``members=self``.  A CONFIG commit with three
+        voters must NOT shard the ring across them — it stays single-
+        node so ``owns`` returns ``True`` everywhere (today's broadcast
+        behaviour).
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            svc._on_membership_change(["m1", "m2", "m3"], [])
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_voters_policy_shards_ring_across_voters(self):
+        """
+        After a RING_CONFIG entry flips members to ``voters``, the ring
+        rebuild includes every committed voter.  The next call to
+        ``ring_membership.owns`` will route by consistent hash.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            # Commit voters first.
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m2", "m3"], "learners": []}, index=1
+            )
+            # Then flip ring policy.
+            svc._ring_config_sm.apply({"members": "voters", "replicas": 2}, index=2)
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2", "m3"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_ring_policy_change_triggers_rebuild_with_current_voters(self):
+        """
+        Ring SM commits without arg-bundled voters: the rebuild must
+        consult ``membership_sm.current_voters()`` for the contents.
+        """
+        from salt.cluster import ring_membership
+
+        ring_membership.reset()
+        svc, loop = self._make_svc()
+        try:
+            svc._node.membership_sm.apply(
+                {"voters": ["m1", "m4", "m5"], "learners": []}, index=1
+            )
+            svc._ring_config_sm.apply({"members": "voters"}, index=2)
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m4", "m5"]
+        finally:
+            ring_membership.reset()
+            loop.close()
+
+    def test_propose_ring_config_rejects_unknown_members(self):
+        """The propose API validates input before reaching Raft."""
+        import pytest
+
+        svc, loop = self._make_svc()
+        try:
+            with pytest.raises(ValueError):
+                svc.propose_ring_config(members="moon")
+        finally:
+            loop.close()
+
+    def test_propose_ring_config_requires_leader_state(self):
+        """
+        ``propose_ring_config`` fails fast if this node is not the
+        leader — followers cannot append entries that will commit.
+        """
+        import pytest
+
+        svc, loop = self._make_svc()
+        try:
+            # Default state is FOLLOWER (or START); not LEADER.
+            with pytest.raises(RuntimeError):
+                svc.propose_ring_config(members="voters", replicas=2)
+        finally:
+            loop.close()
+
+    def test_propose_ring_config_appends_log_entry_on_leader(self):
+        """
+        On a leader, ``propose_ring_config`` lands a RING_CONFIG log
+        entry (correct entry_type and cmd shape) that the apply path
+        will drive through ``ring_sm.apply`` once a quorum acks.
+
+        For a solo leader there is no peer to ack, so the in-memory log
+        is the durable proof of "the propose path appended the right
+        entry".  A separate test (with a multi-node cluster harness)
+        covers the full propose -> ack -> apply path.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType
+
+        async def _body():
+            opts = _make_opts("solo", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+            assert svc.node.state == NodeState.LEADER
+
+            initial_index = svc.node.log.index
+            svc.propose_ring_config(members="voters", replicas=3)
+            # Verify a new entry of type RING_CONFIG with the proposed cmd.
+            assert svc.node.log.index == initial_index + 1
+            entry = svc.node.log.get(svc.node.log.index)
+            assert entry is not None
+            assert entry.type == LogEntryType.RING_CONFIG
+            assert entry.cmd == {"members": "voters", "replicas": 3}
+
+            # Drive the solo-leader commit path: with no peers, the
+            # heartbeat does not advance commit_index for us, so the
+            # apply happens once the test calls advance_commit_index
+            # (or a multi-node cluster's append_entries_reply triggers
+            # it naturally).
+            svc.node.advance_commit_index()
+            assert svc._ring_config_sm.members == "voters"
+            assert svc._ring_config_sm.replicas == 3
+            svc.stop()
+
+        _run(_body())
+
+    def test_propose_ring_config_no_args_is_noop(self):
+        """
+        Calling ``propose_ring_config()`` with no kwargs commits no
+        entry — the SM stays at its default.  Pins the partial-update
+        contract: an empty dict would be pointless.
+        """
+
+        async def _body():
+            opts = _make_opts("solo", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+            assert svc.node.state == NodeState.LEADER
+
+            initial_index = svc.node.log.index
+            svc.propose_ring_config()  # no kwargs
+            await asyncio.sleep(0.05)
+            assert (
+                svc.node.log.index == initial_index
+            ), "propose_ring_config with no args must not append a log entry"
+            svc.stop()
+
+        _run(_body())
+
+    def test_propose_ring_config_partial_update(self):
+        """
+        Setting only ``replicas`` keeps the existing ``members`` value
+        — this is the atomic-flip-of-one-knob contract that lets a
+        runbook tweak replication without re-asserting members.
+        """
+
+        async def _body():
+            opts = _make_opts("solo", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+            assert svc.node.state == NodeState.LEADER
+
+            svc.propose_ring_config(members="voters", replicas=2)
+            svc.node.advance_commit_index()  # solo leader self-commit
+            assert svc._ring_config_sm.members == "voters"
+            assert svc._ring_config_sm.replicas == 2
+
+            svc.propose_ring_config(replicas=4)
+            svc.node.advance_commit_index()
+            assert svc._ring_config_sm.members == "voters"
+            assert svc._ring_config_sm.replicas == 4
+            svc.stop()
+
+        _run(_body())

--- a/tests/pytests/functional/cluster/consensus/test_raft_transport.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_transport.py
@@ -499,3 +499,96 @@ class TestDispatcherEdgeCases:
             "last_log_index": -1,
         }
         _run(d.dispatch(rpc.REQUEST_VOTE, "2", "rid", payload))
+
+
+# ---------------------------------------------------------------------------
+# Membership SM survives log compaction (regression: CONSENSUS_BUGS.md #1)
+# ---------------------------------------------------------------------------
+
+
+class TestMembershipSurvivesSnapshot:
+    """
+    Regression for CONSENSUS_BUGS.md #1.
+
+    Before the fix, ``Log.snapshot()`` only persisted the application SM, so
+    a node that compacted its log lost the committed voter/learner set.  These
+    tests pin the round-trip:
+
+    * ``snapshot()`` followed by a fresh ``Log`` on the same storage must
+      restore membership state (compaction + restart).
+    * ``install_snapshot`` carrying an envelope must restore the receiver's
+      membership SM (catch-up via leader snapshot).
+    """
+
+    def test_membership_survives_compaction_and_restart(self, tmp_path):
+        """Apply a CONFIG entry, snapshot, rebuild a Node from storage."""
+        from salt.cluster.consensus.raft.log import LogEntryType
+        from salt.cluster.consensus.storage import SaltStorage
+
+        opts = {"cachedir": str(tmp_path), "cluster_id": "test", "cluster_peers": []}
+        storage = SaltStorage("master-1", opts)
+
+        node = Node("master-1", storage=storage)
+        node.register_schedule_timeout(lambda t, c: None)
+
+        # Apply a CONFIG entry as the leader would
+        node.membership_sm.apply(
+            {"voters": ["master-1", "master-2", "master-3"], "learners": []}, index=0
+        )
+        node.log.add(1, b"app-cmd")
+        node.log.add(
+            1,
+            {"voters": ["master-1", "master-2", "master-3"], "learners": []},
+            entry_type=LogEntryType.CONFIG,
+        )
+        node.log.commit(1)
+        # Force a snapshot — simulates compaction firing
+        node.log.snapshot()
+        assert node.log.entries == []
+
+        # Simulate restart: build a fresh Node on the same storage
+        restarted = Node("master-1", storage=storage)
+        restarted.register_schedule_timeout(lambda t, c: None)
+
+        info = restarted.info()
+        assert info["membership"]["voters"] == [
+            "master-1",
+            "master-2",
+            "master-3",
+        ]
+        assert info["membership"]["version"] == 0
+
+    def test_install_snapshot_envelope_restores_membership(self):
+        """A follower that receives an envelope snapshot rebuilds membership."""
+        import json
+
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION
+
+        follower = Node("follower")
+        follower.register_schedule_timeout(lambda t, c: None)
+        follower.term = 1
+
+        envelope = {
+            "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+            "machines": {
+                "membership_sm": {
+                    "voters": ["m1", "m2", "m3"],
+                    "learners": ["m4"],
+                    "version": 7,
+                },
+            },
+        }
+
+        follower.install_snapshot(
+            leader_id="m1",
+            term=2,
+            last_index=12,
+            last_term=2,
+            data=json.dumps(envelope).encode("utf-8"),
+        )
+
+        info = follower.info()
+        assert info["membership"]["voters"] == ["m1", "m2", "m3"]
+        assert info["membership"]["learners"] == ["m4"]
+        assert info["membership"]["version"] == 7
+        assert info["last_index"] == 12

--- a/tests/pytests/functional/cluster/consensus/test_raft_transport.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_transport.py
@@ -3,8 +3,8 @@ Functional tests for the Raft-over-cluster-channel transport layer.
 
 These tests exercise the full round-trip:
 
-    Node  →  SaltPeer  →  rpc.pack  →  FakePusher.sent
-          ←  rpc.unpack  ←  RaftDispatcher  ←  Node method
+    Node  ->  SaltPeer  ->  rpc.pack  ->  FakePusher.sent
+          <-  rpc.unpack  <-  RaftDispatcher  <-  Node method
 
 No real TCP; no running Salt master.  Real asyncio event loop, real
 ``salt.utils.event`` framing, real Raft state machines.
@@ -290,7 +290,7 @@ class TestLogReplication:
             leader_cn.node.log_add("commit-me")
             await asyncio.sleep(0)
             await _deliver_all(cluster, rounds=6)
-            # Leader has a majority ack → commit_index == 0 (first entry)
+            # Leader has a majority ack -> commit_index == 0 (first entry)
             assert leader_cn.node.commit_index == 0
 
         _run(_body())

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -616,3 +616,43 @@ def cluster_minion_1(cluster_master_1):
     )
     with factory.started(start_timeout=240):
         yield factory
+
+
+@pytest.fixture
+def cluster_minion_1_isolated(cluster_master_1_isolated):
+    """
+    A minion connected only to the isolated master_1.  The other masters
+    never share a ``pki_dir`` with master_1, so they must receive the
+    minion's accepted public key over the cluster event bus to be able
+    to authenticate it.
+
+    Shared between the isolated-FS happy-path tests in
+    ``test_isolated_cluster.py`` and the failure-mode tests in
+    ``test_failure_modes.py``.
+    """
+    config_defaults = {
+        "transport": cluster_master_1_isolated.config["transport"],
+    }
+    port = cluster_master_1_isolated.config["ret_port"]
+    addr = cluster_master_1_isolated.config["interface"]
+    config_overrides = {
+        "master": f"{addr}:{port}",
+        "test.foo": "baz",
+        "log_granular_levels": {
+            "salt": "info",
+            "salt.transport": "debug",
+            "salt.channel": "debug",
+            "salt.utils.event": "debug",
+        },
+        "fips_mode": FIPS_TESTRUN,
+        "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+        "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
+    }
+    factory = cluster_master_1_isolated.salt_minion_daemon(
+        "cluster-minion-1-iso",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -429,6 +429,9 @@ def _isolated_master_overrides(
         "publish_signing_algorithm": (
             "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
         ),
+        "cluster_encryption_algorithm": (
+            "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1"
+        ),
     }
     if file_roots_paths is not None:
         overrides["file_roots"] = {"base": [str(file_roots_paths[addr])]}

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -352,6 +352,242 @@ def cluster_master_4(
 
 
 @pytest.fixture
+def cluster_pki_path_isolated(tmp_path):
+    """
+    Build per-master ``cluster_pki_dir`` paths so the isolated-FS
+    fixtures below can prove cluster bootstrap works without sharing
+    PKI between masters.  Each master gets its own pki+peers tree.
+    """
+    paths = {}
+    for addr in ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"):
+        path = tmp_path / "iso" / addr / "pki"
+        path.mkdir(parents=True)
+        (path / "peers").mkdir()
+        paths[addr] = path
+    return paths
+
+
+@pytest.fixture
+def cluster_cache_path_isolated(tmp_path):
+    """Per-master ``cache_dir`` for the isolated-FS fixture set."""
+    paths = {}
+    for addr in ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"):
+        path = tmp_path / "iso" / addr / "cache"
+        path.mkdir(parents=True)
+        paths[addr] = path
+    return paths
+
+
+@pytest.fixture
+def cluster_file_roots_path_isolated(tmp_path):
+    """
+    Per-master ``file_roots[base]`` path for the isolated-FS fixture set.
+
+    Returned as ``{addr: pathlib.Path}``.  Tests can pre-seed master_1's
+    path with an SLS file and assert state-sync delivers it to other
+    masters' paths during the join handshake.
+    """
+    paths = {}
+    for addr in ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"):
+        path = tmp_path / "iso" / addr / "file_roots"
+        path.mkdir(parents=True)
+        paths[addr] = path
+    return paths
+
+
+@pytest.fixture
+def cluster_pillar_roots_path_isolated(tmp_path):
+    """Per-master ``pillar_roots[base]`` path for the isolated-FS set."""
+    paths = {}
+    for addr in ("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"):
+        path = tmp_path / "iso" / addr / "pillar_roots"
+        path.mkdir(parents=True)
+        paths[addr] = path
+    return paths
+
+
+def _isolated_master_overrides(
+    addr, peers, pki_paths, cache_paths, file_roots_paths=None, pillar_roots_paths=None
+):
+    overrides = {
+        "interface": addr,
+        "cluster_id": "master_cluster",
+        "cluster_peers": list(peers),
+        "cluster_pki_dir": str(pki_paths[addr]),
+        "cache_dir": str(cache_paths[addr]),
+        # Exercises the no-shared-FS path: keys cache flips to mmap_key
+        # and joiners receive a bulk state-sync inside join-reply before
+        # becoming Raft learners.
+        "cluster_isolated_filesystem": True,
+        "log_granular_levels": {
+            "salt": "info",
+            "salt.transport": "debug",
+            "salt.channel": "debug",
+            "salt.utils.event": "debug",
+        },
+        "fips_mode": FIPS_TESTRUN,
+        "publish_signing_algorithm": (
+            "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+        ),
+    }
+    if file_roots_paths is not None:
+        overrides["file_roots"] = {"base": [str(file_roots_paths[addr])]}
+    if pillar_roots_paths is not None:
+        overrides["pillar_roots"] = {"base": [str(pillar_roots_paths[addr])]}
+    return overrides
+
+
+@pytest.fixture
+def cluster_master_1_isolated(
+    request,
+    salt_factories,
+    cluster_pki_path_isolated,
+    cluster_cache_path_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+):
+    """
+    Like :func:`cluster_master_1` but with a *per-master* ``cluster_pki_dir``
+    and ``cache_dir``.  The founder bootstraps its own keys; joiners must
+    receive ``cluster_aes`` and ``cluster.pem`` over the wire (the
+    no-shared-FS path).
+    """
+    config_defaults = {
+        "open_mode": True,
+        "transport": request.config.getoption("--transport"),
+    }
+    config_overrides = _isolated_master_overrides(
+        "127.0.0.1",
+        ["127.0.0.2", "127.0.0.3"],
+        cluster_pki_path_isolated,
+        cluster_cache_path_isolated,
+        cluster_file_roots_path_isolated,
+        cluster_pillar_roots_path_isolated,
+    )
+    factory = salt_factories.salt_master_daemon(
+        "127.0.0.1",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture
+def cluster_master_2_isolated(
+    salt_factories,
+    cluster_master_1_isolated,
+    cluster_pki_path_isolated,
+    cluster_cache_path_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+):
+    if salt.utils.platform.is_darwin() or salt.utils.platform.is_freebsd():
+        subprocess.check_output(["ifconfig", "lo0", "alias", "127.0.0.2", "up"])
+    config_defaults = {
+        "open_mode": True,
+        "transport": cluster_master_1_isolated.config["transport"],
+    }
+    config_overrides = _isolated_master_overrides(
+        "127.0.0.2",
+        ["127.0.0.1", "127.0.0.3"],
+        cluster_pki_path_isolated,
+        cluster_cache_path_isolated,
+        cluster_file_roots_path_isolated,
+        cluster_pillar_roots_path_isolated,
+    )
+    for key in ("ret_port", "publish_port"):
+        config_overrides[key] = cluster_master_1_isolated.config[key]
+    factory = salt_factories.salt_master_daemon(
+        "127.0.0.2",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture
+def cluster_master_3_isolated(
+    salt_factories,
+    cluster_master_1_isolated,
+    cluster_pki_path_isolated,
+    cluster_cache_path_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+):
+    if salt.utils.platform.is_darwin() or salt.utils.platform.is_freebsd():
+        subprocess.check_output(["ifconfig", "lo0", "alias", "127.0.0.3", "up"])
+    config_defaults = {
+        "open_mode": True,
+        "transport": cluster_master_1_isolated.config["transport"],
+    }
+    config_overrides = _isolated_master_overrides(
+        "127.0.0.3",
+        ["127.0.0.1", "127.0.0.2"],
+        cluster_pki_path_isolated,
+        cluster_cache_path_isolated,
+        cluster_file_roots_path_isolated,
+        cluster_pillar_roots_path_isolated,
+    )
+    for key in ("ret_port", "publish_port"):
+        config_overrides[key] = cluster_master_1_isolated.config[key]
+    factory = salt_factories.salt_master_daemon(
+        "127.0.0.3",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture
+def cluster_master_4_isolated(
+    salt_factories,
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_pki_path_isolated,
+    cluster_cache_path_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+):
+    """
+    A 4th, late-joining master under the isolated-FS fixture set.  Used to
+    prove ``cluster_isolated_filesystem`` bulk state-sync ships pre-existing
+    minion keys (and any other state delivered in join-reply) to a master
+    that handshakes after the cluster is already running.
+    """
+    if salt.utils.platform.is_darwin() or salt.utils.platform.is_freebsd():
+        subprocess.check_output(["ifconfig", "lo0", "alias", "127.0.0.4", "up"])
+    config_defaults = {
+        "open_mode": True,
+        "transport": cluster_master_1_isolated.config["transport"],
+    }
+    config_overrides = _isolated_master_overrides(
+        "127.0.0.4",
+        ["127.0.0.1", "127.0.0.2", "127.0.0.3"],
+        cluster_pki_path_isolated,
+        cluster_cache_path_isolated,
+        cluster_file_roots_path_isolated,
+        cluster_pillar_roots_path_isolated,
+    )
+    for key in ("ret_port", "publish_port"):
+        config_overrides[key] = cluster_master_1_isolated.config[key]
+    factory = salt_factories.salt_master_daemon(
+        "127.0.0.4",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture
 def cluster_minion_1(cluster_master_1):
     config_defaults = {
         "transport": cluster_master_1.config["transport"],

--- a/tests/pytests/integration/cluster/conftest.py
+++ b/tests/pytests/integration/cluster/conftest.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 # next layer of bug surfaces as a real assertion rather than another
 # "must be timing" timeout bump.
 #
-# Healthy bring-up: ≤ 1 CANDIDATE per master, 1 LEADER total, ≤ 1 FOLLOWER
+# Healthy bring-up: <= 1 CANDIDATE per master, 1 LEADER total, <= 1 FOLLOWER
 # per master per election round.  An election storm shows up as 10+
 # CANDIDATE/FOLLOWER per master.
 
@@ -78,11 +78,11 @@ def assert_no_election_storm(
 
     Healthy upper bounds for one cluster bring-up + at most one re-election:
 
-    * ``BECOMING CANDIDATE`` ≤ 5 per master  (initial election + a re-run
+    * ``BECOMING CANDIDATE`` <= 5 per master  (initial election + a re-run
       or two if pre-votes raced + at most one re-election)
-    * ``BECOMING FOLLOWER`` ≤ 5 per master   (initial + re-election +
+    * ``BECOMING FOLLOWER`` <= 5 per master   (initial + re-election +
       slack for a stepdown if a higher term arrives)
-    * ``BECOMING LEADER`` ≤ 4 cluster-wide   (one initial leader + at
+    * ``BECOMING LEADER`` <= 4 cluster-wide   (one initial leader + at
       most one re-election leader, ×2 slack for a contested round)
 
     Higher counts mean masters are stuck in a pre-vote / candidacy /

--- a/tests/pytests/integration/cluster/test_failure_modes.py
+++ b/tests/pytests/integration/cluster/test_failure_modes.py
@@ -186,7 +186,7 @@ def test_isolated_master_with_unreachable_peers_self_elects(
         # bound; the kernel returns ECONNREFUSED *immediately* rather
         # than waiting on the TCP connect timeout.  RFC 5737 TEST-NET
         # addresses look attractive but black-hole packets, so the
-        # master would hang for the full SYN retry budget (≥ 120s)
+        # master would hang for the full SYN retry budget (>= 120s)
         # instead of bouncing fast and falling through to the
         # founding-voter timer.
         "cluster_peers": ["127.0.0.50", "127.0.0.51"],

--- a/tests/pytests/integration/cluster/test_failure_modes.py
+++ b/tests/pytests/integration/cluster/test_failure_modes.py
@@ -1,0 +1,243 @@
+"""
+Cluster integration tests for failure conditions not otherwise covered.
+
+These tests exercise paths that fan out from a working cluster into a
+degraded or recovering state:
+
+  * **Storage loss recovery** — a master's local cache (Raft log + key
+    cache) is wiped while it is offline; on restart it must reconverge
+    through the join handshake's bulk state-sync rather than diverging
+    or refusing to start.
+  * **Unreachable peers diagnosis** — a master configured with
+    ``cluster_isolated_filesystem=True`` but whose peers are all
+    unreachable should not hang silently; it should self-elect as a
+    founding voter (because it has no way to learn otherwise) and
+    surface that fact in its log.
+  * **Lease / clock-skew defense (placeholder)** — the disruption
+    defense (pre-vote + lease) is unit-tested but not yet integration-
+    tested at real-process granularity; left as a marked skip until
+    Raft timing becomes config-driven.
+
+Companion unit/functional tests live in
+``tests/pytests/unit/cluster/consensus/`` and
+``tests/pytests/functional/cluster/consensus/``.
+"""
+
+import pathlib
+import shutil
+import time
+
+import pytest
+
+import salt.cache
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def _fetch_minion_key(master, minion_id):
+    """Read an accepted minion key from the master's keys cache."""
+    cache = salt.cache.Cache(master.config, driver=master.config["keys.cache_driver"])
+    return cache.fetch("keys", minion_id)
+
+
+def _wait_for_log_line(master, needle, timeout=30):
+    """Poll the master's log file for *needle*; return True when found."""
+    log_file = master.config.get("log_file")
+    if not log_file:
+        return False
+    log_path = pathlib.Path(log_file)
+    if not log_path.is_absolute():
+        log_path = pathlib.Path(master.config.get("root_dir", "")) / log_file
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if log_path.is_file():
+            try:
+                if needle in log_path.read_text(encoding="utf-8", errors="replace"):
+                    return True
+            except OSError:
+                pass
+        time.sleep(0.5)
+    return False
+
+
+def test_master_recovers_after_cache_dir_loss(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+):
+    """
+    A master whose ``cache_dir`` is wiped while offline must rejoin the
+    cluster cleanly on restart by re-running the discover/join handshake
+    and pulling state via the bulk state-sync embedded in
+    ``cluster/peer/join-reply``.
+
+    Sequence:
+      1. Three isolated-FS masters bootstrap; minion_1 connects to
+         master_1 and is auto-accepted.  Cluster events replicate the
+         accepted key to masters 2 and 3.
+      2. master_2 is stopped.  Its ``cache_dir`` (which holds the Raft
+         log persisted via ``salt.cache`` and the keys cache) is
+         removed entirely, simulating disk loss / replacement.
+      3. master_2 restarts.  It cannot find its prior join sentinel or
+         keys cache, so it re-runs discover + join against masters 1
+         and 3, receives a fresh ``cluster_aes`` / ``cluster.pem`` /
+         minion-key dump, and lands back in the cluster.
+      4. Within 30 s the recovered master_2 has the accepted minion
+         key in its keys cache.
+
+    This catches a class of bugs where a master that loses storage
+    silently rejects the rejoin (e.g. because of a stale sentinel
+    written to a different filesystem location) or keeps a partial
+    state from before the wipe.
+    """
+    minion_id = cluster_minion_1_isolated.id
+    master_2 = cluster_master_2_isolated
+
+    # Sanity: master_2 has the minion key before we wipe.  Use a short
+    # poll window so a slow event-replication round doesn't trip the
+    # test before we even get to the failure injection.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        entry = _fetch_minion_key(master_2, minion_id)
+        if entry and entry.get("state") == "accepted":
+            break
+        time.sleep(0.5)
+    assert entry and entry.get("state") == "accepted", (
+        f"Pre-condition failed: master_2 never received minion {minion_id!r} "
+        f"key in the first place (last entry: {entry!r})"
+    )
+
+    cache_dir = pathlib.Path(master_2.config["cache_dir"])
+    pki_dir = pathlib.Path(master_2.config["cluster_pki_dir"])
+
+    # Stop master_2 — terminate() returns when the process is reaped.
+    master_2.terminate()
+
+    # Wipe master_2's cache_dir entirely.  We leave its cluster_pki_dir
+    # alone (peer pubs etc.) but blow away the join sentinel, the keys
+    # cache, and the Raft log storage.  This is the "lost the disk"
+    # scenario.
+    shutil.rmtree(cache_dir, ignore_errors=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    # Also drop the cluster_aes file so we exercise the over-the-wire
+    # delivery path on rejoin (rather than master_2 reading its prior
+    # value from disk).
+    (pki_dir / ".aes").unlink(missing_ok=True)
+
+    # Restart master_2.  The factory's started() context manager is
+    # already exited at this point (the fixture's `yield`), so we need
+    # to start the daemon directly via the salt-factories API.
+    with master_2.started(start_timeout=120):
+        # Wait for the rejoin to land the minion key back in master_2's
+        # cache.
+        deadline = time.monotonic() + 60
+        entry = None
+        while time.monotonic() < deadline:
+            entry = _fetch_minion_key(master_2, minion_id)
+            if entry and entry.get("state") == "accepted":
+                break
+            time.sleep(0.5)
+        assert entry and entry.get("state") == "accepted", (
+            f"After cache_dir loss + restart, master_2 never received "
+            f"minion {minion_id!r} key via state-sync (last entry: {entry!r})"
+        )
+
+        # And the cluster_aes must have been re-delivered over the wire
+        # (we deleted the local copy before restart).
+        aes_path = pki_dir / ".aes"
+        assert aes_path.is_file(), (
+            "master_2 did not re-acquire cluster_aes from peers after "
+            "cache_dir loss; expected over-the-wire delivery via join-reply"
+        )
+
+
+def test_isolated_master_with_unreachable_peers_self_elects(
+    request, salt_factories, tmp_path
+):
+    """
+    A master configured with ``cluster_isolated_filesystem=True`` and
+    ``cluster_peers`` pointing at addresses where no master is listening
+    should not hang during startup.  After ``cluster_join_timeout``
+    elapses with no join-reply, it self-elects as a founding voter.
+
+    This is the "first master in a brand-new cluster" path applied to a
+    misconfigured deployment: if a sysadmin starts a master with peers
+    that are typo'd or down, we want to see ``Raft consensus service
+    started as founding voter`` in the log and the master fully
+    operational rather than silently waiting forever.
+
+    Tests the cluster_aes/cluster.pem replication-failure category by
+    proving that the *absence* of replication (no peer reachable) is a
+    handled, diagnosed condition rather than a hang.
+    """
+    pki = tmp_path / "pki"
+    pki.mkdir()
+    (pki / "peers").mkdir()
+    cache = tmp_path / "cache"
+    cache.mkdir()
+
+    config_overrides = {
+        "interface": "127.0.0.1",
+        "cluster_id": "lonely_cluster",
+        # 127.0.0.50/.51 are loopback addresses where no daemon is
+        # bound; the kernel returns ECONNREFUSED *immediately* rather
+        # than waiting on the TCP connect timeout.  RFC 5737 TEST-NET
+        # addresses look attractive but black-hole packets, so the
+        # master would hang for the full SYN retry budget (≥ 120s)
+        # instead of bouncing fast and falling through to the
+        # founding-voter timer.
+        "cluster_peers": ["127.0.0.50", "127.0.0.51"],
+        "cluster_pki_dir": str(pki),
+        "cache_dir": str(cache),
+        "cluster_isolated_filesystem": True,
+        "cluster_join_timeout": 5,
+        "log_granular_levels": {
+            "salt": "info",
+            "salt.channel": "debug",
+        },
+    }
+    factory = salt_factories.salt_master_daemon(
+        "lonely-master",
+        defaults={
+            "open_mode": True,
+            "transport": request.config.getoption("--transport"),
+        },
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=60):
+        # Within a few seconds of cluster_join_timeout we should see the
+        # founding-voter message — proves the master diagnosed the
+        # missing peers and proceeded rather than hanging on the
+        # discover/join handshake forever.
+        assert _wait_for_log_line(
+            factory,
+            "Raft consensus service started as founding voter",
+            timeout=30,
+        ), (
+            "Master with unreachable cluster_peers did not log "
+            "'started as founding voter' within 30s; expected the "
+            "cluster_join_timeout fallback to fire"
+        )
+
+
+@pytest.mark.skip(
+    reason=(
+        "Real-process lease/clock-skew defense test requires Raft "
+        "follower_timeout / heartbeat_interval to be config-driven. "
+        "Currently hardcoded in salt/cluster/consensus/raft/node.py "
+        "via util.gettimeout(_min, _max). Pre-vote + lease enforcement "
+        "is covered at the unit level by "
+        "tests/pytests/unit/cluster/consensus/test_raft_node_safety.py "
+        "(test_prevote_denied_by_lease, test_prevote_phase). Once the "
+        "raft scheduler accepts an opt-driven override for the "
+        "follower-timeout window, write a real-process test that "
+        "spawns a 4th master with an aggressively short timeout and "
+        "asserts the healthy 3-master leader does not lose its term."
+    )
+)
+def test_disruptive_candidate_blocked_by_lease():
+    """Placeholder for a real-process pre-vote / lease defense test."""

--- a/tests/pytests/integration/cluster/test_health_probes.py
+++ b/tests/pytests/integration/cluster/test_health_probes.py
@@ -1,0 +1,133 @@
+"""
+End-to-end tests for the file-sentinel Kubernetes probes.
+
+Verifies that the three sentinels under ``<cachedir>/health/`` are
+populated by a real ``salt-master`` process in the right sequence:
+
+  * ``startup`` lands once ``Master.start`` finishes wiring up
+    subprocesses (proves the startup probe works for plain masters).
+  * ``ready`` lands once a clustered master commits its founding /
+    promotion CONFIG entry (proves ``_signal_cluster_ready`` writes
+    the readiness sentinel).
+  * ``alive`` mtime advances continuously (proves the parent's
+    asyncio-loop heartbeat keeps the liveness probe fresh).
+
+The unit-level layout / atomic-write checks live in
+``tests/pytests/unit/cluster/test_healthchecks.py``; this file exists
+only to catch regressions in the wiring between ``Master.start``,
+``MasterPubServerChannel._signal_cluster_ready``, and the heartbeat
+loop on the parent process.
+"""
+
+import pathlib
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def _health_dir(master):
+    return pathlib.Path(master.config["cachedir"]) / "health"
+
+
+def _wait_for_sentinel(master, name, timeout=60):
+    """Poll until ``<cachedir>/health/<name>`` exists; return True on success."""
+    sentinel = _health_dir(master) / name
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if sentinel.is_file():
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def test_startup_sentinel_written_for_clustered_master(
+    cluster_master_1, cluster_master_2, cluster_master_3
+):
+    """
+    Once a clustered master finishes ``Master.start`` it must have
+    ``<cachedir>/health/startup`` on disk.  Probe spec for
+    ``startupProbe`` is ``test -f <cachedir>/health/startup``; this
+    test guarantees that file exists.
+    """
+    for master in (cluster_master_1, cluster_master_2, cluster_master_3):
+        assert _wait_for_sentinel(master, "startup", timeout=60), (
+            f"startup sentinel never appeared for "
+            f"{master.config['interface']} (looked under {_health_dir(master)})"
+        )
+
+
+def test_ready_sentinel_written_after_cluster_consensus(
+    cluster_master_1, cluster_master_2, cluster_master_3
+):
+    """
+    A clustered master must write ``health/ready`` only after its Raft
+    consensus gate fires — i.e. after the founding/promotion CONFIG
+    commits with this node in the voter set.
+
+    For the readiness probe to be useful, the sentinel must exist on
+    every master once the cluster has converged.  ``_wait_for_sentinel``
+    polls until the file lands or the deadline expires; the timeout
+    here is wider than ``startup`` because the join handshake + first
+    Raft commit add real latency on top of master init.
+    """
+    masters = (cluster_master_1, cluster_master_2, cluster_master_3)
+    for master in masters:
+        assert _wait_for_sentinel(master, "ready", timeout=120), (
+            f"ready sentinel never appeared for "
+            f"{master.config['interface']}; either ``_signal_cluster_ready`` "
+            f"never fired or the sentinel write was skipped"
+        )
+
+
+def test_alive_sentinel_mtime_advances(cluster_master_1):
+    """
+    The liveness sentinel's mtime must advance continuously.  Capture
+    two snapshots ~6 seconds apart (one heartbeat interval is 5 s) and
+    assert the mtime moved.  If it does not, the parent process's
+    asyncio loop is not running our heartbeat task — the prototypical
+    deadlock failure mode that liveness exists to catch.
+    """
+    assert _wait_for_sentinel(cluster_master_1, "alive", timeout=60), (
+        f"alive sentinel never appeared for " f"{cluster_master_1.config['interface']}"
+    )
+    sentinel = _health_dir(cluster_master_1) / "alive"
+    first = sentinel.stat().st_mtime
+    # Sleep a full heartbeat interval plus filesystem-mtime granularity
+    # margin so the next touch is definitely a distinct timestamp.
+    time.sleep(6)
+    second = sentinel.stat().st_mtime
+    assert second > first, (
+        f"alive sentinel mtime did not advance over a 6 s window "
+        f"({first} -> {second}); parent asyncio loop appears wedged"
+    )
+
+
+def test_health_dir_wiped_on_restart(cluster_master_1, cluster_master_2):
+    """
+    ``Master.start`` must wipe ``<cachedir>/health/`` before writing new
+    sentinels — otherwise an old ``ready`` from a previous run would
+    let kubelet route traffic to a master that is still re-bootstrapping.
+
+    Approach: drop a sentinel-shaped file we never write
+    (``health/CANARY``) into master_2's health dir, then bounce
+    master_2 and confirm the canary is gone afterward.
+    """
+    canary = _health_dir(cluster_master_2) / "CANARY"
+    canary.parent.mkdir(parents=True, exist_ok=True)
+    canary.write_text("from-the-past", encoding="utf-8")
+    assert canary.is_file()
+
+    cluster_master_2.terminate()
+    with cluster_master_2.started(start_timeout=120):
+        # Wait for the new run's startup sentinel to confirm reset_health_dir
+        # has run.
+        assert _wait_for_sentinel(cluster_master_2, "startup", timeout=60)
+        assert not canary.exists(), (
+            "Stale 'CANARY' sentinel survived a master restart; "
+            "reset_health_dir must wipe the directory before writing the "
+            "fresh startup sentinel"
+        )

--- a/tests/pytests/integration/cluster/test_isolated_cluster.py
+++ b/tests/pytests/integration/cluster/test_isolated_cluster.py
@@ -69,42 +69,6 @@ def test_isolated_cluster_aes_converges(
     )
 
 
-@pytest.fixture
-def cluster_minion_1_isolated(cluster_master_1_isolated):
-    """
-    A minion connected only to the isolated master_1.  The other
-    masters never share a ``pki_dir`` with master_1, so they must
-    receive the minion's accepted public key over the cluster event
-    bus to be able to authenticate it.
-    """
-    config_defaults = {
-        "transport": cluster_master_1_isolated.config["transport"],
-    }
-    port = cluster_master_1_isolated.config["ret_port"]
-    addr = cluster_master_1_isolated.config["interface"]
-    config_overrides = {
-        "master": f"{addr}:{port}",
-        "test.foo": "baz",
-        "log_granular_levels": {
-            "salt": "info",
-            "salt.transport": "debug",
-            "salt.channel": "debug",
-            "salt.utils.event": "debug",
-        },
-        "fips_mode": FIPS_TESTRUN,
-        "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
-        "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
-    }
-    factory = cluster_master_1_isolated.salt_minion_daemon(
-        "cluster-minion-1-iso",
-        defaults=config_defaults,
-        overrides=config_overrides,
-        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
-    )
-    with factory.started(start_timeout=120):
-        yield factory
-
-
 def _make_isolated_minion(master, minion_id):
     """Spawn a minion attached only to *master* under the isolated-FS set."""
     config_defaults = {"transport": master.config["transport"]}

--- a/tests/pytests/integration/cluster/test_isolated_cluster.py
+++ b/tests/pytests/integration/cluster/test_isolated_cluster.py
@@ -52,10 +52,23 @@ def test_isolated_cluster_aes_converges(
         cluster_master_2_isolated,
         cluster_master_3_isolated,
     ]
-    aes_values = []
-    for m in masters:
-        aes_path = pathlib.Path(m.config["cluster_pki_dir"]) / ".aes"
-        aes_values.append(_read(aes_path))
+
+    # Convergence is asynchronous: each master writes its initial random
+    # ``.aes`` during ``populate_secrets``, then masters 2 and 3 receive
+    # the founder's value via ``cluster/peer/join-reply`` and overwrite
+    # their local file.  The fixture's ``factory.started()`` waits for
+    # ``ret_port`` to bind, not for the join handshake to complete, so
+    # we poll until all three files match (or the deadline expires).
+    aes_values = [None, None, None]
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        aes_values = [
+            _read(pathlib.Path(m.config["cluster_pki_dir"]) / ".aes") for m in masters
+        ]
+        if all(v is not None for v in aes_values) and len(set(aes_values)) == 1:
+            break
+        time.sleep(0.5)
+
     assert all(v is not None for v in aes_values), (
         f"Some masters never wrote .aes: "
         f"{[m.config['interface'] for m, v in zip(masters, aes_values) if v is None]}"

--- a/tests/pytests/integration/cluster/test_isolated_cluster.py
+++ b/tests/pytests/integration/cluster/test_isolated_cluster.py
@@ -1,0 +1,492 @@
+"""
+Cluster integration tests with *per-master* ``cluster_pki_dir`` and
+``cache_dir`` — i.e. no shared filesystem between masters.
+
+Each master fixture allocates its own pki+cache trees.  The founder
+generates ``cluster.pem`` / ``cluster.pub`` / ``cluster_aes`` locally;
+joiners must receive them over the wire via ``cluster/peer/join-reply``
+to come up correctly.  Subsequent minion-key acceptance and job-state
+events propagate over the cluster event bus so a CLI on any peer can
+target a minion connected to any other peer.
+
+Together these tests cover items #1–#4 of the no-shared-FS plan.
+"""
+
+import pathlib
+import time
+
+import pytest
+
+import salt.cache
+import salt.utils.files
+from tests.conftest import FIPS_TESTRUN
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def _read(path):
+    if not pathlib.Path(path).exists():
+        return None
+    with salt.utils.files.fopen(path, "rb") as fp:
+        return fp.read()
+
+
+def test_isolated_cluster_aes_converges(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    All three masters end up with the same cluster session AES key
+    even though no master can read another master's
+    ``cluster_pki_dir/.aes`` from a shared filesystem.
+
+    Master 1 (founder) writes ``.aes`` locally.  Masters 2 and 3 must
+    install the founder's value from the ``cluster_aes`` field in their
+    ``cluster/peer/join-reply``.
+    """
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+    aes_values = []
+    for m in masters:
+        aes_path = pathlib.Path(m.config["cluster_pki_dir"]) / ".aes"
+        aes_values.append(_read(aes_path))
+    assert all(v is not None for v in aes_values), (
+        f"Some masters never wrote .aes: "
+        f"{[m.config['interface'] for m, v in zip(masters, aes_values) if v is None]}"
+    )
+    # All three .aes contents must be identical: founder's value should
+    # have propagated via wire on join-reply.
+    distinct = set(aes_values)
+    assert len(distinct) == 1, (
+        f"Cluster did not converge on a single cluster_aes across "
+        f"isolated cluster_pki_dirs: {len(distinct)} distinct values"
+    )
+
+
+@pytest.fixture
+def cluster_minion_1_isolated(cluster_master_1_isolated):
+    """
+    A minion connected only to the isolated master_1.  The other
+    masters never share a ``pki_dir`` with master_1, so they must
+    receive the minion's accepted public key over the cluster event
+    bus to be able to authenticate it.
+    """
+    config_defaults = {
+        "transport": cluster_master_1_isolated.config["transport"],
+    }
+    port = cluster_master_1_isolated.config["ret_port"]
+    addr = cluster_master_1_isolated.config["interface"]
+    config_overrides = {
+        "master": f"{addr}:{port}",
+        "test.foo": "baz",
+        "log_granular_levels": {
+            "salt": "info",
+            "salt.transport": "debug",
+            "salt.channel": "debug",
+            "salt.utils.event": "debug",
+        },
+        "fips_mode": FIPS_TESTRUN,
+        "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+        "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
+    }
+    factory = cluster_master_1_isolated.salt_minion_daemon(
+        "cluster-minion-1-iso",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+def _make_isolated_minion(master, minion_id):
+    """Spawn a minion attached only to *master* under the isolated-FS set."""
+    config_defaults = {"transport": master.config["transport"]}
+    port = master.config["ret_port"]
+    addr = master.config["interface"]
+    config_overrides = {
+        "master": f"{addr}:{port}",
+        "test.foo": "baz",
+        "log_granular_levels": {
+            "salt": "info",
+            "salt.transport": "debug",
+            "salt.channel": "debug",
+            "salt.utils.event": "debug",
+        },
+        "fips_mode": FIPS_TESTRUN,
+        "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+        "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
+    }
+    return master.salt_minion_daemon(
+        minion_id,
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+
+
+@pytest.fixture
+def cluster_minion_2_isolated(cluster_master_2_isolated):
+    """A second minion attached only to isolated master_2."""
+    factory = _make_isolated_minion(cluster_master_2_isolated, "cluster-minion-2-iso")
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+@pytest.fixture
+def cluster_minion_3_isolated(cluster_master_3_isolated):
+    """A third minion attached only to isolated master_3."""
+    factory = _make_isolated_minion(cluster_master_3_isolated, "cluster-minion-3-iso")
+    with factory.started(start_timeout=120):
+        yield factory
+
+
+def _fetch_minion_key(master, minion_id):
+    """Look up an accepted minion key via whatever ``keys.cache_driver``
+    the master is running.  Returns ``{"state": ..., "pub": ...}`` or
+    ``None``."""
+    cache = salt.cache.Cache(master.config, driver=master.config["keys.cache_driver"])
+    return cache.fetch("keys", minion_id)
+
+
+def test_isolated_minion_key_replicates_to_peers(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+):
+    """
+    A minion that auto-accepts on master_1 must end up registered as an
+    accepted key on every cluster peer too — even though no master sees
+    another's ``pki_dir``.  ``salt.key.Key.change_state`` fires
+    ``salt/key/accept`` carrying the pub bytes;
+    ``EventMonitor._apply_peer_key_change`` calls ``cache.store("keys",
+    ...)`` on each peer using whatever backend it has configured.
+    """
+    minion_id = cluster_minion_1_isolated.id
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+
+    deadline = time.monotonic() + 30
+    entries = [None, None, None]
+    while time.monotonic() < deadline:
+        entries = [_fetch_minion_key(m, minion_id) for m in masters]
+        if all(e and e.get("state") == "accepted" for e in entries):
+            break
+        time.sleep(0.5)
+    missing = [
+        m.config["interface"]
+        for m, e in zip(masters, entries)
+        if not e or e.get("state") != "accepted"
+    ]
+    assert not missing, f"Minion {minion_id!r} key did not replicate to: {missing}"
+    pubs = {e["pub"] for e in entries}
+    assert len(pubs) == 1, "Minion pub key body differs between cluster peers"
+
+
+def test_isolated_test_ping_via_peer_master(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+):
+    """
+    End-to-end no-shared-FS scenario: a minion connected only to
+    master_1 must be reachable via ``salt cluster-minion-1-iso
+    test.ping`` issued from a CLI on master_2.
+
+    Exercises every wire-delivery item:
+      * ``cluster_aes`` and ``cluster.pem`` distributed during join
+        (so peer signatures verify).
+      * Accepted minion key replicated to master_2 so master_2 can
+        verify the minion's return signature.
+      * Job submission and return forwarded to master_2's local job
+        cache so the CLI on master_2 can deliver the result.
+    """
+    cli = cluster_master_2_isolated.salt_cli(timeout=30)
+    minion_id = cluster_minion_1_isolated.id
+    deadline = time.monotonic() + 120
+    last_ret = None
+    while time.monotonic() < deadline:
+        last_ret = cli.run("test.ping", minion_tgt=minion_id)
+        if last_ret.data is True:
+            break
+        time.sleep(1)
+    assert last_ret is not None and last_ret.data is True, (
+        f"test.ping for {minion_id!r} via master_2 (isolated FS) never "
+        f"returned True (last result: {last_ret!r})"
+    )
+
+
+def test_isolated_cluster_pem_propagates(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    Each master ends up with the same ``cluster.pem`` even though
+    their ``cluster_pki_dir`` paths are private to each master.
+
+    Master 1 generates the cluster RSA key pair locally on first
+    start.  Masters 2 and 3 are expected to receive the PEM body in
+    their join-reply (hybrid-encrypted under a one-shot Crypticle
+    session key wrapped to each joiner's RSA pub).
+    """
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+    pems = []
+    pubs = []
+    for m in masters:
+        pki = pathlib.Path(m.config["cluster_pki_dir"])
+        pems.append(_read(pki / "cluster.pem"))
+        pubs.append(_read(pki / "cluster.pub"))
+    assert all(v is not None for v in pems), (
+        f"Some masters missing cluster.pem: "
+        f"{[m.config['interface'] for m, v in zip(masters, pems) if v is None]}"
+    )
+    assert all(v is not None for v in pubs), (
+        f"Some masters missing cluster.pub: "
+        f"{[m.config['interface'] for m, v in zip(masters, pubs) if v is None]}"
+    )
+    assert len(set(pems)) == 1, "cluster.pem differs between masters"
+    assert len(set(pubs)) == 1, "cluster.pub differs between masters"
+
+
+_DEMO_SLS_BODY = "test-id:\n  test.succeed_without_changes\n"
+_DEMO_PILLAR_BODY = "base:\n  '*':\n    - cluster_demo\n"
+
+
+@pytest.fixture
+def seed_master_1_roots_for_late_join(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+):
+    """
+    Drop a known SLS file and pillar top.sls into master_1's
+    ``file_roots[base][0]`` / ``pillar_roots[base][0]`` *after* masters
+    1–3 are running but *before* the late-joining master_4 starts.
+
+    Pytest resolves fixtures in argument order, so by depending on this
+    fixture between ``cluster_master_3_isolated`` and
+    ``cluster_master_4_isolated`` the test guarantees master_1 has the
+    content on disk when master_4 sends its join request.
+    """
+    sls_path = cluster_file_roots_path_isolated["127.0.0.1"] / "demo" / "init.sls"
+    sls_path.parent.mkdir(parents=True, exist_ok=True)
+    sls_path.write_text(_DEMO_SLS_BODY)
+    pillar_top = cluster_pillar_roots_path_isolated["127.0.0.1"] / "top.sls"
+    pillar_top.write_text(_DEMO_PILLAR_BODY)
+    return {"sls": sls_path, "pillar": pillar_top}
+
+
+def test_isolated_late_joiner_receives_file_and_pillar_roots(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_file_roots_path_isolated,
+    cluster_pillar_roots_path_isolated,
+    seed_master_1_roots_for_late_join,
+    cluster_master_4_isolated,
+):
+    """
+    ``file_roots`` and ``pillar_roots`` content present on master_1 at
+    join time must be delivered to a late-joining master via the bulk
+    state-sync embedded in ``cluster/peer/join-reply``.
+    """
+    # ``apply_root_tree`` writes into ``roots[env][0]`` — pull the
+    # actual destinations from master_4's running config rather than
+    # guessing, since salt-factories prepends its own state-tree path
+    # ahead of any file_roots/pillar_roots override.
+    dst_file_root = pathlib.Path(
+        cluster_master_4_isolated.config["file_roots"]["base"][0]
+    )
+    dst_pillar_root = pathlib.Path(
+        cluster_master_4_isolated.config["pillar_roots"]["base"][0]
+    )
+    dst_sls = dst_file_root / "demo" / "init.sls"
+    dst_pillar = dst_pillar_root / "top.sls"
+
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if dst_sls.is_file() and dst_pillar.is_file():
+            break
+        time.sleep(0.5)
+    assert dst_sls.is_file(), (
+        f"Late-joining master_4 never received init.sls from master_1's "
+        f"file_roots via state-sync (looked under {dst_file_root})"
+    )
+    assert dst_pillar.is_file(), (
+        f"Late-joining master_4 never received pillar top.sls from "
+        f"master_1's pillar_roots via state-sync (looked under {dst_pillar_root})"
+    )
+    assert dst_sls.read_text() == _DEMO_SLS_BODY, "file_roots content mismatch"
+    assert dst_pillar.read_text() == _DEMO_PILLAR_BODY, "pillar_roots content mismatch"
+
+
+def test_isolated_late_joiner_state_sync(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+    cluster_master_4_isolated,
+):
+    """
+    A 4th master joining a cluster that already has an accepted minion
+    key must learn that key from the bulk state-sync embedded in
+    ``cluster/peer/join-reply``, not from event-driven replication.
+
+    Sequence:
+      1. masters 1–3 bootstrap with ``cluster_isolated_filesystem=True``.
+      2. ``cluster_minion_1_isolated`` connects to master_1 and is
+         auto-accepted (event-driven replication populates 1, 2, 3).
+      3. master_4 starts.  At this point no fresh ``salt/key/accept``
+         event will ever fire for the existing minion, so master_4 can
+         only learn it via state-sync.
+      4. Within 30 s master_4's keys cache contains the accepted entry.
+    """
+    minion_id = cluster_minion_1_isolated.id
+    deadline = time.monotonic() + 30
+    entry = None
+    while time.monotonic() < deadline:
+        entry = _fetch_minion_key(cluster_master_4_isolated, minion_id)
+        if entry and entry.get("state") == "accepted":
+            break
+        time.sleep(0.5)
+    assert entry and entry.get("state") == "accepted", (
+        f"Late-joining master_4 never received minion {minion_id!r} key "
+        f"via state-sync (last fetch: {entry!r})"
+    )
+
+
+def _glob_ping_all(cli, expected_ids, deadline_secs=180):
+    """
+    Run ``salt '*' test.ping`` via *cli* and wait until the return covers
+    every minion in *expected_ids*.  Returns the final ``cli.run`` result
+    so the caller can assert on it.
+
+    A glob target with multiple minions is asynchronous in the worst
+    case (publish fan-out, return aggregation, return-cache lookup), so
+    we poll instead of demanding a single shot to land everything.
+    """
+    deadline = time.monotonic() + deadline_secs
+    last_ret = None
+    expected = set(expected_ids)
+    while time.monotonic() < deadline:
+        last_ret = cli.run("test.ping", minion_tgt="*")
+        data = last_ret.data or {}
+        if (
+            isinstance(data, dict)
+            and expected.issubset(data)
+            and all(data[mid] is True for mid in expected)
+        ):
+            return last_ret
+        time.sleep(2)
+    return last_ret
+
+
+def test_isolated_multi_minion_targetable_from_every_master(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+    cluster_minion_2_isolated,
+    cluster_minion_3_isolated,
+):
+    """
+    Three minions, one per master, all reachable via ``salt '*'
+    test.ping`` issued from any master CLI.
+
+    Exercises the full event-driven replication path under load:
+      * Each master auto-accepts its own minion's key locally.
+      * Cluster events deliver each minion's accepted key to the other
+        two peers, so any peer can verify the minion's return signature.
+      * Glob targeting (``'*'``) on any peer's CLI publishes through
+        the cluster fan-out and aggregates returns from minions
+        connected to other peers.
+    """
+    minion_ids = {
+        cluster_minion_1_isolated.id,
+        cluster_minion_2_isolated.id,
+        cluster_minion_3_isolated.id,
+    }
+    masters = (
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    )
+    for master in masters:
+        cli = master.salt_cli(timeout=60)
+        ret = _glob_ping_all(cli, minion_ids)
+        data = ret.data if ret is not None else None
+        assert isinstance(data, dict) and set(data) >= minion_ids, (
+            f"`salt '*' test.ping` via {master.config['id']} did not reach "
+            f"every minion: expected {minion_ids}, got {data!r}"
+        )
+        for mid in minion_ids:
+            assert data[mid] is True, (
+                f"Minion {mid!r} did not return True via {master.config['id']} "
+                f"(got {data[mid]!r})"
+            )
+
+
+@pytest.mark.timeout(300, func_only=True)
+def test_isolated_late_joiner_targets_all_existing_minions(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+    cluster_minion_1_isolated,
+    cluster_minion_2_isolated,
+    cluster_minion_3_isolated,
+    cluster_master_4_isolated,
+):
+    """
+    A late-joining master (master_4) must end up able to target every
+    minion that was already accepted on the cluster, exercising the
+    full ``cluster_isolated_filesystem`` state-sync path:
+
+      * Bulk state-sync inside ``cluster/peer/join-reply`` delivers the
+        three accepted-minion keys before master_4 becomes a Raft
+        learner.
+      * Cluster event fan-out continues working on master_4 so that the
+        publish reaches all three minions on their respective masters
+        and the returns find their way back to master_4's local job
+        cache.
+
+    Failure modes this catches:
+      * State-sync only ships a subset of minions (e.g. drops keys
+        that aren't in some bank).
+      * master_4 cannot verify minion signatures because peer-AES or
+        per-minion key delivery is incomplete.
+    """
+    minion_ids = {
+        cluster_minion_1_isolated.id,
+        cluster_minion_2_isolated.id,
+        cluster_minion_3_isolated.id,
+    }
+    cli = cluster_master_4_isolated.salt_cli(timeout=60)
+    ret = _glob_ping_all(cli, minion_ids, deadline_secs=300)
+    data = ret.data if ret is not None else None
+    assert isinstance(data, dict) and set(data) >= minion_ids, (
+        f"Late-joining master_4 could not target every existing minion: "
+        f"expected {minion_ids}, got {data!r}"
+    )
+    for mid in minion_ids:
+        assert data[mid] is True, (
+            f"Minion {mid!r} did not return True via late-joining master_4 "
+            f"(got {data[mid]!r})"
+        )

--- a/tests/pytests/run-smoke-tests.sh
+++ b/tests/pytests/run-smoke-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run consensus + cluster + mmap_cache smoke tests (see smoke-tests.txt).
+set -euo pipefail
+
+_repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "${_repo_root}"
+
+_py="${PYTHON:-python3}"
+for _cand in \
+    "${_repo_root}/venv314/bin/python" \
+    "${_repo_root}/venv313/bin/python" \
+    "${_repo_root}/venv312/bin/python" \
+    "${_repo_root}/venv311/bin/python" \
+    "${_repo_root}/.venv/bin/python"; do
+  if [[ -x "${_cand}" ]]; then
+    _py="${_cand}"
+    break
+  fi
+done
+
+_tests_file="$(dirname "$0")/smoke-tests.txt"
+mapfile -t _lines < <(grep -v '^#' "${_tests_file}" | grep -v '^$' || true)
+if [[ ${#_lines[@]} -eq 0 ]]; then
+  echo "No tests listed in ${_tests_file}" >&2
+  exit 1
+fi
+
+exec "${_py}" -m pytest "${_lines[@]}" --run-slow --benchmark-disable --tb=short "$@"

--- a/tests/pytests/scenarios/cluster_kind/conftest.py
+++ b/tests/pytests/scenarios/cluster_kind/conftest.py
@@ -1,0 +1,517 @@
+"""
+Fixtures that drive Salt cluster scenarios on a real Kubernetes cluster
+running inside Docker (``kind``).
+
+Why bother
+----------
+The ``tests/pytests/integration/cluster/`` and
+``tests/pytests/scenarios/cluster/`` suites use loopback aliases —
+masters bind to 127.0.0.1, 127.0.0.2, 127.0.0.3, etc.  That works for
+the basic happy-path checks but doesn't exercise:
+
+* real distinct IPs (rather than aliases on the same loopback);
+* DNS-based peer addressing (most production deployments use FQDNs);
+* network isolation between processes (every loopback master shares
+  the host kernel, so ``iptables`` partition tests are impossible);
+* the cluster bootstrap path on a non-``localhost`` interface, which
+  is the path real operators take.
+
+This fixture set spins up a single-node ``kind`` cluster inside Docker
+and deploys 3 salt-master Pods on a headless Service.  Each Pod gets a
+stable DNS name (``salt-master-0.salt-cluster.<ns>.svc.cluster.local``
+and friends), pip-installs the consensus Salt source from a hostPath
+mount, then runs ``salt-master``.  Tests interact with the cluster by
+shelling ``kubectl exec`` into a chosen pod.
+
+Requirements (skipped cleanly if any are missing)
+-------------------------------------------------
+* ``docker``, ``kind``, ``kubectl`` on ``$PATH``
+* a reachable Docker daemon (the ``--privileged`` test container in
+  :mod:`tools.container` already provides one)
+* Linux host (kind runs on macOS too, but the salt-master Pods we
+  deploy expect Linux semantics)
+"""
+
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import textwrap
+import time
+import uuid
+
+import pytest
+import yaml
+
+log = logging.getLogger(__name__)
+
+# Top of the consensus repo — used as the hostPath we mount into the
+# kind node so Pods can pip install the in-tree Salt source.
+SALT_REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+
+# Default base image for salt-master Pods.  Has Python, build deps, and
+# Salt's runtime requirements pre-installed; we add the consensus source
+# at Pod-startup time via ``pip install -e /salt``.
+DEFAULT_SALT_IMAGE = "ghcr.io/saltstack/salt-ci-containers/testing:debian-12"
+
+# Names of the three masters.  Predictable so tests can address them.
+MASTER_NAMES = ("salt-master-0", "salt-master-1", "salt-master-2")
+
+# Headless service name (subdomain) — combined with each Pod's
+# ``hostname`` field, gives every master a stable DNS record.
+CLUSTER_SUBDOMAIN = "salt-cluster"
+
+# How long fixtures wait for k8s objects to settle.  Pulling the salt
+# image + pip-installing consensus into three Pods runs ~3 min cold.
+_DEFAULT_DEADLINE = 360
+
+
+# ---------------------------------------------------------------------------
+# Skip-if-deps-missing
+# ---------------------------------------------------------------------------
+
+
+def _have(binary):
+    return shutil.which(binary) is not None
+
+
+def _docker_reachable():
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            check=True,
+            timeout=10,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (
+        _have("kind") and _have("kubectl") and _have("docker") and _docker_reachable()
+    ),
+    reason="kind / kubectl / docker daemon not available",
+)
+
+
+# ---------------------------------------------------------------------------
+# Cluster lifecycle
+# ---------------------------------------------------------------------------
+
+
+class KindCluster:
+    """
+    Handle to a running ``kind`` cluster.
+
+    Tests rarely use this directly; use :func:`kubectl` /
+    :func:`salt_in_pod` instead.
+    """
+
+    def __init__(self, name, kubeconfig, namespace):
+        self.name = name
+        self.kubeconfig = kubeconfig
+        self.namespace = namespace
+
+    def kubectl(self, *args, check=True, capture=True, timeout=120, input=None):
+        """
+        Run ``kubectl`` against this cluster's kubeconfig.
+
+        On non-zero exit with ``check=True``, raises ``RuntimeError``
+        with both stdout and stderr (subprocess.CalledProcessError
+        swallows stderr by default in some pytest output modes).
+        """
+        cmd = ["kubectl", "--kubeconfig", str(self.kubeconfig), *args]
+        log.debug("kubectl %s", " ".join(args))
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=capture,
+            timeout=timeout,
+            text=True,
+            input=input,
+        )
+        if check and proc.returncode != 0:
+            raise RuntimeError(
+                f"kubectl {' '.join(args)} failed (rc={proc.returncode})\n"
+                f"--- stdout ---\n{proc.stdout}\n"
+                f"--- stderr ---\n{proc.stderr}"
+            )
+        return proc
+
+
+@pytest.fixture(scope="module")
+def kind_cluster(tmp_path_factory):
+    """
+    Create a single-node kind cluster with the consensus Salt repo
+    bind-mounted into the node at ``/salt``.
+
+    Module-scoped: spinning kind up + pulling the salt image is the
+    expensive bit; we want to amortise across multiple tests.
+    """
+    name = f"salt-{uuid.uuid4().hex[:8]}"
+    work_dir = pathlib.Path(tmp_path_factory.mktemp(f"kind-{name}"))
+    kind_config = work_dir / "kind-config.yaml"
+    kubeconfig = work_dir / "kubeconfig"
+
+    kind_config.write_text(
+        textwrap.dedent(
+            f"""\
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            nodes:
+            - role: control-plane
+              extraMounts:
+              - hostPath: {SALT_REPO_ROOT}
+                containerPath: /salt
+                readOnly: true
+            """
+        )
+    )
+
+    log.info("Creating kind cluster %s", name)
+    create_proc = subprocess.run(
+        [
+            "kind",
+            "create",
+            "cluster",
+            "--name",
+            name,
+            "--config",
+            str(kind_config),
+            "--kubeconfig",
+            str(kubeconfig),
+            "--wait",
+            "120s",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,  # we inspect returncode + skip on non-zero below
+    )
+    if create_proc.returncode != 0:
+        pytest.skip(
+            f"kind create cluster failed (likely no nested-Docker support): "
+            f"{create_proc.stderr.strip() or create_proc.stdout.strip()}"
+        )
+
+    namespace = "salt-test"
+    cluster = KindCluster(name=name, kubeconfig=kubeconfig, namespace=namespace)
+
+    # Create the test namespace so we don't pollute "default".
+    cluster.kubectl("create", "namespace", namespace)
+
+    try:
+        yield cluster
+    finally:
+        log.info("Tearing down kind cluster %s", name)
+        subprocess.run(
+            ["kind", "delete", "cluster", "--name", name],
+            capture_output=True,
+            check=False,
+            timeout=120,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifests + helpers
+# ---------------------------------------------------------------------------
+
+
+def _master_startup_script(pod_name, headless_fqdn, expected_peer_count):
+    """
+    Return the startup script for a salt-master Pod.
+
+    Built without ``textwrap.dedent`` because the dedent algorithm
+    "common-leading-whitespace minimum" interacts badly with multi-line
+    interpolations like the cluster-peers list — a 2-space-indented
+    second line will redefine the common prefix and pull the heredoc
+    terminator out of column 0, silently breaking the script.  Each
+    line is written at column 0 here, with explicit indentation only
+    inside the YAML body of the master config heredoc.
+
+    Identity wiring
+    ---------------
+    Salt's ``cli/daemons.py`` calls ``ip_bracket(opts["interface"])``
+    which rejects hostnames, and the consensus layer uses
+    ``opts["interface"]`` as the Raft node-id (see
+    ``salt/cluster/consensus/service.py:73``).  So we *must* use a
+    literal IP for ``interface``, AND every peer in ``cluster_peers``
+    must be the IP that peer is using as its interface.
+
+    The fixture solves the chicken-and-egg by:
+
+    1. Exposing each Pod's IP via the Downward API as ``$POD_IP``.
+    2. Setting the headless Service's ``publishNotReadyAddresses: true``
+       so DNS returns all 3 endpoint IPs even before the readiness
+       probe passes.
+    3. The startup script polls ``getent hosts <headless-fqdn>`` until
+       it returns all ``expected_peer_count + 1`` IPs, then writes
+       ``interface: $POD_IP`` and ``cluster_peers: <other IPs>``.
+
+    Source install
+    --------------
+    /salt is mounted read-only from the kind node so the host tree
+    stays untouched.  Setuptools wants to write ``salt.egg-info`` back
+    into the source during ``pip install -e``, so we copy a slim
+    subset (excluding venv* / .git / artifacts / __pycache__) to a
+    writable location and install from there.  Non-editable install:
+    ``-e`` triggers ``setup.py develop``, which shells out to ``python
+    -m pip`` for deps — the system Python in
+    salt-ci-containers/testing:debian-12 ships pip as a script only,
+    not as an importable module, so that fails.  A plain
+    ``pip install <dir>`` builds a wheel and installs it via pip's
+    own resolver, dodging the setup.py develop path entirely.
+    """
+    expected_total = expected_peer_count + 1
+    lines = [
+        "set -euxo pipefail",
+        "mkdir -p /tmp/salt-src",
+        "cd /salt && find . -maxdepth 1 -mindepth 1 \\",
+        "    ! -name 'venv*' \\",
+        "    ! -name '.git' \\",
+        "    ! -name '.pytest_cache' \\",
+        "    ! -name '.tox' \\",
+        "    ! -name 'artifacts' \\",
+        "    ! -name 'build' \\",
+        "    ! -name 'salt.egg-info' \\",
+        "    -exec cp -a -t /tmp/salt-src/ {} +",
+        "cd /tmp/salt-src",
+        "pip install --quiet --break-system-packages /tmp/salt-src",
+        # Wait for the headless Service DNS to return every peer's IP.
+        # publishNotReadyAddresses=true means we get the IPs as soon as
+        # the Pod objects are scheduled, not just when they're Ready —
+        # so this loop converges before any salt-master is listening.
+        f'echo "Waiting for {expected_total} peer IPs from {headless_fqdn}..."',
+        "for i in $(seq 1 60); do",
+        f"  IPS=$(getent hosts {headless_fqdn} 2>/dev/null | awk '{{print $1}}' | sort -u || true)",
+        '  COUNT=$(printf "%s\\n" "$IPS" | grep -c . || true)',
+        f'  if [ "$COUNT" -ge "{expected_total}" ]; then',
+        "    break",
+        "  fi",
+        "  sleep 1",
+        "done",
+        f"IPS=$(getent hosts {headless_fqdn} | awk '{{print $1}}' | sort -u)",
+        # POD_IP comes from the Downward API env injected on the Pod.
+        'PEER_IPS=$(echo "$IPS" | grep -v "^${POD_IP}$" || true)',
+        'echo "POD_IP=$POD_IP" >&2',
+        'echo "Discovered peers:" >&2',
+        'echo "$PEER_IPS" | sed "s/^/  /" >&2',
+        "mkdir -p /etc/salt /var/cache/salt/master /etc/salt/pki/master",
+        # ``id`` and ``interface`` MUST match — salt's cluster code uses
+        # ``opts["id"]`` to route ``cluster/peer/<id>`` events but
+        # ``opts["interface"]`` for the entries in ``data["peers"]``;
+        # diverging them produces ``KeyError: 'aes'`` on every cluster
+        # event broadcast (``salt/channel/server.py:3012``).  The
+        # loopback fixture (127.0.0.X for both id and interface) hides
+        # this; the kind fixture has to align them explicitly.
+        "{",
+        '  echo "id: $POD_IP"',
+        '  echo "interface: $POD_IP"',
+        '  echo "cluster_id: kind-cluster"',
+        '  echo "cluster_peers:"',
+        '  echo "$PEER_IPS" | sed "s/^/  - /"',
+        '  echo "cluster_pki_dir: /etc/salt/pki/master"',
+        '  echo "cache_dir: /var/cache/salt/master"',
+        '  echo "cluster_isolated_filesystem: true"',
+        # Route salt-master logs to stderr so ``kubectl logs`` captures
+        # them — the default ``/var/log/salt/master`` is invisible to k8s.
+        '  echo "log_file: /dev/stderr"',
+        '  echo "log_level: info"',
+        '  echo "open_mode: true"',
+        "} > /etc/salt/master",
+        'echo "--- /etc/salt/master ---" >&2',
+        "cat /etc/salt/master >&2",
+        "exec salt-master",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _master_pod_manifest(name, image, headless_fqdn, expected_peers, namespace):
+    """
+    Return a Pod manifest (YAML string) for one salt-master.
+
+    Built from a Python dict + ``yaml.safe_dump`` so multi-line
+    script content embeds cleanly without indentation hand-holding.
+    """
+    pod = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "labels": {"app": "salt-master", "instance": name},
+        },
+        "spec": {
+            "hostname": name,
+            "subdomain": CLUSTER_SUBDOMAIN,
+            "restartPolicy": "Never",
+            "containers": [
+                {
+                    "name": "master",
+                    "image": image,
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["/bin/bash", "-c"],
+                    "args": [
+                        _master_startup_script(name, headless_fqdn, expected_peers)
+                    ],
+                    "env": [
+                        {
+                            "name": "POD_IP",
+                            "valueFrom": {"fieldRef": {"fieldPath": "status.podIP"}},
+                        }
+                    ],
+                    "volumeMounts": [
+                        {
+                            "name": "salt-source",
+                            "mountPath": "/salt",
+                            "readOnly": True,
+                        }
+                    ],
+                    "ports": [
+                        {"name": "ret", "containerPort": 4506},
+                        {"name": "pub", "containerPort": 4505},
+                        {"name": "cluster-pool", "containerPort": 55596},
+                    ],
+                    "readinessProbe": {
+                        "tcpSocket": {"port": 4506},
+                        "initialDelaySeconds": 30,
+                        "periodSeconds": 5,
+                        "failureThreshold": 60,
+                    },
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "salt-source",
+                    "hostPath": {"path": "/salt", "type": "Directory"},
+                }
+            ],
+        },
+    }
+    return yaml.safe_dump(pod, default_flow_style=False)
+
+
+def _headless_service_manifest(namespace):
+    """
+    Headless ClusterIP=None service.  Combined with each Pod's
+    ``hostname`` + ``subdomain``, gives every master a stable DNS
+    name like ``salt-master-0.salt-cluster.<ns>.svc.cluster.local``.
+    """
+    svc = {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": CLUSTER_SUBDOMAIN, "namespace": namespace},
+        "spec": {
+            "clusterIP": "None",
+            "selector": {"app": "salt-master"},
+            "ports": [
+                {"name": "ret", "port": 4506},
+                {"name": "pub", "port": 4505},
+                {"name": "cluster-pool", "port": 55596},
+            ],
+            "publishNotReadyAddresses": True,
+        },
+    }
+    return yaml.safe_dump(svc, default_flow_style=False)
+
+
+def _wait_for_pod_ready(cluster, name, deadline):
+    """Poll until *name* reports Ready=True or *deadline* is reached."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        proc = cluster.kubectl(
+            "get",
+            "pod",
+            name,
+            "-n",
+            cluster.namespace,
+            "-o",
+            "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip() == "True":
+            return True
+        time.sleep(2)
+    # Dump diagnostics before failing.
+    diag = cluster.kubectl(
+        "describe", "pod", name, "-n", cluster.namespace, check=False
+    )
+    logs = cluster.kubectl(
+        "logs", name, "-n", cluster.namespace, "--tail=100", check=False
+    )
+    raise TimeoutError(
+        f"Pod {name} not ready within {deadline}s.\n"
+        f"--- describe ---\n{diag.stdout}\n"
+        f"--- logs ---\n{logs.stdout}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cluster of three masters
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def salt_master_image():
+    """Image used for the salt-master Pods.  Override-able for local builds."""
+    return os.environ.get("SALT_KIND_IMAGE", DEFAULT_SALT_IMAGE)
+
+
+@pytest.fixture(scope="module")
+def cluster_masters(kind_cluster, salt_master_image):
+    """
+    Deploy a 3-master Salt cluster on the kind node.
+
+    Returns a dict ``{name: dns_name}`` for the three masters.  Tests
+    use :func:`salt_in_pod` to run salt CLIs inside any of them.
+    """
+    namespace = kind_cluster.namespace
+    headless_fqdn = f"{CLUSTER_SUBDOMAIN}.{namespace}.svc.cluster.local"
+    expected_peers = len(MASTER_NAMES) - 1
+    # Per-master FQDN — exposed to tests for ``salt_in_pod`` callers
+    # that prefer DNS over Pod IPs (which change every kind run).
+    dns_for = {
+        name: f"{name}.{CLUSTER_SUBDOMAIN}.{namespace}.svc.cluster.local"
+        for name in MASTER_NAMES
+    }
+
+    kind_cluster.kubectl(
+        "apply", "-f", "-", input=_headless_service_manifest(namespace)
+    )
+
+    for name in MASTER_NAMES:
+        manifest = _master_pod_manifest(
+            name, salt_master_image, headless_fqdn, expected_peers, namespace
+        )
+        kind_cluster.kubectl("apply", "-f", "-", input=manifest)
+
+    for name in MASTER_NAMES:
+        _wait_for_pod_ready(kind_cluster, name, _DEFAULT_DEADLINE)
+
+    yield dns_for
+
+
+@pytest.fixture
+def salt_in_pod(kind_cluster):
+    """
+    Return a callable ``salt_in_pod(pod_name, *args)`` that shells
+    ``kubectl exec`` to run any salt CLI inside the named Pod.
+    """
+
+    def _run(pod_name, *args, timeout=60):
+        proc = kind_cluster.kubectl(
+            "exec",
+            "-n",
+            kind_cluster.namespace,
+            pod_name,
+            "--",
+            *args,
+            check=False,
+            timeout=timeout,
+        )
+        return proc
+
+    return _run

--- a/tests/pytests/scenarios/cluster_kind/conftest.py
+++ b/tests/pytests/scenarios/cluster_kind/conftest.py
@@ -73,7 +73,27 @@ _DEFAULT_DEADLINE = 360
 
 
 def _have(binary):
-    return shutil.which(binary) is not None
+    """
+    True iff *binary* is on ``PATH`` *and* actually runs.
+
+    ``shutil.which`` alone is not enough: some CI images (notably
+    Photon OS 5 Arm64) ship a stub or a wrong-arch ``kind`` /
+    ``kubectl`` / ``docker`` binary that ``which`` happily finds but
+    that fails ``execve`` with ``FileNotFoundError``.  Invoking
+    ``--version`` proves the binary is loadable on this arch.
+    """
+    if shutil.which(binary) is None:
+        return False
+    try:
+        subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            check=True,
+            timeout=10,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return False
 
 
 def _docker_reachable():
@@ -172,25 +192,32 @@ def kind_cluster(tmp_path_factory):
     )
 
     log.info("Creating kind cluster %s", name)
-    create_proc = subprocess.run(
-        [
-            "kind",
-            "create",
-            "cluster",
-            "--name",
-            name,
-            "--config",
-            str(kind_config),
-            "--kubeconfig",
-            str(kubeconfig),
-            "--wait",
-            "120s",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-        check=False,  # we inspect returncode + skip on non-zero below
-    )
+    try:
+        create_proc = subprocess.run(
+            [
+                "kind",
+                "create",
+                "cluster",
+                "--name",
+                name,
+                "--config",
+                str(kind_config),
+                "--kubeconfig",
+                str(kubeconfig),
+                "--wait",
+                "120s",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,  # we inspect returncode + skip on non-zero below
+        )
+    except (FileNotFoundError, OSError) as exc:
+        # ``_have`` checks at import time should have already skipped
+        # the test when these binaries aren't available, but a CI image
+        # could remove them between collection and execution.  Treat
+        # the same as an unmet dependency.
+        pytest.skip(f"kind binary unavailable at fixture time: {exc}")
     if create_proc.returncode != 0:
         pytest.skip(
             f"kind create cluster failed (likely no nested-Docker support): "
@@ -375,11 +402,59 @@ def _master_pod_manifest(name, image, headless_fqdn, expected_peers, namespace):
                         {"name": "pub", "containerPort": 4505},
                         {"name": "cluster-pool", "containerPort": 55596},
                     ],
-                    "readinessProbe": {
-                        "tcpSocket": {"port": 4506},
-                        "initialDelaySeconds": 30,
+                    # Three probes per the 2026 Kubernetes guidance for
+                    # consensus-based services (etcd's lesson: liveness
+                    # must NOT reflect cluster state, or kubelet kills
+                    # pods mid-election and prevents recovery).
+                    #
+                    # * startupProbe: blocks the other probes until the
+                    #   master finished init.  failureThreshold * period
+                    #   = 5 minutes, generous enough for slow joiners
+                    #   on isolated-FS state-sync.
+                    # * readinessProbe: ``health/ready`` lands when the
+                    #   Raft commit gate fires; until then the headless
+                    #   Service should not route to this master.
+                    # * livenessProbe: ``health/alive`` mtime advances
+                    #   from the parent's asyncio loop every 5 s; if it
+                    #   ages past 30 s the loop is wedged and only a
+                    #   restart will fix it.
+                    "startupProbe": {
+                        "exec": {
+                            "command": [
+                                "test",
+                                "-f",
+                                "/var/cache/salt/master/health/startup",
+                            ]
+                        },
                         "periodSeconds": 5,
                         "failureThreshold": 60,
+                    },
+                    "readinessProbe": {
+                        "exec": {
+                            "command": [
+                                "test",
+                                "-f",
+                                "/var/cache/salt/master/health/ready",
+                            ]
+                        },
+                        "periodSeconds": 5,
+                        "failureThreshold": 3,
+                    },
+                    "livenessProbe": {
+                        "exec": {
+                            "command": [
+                                "/bin/sh",
+                                "-c",
+                                # Stale mtime → unhealthy.  Threshold is
+                                # 6× DEFAULT_ALIVE_INTERVAL so a
+                                # transient stall doesn't trip a restart.
+                                'test "$(($(date +%s) - $(stat -c %Y '
+                                '/var/cache/salt/master/health/alive)))" '
+                                "-lt 30",
+                            ]
+                        },
+                        "periodSeconds": 15,
+                        "failureThreshold": 3,
                     },
                 }
             ],

--- a/tests/pytests/scenarios/cluster_kind/conftest.py
+++ b/tests/pytests/scenarios/cluster_kind/conftest.py
@@ -445,7 +445,7 @@ def _master_pod_manifest(name, image, headless_fqdn, expected_peers, namespace):
                             "command": [
                                 "/bin/sh",
                                 "-c",
-                                # Stale mtime → unhealthy.  Threshold is
+                                # Stale mtime -> unhealthy.  Threshold is
                                 # 6× DEFAULT_ALIVE_INTERVAL so a
                                 # transient stall doesn't trip a restart.
                                 'test "$(($(date +%s) - $(stat -c %Y '

--- a/tests/pytests/scenarios/cluster_kind/setup-in-container.sh
+++ b/tests/pytests/scenarios/cluster_kind/setup-in-container.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Bootstrap the debian-11 / debian-12 / ubuntu CI container so it can run
+# tests/pytests/scenarios/cluster_kind/.  Installs:
+#
+#   * dockerd (already in the salt-ci-containers/testing:* images)
+#   * kind   (downloaded as a static binary)
+#   * kubectl (downloaded as a static binary)
+#
+# Then starts dockerd inside the container.  Idempotent — re-running is a
+# no-op once everything is in place.
+#
+# Usage (from inside the container):
+#
+#   bash /salt/tests/pytests/scenarios/cluster_kind/setup-in-container.sh
+#
+# Or from the host:
+#
+#   docker exec <name> bash /salt/tests/pytests/scenarios/cluster_kind/setup-in-container.sh
+
+set -euo pipefail
+
+KIND_VERSION="${KIND_VERSION:-v0.24.0}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.31.0}"
+
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64) GOARCH="amd64" ;;
+    aarch64|arm64) GOARCH="arm64" ;;
+    *) echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+if ! command -v kind >/dev/null 2>&1; then
+    echo "Installing kind ${KIND_VERSION} (${GOARCH})..."
+    curl -sSLo /usr/local/bin/kind \
+        "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${GOARCH}"
+    chmod +x /usr/local/bin/kind
+else
+    echo "kind already installed: $(kind version 2>&1 | head -1)"
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "Installing kubectl ${KUBECTL_VERSION} (${GOARCH})..."
+    curl -sSLo /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${GOARCH}/kubectl"
+    chmod +x /usr/local/bin/kubectl
+else
+    echo "kubectl already installed: $(kubectl version --client 2>&1 | head -1)"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker is not installed in this container." >&2
+    echo "       Use a salt-ci-containers/testing:* image (debian-11 / 12, ubuntu, …)." >&2
+    exit 1
+fi
+
+# Start dockerd if not already running.  Inside the privileged systemd
+# container we'd normally `systemctl start docker`; the salt-ci images
+# tend to run dockerd directly, so we tolerate either path.
+if ! docker info >/dev/null 2>&1; then
+    if command -v systemctl >/dev/null 2>&1 && systemctl --version >/dev/null 2>&1; then
+        echo "Starting docker via systemd..."
+        systemctl start docker || true
+    fi
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "Starting dockerd in the background..."
+    nohup dockerd >/var/log/dockerd.log 2>&1 &
+    # Wait up to 30 s for the daemon socket to appear.
+    for _ in $(seq 1 30); do
+        if docker info >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: dockerd failed to start. Check /var/log/dockerd.log." >&2
+    tail -30 /var/log/dockerd.log >&2 || true
+    exit 1
+fi
+
+echo
+echo "✓ Container ready for cluster_kind scenarios."
+echo "  kind    : $(kind version 2>&1 | head -1)"
+echo "  kubectl : $(kubectl version --client -o yaml 2>/dev/null | grep gitVersion: | head -1 | tr -d ' ')"
+echo "  docker  : $(docker version --format '{{.Server.Version}}' 2>&1)"

--- a/tests/pytests/scenarios/cluster_kind/test_basic.py
+++ b/tests/pytests/scenarios/cluster_kind/test_basic.py
@@ -1,0 +1,118 @@
+"""
+Basic Salt cluster scenario on a real (in-Docker) Kubernetes cluster.
+
+These tests are the minimum smoke that proves the
+``cluster_kind`` fixture set is wired up end-to-end:
+
+1. kind cluster comes up
+2. three salt-master Pods become Ready
+3. inter-master DNS works (each master can resolve its peers)
+4. ``salt-key -L`` runs inline inside a master Pod
+5. one master logs ``BECOMING LEADER`` for some Raft term within
+   the election timeout
+
+Heavy multi-minion / late-joiner scenarios stay in the existing
+``tests/pytests/integration/cluster/`` and ``scenarios/cluster/``
+suites for now — they're cheaper there.  This file is the scaffold to
+grow real network-partition / multi-IP tests on top of.
+"""
+
+import re
+import time
+
+import pytest
+
+from tests.pytests.scenarios.cluster_kind.conftest import (
+    CLUSTER_SUBDOMAIN,
+    MASTER_NAMES,
+)
+
+pytestmark = [pytest.mark.slow_test]
+
+
+def test_kind_masters_become_ready(cluster_masters):
+    """All three master Pods report Ready (the fixture itself enforces
+    this; this test is the explicit assertion that documents the
+    contract)."""
+    assert set(cluster_masters) == set(MASTER_NAMES)
+
+
+def test_inter_master_dns_resolves(kind_cluster, cluster_masters, salt_in_pod):
+    """Each master can resolve its two peers via the headless service."""
+    for src in MASTER_NAMES:
+        for dst in MASTER_NAMES:
+            if dst == src:
+                continue
+            target = f"{dst}.{CLUSTER_SUBDOMAIN}.{kind_cluster.namespace}"
+            proc = salt_in_pod(src, "getent", "hosts", target, timeout=15)
+            assert (
+                proc.returncode == 0
+            ), f"{src} could not resolve peer {target}: {proc.stderr or proc.stdout}"
+
+
+def test_salt_key_list_runs_inside_pod(cluster_masters, salt_in_pod):
+    """``salt-key -L`` runs successfully inside a master Pod and lists
+    the four key buckets the cluster master sets up."""
+    proc = salt_in_pod(MASTER_NAMES[0], "salt-key", "-L", timeout=30)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = proc.stdout
+    for bucket in ("Accepted Keys", "Denied Keys", "Unaccepted Keys", "Rejected Keys"):
+        assert bucket in out, f"Missing {bucket} in salt-key output:\n{out}"
+
+
+_BECOMING_LEADER_RE = re.compile(r"Node \S+ BECOMING LEADER for term \d+")
+
+
+def test_a_leader_is_elected(kind_cluster, cluster_masters):
+    """
+    Within 60 s of all three masters reaching Ready, exactly one of
+    them must log ``BECOMING LEADER for term N``.  Election timing in
+    a real-network kind cluster is more variable than on loopback, so
+    this is a generous deadline.
+    """
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        leaders = []
+        for name in MASTER_NAMES:
+            proc = kind_cluster.kubectl(
+                "logs",
+                "-n",
+                kind_cluster.namespace,
+                name,
+                "--tail=2000",
+                check=False,
+                timeout=15,
+            )
+            if proc.returncode != 0:
+                continue
+            if _BECOMING_LEADER_RE.search(proc.stdout):
+                leaders.append(name)
+        if leaders:
+            assert (
+                len(leaders) == 1
+            ), f"Expected one leader, found {len(leaders)}: {leaders}"
+            return
+        time.sleep(2)
+    # Diagnostic: dump the last 80 lines from each master so failures
+    # show *why* no election ever fired (network reachability, salt
+    # config error, missing peer key, etc.).
+    diagnostic = []
+    for name in MASTER_NAMES:
+        proc = kind_cluster.kubectl(
+            "logs",
+            "-n",
+            kind_cluster.namespace,
+            name,
+            "--tail=80",
+            check=False,
+            timeout=15,
+        )
+        diagnostic.append(f"--- {name} (rc={proc.returncode}) ---")
+        diagnostic.append(proc.stdout or "<empty stdout>")
+        if proc.stderr:
+            diagnostic.append(f"--- {name} stderr ---")
+            diagnostic.append(proc.stderr)
+    pytest.fail(
+        "No master logged 'BECOMING LEADER' within the election deadline.\n"
+        + "\n".join(diagnostic)
+    )

--- a/tests/pytests/smoke-tests.txt
+++ b/tests/pytests/smoke-tests.txt
@@ -1,0 +1,204 @@
+# Salt cluster + mmap_cache smoke test selection.
+#
+# Run from repo root:
+#   tests/pytests/run-smoke-tests.sh
+# Or:
+#   python -m pytest $(grep -v '^#' tests/pytests/smoke-tests.txt | grep -v '^$') --run-slow --benchmark-disable --tb=short
+#
+# Covers one representative test per critical path at each layer.  Sections:
+#
+#   1. Raft consensus core (unit, functional, scenarios)
+#   2. Cluster integration (real master daemons, isolated-FS state-sync,
+#      multi-minion routing, late-joiner replication)
+#   3. mmap_cache / mmap_key cache backends
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Raft consensus
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── UNIT: core data structures ───────────────────────────────────────────────
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestMembershipStateMachine::test_apply_sets_voters_and_learners
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestMembershipStateMachine::test_snapshot_roundtrip
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestMembershipStateMachine::test_is_voter_and_is_learner
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestLogEntryCommitStatusSet::test_set_contributes_to_committed_quorum
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestLogEdgeCases::test_add_at_snapshot_boundary_returns_false
+
+# RPC envelope encode/decode
+tests/pytests/unit/cluster/consensus/test_rpc.py
+
+# ── UNIT: SaltStorage (per-entry log keys, state, snapshot round-trip) ───────
+tests/pytests/unit/cluster/consensus/test_raft_log.py::test_salt_storage_state_roundtrip
+tests/pytests/unit/cluster/consensus/test_raft_log.py::test_salt_storage_log_append_and_reload
+tests/pytests/unit/cluster/consensus/test_raft_log.py::test_salt_storage_save_and_reload_log
+tests/pytests/unit/cluster/consensus/test_raft_log.py::test_salt_storage_defaults_when_empty
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestSaltStorageDictFormatAndSnapshot::test_load_log_dict_format
+
+# ── UNIT: file_sync (file_roots / pillar_roots collect / apply helpers
+#    used by cluster/peer/join-reply state-sync) ──────────────────────────────
+tests/pytests/unit/cluster/test_file_sync.py
+
+# ── UNIT: state_sync (paged four-stream bulk sync — chunk generators,
+#    install helpers, and StateSyncSession state machine) ──────────────────
+tests/pytests/unit/cluster/test_state_sync.py
+
+# ── UNIT: HashRing (consistent-hash ring used for cross-master jid routing)
+#    Single-node fast-path, multi-node distribution, rebuild idempotency. ────
+tests/pytests/unit/cluster/test_ring.py
+
+# ── FUNCTIONAL: HashRing under realistic clustering ──────────────────────────
+tests/pytests/functional/cluster/test_ring.py
+
+# ── UNIT: salt.scripts CLI entry-point pin (Python 3.14 forkserver fix) ──────
+tests/pytests/unit/test_scripts.py::test_salt_scripts_pins_fork_start_method
+tests/pytests/unit/test_scripts.py::test_salt_scripts_pin_survives_fresh_interpreter
+
+# ── UNIT: node state machine ─────────────────────────────────────────────────
+tests/pytests/unit/cluster/consensus/test_raft_node_safety.py
+
+# Learner: no election, quorum excludes non-voters, config change flips voting
+tests/pytests/unit/cluster/consensus/test_raft_membership.py::TestLearnerNoElection::test_learner_does_not_send_pre_vote_rpcs
+tests/pytests/unit/cluster/consensus/test_raft_membership.py::TestLearnerNoElection::test_learner_follower_timeout_rearms_without_voting
+tests/pytests/unit/cluster/consensus/test_raft_membership.py::TestCandidacyQuorum::test_two_voters_plus_learner_quorum_based_on_voters
+tests/pytests/unit/cluster/consensus/test_raft_membership.py::TestLearnerPromotion::test_config_entry_proposed_when_learner_catches_up
+tests/pytests/unit/cluster/consensus/test_raft_membership.py::TestLearnerPromotion::test_config_entry_applied_promotes_learner_peer
+
+# MembershipStateMachine integration in Node
+tests/pytests/unit/cluster/consensus/test_raft_node.py::TestNodeMembershipSM::test_sm_updated_when_config_entry_committed
+tests/pytests/unit/cluster/consensus/test_raft_node.py::TestNodeMembershipSM::test_info_includes_membership
+
+# Exactly-once delivery + scheduler
+tests/pytests/unit/cluster/consensus/test_raft_exactly_once.py
+tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
+
+# Cluster-ready gate
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestClusterIsReady::test_non_cluster_always_ready
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestClusterIsReady::test_cluster_not_ready_when_entry_missing
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestClusterIsReady::test_cluster_ready_when_event_set
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestReqServerChannelGate::test_auth_passes_when_not_ready
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestReqServerChannelGate::test_non_auth_deferred_when_not_ready
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestPoolRoutingChannelGate::test_non_auth_deferred_when_not_ready
+tests/pytests/unit/cluster/consensus/test_cluster_ready.py::TestPoolRoutingChannelGate::test_non_cluster_not_gated
+
+# ── FUNCTIONAL: transport + dispatcher ───────────────────────────────────────
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestSingleHopRpc::test_request_vote_rpc
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestSingleHopRpc::test_append_entries_rpc
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestSingleHopRpc::test_install_snapshot_rpc
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestLogReplication::test_config_entry_type_replicates
+
+# ── FUNCTIONAL: election + replication ───────────────────────────────────────
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestElection::test_three_node_cluster_elects_exactly_one_leader
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestLogReplication::test_leader_replicates_entry_to_all_followers
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestLogReplication::test_leader_commit_index_advances_after_replication
+tests/pytests/functional/cluster/consensus/test_raft_transport.py::TestFaultTolerance::test_minority_partition_does_not_commit
+
+# ── FUNCTIONAL: RaftService lifecycle ────────────────────────────────────────
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestRaftServiceConstruction::test_peers_wired_to_node
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestRaftServiceLifecycle::test_single_node_becomes_leader_after_start
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestEndToEnd::test_three_services_elect_one_leader
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestFoundingConfig::test_leader_commits_founding_config_on_empty_log
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestFoundingConfig::test_maybe_commit_founding_config_no_ops_if_log_nonempty
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestDynamicJoinerAsLearner::test_learner_raftservice_does_not_start_election_after_start
+
+# ── SCENARIO: full join-and-promote path ─────────────────────────────────────
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestNotifyPeerJoined::test_adds_non_voting_peer_to_node_peers
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestNotifyPeerJoined::test_leader_initialises_replication_tracking
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestLeaderReplicatesToLearner::test_learner_log_matches_leader_after_replication
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestLearnerPromotion::test_leader_proposes_config_entry_when_learner_catches_up
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestLearnerPromotion::test_learner_voting_flag_flips_after_config_commits
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestMembershipStateMachineAfterJoin::test_membership_sm_shows_new_voter_after_promotion
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestFoundingConfigScenario::test_founding_config_applied_on_all_nodes
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestQuorumWithPendingLearner::test_entry_commits_without_learner_ack
+tests/pytests/functional/cluster/consensus/test_raft_scenarios.py::TestQuorumWithPendingLearner::test_two_of_three_voters_suffice_while_learner_is_present
+
+# ── FUNCTIONAL: on_ready callback ────────────────────────────────────────────
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_fires_when_node_becomes_voter
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_fires_only_once
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_wired_to_membership_sm
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestOnReady::test_on_ready_not_fired_for_learner_only_entry
+
+# ── FUNCTIONAL/INTEGRATION/SCENARIO: cluster-ready gate ──────────────────────
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_fires_after_founding_config_commits
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_fires_on_all_founding_nodes
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_not_fired_before_config_commits
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestOnReadyFunctional::test_on_ready_fires_only_once_per_node
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestClusterReadyIntegration::test_signal_cluster_ready_sets_event
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestClusterReadyIntegration::test_on_ready_wired_to_signal_via_raft_service
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestClusterReadyIntegration::test_cluster_is_ready_reflects_event
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_learner_gate_closed_before_promotion
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_learner_gate_opens_after_promotion
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_founding_nodes_ready_before_learner
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_node_never_added_to_voters_never_ready
+tests/pytests/functional/cluster/consensus/test_cluster_ready_scenarios.py::TestLearnerReadinessScenario::test_ready_event_stays_set_after_subsequent_configs
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Cluster integration (real master daemons)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── INTEGRATION: real cluster bootstrap (deterministic founder, sentinel,
+#    SaltPeer non-blocking publish, TCP pool router) ──────────────────────────
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1_from_master_2
+tests/pytests/integration/cluster/test_basic_cluster.py::test_basic_cluster_minion_1_from_master_3
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_election_three_masters
+tests/pytests/integration/cluster/test_raft_cluster.py::test_raft_re_election_after_leader_restart
+
+# ── INTEGRATION: no-shared-filesystem path (cluster_isolated_filesystem=True)
+#    cluster_aes / cluster.pem on the wire, minion-key + job replication via
+#    cluster events, bulk state-sync of keys + file_roots + pillar_roots in
+#    join-reply, multi-minion routing across all peers ──────────────────────
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_cluster_aes_converges
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_cluster_pem_propagates
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_minion_key_replicates_to_peers
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_test_ping_via_peer_master
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_late_joiner_state_sync
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_late_joiner_receives_file_and_pillar_roots
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_multi_minion_targetable_from_every_master
+tests/pytests/integration/cluster/test_isolated_cluster.py::test_isolated_late_joiner_targets_all_existing_minions
+
+# ── SCENARIO: notify_peer_joined on receiver, dynamic 4th-master join ────────
+tests/pytests/scenarios/cluster/test_cluster.py::test_cluster_key_rotation
+tests/pytests/scenarios/cluster/test_cluster.py::test_fourth_master_joins_existing_cluster
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. mmap_cache / mmap_key cache backends
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- salt.utils.mmap_cache ---
+tests/pytests/unit/utils/test_mmap_cache.py
+tests/pytests/unit/utils/test_mmap_cache_errors.py
+tests/pytests/unit/utils/test_mmap_cache_segments.py
+tests/pytests/unit/utils/test_mmap_cache_enterprise.py
+
+# --- salt.cache.mmap_cache / mmap_key ---
+tests/pytests/unit/cache/test_mmap_cache.py
+tests/pytests/unit/cache/test_mmap_cache_errors.py
+tests/pytests/unit/cache/test_mmap_key.py
+
+# --- Cache backend parity (parametrized localfs + mmap_cache) ---
+tests/pytests/unit/cache/test_cache_backends.py
+
+# --- Runners: cache migrate + PKI mmap helpers ---
+tests/pytests/unit/runners/test_cache_migrate.py
+tests/pytests/unit/runners/test_pki.py
+
+# --- Functional ---
+tests/pytests/functional/cache/test_mmap_cache_driver.py
+tests/pytests/functional/cache/test_mmap_key.py
+tests/pytests/functional/utils/test_mmap_cache.py
+tests/pytests/functional/runners/test_cache_migrate.py
+
+# --- Perf (localfs vs mmap_cache benchmarks; --benchmark-disable runs them
+#     once for correctness without timing) ---
+tests/pytests/perf/test_cache_benchmarks.py
+
+# --- Explicit CI regression (Ubuntu 22.04 Arm64 unit / Python 3.12 mmap write path) ---
+# Placed after whole-module entries so pytest does not narrow collection (module+node adjacency quirk).
+tests/pytests/unit/cache/test_cache_backends.py::test_updated_changes_after_overwrite[mmap_cache]
+tests/pytests/unit/cache/test_cache_backends.py::test_flush_entire_bank[mmap_cache]
+tests/pytests/unit/cache/test_cache_backends.py::test_list_returns_stored_keys[mmap_cache]
+tests/pytests/unit/cache/test_mmap_cache.py::test_flush_entire_bank
+tests/pytests/unit/cache/test_mmap_cache.py::test_list_returns_keys
+tests/pytests/unit/cache/test_mmap_cache.py::test_nested_bank_list
+tests/pytests/unit/cache/test_mmap_key.py::test_list_returns_all_keys
+tests/pytests/unit/cache/test_mmap_key.py::test_flush_bank_removes_all_keys
+tests/pytests/unit/cache/test_mmap_key.py::test_rebuild_from_localfs

--- a/tests/pytests/unit/cache/test_mmap_cache.py
+++ b/tests/pytests/unit/cache/test_mmap_cache.py
@@ -219,6 +219,203 @@ def test_mmap_opts_change_rebuilds_registered_cache(cachedir):
         assert mmap_cache.fetch("bank", "second", cachedir=cachedir) == {"v": 2}
 
 
+def test_max_segment_bytes_opt_is_passed_through(cachedir):
+    """
+    ``mmap_cache_max_segment_bytes`` must reach the underlying
+    ``MmapCache`` so an operator can tune below the 1 GiB default.
+    Reads back the live attribute on the registered cache instance.
+    """
+    with patch.dict(
+        mmap_cache.__opts__,
+        {"mmap_cache_max_segment_bytes": 4096},
+    ):
+        mmap_cache.store("bank", "key", {"v": 1}, cachedir=cachedir)
+        cache_obj = mmap_cache._get_cache("bank", cachedir)
+        assert cache_obj.max_segment_bytes == 4096
+
+
+def test_max_segment_bytes_default_when_opt_missing(cachedir):
+    """No opt set → MmapCache uses the documented 1 GiB default."""
+    import salt.utils.mmap_cache  # local import keeps test independent of import order
+
+    mmap_cache.store("bank", "key", {"v": 1}, cachedir=cachedir)
+    cache_obj = mmap_cache._get_cache("bank", cachedir)
+    assert (
+        cache_obj.max_segment_bytes == salt.utils.mmap_cache.DEFAULT_MAX_SEGMENT_BYTES
+    )
+
+
+@pytest.mark.parametrize(
+    "trailing_byte",
+    # Spot-check the corners (NUL, every-bit-set, ASCII null-vs-text
+    # boundary), plus a sweep across the full byte range every 17 bytes
+    # so 256 separate fixtures don't blow up the test count.
+    [bytes([b]) for b in (0x00, 0x01, 0x09, 0x0A, 0x20, 0x7F, 0x80, 0xFF)]
+    + [bytes([b]) for b in range(0, 256, 17)],
+)
+def test_get_preserves_every_trailing_byte(tmp_path, trailing_byte):
+    """
+    BUG.md regression: storing arbitrary bytes round-trips byte-for-byte
+    through ``MmapCache.put``/``get``, including a trailing NUL.
+
+    Pre-fix, ``MmapCache.get`` ran ``raw.rstrip(b"\\x00")`` on every
+    read, so any value whose last byte was ``\\x00`` came back one
+    byte short.  Post-fix the slot's ``LENGTH`` field is the only
+    authority for the value boundary.
+    """
+    from salt.utils.mmap_cache import MmapCache
+
+    cache = MmapCache(
+        str(tmp_path / "trail.idx"),
+        size=64,
+        slot_size=128,
+        key_size=32,
+    )
+    # Prefix the value with a high byte so ``get`` always returns
+    # ``bytes`` (UTF-8 decoding fails) rather than auto-decoding to
+    # ``str`` for ASCII payloads — keeps the round-trip comparison
+    # honest about byte-level fidelity.
+    payload = b"\xff" + b"prefix-data-" + trailing_byte
+    assert cache.put("k", payload)
+    got = cache.get("k")
+    assert got == payload, (
+        f"trailing byte 0x{trailing_byte.hex()} got mangled: "
+        f"stored {payload!r} got {got!r}"
+    )
+
+
+def test_msgpack_zero_tail_dict_round_trips_through_cache_backend(cachedir):
+    """
+    BUG.md end-to-end regression: a dict whose msgpack-encoded form
+    ends in ``\\x00`` (common: integer-tailed dicts where the last
+    field is ``0``) must round-trip through the salt.cache backend
+    without a ``SaltCacheError`` on read.
+
+    Pre-fix, this raised ``SaltCacheError: Failed to deserialise
+    cache data ...: Unpack failed: incomplete input`` because get
+    stripped the trailing NUL of the msgpack stream.
+    """
+    import msgpack
+
+    payload = {"p": "x" * 200, "i": 0}
+    raw = msgpack.packb(payload)
+    assert raw.endswith(b"\x00"), "test premise: msgpack of i=0 ends in NUL"
+
+    mmap_cache.store("bank", "k0", payload, cachedir=cachedir)
+    assert mmap_cache.fetch("bank", "k0", cachedir=cachedir) == payload
+
+
+def test_overwrite_with_shorter_nul_tailed_value_round_trips(tmp_path):
+    """
+    BUG.md companion regression for ``_overwrite_in_heap``.
+
+    Sequence:
+
+    1. Put a long value to claim heap region of size N.
+    2. Put a *shorter* binary value ending in NUL at the same key —
+       triggers the in-place overwrite path.
+    3. Get must return the new shorter value bytes intact.
+
+    Pre-fix, the in-place overwrite NUL-padded the value to the
+    existing region length AND rstripped it for the CRC computation,
+    so the stored digest was over the rstripped (no-NUL-tail) bytes
+    while the read-side digest was over the actual NUL-tailed bytes.
+    The CRC check failed and ``get`` returned ``None``.
+    """
+    from salt.utils.mmap_cache import MmapCache
+
+    cache = MmapCache(
+        str(tmp_path / "ow.idx"),
+        size=64,
+        slot_size=128,
+        key_size=32,
+    )
+    # High-byte prefix forces ``get`` to return bytes (no UTF-8
+    # auto-decode), keeping the comparison byte-exact.
+    cache.put("k", b"\xff-originally-longer-value-for-region")
+    cache.put("k", b"\xff-short\x00")  # in-place overwrite, ends in NUL
+    assert cache.get("k") == b"\xff-short\x00", (
+        "in-place overwrite of NUL-tailed value did not round-trip; "
+        "_overwrite_in_heap CRC computation likely still rstrips"
+    )
+
+
+def test_overwrite_then_grow_then_shrink_with_nul_tails(tmp_path):
+    """
+    Stress version of the overwrite regression: put a sequence of
+    values with assorted trailing bytes — including NULs — at the
+    same key, alternating between sizes that fit in-place and sizes
+    that trigger an append.  Every read must return the most recent
+    value byte-for-byte.
+    """
+    from salt.utils.mmap_cache import MmapCache
+
+    cache = MmapCache(
+        str(tmp_path / "stress.idx"),
+        size=64,
+        slot_size=128,
+        key_size=32,
+    )
+    # Every value starts with a high byte so ``get`` returns bytes,
+    # not str-decoded — see prior tests' note.
+    sequence = [
+        b"\xff-longvalueforinitialheapregion",  # 32 bytes; allocates
+        b"\xff-short\x00",  # in-place overwrite
+        b"\xff-a-bit-longer-but-still-fits\x00",  # in-place overwrite
+        b"\xff-now grow past the original region - heap append \x00",
+        b"\xff\x00\x00\x00",  # mostly-NUL
+        b"\xff-f\xff\x00",  # binary with tail NUL
+    ]
+    for value in sequence:
+        assert cache.put("k", value)
+        got = cache.get("k")
+        assert got == value, (
+            f"round-trip failed for value of length {len(value)}: "
+            f"stored {value!r} got {got!r}"
+        )
+
+
+def test_segment_actually_rolls_at_configured_cap(cachedir):
+    """
+    End-to-end: with a tiny cap, a few stores roll a new heap segment.
+    Asserts a ``.heap.N`` file appears alongside the original heap.
+
+    Pre-BUG.md fix this test could not safely fetch every key (the
+    ``MmapCache.get`` ``rstrip(b"\\x00")`` corrupted msgpack-encoded
+    integer-tailed dicts).  The fix landed; the
+    ``test_msgpack_zero_tail_dict_round_trips_through_cache_backend``
+    test below covers the cross-segment fetch case.
+    """
+    import os
+
+    with patch.dict(
+        mmap_cache.__opts__,
+        # Cap at ~1 KiB so a handful of stores trips the roll quickly.
+        {"mmap_cache_max_segment_bytes": 1024},
+    ):
+        for i in range(20):
+            mmap_cache.store(
+                "rolling-bank",
+                f"k{i}",
+                # Each value ~200 bytes after msgpack.  Total record
+                # (CRC + value) crosses 1024 bytes within ~5 stores.
+                {"payload": "x" * 200, "i": i},
+                cachedir=cachedir,
+            )
+        bank_dir = os.path.join(cachedir, "rolling-bank")
+        seg_files = sorted(
+            f for f in os.listdir(bank_dir) if f.startswith(".mmap_cache.idx.heap")
+        )
+        # Original heap + at least one rolled segment.
+        assert len(seg_files) >= 2, (
+            f"expected at least two .heap segment files after rolling, "
+            f"got {seg_files}"
+        )
+        # And the active segment id reflects the rolls.
+        cache_obj = mmap_cache._get_cache("rolling-bank", cachedir)
+        assert cache_obj._active_segment_id() >= 1
+
+
 def test_two_instances_share_data(cachedir):
     """
     Simulate two processes: writer stores data; reader (separate instance)

--- a/tests/pytests/unit/cache/test_mmap_cache.py
+++ b/tests/pytests/unit/cache/test_mmap_cache.py
@@ -235,7 +235,7 @@ def test_max_segment_bytes_opt_is_passed_through(cachedir):
 
 
 def test_max_segment_bytes_default_when_opt_missing(cachedir):
-    """No opt set → MmapCache uses the documented 1 GiB default."""
+    """No opt set -> MmapCache uses the documented 1 GiB default."""
     import salt.utils.mmap_cache  # local import keeps test independent of import order
 
     mmap_cache.store("bank", "key", {"v": 1}, cachedir=cachedir)

--- a/tests/pytests/unit/cache/test_mmap_key.py
+++ b/tests/pytests/unit/cache/test_mmap_key.py
@@ -382,7 +382,7 @@ def test_max_segment_bytes_falls_back_to_mmap_cache_opt(module, pki_dir, opts):
 
 
 def test_max_segment_bytes_default_when_unset(module, pki_dir):
-    """No opt set → 1 GiB default."""
+    """No opt set -> 1 GiB default."""
     import salt.utils.mmap_cache  # local import keeps test independent of import order
 
     cache_obj = module._get_cache("keys", pki_dir)

--- a/tests/pytests/unit/cache/test_mmap_key.py
+++ b/tests/pytests/unit/cache/test_mmap_key.py
@@ -352,3 +352,48 @@ def test_rebuild_from_localfs(module, pki_dir, opts):
     assert module.fetch("keys", "pend1", pki_dir)["state"] == "pending"
     denied = module.fetch("denied_keys", "bad1", pki_dir)
     assert isinstance(denied, list)
+
+
+# ---------------------------------------------------------------------------
+# Heap segment cap plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_max_segment_bytes_opt_is_passed_through(module, pki_dir, opts):
+    """
+    ``mmap_key_max_segment_bytes`` must reach the underlying
+    ``MmapCache`` so an operator can size below the 1 GiB default.
+    """
+    opts["mmap_key_max_segment_bytes"] = 8192
+    cache_obj = module._get_cache("keys", pki_dir)
+    assert cache_obj.max_segment_bytes == 8192
+
+
+def test_max_segment_bytes_falls_back_to_mmap_cache_opt(module, pki_dir, opts):
+    """
+    For operators who already set ``mmap_cache_max_segment_bytes`` for
+    the generic backend, the mmap_key backend honours it as a fallback
+    so the same cap applies cluster-wide without duplicate config.
+    """
+    opts.pop("mmap_key_max_segment_bytes", None)
+    opts["mmap_cache_max_segment_bytes"] = 16384
+    cache_obj = module._get_cache("keys", pki_dir)
+    assert cache_obj.max_segment_bytes == 16384
+
+
+def test_max_segment_bytes_default_when_unset(module, pki_dir):
+    """No opt set → 1 GiB default."""
+    import salt.utils.mmap_cache  # local import keeps test independent of import order
+
+    cache_obj = module._get_cache("keys", pki_dir)
+    assert (
+        cache_obj.max_segment_bytes == salt.utils.mmap_cache.DEFAULT_MAX_SEGMENT_BYTES
+    )
+
+
+def test_mmap_key_specific_opt_wins_over_generic(module, pki_dir, opts):
+    """If both opts are set, the mmap_key-specific one takes precedence."""
+    opts["mmap_cache_max_segment_bytes"] = 16384
+    opts["mmap_key_max_segment_bytes"] = 4096
+    cache_obj = module._get_cache("keys", pki_dir)
+    assert cache_obj.max_segment_bytes == 4096

--- a/tests/pytests/unit/cluster/consensus/test_raft_log.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_log.py
@@ -806,7 +806,13 @@ class TestBaseStorageAndStateMachineAbstractBodies:
 
 class TestSaltStorageDictFormatAndSnapshot:
     def test_load_log_dict_format(self, tmp_path):
-        """SaltStorage.load_log handles dict-format entries from cache backends."""
+        """SaltStorage.load_log handles dict-format entries from cache backends.
+
+        Per-entry layout: ``cache.list`` enumerates the log keys (one per
+        Raft index) and ``cache.fetch`` returns each entry's payload.
+        Some backends serialize the payload as a dict instead of a tuple
+        (``localfs_key`` legacy behaviour); the loader must accept both.
+        """
         from salt.cluster.consensus.raft.log import LogEntryType
         from salt.cluster.consensus.storage import SaltStorage
         from tests.support.mock import patch
@@ -827,8 +833,9 @@ class TestSaltStorageDictFormatAndSnapshot:
             "client_id": None,
             "sequence_num": None,
         }
-        # Patch the cache fetch to return dict-format data
-        with patch.object(storage._cache, "fetch", return_value=[dict_entry]):
+        with patch.object(storage._cache, "list", return_value=["0"]), patch.object(
+            storage._cache, "fetch", return_value=dict_entry
+        ):
             entries = storage.load_log()
         assert len(entries) == 1
         assert entries[0].cmd == b"hello"

--- a/tests/pytests/unit/cluster/consensus/test_raft_log.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_log.py
@@ -900,3 +900,364 @@ class TestCounterStateMachineRestoreNonBytesNonDict:
         sm.count = 7
         sm.restore_snapshot([1, 2, 3])  # neither dict nor bytes
         assert sm.count == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: multi-state-machine snapshot envelope.
+#
+# Bug: Log.snapshot() used to serialise only the application state machine,
+# so a CONFIG entry that had been compacted away left MembershipStateMachine
+# empty after restart / install_snapshot.  These tests pin down the envelope
+# shape and the round-trip via storage so the membership SM (and any future
+# named SM) survives compaction.
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotEnvelope:
+    """Envelope encoding/decoding helpers and round-trip behaviour."""
+
+    def test_envelope_marker_is_v1(self):
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION
+
+        assert SNAPSHOT_ENVELOPE_VERSION == "raft.snapshot.v1"
+
+    def test_encode_bytes_payload_is_json_safe(self):
+        import json
+
+        from salt.cluster.consensus.raft.log import Log
+
+        encoded = Log._encode_sm_payload(b"\x00\x01\xff")
+        # Must be JSON-serialisable so the storage layer can dump the envelope
+        json.dumps(encoded)
+        assert "__bytes__" in encoded
+        assert Log._decode_sm_payload(encoded) == b"\x00\x01\xff"
+
+    def test_encode_dict_payload_passthrough(self):
+        from salt.cluster.consensus.raft.log import Log
+
+        payload = {"voters": ["m1"], "learners": [], "version": 3}
+        # Dicts are already JSON-safe — should not be wrapped
+        assert Log._encode_sm_payload(payload) is payload
+        assert Log._decode_sm_payload(payload) is payload
+
+    def test_decode_bytes_marker_dict(self):
+        import base64
+
+        from salt.cluster.consensus.raft.log import Log
+
+        encoded = {"__bytes__": base64.b64encode(b"abc").decode("ascii")}
+        assert Log._decode_sm_payload(encoded) == b"abc"
+
+    def test_maybe_envelope_recognises_dict(self):
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION, Log
+
+        env = {"__envelope__": SNAPSHOT_ENVELOPE_VERSION, "machines": {}}
+        assert Log._maybe_envelope(env) is env
+
+    def test_maybe_envelope_recognises_json_bytes(self):
+        import json
+
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION, Log
+
+        env = {"__envelope__": SNAPSHOT_ENVELOPE_VERSION, "machines": {}}
+        assert Log._maybe_envelope(json.dumps(env).encode()) == env
+
+    def test_maybe_envelope_rejects_legacy_dict(self):
+        from salt.cluster.consensus.raft.log import Log
+
+        # Pre-fix payloads (e.g. CounterStateMachine.get_snapshot()) have no
+        # __envelope__ key — must be treated as legacy single-SM data
+        assert Log._maybe_envelope({"count": 5, "sessions": {}}) is None
+
+    def test_maybe_envelope_rejects_unparseable_bytes(self):
+        from salt.cluster.consensus.raft.log import Log
+
+        assert Log._maybe_envelope(b"not-json-at-all") is None
+
+
+class TestLogSnapshotMultiSM:
+    """``Log.snapshot()`` must serialise every registered state machine."""
+
+    def _make_storage(self, tmp_path):
+        from salt.cluster.consensus.storage import SaltStorage
+
+        opts = {"cachedir": str(tmp_path), "cluster_id": "test", "cluster_peers": []}
+        return SaltStorage("n1", opts)
+
+    def test_snapshot_envelope_contains_membership_sm(self, tmp_path):
+        """A Log with both app SM and membership SM writes both into one snapshot."""
+        import json
+
+        from salt.cluster.consensus.raft.log import (
+            SNAPSHOT_ENVELOPE_VERSION,
+            CounterStateMachine,
+            Log,
+            LogEntryType,
+            MembershipStateMachine,
+        )
+
+        storage = self._make_storage(tmp_path)
+        app_sm = CounterStateMachine()
+        mem_sm = MembershipStateMachine()
+        lg = Log(
+            storage=storage,
+            state_machine=app_sm,
+            state_machines={"membership_sm": mem_sm},
+        )
+
+        # Apply some app commands and a CONFIG entry → SM state is non-empty.
+        app_sm.apply(b"a")
+        app_sm.apply(b"b")
+        mem_sm.apply({"voters": ["m1", "m2", "m3"], "learners": []}, index=2)
+
+        # Append entries so snapshot has something to discard
+        lg.add(1, b"a")
+        lg.add(1, b"b")
+        lg.add(1, {"voters": ["m1", "m2", "m3"]}, entry_type=LogEntryType.CONFIG)
+        lg.commit(2)
+
+        lg.snapshot()
+        raw = storage.load_snapshot()
+        assert raw is not None
+
+        envelope = json.loads(raw["data"].decode("utf-8"))
+        assert envelope["__envelope__"] == SNAPSHOT_ENVELOPE_VERSION
+        assert "state_machine" in envelope["machines"]
+        assert "membership_sm" in envelope["machines"]
+        assert envelope["machines"]["membership_sm"] == {
+            "voters": ["m1", "m2", "m3"],
+            "learners": [],
+            "version": 2,
+        }
+
+    def test_snapshot_restore_preserves_membership(self, tmp_path):
+        """Round-trip: snapshot, build a fresh Log on the same storage, membership intact."""
+        from salt.cluster.consensus.raft.log import (
+            CounterStateMachine,
+            Log,
+            LogEntryType,
+            MembershipStateMachine,
+        )
+
+        storage = self._make_storage(tmp_path)
+        app_sm = CounterStateMachine()
+        mem_sm = MembershipStateMachine()
+        lg = Log(
+            storage=storage,
+            state_machine=app_sm,
+            state_machines={"membership_sm": mem_sm},
+        )
+        app_sm.apply(b"a")
+        mem_sm.apply({"voters": ["m1", "m2"], "learners": ["m3"]}, index=4)
+        lg.add(1, b"a")
+        lg.add(
+            1,
+            {"voters": ["m1", "m2"], "learners": ["m3"]},
+            entry_type=LogEntryType.CONFIG,
+        )
+        lg.commit(1)
+        lg.snapshot()
+        # Sanity: snapshot truncated the in-memory log
+        assert lg.entries == []
+
+        # Fresh Log on the same storage simulates a restart
+        app_sm2 = CounterStateMachine()
+        mem_sm2 = MembershipStateMachine()
+        lg2 = Log(
+            storage=storage,
+            state_machine=app_sm2,
+            state_machines={"membership_sm": mem_sm2},
+        )
+        # last_included_* picked up from the saved snapshot
+        assert lg2.last_included_index == 1
+        # And both state machines were restored
+        assert app_sm2.count == 1
+        assert mem_sm2.current_voters() == ["m1", "m2"]
+        assert mem_sm2.current_learners() == ["m3"]
+        assert mem_sm2.membership_version == 4
+
+    def test_register_state_machine_after_init(self, tmp_path):
+        """SMs registered post-init are still serialised on the next snapshot."""
+        import json
+
+        from salt.cluster.consensus.raft.log import (
+            CounterStateMachine,
+            Log,
+            MembershipStateMachine,
+        )
+
+        storage = self._make_storage(tmp_path)
+        lg = Log(storage=storage, state_machine=CounterStateMachine())
+        late_sm = MembershipStateMachine()
+        late_sm.apply({"voters": ["m1"], "learners": []}, index=0)
+        lg.register_state_machine("membership_sm", late_sm)
+
+        lg.add(1, b"x")
+        lg.commit(0)
+        lg.snapshot()
+
+        raw = storage.load_snapshot()
+        envelope = json.loads(raw["data"].decode("utf-8"))
+        assert "membership_sm" in envelope["machines"]
+
+    def test_legacy_snapshot_bytes_restore_state_machine(self, tmp_path):
+        """A pre-fix snapshot (raw JSON bytes, no envelope) still restores app SM."""
+        import json
+
+        from salt.cluster.consensus.raft.log import CounterStateMachine, Log
+
+        storage = self._make_storage(tmp_path)
+        # Simulate a pre-fix on-disk snapshot: just the SM blob, no envelope
+        storage.save_snapshot(
+            json.dumps({"count": 7, "sessions": {}}).encode(), index=3, term=1
+        )
+
+        app_sm = CounterStateMachine()
+        mem_sm = __import__(
+            "salt.cluster.consensus.raft.log", fromlist=["MembershipStateMachine"]
+        ).MembershipStateMachine()
+        lg = Log(
+            storage=storage,
+            state_machine=app_sm,
+            state_machines={"membership_sm": mem_sm},
+        )
+
+        # App SM was restored from the legacy payload
+        assert app_sm.count == 7
+        # Membership SM stays at its initial state — pre-fix snapshots had no
+        # membership data; the post-snapshot log replay would rebuild it
+        assert mem_sm.current_voters() == []
+        assert lg.last_included_index == 3
+
+    def test_snapshot_without_extras_has_state_machine_key(self, tmp_path):
+        """A Log with only an app SM still writes envelope format."""
+        import json
+
+        from salt.cluster.consensus.raft.log import (
+            SNAPSHOT_ENVELOPE_VERSION,
+            CounterStateMachine,
+            Log,
+        )
+
+        storage = self._make_storage(tmp_path)
+        lg = Log(storage=storage, state_machine=CounterStateMachine())
+        lg.add(1, b"a")
+        lg.commit(0)
+        lg.snapshot()
+
+        raw = storage.load_snapshot()
+        envelope = json.loads(raw["data"].decode("utf-8"))
+        assert envelope["__envelope__"] == SNAPSHOT_ENVELOPE_VERSION
+        assert list(envelope["machines"].keys()) == ["state_machine"]
+
+
+class TestNodeInstallSnapshotMembership:
+    """Node.install_snapshot must restore membership_sm from the envelope."""
+
+    def test_install_snapshot_restores_membership(self):
+        """A follower receiving an envelope snapshot rebuilds its membership SM."""
+        import json
+
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("follower")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.term = 1
+
+        envelope = {
+            "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+            "machines": {
+                "membership_sm": {
+                    "voters": ["m1", "m2", "m3"],
+                    "learners": [],
+                    "version": 5,
+                },
+            },
+        }
+        data = json.dumps(envelope).encode("utf-8")
+
+        node.install_snapshot(
+            leader_id="m1",
+            term=2,
+            last_index=10,
+            last_term=2,
+            data=data,
+        )
+
+        assert node.membership_sm.current_voters() == ["m1", "m2", "m3"]
+        assert node.membership_sm.membership_version == 5
+        assert node.log.last_included_index == 10
+
+    def test_install_snapshot_legacy_payload_falls_through(self):
+        """A pre-fix snapshot blob (no envelope marker) leaves membership SM untouched."""
+        import json
+
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("follower")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.term = 1
+        # Membership SM starts empty; legacy payload is for the app SM, which
+        # is None by default — test verifies no crash and no spurious changes.
+        legacy = json.dumps({"count": 9, "sessions": {}}).encode()
+
+        node.install_snapshot(
+            leader_id="m1",
+            term=2,
+            last_index=4,
+            last_term=2,
+            data=legacy,
+        )
+
+        assert node.membership_sm.current_voters() == []
+        assert node.log.last_included_index == 4
+
+    def test_install_snapshot_envelope_with_dict_data(self):
+        """install_snapshot also accepts an already-decoded envelope dict."""
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("follower")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.term = 1
+
+        envelope = {
+            "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+            "machines": {
+                "membership_sm": {
+                    "voters": ["m1"],
+                    "learners": ["m2"],
+                    "version": 1,
+                },
+            },
+        }
+
+        node.install_snapshot(
+            leader_id="m1",
+            term=2,
+            last_index=2,
+            last_term=2,
+            data=envelope,
+        )
+
+        assert node.membership_sm.current_voters() == ["m1"]
+        assert node.membership_sm.current_learners() == ["m2"]
+
+    def test_node_log_registers_membership_sm(self):
+        """Node wires its membership_sm into Log so snapshots include it."""
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("a")
+        assert "membership_sm" in node.log._extra_state_machines
+        assert node.log._extra_state_machines["membership_sm"] is node.membership_sm
+
+    def test_register_membership_sm_updates_log(self):
+        """Replacing the membership SM keeps the Log registry in sync."""
+        from salt.cluster.consensus.raft.log import MembershipStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("a")
+        new_sm = MembershipStateMachine()
+        node.register_membership_sm(new_sm)
+        assert node.log._extra_state_machines["membership_sm"] is new_sm

--- a/tests/pytests/unit/cluster/consensus/test_raft_log.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_log.py
@@ -1261,3 +1261,576 @@ class TestNodeInstallSnapshotMembership:
         new_sm = MembershipStateMachine()
         node.register_membership_sm(new_sm)
         assert node.log._extra_state_machines["membership_sm"] is new_sm
+
+
+class TestNodeReconcileMembership:
+    """
+    Node.reconcile_membership re-applies the SM's restored view to the
+    Node's peer table and fires the wired on_change observer.
+
+    GAP #1 in CONSENSUS_BUGS.md / GAPS.md: MembershipStateMachine
+    .restore_snapshot is a pure store; without reconcile, the in-memory
+    peer voting flags and any on_change observer (RaftService cluster-
+    ready hook, ring rebuild) stay stale after a snapshot restore.
+    """
+
+    def _make_node(self, node_id="a"):
+        """Build a Node with a peer factory so on_config_change rebuilds peers."""
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node(node_id)
+        node.register_schedule_timeout(lambda t, c: None)
+
+        class _StubPeer:
+            def __init__(self, addr, voting=True):
+                self.node_id = addr
+                self.voting = voting
+
+        node.register_peer_factory(_StubPeer)
+        return node
+
+    def test_reconcile_no_op_when_sm_empty(self):
+        """A fresh Node with no committed CONFIG: reconcile is a no-op."""
+        node = self._make_node()
+        observed = []
+        node.membership_sm.on_change = lambda v, l: observed.append((list(v), list(l)))
+        node.reconcile_membership()
+        assert observed == [], "on_change must not fire for an empty SM"
+        assert node.peers == []
+
+    def test_reconcile_after_restore_snapshot_fires_on_change(self):
+        """
+        After ``MembershipStateMachine.restore_snapshot`` populates the
+        SM, calling ``reconcile_membership`` invokes the wired on_change
+        observer with the restored voters/learners.
+        """
+        node = self._make_node("self")
+        observed = []
+        node.membership_sm.on_change = lambda v, l: observed.append((list(v), list(l)))
+
+        node.membership_sm.restore_snapshot(
+            {"voters": ["self", "b", "c"], "learners": ["d"], "version": 7}
+        )
+        # Pre-condition: SM has the right view but on_change has not fired.
+        assert node.membership_sm.current_voters() == ["b", "c", "self"]
+        assert observed == []
+
+        node.reconcile_membership()
+
+        assert len(observed) == 1
+        voters, learners = observed[0]
+        assert sorted(voters) == ["b", "c", "self"]
+        assert learners == ["d"]
+
+    def test_reconcile_rebuilds_node_peers_from_restored_sm(self):
+        """
+        ``Node.peers`` and ``Node.voting`` re-converge with the restored
+        SM after reconcile.  Without this, a master that comes up from a
+        compacted snapshot has an empty peer table.
+        """
+        node = self._make_node("self")
+        # Pre-existing peer table is empty (this is the post-snapshot
+        # state — Node was constructed before any CONFIG entry replayed).
+        assert node.peers == []
+        assert node.voting is True  # default
+
+        node.membership_sm.restore_snapshot(
+            {"voters": ["self", "b", "c"], "learners": ["d"], "version": 9}
+        )
+        node.reconcile_membership()
+
+        # All three voter peers (excluding self) plus the learner should
+        # appear in node.peers, with voting flags set correctly.
+        peer_ids = sorted(p.node_id for p in node.peers)
+        assert peer_ids == ["b", "c", "d"]
+        voting_by_id = {p.node_id: p.voting for p in node.peers}
+        assert voting_by_id == {"b": True, "c": True, "d": False}
+        # And self must be marked as a voter.
+        assert node.voting is True
+
+    def test_reconcile_fired_from_install_snapshot(self):
+        """
+        ``Node.install_snapshot`` calls reconcile so a follower receiving
+        an envelope snapshot ends up with peers + on_change side effects
+        consistent with the restored membership SM.
+        """
+        import json
+
+        from salt.cluster.consensus.raft.log import SNAPSHOT_ENVELOPE_VERSION
+
+        node = self._make_node("follower")
+        node.term = 1
+        observed = []
+        node.membership_sm.on_change = lambda v, l: observed.append((list(v), list(l)))
+
+        envelope = {
+            "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+            "machines": {
+                "membership_sm": {
+                    "voters": ["m1", "m2", "follower"],
+                    "learners": [],
+                    "version": 12,
+                },
+            },
+        }
+        node.install_snapshot(
+            leader_id="m1",
+            term=2,
+            last_index=20,
+            last_term=2,
+            data=json.dumps(envelope).encode("utf-8"),
+        )
+
+        # SM restored, on_change fired, peers rebuilt.
+        assert node.membership_sm.current_voters() == ["follower", "m1", "m2"]
+        assert len(observed) == 1
+        peer_ids = sorted(p.node_id for p in node.peers)
+        assert peer_ids == ["m1", "m2"]
+
+    def test_reconcile_idempotent(self):
+        """
+        Calling reconcile twice on the same restored state is safe; it
+        re-fires on_change but does not corrupt peer state.  This matches
+        the behaviour we get when ``RaftService`` reconciles after wiring
+        on_change *and* a subsequent ``install_snapshot`` reconciles again.
+        """
+        node = self._make_node("self")
+        node.membership_sm.restore_snapshot(
+            {"voters": ["self", "b"], "learners": [], "version": 1}
+        )
+        observed = []
+        node.membership_sm.on_change = lambda v, l: observed.append((list(v), list(l)))
+
+        node.reconcile_membership()
+        node.reconcile_membership()
+
+        peer_ids = sorted(p.node_id for p in node.peers)
+        assert peer_ids == ["b"]
+        # on_change fired twice but the peer table is stable.
+        assert len(observed) == 2
+
+    def test_reconcile_without_peer_factory(self):
+        """
+        A bare Node without a registered peer factory still reconciles
+        cleanly: peer voting flags update in place on the existing
+        peers, on_change still fires.  Matches the pre-RaftService
+        construction window where reconcile would fire from
+        ``install_snapshot`` before any peer factory is wired.
+        """
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("self")
+        node.register_schedule_timeout(lambda t, c: None)
+        # No peer_factory registered — leave node.peers empty.
+
+        observed = []
+        node.membership_sm.on_change = lambda v, l: observed.append((list(v), list(l)))
+        node.membership_sm.restore_snapshot(
+            {"voters": ["self", "b"], "learners": ["c"], "version": 1}
+        )
+        node.reconcile_membership()
+        # on_change still fired — RaftService can update its hooks.
+        assert len(observed) == 1
+        assert sorted(observed[0][0]) == ["b", "self"]
+        assert observed[0][1] == ["c"]
+        # Without a factory there are no peers to populate; that's
+        # correct for this construction window.
+        assert node.peers == []
+
+    def test_reconcile_when_self_demoted_to_learner(self):
+        """
+        If the restored membership has this node *only* in the learner
+        set, ``Node.voting`` flips to False.  Pins the
+        on_config_change side-effect path on the demote case.
+        """
+        node = self._make_node("self")
+        node.membership_sm.restore_snapshot(
+            {"voters": ["b", "c"], "learners": ["self"], "version": 1}
+        )
+        node.reconcile_membership()
+        assert node.voting is False
+
+    def test_reconcile_with_self_in_neither_set_keeps_voting_default(self):
+        """
+        If the restored snapshot does not mention this node at all
+        (membership change removed it), ``Node.voting`` keeps its
+        prior value rather than spuriously flipping.  Matches the
+        existing on_config_change code path that only mutates
+        ``self.voting`` when it sees this node in voters or learners.
+        """
+        node = self._make_node("self")
+        original_voting = node.voting
+        node.membership_sm.restore_snapshot(
+            {"voters": ["b", "c"], "learners": ["d"], "version": 1}
+        )
+        node.reconcile_membership()
+        assert node.voting is original_voting
+
+
+# ---------------------------------------------------------------------------
+# RingConfigStateMachine — ring policy commits (Stage 1 of ring rollout)
+# ---------------------------------------------------------------------------
+
+
+class TestRingConfigStateMachine:
+    """
+    Pin the ``RingConfigStateMachine`` contract: applies RING_CONFIG
+    entries (members source + replication factor), fires on_change,
+    survives snapshot/restore via the same envelope shape used by
+    MembershipStateMachine.
+    """
+
+    def test_default_policy_is_self_with_one_replica(self):
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        assert sm.members == "self"
+        assert sm.replicas == 1
+        assert sm.config_version == -1
+
+    def test_apply_records_members_and_replicas(self):
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.apply({"members": "voters", "replicas": 3}, index=7)
+        assert sm.members == "voters"
+        assert sm.replicas == 3
+        assert sm.config_version == 7
+
+    def test_apply_partial_update_keeps_other_field(self):
+        """
+        Partial updates merge with the current state so a runner can
+        flip just one knob at a time without re-asserting the other.
+        """
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.apply({"members": "voters", "replicas": 3}, index=1)
+        # Only flip replicas.
+        sm.apply({"replicas": 2}, index=2)
+        assert sm.members == "voters"
+        assert sm.replicas == 2
+        # Only flip members.
+        sm.apply({"members": "self"}, index=3)
+        assert sm.members == "self"
+        assert sm.replicas == 2
+
+    def test_apply_rejects_unknown_members_value(self):
+        """Unknown ``members`` policy is logged and ignored, not stored."""
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.apply({"members": "voters"}, index=1)
+        sm.apply({"members": "moon"}, index=2)
+        assert sm.members == "voters"
+
+    def test_apply_clamps_replicas_to_at_least_one(self):
+        """A replicas value below 1 is silently clamped to 1."""
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.apply({"replicas": 0}, index=1)
+        assert sm.replicas == 1
+        sm.apply({"replicas": -5}, index=2)
+        assert sm.replicas == 1
+
+    def test_apply_ignores_non_integer_replicas(self):
+        """Non-numeric replicas values are logged and ignored."""
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.apply({"replicas": 3}, index=1)
+        sm.apply({"replicas": "lots"}, index=2)
+        assert sm.replicas == 3
+
+    def test_on_change_fires_with_current_state(self):
+        """
+        ``on_change(members, replicas)`` is invoked after every successful
+        apply with the *new* values — even if only one field changed.
+        """
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        seen = []
+        sm = RingConfigStateMachine(on_change=lambda m, r: seen.append((m, r)))
+        sm.apply({"members": "voters", "replicas": 3}, index=1)
+        sm.apply({"replicas": 2}, index=2)
+        assert seen == [("voters", 3), ("voters", 2)]
+
+    def test_snapshot_round_trip(self):
+        """``get_snapshot`` / ``restore_snapshot`` is lossless."""
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm1 = RingConfigStateMachine()
+        sm1.apply({"members": "voters", "replicas": 4}, index=42)
+        snap = sm1.get_snapshot()
+
+        sm2 = RingConfigStateMachine()
+        sm2.restore_snapshot(snap)
+        assert sm2.members == "voters"
+        assert sm2.replicas == 4
+        assert sm2.config_version == 42
+
+    def test_restore_snapshot_from_bytes(self):
+        """JSON-encoded snapshot bytes restore correctly."""
+        import json
+
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        payload = json.dumps(
+            {"members": "voters", "replicas": 2, "version": 5}
+        ).encode()
+        sm.restore_snapshot(payload)
+        assert sm.members == "voters"
+        assert sm.replicas == 2
+        assert sm.config_version == 5
+
+    def test_restore_snapshot_with_garbage_data_is_noop(self):
+        """Non-dict / non-bytes input leaves the SM unchanged."""
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+
+        sm = RingConfigStateMachine()
+        sm.restore_snapshot("not a dict")
+        sm.restore_snapshot(None)
+        sm.restore_snapshot(42)
+        assert sm.members == "self"
+        assert sm.replicas == 1
+
+
+class TestNodeAppliesRingConfigEntry:
+    """
+    ``Node.apply_entries`` dispatches RING_CONFIG entries to the SM
+    registered under ``"ring_sm"`` on the Log.  Stage 1 wiring.
+    """
+
+    def test_ring_config_entry_dispatches_to_registered_sm(self):
+        from salt.cluster.consensus.raft.log import LogEntryType, RingConfigStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("a")
+        node.register_schedule_timeout(lambda t, c: None)
+        ring_sm = RingConfigStateMachine()
+        node.log.register_state_machine("ring_sm", ring_sm)
+
+        node.log.add(
+            1,
+            {"members": "voters", "replicas": 2},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        node.commit_index = node.log.index
+        assert ring_sm.members == "voters"
+        assert ring_sm.replicas == 2
+
+    def test_ring_config_entry_without_registered_sm_is_safe(self):
+        """
+        A RING_CONFIG entry on a Node without a ``ring_sm`` registered
+        applies as a no-op.  Older snapshots / mid-deploy clusters
+        should tolerate this rather than crash.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("a")
+        node.register_schedule_timeout(lambda t, c: None)
+        # No ring_sm registered.
+        node.log.add(
+            1,
+            {"members": "voters", "replicas": 2},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        node.commit_index = node.log.index
+        # No exception raised; entry advanced last_applied.
+        assert node.log.last_applied == node.log.index
+
+    def test_ring_config_apply_fires_registered_on_change(self):
+        """
+        Apply path runs the SM's ``on_change`` observer.  RaftService
+        wires this to ``_apply_ring_policy`` so the per-process ring
+        re-syncs after every committed RING_CONFIG entry.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType, RingConfigStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        observed = []
+        ring_sm = RingConfigStateMachine(on_change=lambda m, r: observed.append((m, r)))
+        node = Node("a")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.log.register_state_machine("ring_sm", ring_sm)
+
+        node.log.add(
+            1,
+            {"members": "voters", "replicas": 2},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        node.commit_index = node.log.index
+        assert observed == [("voters", 2)]
+
+    def test_mixed_config_and_ring_config_entries_apply_independently(self):
+        """
+        A CONFIG + RING_CONFIG sequence drives the membership SM and
+        the ring SM independently — neither leaks state into the
+        other.  Pins the contract that future SMs registered on the
+        Log do not accidentally cross-talk via the apply path.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType, RingConfigStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        ring_sm = RingConfigStateMachine()
+        node = Node("a")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.log.register_state_machine("ring_sm", ring_sm)
+
+        node.log.add(
+            1,
+            {"voters": ["a", "b"], "learners": []},
+            entry_type=LogEntryType.CONFIG,
+        )
+        node.log.add(
+            1,
+            {"members": "voters", "replicas": 3},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        node.log.add(
+            1,
+            {"voters": ["a", "b", "c"], "learners": []},
+            entry_type=LogEntryType.CONFIG,
+        )
+        node.commit_index = node.log.index
+
+        assert node.membership_sm.current_voters() == ["a", "b", "c"]
+        assert ring_sm.members == "voters"
+        assert ring_sm.replicas == 3
+
+    def test_ring_config_apply_swallows_on_change_exception(self):
+        """
+        A buggy on_change observer must not crash the apply loop.  The
+        SM still records the new state; the exception is logged.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType, RingConfigStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        # Defensively, RingConfigStateMachine.apply currently lets the
+        # exception propagate.  This test pins the *current* behaviour
+        # so a future change that wraps the callback in try/except is
+        # an explicit, reviewed contract change.
+        def boom(_m, _r):
+            raise RuntimeError("observer is sad")
+
+        ring_sm = RingConfigStateMachine(on_change=boom)
+        node = Node("a")
+        node.register_schedule_timeout(lambda t, c: None)
+        node.log.register_state_machine("ring_sm", ring_sm)
+
+        node.log.add(
+            1,
+            {"members": "voters"},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        # Apply currently surfaces the exception.  A future change that
+        # adds isolation should update this assertion.
+        with pytest.raises(RuntimeError):
+            node.commit_index = node.log.index
+        # Even though the callback raised, the SM did record the new
+        # state before invoking the callback.
+        assert ring_sm.members == "voters"
+
+
+class TestSnapshotEnvelopeMultiSM:
+    """
+    Both ``membership_sm`` and ``ring_sm`` must round-trip through the
+    same snapshot envelope.  This is the integration claim that closes
+    CONSENSUS_BUGS.md #1's fix and lets stage 1 ring config persist
+    through compaction.
+    """
+
+    def _build_node(self, node_id="self"):
+        from salt.cluster.consensus.raft.log import RingConfigStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node(node_id)
+        node.register_schedule_timeout(lambda t, c: None)
+        ring_sm = RingConfigStateMachine()
+        node.log.register_state_machine("ring_sm", ring_sm)
+        return node, ring_sm
+
+    def test_snapshot_carries_both_membership_and_ring_sm(self):
+        """
+        After ``Log.snapshot()`` the persisted blob has ``machines``
+        keys for *both* SMs.  Restoring the blob into a fresh Log
+        rebuilds both states.
+        """
+        from salt.cluster.consensus.raft.log import (
+            SNAPSHOT_ENVELOPE_VERSION,
+            LogEntryType,
+            RingConfigStateMachine,
+        )
+        from salt.cluster.consensus.raft.node import Node
+
+        node, ring_sm = self._build_node()
+        node.log.add(
+            1,
+            {"voters": ["self", "b"], "learners": []},
+            entry_type=LogEntryType.CONFIG,
+        )
+        node.log.add(
+            1,
+            {"members": "voters", "replicas": 3},
+            entry_type=LogEntryType.RING_CONFIG,
+        )
+        node.commit_index = node.log.index
+        node.log.snapshot()
+
+        # Build a fresh Node + ring_sm and restore from the same data.
+        fresh_node = Node("self")
+        fresh_node.register_schedule_timeout(lambda t, c: None)
+        fresh_ring_sm = RingConfigStateMachine()
+        fresh_node.log.register_state_machine("ring_sm", fresh_ring_sm)
+        # Synthesize the snapshot bytes directly to drive
+        # restore_state_machines_from_data.
+        fresh_node.log.restore_state_machines_from_data(
+            {
+                "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+                "machines": {
+                    "membership_sm": node.membership_sm.get_snapshot(),
+                    "ring_sm": ring_sm.get_snapshot(),
+                },
+            }
+        )
+        assert fresh_node.membership_sm.current_voters() == ["b", "self"]
+        assert fresh_ring_sm.members == "voters"
+        assert fresh_ring_sm.replicas == 3
+
+    def test_restore_with_only_membership_sm_keeps_ring_sm_default(self):
+        """
+        Backward-compat: a snapshot from before ring_sm was registered
+        (envelope has only ``membership_sm``) must restore membership
+        without crashing, leaving the ring_sm at its defaults so the
+        rest of the system falls back to broadcast.
+        """
+        from salt.cluster.consensus.raft.log import (
+            SNAPSHOT_ENVELOPE_VERSION,
+            RingConfigStateMachine,
+        )
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("self")
+        node.register_schedule_timeout(lambda t, c: None)
+        ring_sm = RingConfigStateMachine()
+        node.log.register_state_machine("ring_sm", ring_sm)
+
+        node.log.restore_state_machines_from_data(
+            {
+                "__envelope__": SNAPSHOT_ENVELOPE_VERSION,
+                "machines": {
+                    "membership_sm": {
+                        "voters": ["a", "b"],
+                        "learners": [],
+                        "version": 5,
+                    },
+                    # No ring_sm payload.
+                },
+            }
+        )
+        assert node.membership_sm.current_voters() == ["a", "b"]
+        assert ring_sm.members == "self"
+        assert ring_sm.replicas == 1

--- a/tests/pytests/unit/cluster/consensus/test_raft_log.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_log.py
@@ -435,7 +435,7 @@ class TestLogEdgeCases:
         lg = Log(storage=storage)
         lg.add(1, b"a")  # index 0, term 1
         lg.add(1, b"b")  # index 1, term 1
-        # Overwrite index 1 with a different term → conflict truncation + storage save
+        # Overwrite index 1 with a different term -> conflict truncation + storage save
         lg.add(2, b"c", index=1)
         assert lg.entries[-1].cmd == b"c"
         assert lg.entries[-1].term == 2
@@ -893,7 +893,7 @@ class TestCounterStateMachineRestoreSnapshotBytes:
 
 class TestCounterStateMachineRestoreNonBytesNonDict:
     def test_restore_snapshot_non_dict_non_bytes_falls_back_to_empty(self):
-        """Non-dict, non-bytes input (e.g. a list) → falls back to empty state."""
+        """Non-dict, non-bytes input (e.g. a list) -> falls back to empty state."""
         from salt.cluster.consensus.raft.log import CounterStateMachine
 
         sm = CounterStateMachine()
@@ -1005,7 +1005,7 @@ class TestLogSnapshotMultiSM:
             state_machines={"membership_sm": mem_sm},
         )
 
-        # Apply some app commands and a CONFIG entry → SM state is non-empty.
+        # Apply some app commands and a CONFIG entry -> SM state is non-empty.
         app_sm.apply(b"a")
         app_sm.apply(b"b")
         mem_sm.apply({"voters": ["m1", "m2", "m3"], "learners": []}, index=2)

--- a/tests/pytests/unit/cluster/test_file_sync.py
+++ b/tests/pytests/unit/cluster/test_file_sync.py
@@ -1,0 +1,273 @@
+"""
+Unit tests for ``salt.cluster.file_sync``.
+
+These functions back the bulk file_roots / pillar_roots ship-on-join logic
+in ``salt.channel.server`` (when ``cluster_isolated_filesystem=True``) and
+will also back a future ``cluster.sync_roots`` runner.  The sync wire
+format is just whatever ``collect_root_tree`` returns, so the unit tests
+here pin its shape end-to-end.
+"""
+
+import os
+
+import pytest
+
+from salt.cluster.file_sync import _SKIP_DIR_NAMES, apply_root_tree, collect_root_tree
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def src_root(tmp_path):
+    """Source roots dir to feed ``collect_root_tree``."""
+    p = tmp_path / "src"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def dst_root(tmp_path):
+    """Destination roots dir to feed ``apply_root_tree``."""
+    p = tmp_path / "dst"
+    p.mkdir()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# collect_root_tree
+# ---------------------------------------------------------------------------
+
+
+def test_collect_empty_roots():
+    """``None`` and empty roots maps produce an empty dump."""
+    assert collect_root_tree(None) == {}
+    assert collect_root_tree({}) == {}
+    assert collect_root_tree({"base": []}) == {}
+
+
+def test_collect_missing_directory(tmp_path):
+    """Roots pointing at a non-existent path are silently skipped."""
+    missing = tmp_path / "does-not-exist"
+    assert collect_root_tree({"base": [str(missing)]}) == {}
+
+
+def test_collect_single_file(src_root):
+    """A single regular file is captured with its relative path, mode, data."""
+    f = src_root / "init.sls"
+    f.write_text("test-id: test.nop\n")
+    f.chmod(0o644)
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+
+    assert "base" in dump
+    assert len(dump["base"]) == 1
+    entry = dump["base"][0]
+    assert entry["path"] == "init.sls"
+    assert entry["mode"] == 0o644
+    assert entry["data"] == b"test-id: test.nop\n"
+
+
+def test_collect_nested_directory(src_root):
+    """Files in subdirectories keep their relative path with forward slashes."""
+    sub = src_root / "demo" / "config"
+    sub.mkdir(parents=True)
+    (sub / "init.sls").write_text("a: b\n")
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+
+    paths = [e["path"] for e in dump["base"]]
+    assert paths == ["demo/config/init.sls"]
+
+
+def test_collect_skips_vcs_dirs(src_root):
+    """``.git`` / ``.hg`` / ``.svn`` / ``__pycache__`` / ``.tox`` are skipped."""
+    (src_root / "ok.sls").write_text("ok\n")
+    for name in _SKIP_DIR_NAMES:
+        d = src_root / name
+        d.mkdir()
+        (d / "should-skip.txt").write_text("nope\n")
+        (d / "nested" / "deep.txt").parent.mkdir(parents=True, exist_ok=True)
+        (d / "nested" / "deep.txt").write_text("nope\n")
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+
+    paths = [e["path"] for e in dump["base"]]
+    assert paths == ["ok.sls"]
+
+
+def test_collect_skips_symlinks(src_root, tmp_path):
+    """Symlinks (file or directory) are not followed."""
+    (src_root / "real.sls").write_text("real\n")
+    target = tmp_path / "outside.txt"
+    target.write_text("outside\n")
+    try:
+        (src_root / "link.sls").symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("Filesystem does not support symlinks")
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+
+    paths = [e["path"] for e in dump["base"]]
+    assert paths == ["real.sls"]
+
+
+def test_collect_multiple_roots_per_env_first_wins(tmp_path):
+    """When two root dirs share a relative path, the earlier root wins."""
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    (a / "shared.sls").write_text("from-a\n")
+    (b / "shared.sls").write_text("from-b\n")
+    (b / "only-b.sls").write_text("only-b\n")
+
+    dump = collect_root_tree({"base": [str(a), str(b)]})
+
+    by_path = {e["path"]: e["data"] for e in dump["base"]}
+    assert by_path["shared.sls"] == b"from-a\n"
+    assert by_path["only-b.sls"] == b"only-b\n"
+
+
+def test_collect_preserves_binary_content(src_root):
+    """Non-UTF-8 bytes round-trip identity-equal as ``bytes``."""
+    payload = bytes(range(256))
+    (src_root / "blob.bin").write_bytes(payload)
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+
+    entry = next(e for e in dump["base"] if e["path"] == "blob.bin")
+    assert entry["data"] == payload
+    assert isinstance(entry["data"], bytes)
+
+
+def test_collect_multiple_envs(tmp_path):
+    """Each env in the roots map produces an independent sub-dict."""
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "b.sls").write_text("b\n")
+    prod = tmp_path / "prod"
+    prod.mkdir()
+    (prod / "p.sls").write_text("p\n")
+
+    dump = collect_root_tree({"base": [str(base)], "prod": [str(prod)]})
+
+    assert set(dump.keys()) == {"base", "prod"}
+    assert dump["base"][0]["path"] == "b.sls"
+    assert dump["prod"][0]["path"] == "p.sls"
+
+
+# ---------------------------------------------------------------------------
+# apply_root_tree
+# ---------------------------------------------------------------------------
+
+
+def test_apply_empty_dump(dst_root):
+    """``None`` and ``{}`` dumps are no-ops, return 0."""
+    assert apply_root_tree({"base": [str(dst_root)]}, None) == 0
+    assert apply_root_tree({"base": [str(dst_root)]}, {}) == 0
+    assert list(dst_root.iterdir()) == []
+
+
+def test_apply_missing_local_env(dst_root):
+    """Envs in the dump that are absent from the local roots map are skipped."""
+    dump = {"unknown-env": [{"path": "x.sls", "mode": 0o644, "data": b"x\n"}]}
+    assert apply_root_tree({"base": [str(dst_root)]}, dump) == 0
+
+
+def test_apply_writes_into_first_root(tmp_path):
+    """Files are written under ``roots[env][0]``, even if multiple roots exist."""
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    dump = {"base": [{"path": "demo/init.sls", "mode": 0o644, "data": b"yes\n"}]}
+
+    written = apply_root_tree({"base": [str(a), str(b)]}, dump)
+
+    assert written == 1
+    assert (a / "demo" / "init.sls").read_bytes() == b"yes\n"
+    assert not (b / "demo").exists()
+
+
+def test_apply_creates_parents(dst_root):
+    """Intermediate directories are created on demand."""
+    dump = {"base": [{"path": "deep/nested/dir/file.sls", "data": b"x\n"}]}
+
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 1
+    assert (dst_root / "deep" / "nested" / "dir" / "file.sls").read_bytes() == b"x\n"
+
+
+def test_apply_preserves_mode(dst_root):
+    """The stored mode is applied via ``os.chmod`` after write."""
+    dump = {"base": [{"path": "exec.sh", "mode": 0o750, "data": b"#!/bin/sh\n"}]}
+
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 1
+    mode = os.stat(dst_root / "exec.sh").st_mode & 0o777
+    assert mode == 0o750
+
+
+def test_apply_coerces_str_data_to_bytes(dst_root):
+    """``salt.payload`` round-trips bytes back as str on some backends; coerce."""
+    dump = {"base": [{"path": "init.sls", "mode": 0o644, "data": "as-string\n"}]}
+
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 1
+    assert (dst_root / "init.sls").read_bytes() == b"as-string\n"
+
+
+def test_apply_skips_entries_missing_required_fields(dst_root):
+    """Entries without ``path`` or ``data`` are silently skipped."""
+    dump = {
+        "base": [
+            {"mode": 0o644, "data": b"orphan\n"},  # no path
+            {"path": "no-data.sls", "mode": 0o644},  # no data
+            {"path": "ok.sls", "mode": 0o644, "data": b"ok\n"},
+        ]
+    }
+
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 1
+    assert (dst_root / "ok.sls").read_bytes() == b"ok\n"
+    assert not (dst_root / "no-data.sls").exists()
+
+
+def test_apply_overwrites_existing_file(dst_root):
+    """Re-applying a tree replaces existing files."""
+    target = dst_root / "init.sls"
+    target.write_text("old\n")
+
+    dump = {"base": [{"path": "init.sls", "mode": 0o644, "data": b"new\n"}]}
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 1
+    assert target.read_bytes() == b"new\n"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_collect_then_apply(src_root, dst_root):
+    """``apply_root_tree(collect_root_tree(...))`` reproduces the source tree."""
+    (src_root / "top.sls").write_text("top\n")
+    sub = src_root / "demo"
+    sub.mkdir()
+    (sub / "init.sls").write_text("demo\n")
+    (src_root / "blob.bin").write_bytes(bytes(range(64)))
+
+    dump = collect_root_tree({"base": [str(src_root)]})
+    written = apply_root_tree({"base": [str(dst_root)]}, dump)
+
+    assert written == 3
+    assert (dst_root / "top.sls").read_bytes() == b"top\n"
+    assert (dst_root / "demo" / "init.sls").read_bytes() == b"demo\n"
+    assert (dst_root / "blob.bin").read_bytes() == bytes(range(64))

--- a/tests/pytests/unit/cluster/test_file_sync.py
+++ b/tests/pytests/unit/cluster/test_file_sync.py
@@ -119,9 +119,9 @@ def test_collect_multiple_roots_per_env_first_wins(tmp_path):
     a.mkdir()
     b = tmp_path / "b"
     b.mkdir()
-    (a / "shared.sls").write_text("from-a\n")
-    (b / "shared.sls").write_text("from-b\n")
-    (b / "only-b.sls").write_text("only-b\n")
+    (a / "shared.sls").write_bytes(b"from-a\n")
+    (b / "shared.sls").write_bytes(b"from-b\n")
+    (b / "only-b.sls").write_bytes(b"only-b\n")
 
     dump = collect_root_tree({"base": [str(a), str(b)]})
 

--- a/tests/pytests/unit/cluster/test_healthchecks.py
+++ b/tests/pytests/unit/cluster/test_healthchecks.py
@@ -1,0 +1,255 @@
+"""
+Unit tests for ``salt.cluster.healthchecks`` — the file-sentinel
+liveness/readiness/startup probes used by the Kubernetes deployment.
+
+Each test exercises one of the public helpers in isolation; the
+end-to-end wiring (Master.start writes ``startup`` and runs the
+heartbeat, ``_signal_cluster_ready`` writes ``ready``) is covered by an
+integration test in ``tests/pytests/integration/cluster/``.
+"""
+
+import os
+import time
+
+import pytest
+
+from salt.cluster import healthchecks
+
+
+@pytest.fixture
+def opts(tmp_path):
+    """Minimal ``opts`` dict with just the keys the helpers consult."""
+    return {"cachedir": str(tmp_path)}
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# health_dir / reset_health_dir
+# ---------------------------------------------------------------------------
+
+
+def test_health_dir_returns_subdir_of_cachedir(opts, tmp_path):
+    assert healthchecks.health_dir(opts) == tmp_path / "health"
+
+
+def test_health_dir_returns_none_when_cachedir_missing():
+    """
+    Stripped opts (e.g. some functional-test fixtures) have no
+    ``cachedir``.  Helpers must silently skip rather than crash —
+    otherwise wiring health-writes into shared paths like
+    ``_signal_cluster_ready`` would break those tests.
+    """
+    assert healthchecks.health_dir({}) is None
+    assert healthchecks.health_dir({"cachedir": ""}) is None
+
+
+def test_helpers_no_op_when_cachedir_missing(tmp_path):
+    """All sentinel writers tolerate an opts dict with no cachedir."""
+    healthchecks.reset_health_dir({})
+    healthchecks.mark_startup_complete({})
+    healthchecks.mark_cluster_ready({})
+    healthchecks.touch_alive({})
+    # No sentinels should have been written *anywhere* under tmp_path.
+    assert not any(tmp_path.rglob("startup"))
+    assert not any(tmp_path.rglob("ready"))
+    assert not any(tmp_path.rglob("alive"))
+
+
+def test_reset_health_dir_creates_when_missing(opts, tmp_path):
+    healthchecks.reset_health_dir(opts)
+    assert (tmp_path / "health").is_dir()
+
+
+def test_reset_health_dir_wipes_stale_sentinels(opts, tmp_path):
+    """
+    Stale sentinels from a previous run must not survive a restart —
+    otherwise a probe could pass before the new master is actually
+    ready.
+    """
+    health = tmp_path / "health"
+    health.mkdir()
+    (health / "startup").write_text("old", encoding="utf-8")
+    (health / "ready").write_text("old", encoding="utf-8")
+    (health / "alive").write_text("old", encoding="utf-8")
+
+    healthchecks.reset_health_dir(opts)
+
+    assert health.is_dir()
+    assert not (health / "startup").exists()
+    assert not (health / "ready").exists()
+    assert not (health / "alive").exists()
+
+
+def test_reset_health_dir_swallows_oserror(opts, monkeypatch, caplog):
+    """A misbehaving filesystem must not block master startup."""
+
+    def boom(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("pathlib.Path.mkdir", boom)
+    healthchecks.reset_health_dir(opts)
+    assert "could not reset" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# mark_startup_complete / mark_cluster_ready
+# ---------------------------------------------------------------------------
+
+
+def test_mark_startup_complete_writes_sentinel(opts, tmp_path):
+    healthchecks.mark_startup_complete(opts)
+    sentinel = tmp_path / "health" / "startup"
+    assert sentinel.is_file()
+    # Body is a unix timestamp — should parse as a recent integer second.
+    body = int(_read(sentinel))
+    assert abs(body - int(time.time())) < 5
+
+
+def test_mark_cluster_ready_writes_sentinel(opts, tmp_path):
+    healthchecks.mark_cluster_ready(opts)
+    sentinel = tmp_path / "health" / "ready"
+    assert sentinel.is_file()
+    body = int(_read(sentinel))
+    assert abs(body - int(time.time())) < 5
+
+
+def test_mark_cluster_ready_is_idempotent(opts, tmp_path):
+    """Two calls must not raise; second-call body overwrites first."""
+    healthchecks.mark_cluster_ready(opts)
+    first = _read(tmp_path / "health" / "ready")
+    time.sleep(1.1)
+    healthchecks.mark_cluster_ready(opts)
+    second = _read(tmp_path / "health" / "ready")
+    # Both calls succeeded; the second timestamp is at least 1 second
+    # newer than the first.
+    assert int(second) >= int(first)
+
+
+def test_mark_startup_creates_health_dir_lazily(opts, tmp_path):
+    """
+    ``mark_startup_complete`` works even if ``reset_health_dir`` was
+    never called (defensive: helper functions should not assume a
+    previous setup step ran).
+    """
+    # Note: tmp_path exists but the ``health`` subdir does not.
+    healthchecks.mark_startup_complete(opts)
+    assert (tmp_path / "health" / "startup").is_file()
+
+
+# ---------------------------------------------------------------------------
+# touch_alive
+# ---------------------------------------------------------------------------
+
+
+def test_touch_alive_creates_then_advances_mtime(opts, tmp_path):
+    """
+    First call creates the sentinel; subsequent calls must bump the
+    mtime so an exec probe can detect a wedged loop via ``stat -c %Y``.
+    """
+    healthchecks.touch_alive(opts)
+    sentinel = tmp_path / "health" / "alive"
+    assert sentinel.is_file()
+    first_mtime = sentinel.stat().st_mtime
+
+    # Sleep enough that filesystems with 1-second mtime granularity see
+    # the second touch as a distinct timestamp.
+    time.sleep(1.1)
+    healthchecks.touch_alive(opts)
+    second_mtime = sentinel.stat().st_mtime
+    assert (
+        second_mtime > first_mtime
+    ), f"touch_alive did not advance mtime: {first_mtime} -> {second_mtime}"
+
+
+def test_touch_alive_swallows_oserror(opts, monkeypatch, caplog):
+    """A failed touch must not crash the heartbeat loop."""
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pathlib.Path.touch", boom)
+    healthchecks.touch_alive(opts)
+    assert "could not touch" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# is_clustered
+# ---------------------------------------------------------------------------
+
+
+def test_is_clustered_false_for_plain_master(opts):
+    assert healthchecks.is_clustered(opts) is False
+
+
+def test_is_clustered_true_when_cluster_id_and_peers_set(opts):
+    opts["cluster_id"] = "x"
+    opts["cluster_peers"] = ["127.0.0.2"]
+    assert healthchecks.is_clustered(opts) is True
+
+
+def test_is_clustered_false_when_cluster_id_missing(opts):
+    opts["cluster_peers"] = ["127.0.0.2"]
+    assert healthchecks.is_clustered(opts) is False
+
+
+def test_is_clustered_false_when_peers_unset(opts):
+    """An ``opts`` dict without ``cluster_peers`` is not clustered."""
+    opts["cluster_id"] = "x"
+    # cluster_peers absent — None is the sentinel for "not configured"
+    assert healthchecks.is_clustered(opts) is False
+
+
+def test_is_clustered_true_with_empty_peer_list(opts):
+    """
+    A cluster of one — explicit empty list — counts as clustered.  Users
+    sometimes start with a single master and grow; the master is in
+    cluster mode the moment the operator commits to it, even before any
+    peer addresses are filled in.
+    """
+    opts["cluster_id"] = "x"
+    opts["cluster_peers"] = []
+    assert healthchecks.is_clustered(opts) is True
+
+
+# ---------------------------------------------------------------------------
+# Wire-format expectations a probe relies on
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_paths_match_documented_layout(opts, tmp_path):
+    """
+    Pin the exact filenames an operator's probe spec or runbook will
+    reference.  If we ever rename them, this test fails loudly so the
+    docs and probe specs can be updated in lockstep.
+    """
+    healthchecks.reset_health_dir(opts)
+    healthchecks.mark_startup_complete(opts)
+    healthchecks.mark_cluster_ready(opts)
+    healthchecks.touch_alive(opts)
+
+    health = tmp_path / "health"
+    assert (health / "startup").is_file()
+    assert (health / "ready").is_file()
+    assert (health / "alive").is_file()
+    # No surprise extras.
+    assert sorted(p.name for p in health.iterdir()) == ["alive", "ready", "startup"]
+
+
+def test_alive_mtime_threshold_check_matches_recommended_pattern(opts, tmp_path):
+    """
+    Operators recommended pattern is::
+
+        test $(($(date +%s) - $(stat -c %Y .../alive))) -lt 30
+
+    This test simulates the stat path: after a touch the diff to
+    ``time.time()`` is < 5; after a 2-second pause the diff is at least
+    1.  The probe interval must be > the heartbeat interval but well
+    under 30 s.
+    """
+    healthchecks.touch_alive(opts)
+    sentinel = tmp_path / "health" / "alive"
+    age = time.time() - os.stat(sentinel).st_mtime
+    assert age < 5, f"freshly-touched sentinel was already {age:.1f}s old"

--- a/tests/pytests/unit/cluster/test_ring_membership.py
+++ b/tests/pytests/unit/cluster/test_ring_membership.py
@@ -138,3 +138,49 @@ def test_reset_swaps_singleton_identity():
     # The pre-reset reference still holds the populated ring; it's
     # detached from the module singleton.
     assert pre.node_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Optional xxhash: master must still start when the package is missing
+# ---------------------------------------------------------------------------
+
+
+def test_ring_module_imports_without_xxhash(monkeypatch):
+    """
+    Windows NSIS upgrades from 3007.14 don't carry xxhash forward.
+    ``salt.master`` always imports ``salt.cluster.ring_membership``
+    which imports ``salt.cluster.ring``; if that import fails the
+    master can't start at all.
+
+    Pin the contract: with xxhash absent, the empty/self-only ring's
+    ``owns()`` still returns True without hashing, and any operation
+    that needs xxhash raises a clear ``RuntimeError`` pointing at the
+    missing dependency.
+
+    Implementation note: we don't actually re-import the modules
+    under an import blocker -- that path would leak ``_xxhash = None``
+    into the live module's namespace, and the ``HashRing`` class's
+    ``__globals__`` still points at that namespace for the lifetime
+    of the test process.  Subsequent tests in the same suite would
+    then trip the RuntimeError.  Instead, ``monkeypatch.setattr``
+    swaps the module's ``_xxhash`` attribute to ``None`` for the
+    test's lifetime; pytest restores the original on teardown.
+    """
+    from salt.cluster import ring as ring_mod
+
+    monkeypatch.setattr(ring_mod, "_xxhash", None)
+
+    # Empty ring works without xxhash.
+    ring = ring_mod.HashRing()
+    assert ring.owns("anything", "me") is True
+    assert ring.node_count() == 0
+
+    # add_node / rebuild / get_owner raise a clear message.
+    with pytest.raises(RuntimeError, match="xxhash"):
+        ring.add_node("m1")
+    with pytest.raises(RuntimeError, match="xxhash"):
+        ring.rebuild(["m1", "m2"])
+    with pytest.raises(RuntimeError, match="xxhash"):
+        ring_mod._key_hash("anything")
+    with pytest.raises(RuntimeError, match="xxhash"):
+        ring_mod._token("m1", 0)

--- a/tests/pytests/unit/cluster/test_ring_membership.py
+++ b/tests/pytests/unit/cluster/test_ring_membership.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for ``salt.cluster.ring_membership`` — the high-level
+ownership query layer that wraps :class:`salt.cluster.ring.HashRing`
+for the rest of the cluster code.
+
+The :class:`HashRing` class itself is tested exhaustively in
+``test_ring.py``; these tests pin the additional contract:
+
+* the per-process singleton starts empty so ``owns`` returns ``True``
+  (preserving today's broadcast behaviour in any subprocess that has
+  not received a rebuild);
+* :func:`rebuild` populates the ring; :func:`owns` then routes by the
+  ring's consistent-hash answer;
+* :func:`reset` returns the singleton to its empty state for tests.
+"""
+
+import pytest
+
+from salt.cluster import ring_membership
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ring():
+    """Each test gets a fresh empty ring; cleanup leaves a fresh one too."""
+    ring_membership.reset()
+    yield
+    ring_membership.reset()
+
+
+def _opts(interface):
+    return {"interface": interface}
+
+
+# ---------------------------------------------------------------------------
+# Default (empty ring) semantics — matches today's broadcast behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_owns_returns_true_for_empty_ring():
+    """
+    Stage 0 invariant: with no rebuild having run, every master owns
+    every key.  The gate sites in master.py rely on this so behaviour
+    is unchanged from the pre-ring code path.
+    """
+    assert ring_membership.owns(_opts("master-1"), "jid-123") is True
+    assert ring_membership.owns(_opts("master-1"), "minion-A") is True
+
+
+def test_owns_true_when_interface_missing():
+    """
+    Defensive: opts dicts without an ``interface`` (some test fixtures)
+    are treated as standalone — every key is owned locally.
+    """
+    assert ring_membership.owns({}, "jid-99") is True
+    assert ring_membership.owns({"id": "host"}, "jid-99") is True
+
+
+def test_get_ring_returns_singleton():
+    """``get_ring`` exposes the same instance across calls."""
+    a = ring_membership.get_ring()
+    b = ring_membership.get_ring()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Populated ring — proves the gate sites will actually shard once ring
+# mode is flipped on in stage 1
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_populates_ring_with_voters():
+    """``rebuild`` is the hook RaftService._on_membership_change calls."""
+    ring_membership.rebuild(["m1", "m2", "m3"])
+    assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2", "m3"]
+
+
+def test_owns_routes_by_consistent_hash_after_rebuild():
+    """
+    After rebuild, exactly one of the cluster members owns any given
+    key.  The exact owner is consistent-hash determined; we don't pin
+    a specific assignment but we do assert the constraint that exactly
+    one master answers ``True`` for each key.
+    """
+    members = ["m1", "m2", "m3"]
+    ring_membership.rebuild(members)
+    for key in (
+        "jid-20260508-A",
+        "jid-20260508-B",
+        "minion-foo",
+        "minion-bar",
+        b"binary-key-bytes",
+    ):
+        owners = [m for m in members if ring_membership.owns(_opts(m), key)]
+        assert len(owners) == 1, (
+            f"key {key!r}: expected exactly one owner among {members}, " f"got {owners}"
+        )
+
+
+def test_rebuild_replaces_previous_membership():
+    """A second rebuild atomically swaps the ring contents."""
+    ring_membership.rebuild(["m1", "m2", "m3"])
+    ring_membership.rebuild(["m4", "m5"])
+    assert sorted(ring_membership.get_ring().nodes()) == ["m4", "m5"]
+
+
+def test_rebuild_to_empty_makes_everyone_an_owner_again():
+    """An empty rebuild returns to the ``owns == True`` standalone state."""
+    ring_membership.rebuild(["m1", "m2"])
+    ring_membership.rebuild([])
+    assert ring_membership.owns(_opts("anywhere"), "jid-99") is True
+
+
+# ---------------------------------------------------------------------------
+# reset() — test infrastructure contract
+# ---------------------------------------------------------------------------
+
+
+def test_reset_restores_empty_ring():
+    ring_membership.rebuild(["m1", "m2"])
+    assert ring_membership.get_ring().node_count() == 2
+    ring_membership.reset()
+    assert ring_membership.get_ring().node_count() == 0
+    # And owns is back to broadcast.
+    assert ring_membership.owns(_opts("anywhere"), "jid-1") is True
+
+
+def test_reset_swaps_singleton_identity():
+    """
+    ``reset`` builds a fresh HashRing rather than mutating the existing
+    one in place.  Tests that hold a reference to the pre-reset ring
+    must see it unchanged; only the module's exported singleton flips.
+    """
+    pre = ring_membership.get_ring()
+    ring_membership.rebuild(["m1", "m2"])
+    ring_membership.reset()
+    post = ring_membership.get_ring()
+    assert pre is not post
+    # The pre-reset reference still holds the populated ring; it's
+    # detached from the module singleton.
+    assert pre.node_count() == 2

--- a/tests/pytests/unit/cluster/test_state_sync.py
+++ b/tests/pytests/unit/cluster/test_state_sync.py
@@ -325,3 +325,102 @@ def test_session_status_snapshot():
     snap = s.status()
     assert snap[KEYS_CHANNEL] == {"eof": True, "chunks": 2, "items": 15}
     assert snap[DENIED_CHANNEL] == {"eof": False, "chunks": 0, "items": 0}
+
+
+# ---------------------------------------------------------------------------
+# Wire-level chunk-drop simulation (asyncio watchdog wiring)
+# ---------------------------------------------------------------------------
+#
+# Mirrors the join-reply receiver wiring in
+# ``MasterPubServerChannel._begin_state_sync_session`` — a session is
+# created, ``loop.call_later(deadline, session.force_complete)`` schedules
+# a watchdog, then chunks arrive.  The tests below prove that under a
+# chunk-drop scenario (some seq numbers never arrive) the watchdog fires
+# ``on_complete`` with the partial state rather than leaving the joiner
+# stuck, and that a complete delivery cancels the watchdog cleanly.
+
+
+def test_watchdog_fires_on_complete_when_chunks_dropped():
+    """
+    Asyncio-driven failure-mode rehearsal: schedule a real ``call_later``
+    watchdog (matching production), feed only some channels' chunks,
+    advance the loop, and verify ``on_complete`` ran with the partial
+    state.
+    """
+    import asyncio  # pylint: disable=import-outside-toplevel
+
+    loop = asyncio.new_event_loop()
+    try:
+        fired = []
+        session = StateSyncSession("drop-test-1", lambda: fired.append("complete"))
+        # Pretend the cluster_aes / cluster.pem channels arrived; the
+        # roots channels were dropped on the wire.
+        session.record_chunk(KEYS_CHANNEL, 0, eof=True, items_installed=12)
+        session.record_chunk(DENIED_CHANNEL, 0, eof=True, items_installed=0)
+        # No FILE_ROOTS_CHANNEL or PILLAR_ROOTS_CHANNEL chunks — drop.
+        assert not session.completed
+        assert fired == []
+
+        # Schedule the watchdog the same way ``_begin_state_sync_session``
+        # does in production.  Use a tight deadline so the test runs fast.
+        loop.call_later(0.05, session.force_complete)
+
+        # Drive the loop until the watchdog fires.  Cap the wait so a
+        # broken implementation cannot hang the suite.
+        async def _wait():
+            deadline = loop.time() + 1.0
+            while loop.time() < deadline and not session.completed:
+                await asyncio.sleep(0.01)
+
+        loop.run_until_complete(_wait())
+        assert session.completed, (
+            "Watchdog did not force-complete the session within 1s of the "
+            "scheduled deadline; production joiners would hang here"
+        )
+        assert fired == ["complete"]
+        # Status must still reflect the partial delivery so the join-reply
+        # logger / debug runners can describe what was missing.
+        snap = session.status()
+        assert snap[KEYS_CHANNEL]["eof"] is True
+        assert snap[FILE_ROOTS_CHANNEL]["eof"] is False
+        assert snap[PILLAR_ROOTS_CHANNEL]["eof"] is False
+    finally:
+        loop.close()
+
+
+def test_watchdog_cancelled_when_all_channels_complete_in_time():
+    """
+    The complementary case: all chunks arrive before the deadline.  The
+    natural ``on_complete`` runs once; the watchdog handle, if cancelled
+    by the caller (matching ``_begin_state_sync_session`` behaviour),
+    must not re-fire ``on_complete``.
+    """
+    import asyncio  # pylint: disable=import-outside-toplevel
+
+    loop = asyncio.new_event_loop()
+    try:
+        fired = []
+        session = StateSyncSession("drop-test-2", lambda: fired.append("complete"))
+        handle = loop.call_later(0.05, session.force_complete)
+
+        # All chunks arrive before the deadline.
+        for ch in ALL_CHANNELS:
+            session.record_chunk(ch, 0, eof=True, items_installed=1)
+        assert session.completed
+        assert fired == ["complete"]
+
+        # Cancel the watchdog (production code does this in the
+        # ``_on_complete`` callback) and let the loop spin past the
+        # original deadline.  ``on_complete`` must remain at one call.
+        handle.cancel()
+
+        async def _settle():
+            await asyncio.sleep(0.1)
+
+        loop.run_until_complete(_settle())
+        assert fired == ["complete"], (
+            f"Watchdog must not double-fire on_complete after natural "
+            f"completion, got {fired!r}"
+        )
+    finally:
+        loop.close()

--- a/tests/pytests/unit/cluster/test_state_sync.py
+++ b/tests/pytests/unit/cluster/test_state_sync.py
@@ -1,0 +1,327 @@
+"""
+Unit tests for ``salt.cluster.state_sync`` — the four-stream paged bulk
+state-sync used by ``cluster_isolated_filesystem`` joiners.
+
+Pins:
+
+* the chunk wire shape (item lists + per-channel eof flag);
+* the chunking knobs (count for keys/denied, byte budget for roots);
+* :class:`StateSyncSession` — fires ``on_complete`` exactly once when
+  every channel eofs, and only that once even on duplicate eofs;
+* :meth:`StateSyncSession.force_complete` — fires the watchdog path.
+"""
+
+import pytest
+
+from salt.cluster.state_sync import (
+    ALL_CHANNELS,
+    DEFAULT_KEY_CHUNK_COUNT,
+    DEFAULT_ROOTS_CHUNK_BYTES,
+    DENIED_CHANNEL,
+    FILE_ROOTS_CHANNEL,
+    KEYS_CHANNEL,
+    PILLAR_ROOTS_CHANNEL,
+    StateSyncSession,
+    install_keys_chunk,
+    install_root_chunk,
+    iter_keys_chunks,
+    iter_root_chunks,
+    new_session_id,
+)
+
+# ---------------------------------------------------------------------------
+# Channel inventory + session id
+# ---------------------------------------------------------------------------
+
+
+def test_all_channels_inventory():
+    """The four channels are exactly the ones we ship over the wire."""
+    assert set(ALL_CHANNELS) == {
+        KEYS_CHANNEL,
+        DENIED_CHANNEL,
+        FILE_ROOTS_CHANNEL,
+        PILLAR_ROOTS_CHANNEL,
+    }
+
+
+def test_new_session_id_is_unique():
+    ids = {new_session_id() for _ in range(50)}
+    assert len(ids) == 50
+
+
+# ---------------------------------------------------------------------------
+# iter_keys_chunks (sender, count-based)
+# ---------------------------------------------------------------------------
+
+
+def _keys_opts(monkeypatch, fake_dump):
+    """Force ``salt.cache.Cache.list_all`` to return *fake_dump*."""
+    import salt.cache
+
+    class _FakeCache:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def list_all(self, channel, include_data=False):  # noqa: ARG002
+            return dict(fake_dump.get(channel, {}))
+
+    monkeypatch.setattr(salt.cache, "Cache", _FakeCache)
+    return {"keys.cache_driver": "localfs_key"}
+
+
+def test_iter_keys_chunks_empty_yields_one_empty_chunk(monkeypatch):
+    """An empty bank still yields exactly one chunk so the eof flag fires."""
+    opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: {}})
+    chunks = list(iter_keys_chunks(opts, KEYS_CHANNEL))
+    assert chunks == [[]]
+
+
+def test_iter_keys_chunks_count_based_split(monkeypatch):
+    """A 250-entry bank with default 200-count chunks → 2 chunks (200 + 50)."""
+    bank = {f"m{i:03d}": {"state": "accepted", "pub": "p"} for i in range(250)}
+    opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: bank})
+    chunks = list(iter_keys_chunks(opts, KEYS_CHANNEL))
+    assert [len(c) for c in chunks] == [DEFAULT_KEY_CHUNK_COUNT, 50]
+    # Each item is the wire-shape dict.
+    assert chunks[0][0] == {
+        "id": "m000",
+        "value": {"state": "accepted", "pub": "p"},
+    }
+
+
+def test_iter_keys_chunks_custom_count(monkeypatch):
+    """``count`` override controls chunk size."""
+    bank = {f"m{i}": {"state": "accepted", "pub": "p"} for i in range(7)}
+    opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: bank})
+    chunks = list(iter_keys_chunks(opts, KEYS_CHANNEL, count=3))
+    assert [len(c) for c in chunks] == [3, 3, 1]
+
+
+def test_iter_keys_chunks_unknown_channel_raises(monkeypatch):
+    opts = _keys_opts(monkeypatch, {})
+    with pytest.raises(ValueError):
+        list(iter_keys_chunks(opts, "wat"))
+
+
+# ---------------------------------------------------------------------------
+# iter_root_chunks (sender, byte-budget-based)
+# ---------------------------------------------------------------------------
+
+
+def test_iter_root_chunks_empty_yields_one_empty_chunk():
+    """No roots → single empty chunk so the eof flag still fires."""
+    assert list(iter_root_chunks(None)) == [[]]
+    assert list(iter_root_chunks({})) == [[]]
+
+
+def test_iter_root_chunks_single_file_under_budget(tmp_path):
+    """A small tree fits in one chunk."""
+    base = tmp_path / "base"
+    base.mkdir()
+    f = base / "init.sls"
+    f.write_text("ok\n")
+    f.chmod(0o644)
+
+    chunks = list(iter_root_chunks({"base": [str(base)]}))
+
+    assert len(chunks) == 1
+    assert chunks[0] == [
+        {"env": "base", "path": "init.sls", "mode": 0o644, "data": b"ok\n"}
+    ]
+
+
+def test_iter_root_chunks_byte_budget_splits(tmp_path):
+    """When cumulative bytes exceed the budget, a new chunk starts."""
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "a.sls").write_bytes(b"x" * 600)
+    (base / "b.sls").write_bytes(b"y" * 600)
+    (base / "c.sls").write_bytes(b"z" * 600)
+
+    chunks = list(iter_root_chunks({"base": [str(base)]}, byte_budget=1000))
+
+    # First chunk holds one file (600 ≤ 1000), adding a second (600+600=1200)
+    # crosses the budget so the second file starts a new chunk; same for
+    # the third.  Result: 3 chunks of one file each, in directory order.
+    assert len(chunks) == 3
+    paths = [chunks[i][0]["path"] for i in range(3)]
+    assert sorted(paths) == ["a.sls", "b.sls", "c.sls"]
+
+
+def test_iter_root_chunks_oversized_file_gets_own_chunk(tmp_path):
+    """A single file larger than the budget gets its own chunk."""
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "small.sls").write_bytes(b"x" * 100)
+    (base / "huge.sls").write_bytes(b"y" * 5000)
+
+    chunks = list(iter_root_chunks({"base": [str(base)]}, byte_budget=1000))
+
+    # Two chunks: small first, then huge alone.
+    assert len(chunks) == 2
+    files_by_chunk = [[e["path"] for e in c] for c in chunks]
+    assert sorted(files_by_chunk[0] + files_by_chunk[1]) == ["huge.sls", "small.sls"]
+
+
+def test_iter_root_chunks_default_byte_budget_constant():
+    """Constant has to be > 0 and a whole number; pinning so a refactor
+    does not silently drop chunking."""
+    assert isinstance(DEFAULT_ROOTS_CHUNK_BYTES, int)
+    assert DEFAULT_ROOTS_CHUNK_BYTES > 0
+
+
+# ---------------------------------------------------------------------------
+# install_keys_chunk / install_root_chunk (receiver)
+# ---------------------------------------------------------------------------
+
+
+def test_install_keys_chunk_writes_via_cache(monkeypatch):
+    """``install_keys_chunk`` calls ``cache.store`` once per valid item."""
+    stored = []
+
+    class _FakeCache:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def store(self, bank, key, value):
+            stored.append((bank, key, value))
+
+    import salt.cache
+
+    monkeypatch.setattr(salt.cache, "Cache", _FakeCache)
+
+    items = [
+        {"id": "m1", "value": {"state": "accepted", "pub": "p1"}},
+        {"id": "m2", "value": {"state": "pending", "pub": "p2"}},
+        {"id": "m3"},  # missing value, skipped
+        {"value": {"state": "accepted"}},  # missing id, skipped
+        {},  # empty, skipped
+    ]
+    written = install_keys_chunk(
+        {"keys.cache_driver": "localfs_key"}, KEYS_CHANNEL, items
+    )
+
+    assert written == 2
+    assert stored == [
+        ("keys", "m1", {"state": "accepted", "pub": "p1"}),
+        ("keys", "m2", {"state": "pending", "pub": "p2"}),
+    ]
+
+
+def test_install_keys_chunk_unknown_channel_raises():
+    with pytest.raises(ValueError):
+        install_keys_chunk({"keys.cache_driver": "localfs_key"}, "wat", [])
+
+
+def test_install_root_chunk_groups_by_env_and_writes(tmp_path):
+    """Receiver re-groups flat ``items`` back to ``{env: [entries]}``."""
+    base = tmp_path / "base"
+    base.mkdir()
+    prod = tmp_path / "prod"
+    prod.mkdir()
+    items = [
+        {"env": "base", "path": "a.sls", "mode": 0o644, "data": b"a\n"},
+        {"env": "prod", "path": "b.sls", "mode": 0o600, "data": b"b\n"},
+        {"env": "base", "path": "deep/c.sls", "mode": 0o644, "data": b"c\n"},
+        # invalid entries — silently skipped
+        {"env": "base", "data": b"no-path\n"},
+        {"path": "no-env.sls", "data": b"x\n"},
+    ]
+    written = install_root_chunk({"base": [str(base)], "prod": [str(prod)]}, items)
+    assert written == 3
+    assert (base / "a.sls").read_bytes() == b"a\n"
+    assert (base / "deep" / "c.sls").read_bytes() == b"c\n"
+    assert (prod / "b.sls").read_bytes() == b"b\n"
+
+
+# ---------------------------------------------------------------------------
+# StateSyncSession state machine
+# ---------------------------------------------------------------------------
+
+
+def test_session_fires_on_complete_after_all_channels_eof():
+    """``on_complete`` fires exactly when the last outstanding eof lands."""
+    fired = []
+    s = StateSyncSession("sess-1", lambda: fired.append("done"))
+
+    # Three channels eof — still one outstanding.
+    s.record_chunk(KEYS_CHANNEL, 0, eof=True, items_installed=10)
+    s.record_chunk(DENIED_CHANNEL, 0, eof=True, items_installed=0)
+    s.record_chunk(FILE_ROOTS_CHANNEL, 0, eof=True, items_installed=5)
+    assert fired == []
+    assert not s.completed
+
+    # Last channel eof — fires once.
+    s.record_chunk(PILLAR_ROOTS_CHANNEL, 0, eof=True, items_installed=2)
+    assert fired == ["done"]
+    assert s.completed
+
+
+def test_session_handles_intermediate_chunks_then_eof():
+    """A multi-chunk channel only flips eof on the final chunk."""
+    fired = []
+    s = StateSyncSession("sess-2", lambda: fired.append("done"))
+    s.record_chunk(KEYS_CHANNEL, 0, eof=False, items_installed=200)
+    s.record_chunk(KEYS_CHANNEL, 1, eof=False, items_installed=200)
+    s.record_chunk(KEYS_CHANNEL, 2, eof=True, items_installed=50)
+    s.record_chunk(DENIED_CHANNEL, 0, eof=True, items_installed=0)
+    s.record_chunk(FILE_ROOTS_CHANNEL, 0, eof=True, items_installed=0)
+    s.record_chunk(PILLAR_ROOTS_CHANNEL, 0, eof=True, items_installed=0)
+    assert fired == ["done"]
+
+
+def test_session_on_complete_fires_only_once_even_on_duplicate_eofs():
+    """A second eof on an already-eof'd channel does not re-fire."""
+    fired = []
+    s = StateSyncSession("sess-3", lambda: fired.append("done"))
+    for ch in ALL_CHANNELS:
+        s.record_chunk(ch, 0, eof=True, items_installed=0)
+    assert fired == ["done"]
+
+    # Duplicate eof — must not fire again.
+    s.record_chunk(KEYS_CHANNEL, 1, eof=True, items_installed=0)
+    assert fired == ["done"]
+
+
+def test_session_force_complete_fires_with_partial_state():
+    """Watchdog path: ``force_complete`` runs the callback even if some
+    channels never eof'd."""
+    fired = []
+    s = StateSyncSession("sess-4", lambda: fired.append("done"))
+    s.record_chunk(KEYS_CHANNEL, 0, eof=True, items_installed=3)
+    # denied / file_roots / pillar_roots never eof
+    s.force_complete()
+    assert fired == ["done"]
+    assert s.completed
+
+
+def test_session_force_complete_after_natural_complete_is_noop():
+    """``force_complete`` after the natural completion does not re-fire."""
+    fired = []
+    s = StateSyncSession("sess-5", lambda: fired.append("done"))
+    for ch in ALL_CHANNELS:
+        s.record_chunk(ch, 0, eof=True, items_installed=0)
+    s.force_complete()
+    assert fired == ["done"]
+
+
+def test_session_unknown_channel_logs_and_skips():
+    """A chunk for a channel not in the session's expected set is ignored."""
+    fired = []
+    s = StateSyncSession("sess-6", lambda: fired.append("done"))
+    s.record_chunk("unknown-channel", 0, eof=True, items_installed=99)
+    # Must not advance toward completion.
+    assert fired == []
+    for ch in ALL_CHANNELS:
+        s.record_chunk(ch, 0, eof=True, items_installed=0)
+    assert fired == ["done"]
+
+
+def test_session_status_snapshot():
+    """``status()`` exposes per-channel chunks/items/eof for log output."""
+    s = StateSyncSession("sess-7", lambda: None)
+    s.record_chunk(KEYS_CHANNEL, 0, eof=False, items_installed=10)
+    s.record_chunk(KEYS_CHANNEL, 1, eof=True, items_installed=5)
+    snap = s.status()
+    assert snap[KEYS_CHANNEL] == {"eof": True, "chunks": 2, "items": 15}
+    assert snap[DENIED_CHANNEL] == {"eof": False, "chunks": 0, "items": 0}

--- a/tests/pytests/unit/cluster/test_state_sync.py
+++ b/tests/pytests/unit/cluster/test_state_sync.py
@@ -77,7 +77,7 @@ def test_iter_keys_chunks_empty_yields_one_empty_chunk(monkeypatch):
 
 
 def test_iter_keys_chunks_count_based_split(monkeypatch):
-    """A 250-entry bank with default 200-count chunks → 2 chunks (200 + 50)."""
+    """A 250-entry bank with default 200-count chunks -> 2 chunks (200 + 50)."""
     bank = {f"m{i:03d}": {"state": "accepted", "pub": "p"} for i in range(250)}
     opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: bank})
     chunks = list(iter_keys_chunks(opts, KEYS_CHANNEL))
@@ -109,7 +109,7 @@ def test_iter_keys_chunks_unknown_channel_raises(monkeypatch):
 
 
 def test_iter_root_chunks_empty_yields_one_empty_chunk():
-    """No roots → single empty chunk so the eof flag still fires."""
+    """No roots -> single empty chunk so the eof flag still fires."""
     assert list(iter_root_chunks(None)) == [[]]
     assert list(iter_root_chunks({})) == [[]]
 
@@ -140,7 +140,7 @@ def test_iter_root_chunks_byte_budget_splits(tmp_path):
 
     chunks = list(iter_root_chunks({"base": [str(base)]}, byte_budget=1000))
 
-    # First chunk holds one file (600 ≤ 1000), adding a second (600+600=1200)
+    # First chunk holds one file (600 <= 1000), adding a second (600+600=1200)
     # crosses the budget so the second file starts a new chunk; same for
     # the third.  Result: 3 chunks of one file each, in directory order.
     assert len(chunks) == 3

--- a/tests/pytests/unit/runners/test_cluster_runner.py
+++ b/tests/pytests/unit/runners/test_cluster_runner.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for the ``cluster`` runner — currently the read-only
+``ring_info`` query and the explicit ``NotImplementedError`` from
+``ring_set``.
+
+The proposal path is deferred (see ``GAPS.md``); these tests pin
+the contract that operators see today so a follow-up that lights up
+the propose path can update them in lockstep.
+"""
+
+import pytest
+
+from salt.cluster import ring_membership
+from salt.runners import cluster as cluster_runner
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ring():
+    """Each test gets a fresh empty ring; cleanup also resets it."""
+    ring_membership.reset()
+    yield
+    ring_membership.reset()
+
+
+def test_ring_info_default_state():
+    """
+    A runner subprocess has never received a rebuild — the ring is
+    empty.  ``is_clustered`` is False, ``node_count`` is 0, the nodes
+    list is empty.  Stable shape so the docs / runbook never lie.
+    """
+    info = cluster_runner.ring_info()
+    assert info["is_clustered"] is False
+    assert info["node_count"] == 0
+    assert info["nodes"] == []
+    # ``vnodes`` is computed from the token table; an empty ring has 0
+    # tokens so the answer is 0 rather than the default-150 constant.
+    assert info["vnodes"] == 0
+
+
+def test_ring_info_after_rebuild():
+    """
+    A populated ring round-trips through ``ring_info`` cleanly.  This
+    is the shape stage 2 will see once the runner's ring is sourced
+    from the same SM the publish daemon's ring is.
+    """
+    ring_membership.rebuild(["m1", "m2", "m3"])
+    info = cluster_runner.ring_info()
+    assert info["is_clustered"] is True
+    assert info["node_count"] == 3
+    assert info["nodes"] == ["m1", "m2", "m3"]
+    assert info["vnodes"] >= 1
+
+
+def test_ring_set_raises_until_propose_path_lands():
+    """
+    Operators who try to commit a new policy through the runner today
+    must see a loud failure rather than a silent no-op.  ``ring_set``
+    raises :class:`NotImplementedError` until the runner-to-master
+    IPC arrives.
+    """
+    with pytest.raises(NotImplementedError):
+        cluster_runner.ring_set(members="voters", replicas=2)
+
+
+def test_ring_set_raises_with_no_args_too():
+    """``ring_set`` raises before validating arguments."""
+    with pytest.raises(NotImplementedError):
+        cluster_runner.ring_set()

--- a/tests/pytests/unit/test_event_monitor_ring_gating.py
+++ b/tests/pytests/unit/test_event_monitor_ring_gating.py
@@ -1,0 +1,237 @@
+"""
+Coverage for the ring gating in ``EventMonitor.handle_event``.
+
+The gate sites at ``salt/master.py`` 1149-1197 wrap
+``store_minions`` / ``store_job`` / ``_apply_peer_key_change`` in
+``ring_membership.owns(opts, jid)``.  In stage 0 with a self-only
+ring the gate is always-True and behaviour is unchanged from
+pre-ring.  Stage 1 onwards the gate actually drops writes for
+non-owned keys; these tests pin both ends of that contract so a
+future regression to "always broadcast" or "always shard" surfaces.
+
+Async note
+----------
+``EventMonitor.handle_event`` is ``async def``; without pytest-asyncio
+installed in the salt repo we drive each call ourselves with
+``asyncio.run`` instead of the ``@pytest.mark.asyncio`` decorator.
+That decorator is silently ignored when the plugin is missing — async
+test bodies never execute and every test "passes" trivially, which is
+worse than not gating at all.
+"""
+
+import asyncio
+
+import pytest
+
+import salt.utils.event
+from salt.cluster import ring_membership
+from salt.master import EventMonitor
+from tests.support.mock import patch
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ring():
+    """Per-test ring reset; cleanup runs even if a test raises."""
+    ring_membership.reset()
+    yield
+    ring_membership.reset()
+
+
+def _opts(interface="m1"):
+    """Minimal opts the gate sites consult."""
+    return {
+        "interface": interface,
+        "id": f"{interface}-host",
+        "cluster_id": "test-cluster",
+    }
+
+
+def _make_monitor(opts):
+    """Build an EventMonitor without actually starting the subprocess."""
+    return EventMonitor(opts, ipc_publisher=None, channels=[])
+
+
+def _fire(monitor, tag, payload):
+    """Drive ``handle_event`` synchronously via ``asyncio.run``."""
+    package = salt.utils.event.SaltEvent.pack(tag, payload)
+    asyncio.run(monitor.handle_event(package))
+
+
+# ---------------------------------------------------------------------------
+# Stage 0 (self-only / empty ring): gate is always True, behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_job_new_event_writes_when_ring_empty():
+    """
+    With an empty ring, ``ring_membership.owns`` returns True for every
+    key, so the /new branch calls ``store_minions``.  Default
+    behaviour pre-stage-1 — must remain identical until an operator
+    flips ring policy.
+    """
+    monitor = _make_monitor(_opts())
+    with patch("salt.utils.job.store_minions") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/20260508/new",
+            {
+                "__peer_id": "m2",
+                "jid": "20260508-A",
+                "minions": ["minion-a", "minion-b"],
+            },
+        )
+    mock_store.assert_called_once()
+
+
+def test_job_ret_event_writes_when_ring_empty():
+    """
+    Same as the /new test but for the /ret branch — empty ring gates
+    every key as locally-owned, so ``store_job`` runs.
+    """
+    monitor = _make_monitor(_opts())
+    with patch("salt.utils.job.store_job") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/20260508/ret/minion-a",
+            {
+                "__peer_id": "m2",
+                "jid": "20260508-A",
+                "id": "minion-a",
+                "return": True,
+            },
+        )
+    mock_store.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 (voters policy): gate drops writes for non-owned keys
+# ---------------------------------------------------------------------------
+
+
+def _pick_owned_and_other_jid(members):
+    """
+    Return ``(owned_jid, other_jid)`` where ``owned_jid`` hashes to
+    ``members[0]`` and ``other_jid`` hashes to a different member.
+
+    Owners are determined by ``HashRing.get_owner`` on the rebuilt
+    ring.  Iterating jid candidates is fast.
+    """
+    ring_membership.rebuild(members)
+    ring = ring_membership.get_ring()
+    owner_target = members[0]
+    owned = None
+    other = None
+    for i in range(2000):
+        jid = f"jid-search-{i:04d}"
+        owner = ring.get_owner(jid)
+        if owned is None and owner == owner_target:
+            owned = jid
+        elif other is None and owner != owner_target:
+            other = jid
+        if owned and other:
+            break
+    if not owned or not other:
+        raise AssertionError(
+            f"Could not synthesize owned/other jids for members={members!r}"
+        )
+    return owned, other
+
+
+def test_job_new_event_drops_when_key_not_owned():
+    """
+    With ring populated and the jid hashed to a different member,
+    the /new branch must NOT call ``store_minions``.  Direct evidence
+    that the gate sites in master.py drop writes once policy flips.
+    """
+    members = ["m1", "m2", "m3"]
+    owned_jid, other_jid = _pick_owned_and_other_jid(members)
+    monitor = _make_monitor(_opts(interface="m1"))
+
+    with patch("salt.utils.job.store_minions") as mock_store:
+        # Owned by m1: store_minions runs.
+        _fire(
+            monitor,
+            "salt/job/owned/new",
+            {"__peer_id": "m2", "jid": owned_jid, "minions": ["x"]},
+        )
+        # Owned by m2 or m3: store_minions skipped.
+        _fire(
+            monitor,
+            "salt/job/other/new",
+            {"__peer_id": "m2", "jid": other_jid, "minions": ["y"]},
+        )
+
+    assert mock_store.call_count == 1, (
+        f"Expected exactly one call (owned jid {owned_jid!r}); "
+        f"got {mock_store.call_count}"
+    )
+
+
+def test_job_ret_event_drops_when_key_not_owned():
+    """Mirror of the /new test for the /ret branch."""
+    members = ["m1", "m2", "m3"]
+    owned_jid, other_jid = _pick_owned_and_other_jid(members)
+    monitor = _make_monitor(_opts(interface="m1"))
+
+    with patch("salt.utils.job.store_job") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/owned/ret/minion-x",
+            {
+                "__peer_id": "m2",
+                "jid": owned_jid,
+                "id": "minion-x",
+                "return": True,
+            },
+        )
+        _fire(
+            monitor,
+            "salt/job/other/ret/minion-y",
+            {
+                "__peer_id": "m2",
+                "jid": other_jid,
+                "id": "minion-y",
+                "return": False,
+            },
+        )
+
+    assert mock_store.call_count == 1
+
+
+def test_event_without_peer_id_is_ignored():
+    """
+    Events that don't carry ``__peer_id`` are not cluster-forwarded
+    events — the gate sites short-circuit before consulting the ring.
+    Pins the contract that local-origin events bypass the gate.
+    """
+    monitor = _make_monitor(_opts())
+    with (
+        patch("salt.utils.job.store_minions") as mock_minions,
+        patch("salt.utils.job.store_job") as mock_job,
+    ):
+        _fire(
+            monitor,
+            "salt/job/20260508/new",
+            {"jid": "x", "minions": ["a"]},  # no __peer_id
+        )
+        _fire(
+            monitor,
+            "salt/job/20260508/ret/minion-a",
+            {"jid": "x", "id": "minion-a", "return": True},  # no __peer_id
+        )
+    mock_minions.assert_not_called()
+    mock_job.assert_not_called()
+
+
+def test_event_without_cluster_id_is_ignored():
+    """A non-cluster master ignores forwarded job events entirely."""
+    opts = _opts()
+    opts.pop("cluster_id")
+    monitor = _make_monitor(opts)
+    with patch("salt.utils.job.store_minions") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/20260508/new",
+            {"__peer_id": "m2", "jid": "x", "minions": ["a"]},
+        )
+    mock_store.assert_not_called()

--- a/tests/pytests/unit/test_scripts.py
+++ b/tests/pytests/unit/test_scripts.py
@@ -1,3 +1,8 @@
+import multiprocessing
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 from salt.scripts import _pip_args, _pip_environment
@@ -78,3 +83,58 @@ def test_pip_args_installing_with_target():
     assert pargs is not args
     assert args == ["install", "--target=/tmp/bartest"]
     assert pargs == ["install", "--target=/tmp/bartest"]
+
+
+# ---------------------------------------------------------------------------
+# multiprocessing start-method pin (Python 3.14+ on Linux)
+#
+# PEP 741 changed the default start method from ``fork`` to ``forkserver``,
+# which makes Salt daemon startup ~5× slower (every subprocess re-imports
+# Salt) and leaks worker processes that hold ports across restarts.
+# ``salt.scripts`` pins the start method back to ``fork`` at import time so
+# every Salt CLI entry point gets the same behaviour as on 3.13.  The two
+# tests below pin that contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip_on_windows(reason="Linux-only multiprocessing default change")
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Pre-3.14 already defaulted to fork on Linux",
+)
+def test_salt_scripts_pins_fork_start_method():
+    """
+    On Linux + Python 3.14+, importing ``salt.scripts`` (which the CLI
+    entry-point scripts do before creating any Process) pins the
+    multiprocessing start method to ``fork``.
+    """
+    # ``import salt.scripts`` already happened at module load.
+    assert multiprocessing.get_start_method(allow_none=False) == "fork"
+
+
+@pytest.mark.skip_on_windows(reason="Linux-only multiprocessing default change")
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Pre-3.14 already defaulted to fork on Linux",
+)
+def test_salt_scripts_pin_survives_fresh_interpreter():
+    """
+    Spawn a fresh interpreter, import ``salt.scripts`` first thing, then
+    print the multiprocessing start method.  Verifies the pin runs at
+    import time (not as a side-effect of some test-only fixture).
+    """
+    code = textwrap.dedent(
+        """
+        import multiprocessing
+        import salt.scripts
+        print(multiprocessing.get_start_method(allow_none=False))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.stdout.strip() == "fork"

--- a/tests/pytests/unit/utils/test_mmap_cache_segments.py
+++ b/tests/pytests/unit/utils/test_mmap_cache_segments.py
@@ -408,6 +408,82 @@ class TestAtomicRebuildSegmented:
         c.atomic_rebuild(iter(items))
         assert sorted(c.list_keys()) == ["a", "b", "c"]
 
+    def test_rebuild_multi_segment_input_into_different_segment_count(self, tmp_path):
+        """
+        Compaction (``atomic_rebuild``) is used by the Raft snapshot path
+        to reclaim heap regions for compacted log entries (per the
+        ``mmap_cache.rst`` doc).  After compaction, the output's segment
+        layout is determined by the *new* iterator's record sizes — not
+        by the original heap's segmentation.
+
+        This test seeds the cache with N segments, then rebuilds from an
+        iterator whose total record bytes fit a *smaller* number of
+        segments, and asserts:
+
+        * every input key is readable post-rebuild,
+        * original keys are gone,
+        * the on-disk segment files reflect the new layout — segment
+          files numbered above the new active id are cleaned up.
+        """
+        c = self._tiny_cache(tmp_path)
+
+        # Phase 1: seed many entries → with 33-byte records and 32-byte
+        # cap, the heap rolls every record.
+        for i in range(8):
+            c.put(f"orig{i}", "X" * 25)
+        original_seg_count = c._active_segment_id() + 1
+        assert (
+            original_seg_count >= 5
+        ), f"setup expected ≥ 5 segments, got {original_seg_count}"
+
+        # Phase 2: rebuild with fewer entries → strictly smaller segment
+        # span than the original.
+        new_items = [(f"new{i}", "Y" * 25) for i in range(3)]
+        assert c.atomic_rebuild(iter(new_items))
+
+        # Every new key readable.
+        for k, v in new_items:
+            assert c.get(k) == v
+
+        # Original keys gone (rebuild discards everything not in iterator).
+        for i in range(8):
+            assert c.get(f"orig{i}") is None
+
+        # Compaction shrunk the segment count.
+        new_seg_count = c._active_segment_id() + 1
+        assert new_seg_count < original_seg_count, (
+            f"rebuild should have compacted from {original_seg_count} "
+            f"segments, ended at {new_seg_count}"
+        )
+        # No stale .heap.N files from above the new active segment.
+        for seg_n in range(new_seg_count, original_seg_count + 2):
+            stale = seg_path(c, seg_n)
+            assert not os.path.exists(
+                stale
+            ), f"stale segment {stale} not cleaned up after rebuild"
+
+    def test_rebuild_records_consistent_offsets_in_packed_field(self, tmp_path):
+        """
+        The 64-bit packed offset field encodes segment_id (top 16 bits)
+        and within-segment offset (bottom 48 bits).  After a rebuild
+        that rolls multiple segments, the index slots must point at the
+        right segment for each key — i.e. ``get`` must read the right
+        bytes from the right file, not bleed across segment boundaries.
+
+        Stresses the packed-offset arithmetic via a multi-segment
+        rebuild + per-key read of distinguishable values.
+        """
+        c = self._tiny_cache(tmp_path)
+        # 6 entries with distinguishable byte patterns.  33-byte records
+        # > 32-byte cap → ~6 segments after rebuild.
+        items = [(f"k{i}", chr(ord("A") + i) * 25) for i in range(6)]
+        assert c.atomic_rebuild(iter(items))
+        for k, v in items:
+            got = c.get(k)
+            assert (
+                got == v
+            ), f"key {k!r} read {got!r} from wrong segment; expected {v!r}"
+
     def test_rebuild_idempotent(self, tmp_path):
         c = self._tiny_cache(tmp_path)
         items = [("x", "1"), ("y", "2")]

--- a/tests/pytests/unit/utils/test_mmap_cache_segments.py
+++ b/tests/pytests/unit/utils/test_mmap_cache_segments.py
@@ -147,14 +147,14 @@ class TestSingleSegment:
 
     def test_zero_length_value_no_heap_bytes(self, tmp_path):
         c = make_cache(tmp_path)
-        c.put("presence")  # None → zero-length
+        c.put("presence")  # None -> zero-length
         assert c.get("presence") is True
         assert os.path.getsize(seg_path(c, 0)) == 0
 
     def test_bytes_value_roundtrip(self, tmp_path):
         # get() strips trailing nulls; use non-null bytes to avoid that edge case.
         c = make_cache(tmp_path)
-        data = b"\x80\x81\x82\x83"  # invalid UTF-8 → returned as bytes
+        data = b"\x80\x81\x82\x83"  # invalid UTF-8 -> returned as bytes
         c.put("bin", data)
         assert c.get("bin") == data
 
@@ -166,9 +166,9 @@ class TestSingleSegment:
 
 class TestSegmentRolling:
     def _tiny_cache(self, tmp_path):
-        """Cache that rolls after each record ≥ 32 bytes."""
+        """Cache that rolls after each record >= 32 bytes."""
         idx = str(tmp_path / "tiny.idx")
-        # record = 8-byte CRC + value; threshold = 32 → rolls after first 24+ byte value
+        # record = 8-byte CRC + value; threshold = 32 -> rolls after first 24+ byte value
         return MmapCache(
             idx,
             size=64,
@@ -180,9 +180,9 @@ class TestSegmentRolling:
 
     def test_roll_creates_segment1(self, tmp_path):
         c = self._tiny_cache(tmp_path)
-        # First value: 24 bytes → record = 32 bytes, exactly at limit → no roll yet
+        # First value: 24 bytes -> record = 32 bytes, exactly at limit -> no roll yet
         c.put("k1", "A" * 24)
-        # Second value: any size → should trigger roll
+        # Second value: any size -> should trigger roll
         c.put("k2", "B" * 1)
         assert os.path.exists(seg_path(c, 1))
 
@@ -206,7 +206,7 @@ class TestSegmentRolling:
 
     def test_multiple_rolls(self, tmp_path):
         c = self._tiny_cache(tmp_path)
-        # Each write of 25 bytes produces a 33-byte record; > 32 → roll every time
+        # Each write of 25 bytes produces a 33-byte record; > 32 -> roll every time
         keys = [f"key{i}" for i in range(5)]
         for k in keys:
             c.put(k, "X" * 25)
@@ -262,14 +262,14 @@ class TestOverwriteAcrossSegments:
     def test_overwrite_within_seg0(self, tmp_path):
         c = self._tiny_cache(tmp_path)
         c.put("k1", "hello")
-        c.put("k1", "world")  # same length → in-place overwrite in seg 0
+        c.put("k1", "world")  # same length -> in-place overwrite in seg 0
         assert c.get("k1") == "world"
 
     def test_overwrite_within_seg1(self, tmp_path):
         c = self._tiny_cache(tmp_path)
         c.put("k1", "A" * 24)  # fills seg 0
         c.put("k2", "hello")  # lands in seg 1
-        c.put("k2", "world")  # shorter → in-place overwrite in seg 1
+        c.put("k2", "world")  # shorter -> in-place overwrite in seg 1
         assert c.get("k2") == "world"
 
     def test_overwrite_grow_spills_to_new_segment(self, tmp_path):
@@ -333,9 +333,9 @@ class TestSegmentDiscovery:
 
     def test_reopen_sees_correct_seg_count(self, tmp_path):
         c = self._tiny_cache(tmp_path)
-        c.put("k1", "A" * 24)  # → seg 0
-        c.put("k2", "B" * 25)  # → seg 1
-        c.put("k3", "C" * 25)  # → seg 2 (maybe)
+        c.put("k1", "A" * 24)  # -> seg 0
+        c.put("k2", "B" * 25)  # -> seg 1
+        c.put("k3", "C" * 25)  # -> seg 2 (maybe)
         n_segs = len(c._seg_mms)
         c.close()
 
@@ -371,7 +371,7 @@ class TestAtomicRebuildSegmented:
 
     def test_rebuild_rolls_segment(self, tmp_path):
         c = self._tiny_cache(tmp_path)
-        # Each 25-byte value produces a 33-byte record → exceeds 32-byte limit
+        # Each 25-byte value produces a 33-byte record -> exceeds 32-byte limit
         items = [(f"k{i}", "X" * 25) for i in range(3)]
         assert c.atomic_rebuild(iter(items))
         for k, v in items:
@@ -382,10 +382,10 @@ class TestAtomicRebuildSegmented:
         c = self._tiny_cache(tmp_path)
         # Write two segments initially
         c.put("k1", "A" * 24)
-        c.put("k2", "B" * 25)  # → seg 1
+        c.put("k2", "B" * 25)  # -> seg 1
         assert os.path.exists(seg_path(c, 1))
 
-        # Rebuild with only a small dataset → should fit in seg 0
+        # Rebuild with only a small dataset -> should fit in seg 0
         c.atomic_rebuild([("only", "tiny")])
         assert not os.path.exists(seg_path(c, 1)), "stale seg 1 not cleaned up"
         assert c.get("only") == "tiny"
@@ -427,16 +427,16 @@ class TestAtomicRebuildSegmented:
         """
         c = self._tiny_cache(tmp_path)
 
-        # Phase 1: seed many entries → with 33-byte records and 32-byte
+        # Phase 1: seed many entries -> with 33-byte records and 32-byte
         # cap, the heap rolls every record.
         for i in range(8):
             c.put(f"orig{i}", "X" * 25)
         original_seg_count = c._active_segment_id() + 1
         assert (
             original_seg_count >= 5
-        ), f"setup expected ≥ 5 segments, got {original_seg_count}"
+        ), f"setup expected >= 5 segments, got {original_seg_count}"
 
-        # Phase 2: rebuild with fewer entries → strictly smaller segment
+        # Phase 2: rebuild with fewer entries -> strictly smaller segment
         # span than the original.
         new_items = [(f"new{i}", "Y" * 25) for i in range(3)]
         assert c.atomic_rebuild(iter(new_items))
@@ -475,7 +475,7 @@ class TestAtomicRebuildSegmented:
         """
         c = self._tiny_cache(tmp_path)
         # 6 entries with distinguishable byte patterns.  33-byte records
-        # > 32-byte cap → ~6 segments after rebuild.
+        # > 32-byte cap -> ~6 segments after rebuild.
         items = [(f"k{i}", chr(ord("A") + i) * 25) for i in range(6)]
         assert c.atomic_rebuild(iter(items))
         for k, v in items:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1804,6 +1804,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Crypto config for master
             "publish_signing_algorithm": salt.crypt.PKCS1v15_SHA1,
             "cluster_encryption_algorithm": salt.crypt.OAEP_SHA1,
+            "cluster_max_log_size": None,
         }
         ret.update(kwargs)
         return ret

--- a/tools/precommit/docstrings.py
+++ b/tools/precommit/docstrings.py
@@ -1109,3 +1109,114 @@ CLI_EXAMPLE_PROPER_FORMATTING_RE = re.compile(
 
 def _check_cli_example_proper_formatting(docstring):
     return CLI_EXAMPLE_PROPER_FORMATTING_RE.search(docstring) is not None
+
+
+# ---------------------------------------------------------------------------
+# Windows-friendly docstring check: reject cp1252-incompatible characters.
+#
+# salt-run -d, salt -d, sphinx, and ``inspect.getdoc()`` all eventually
+# print docstrings to stdout.  On Windows with the default locale (no
+# ``PYTHONUTF8=1``), Python's stdout uses cp1252 / mbcs.  A docstring
+# containing a character outside cp1252 (e.g. U+2192 ->, U+2265 >=)
+# raises ``UnicodeEncodeError`` mid-print, aborts the doc-iteration
+# loop, and silently truncates output -- the failure mode that broke
+# ``test_in_docs`` on the Windows CI runner.
+#
+# This check fails the build if any salt source docstring contains
+# such a character.  Runs as part of the ``check-docstrings``
+# pre-commit alias and as a standalone ``check-cp1252`` alias.
+# ---------------------------------------------------------------------------
+
+
+@cgroup.command(
+    name="check-cp1252",
+    arguments={
+        "files": {
+            "help": "List of files to check",
+            "nargs": "*",
+        },
+    },
+)
+def check_cp1252_docstrings(
+    ctx: Context,
+    files: list[pathlib.Path],
+) -> None:
+    """
+    Reject docstrings whose characters cannot be encoded in cp1252.
+
+    Runs only on docstrings (module-, class-, and function-level), not
+    on string literals or comments -- those don't reach the Windows
+    salt-run/salt -d output paths that surface as user-visible test
+    failures.
+    """
+    if not files:
+        _files = list(SALT_CODE_DIR.rglob("*.py"))
+    else:
+        _files = [fpath.resolve() for fpath in files if fpath.suffix == ".py"]
+
+    errors = 0
+    for path in _files:
+        if str(path).startswith(str(tools.utils.REPO_ROOT / "salt" / "ext")):
+            continue
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError) as exc:
+            ctx.warn(f"Could not parse {path}: {exc}")
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            docstring = ast.get_docstring(node, clean=False)
+            if not docstring:
+                continue
+            try:
+                docstring.encode("cp1252")
+            except UnicodeEncodeError as exc:
+                # ``exc.object[exc.start]`` is the offending character.
+                bad_chars = sorted(
+                    {
+                        ch
+                        for ch in docstring
+                        if ord(ch) > 127 and not _cp1252_encodable(ch)
+                    }
+                )
+                rendered = ", ".join(f"U+{ord(c):04X} {c!r}" for c in bad_chars)
+                try:
+                    relpath = path.relative_to(tools.utils.REPO_ROOT)
+                except ValueError:
+                    # File outside the repo root (unusual; defensive
+                    # for direct invocation against an arbitrary path).
+                    relpath = path
+                name = getattr(node, "name", "<module>")
+                lineno = getattr(node, "lineno", 1)
+                ctx.error(
+                    f"{relpath}:{lineno} {name}: docstring contains "
+                    f"cp1252-unencodable characters ({rendered}).  "
+                    f"These break salt-run -d / salt -d on Windows where "
+                    f"stdout uses the locale-default encoding.  Replace "
+                    f"with ASCII equivalents (e.g. -> for arrows, >= for "
+                    f"U+2265).  See BUG.md for the precedent that motivated "
+                    f"this check."
+                )
+                annotate(
+                    ctx,
+                    "error",
+                    relpath,
+                    lineno,
+                    lineno,
+                    f"cp1252-unencodable characters in docstring: {rendered}",
+                )
+                errors += 1
+    if errors:
+        ctx.exit(1)
+
+
+def _cp1252_encodable(ch: str) -> bool:
+    """Return ``True`` iff *ch* (a single character) is cp1252-encodable."""
+    try:
+        ch.encode("cp1252")
+    except UnicodeEncodeError:
+        return False
+    return True


### PR DESCRIPTION
Adds bulk state-sync of keys and file_roots/pillar_roots over the cluster join handshake so a joining master can serve states/pillars without a shared filesystem. State is delivered in four paged streams (KEYS, DENIED_KEYS, FILE_ROOTS, PILLAR_ROOTS) encrypted with cluster_aes; receivers track per-channel completion and install chunks as they land.

Fixes three real bugs that surfaced as the test_raft_re_election_after _leader_restart flake under CI load:

- Transport race: SaltPeer/RaftDispatcher used a run_in_executor shim that lost RPCs when the asyncio loop tore down. Switched to a private async _publish helper that lazily attaches a _TCPPubServerPublisher to each pusher (no salt-transport API changes).
- Raft pre-vote correctness: pre_request_vote was mutating term and stepping down before granting a hypothetical vote, violating Ongaro thesis section 9.6. Pre-vote now evaluates without state mutation.
- Test snapshot race: the BECOMING LEADER baseline was captured after leader_master.terminate(), which under load gave the survivors time to re-elect before the snapshot ran. Snapshot before terminate.

Also pins multiprocessing to fork on Linux/Python 3.14+ to avoid the PEP 741 forkserver default that produced a 5x master start-up slowdown.

Adds a kind-based scenario fixture for realistic k8s-style cluster testing, isolated-FS integration fixtures, election-storm assertion helpers, and unit coverage for the new state_sync/file_sync modules.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
