### PR TITLE
Document retry_dns failover behavior

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -366,6 +366,10 @@ Set the number of seconds to wait before attempting to resolve
 the master hostname if name resolution fails. Defaults to 30 seconds.
 Set to zero if the minion should shutdown and not retry.
 
+When :conf_minion:`master_type` is set to ``failover``, Salt sets
+``retry_dns`` to ``0`` during startup so the minion can fail over to the
+next master on DNS errors.
+
 .. code-block:: yaml
 
     retry_dns: 30


### PR DESCRIPTION
### What does this PR do?

Documents the `retry_dns` behavior when the minion is configured with `master_type: failover`.

The current minion code forces `retry_dns` to `0` during startup in that mode so DNS errors move to the next configured master instead of retrying the same name resolution.

### What issues does this PR fix or reference?
Fixes #69109

### Previous Behavior

The `retry_dns` reference only described the default retry interval and the general `0` behavior, so the failover-specific override was not visible from the minion configuration docs.

### New Behavior

The `retry_dns` reference now notes that `master_type: failover` causes Salt to set `retry_dns` to `0` during startup to allow failover on DNS errors.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [ ] Changelog - documentation-only reference update
- [ ] Tests written/updated - documentation-only reference update

### Commits signed with GPG?
No

### Verification

- `git diff --check`
- `Select-String -Path doc\ref\configuration\minion.rst -Pattern 'master_type.*failover','retry_dns`` to ``0','conf_minion:: retry_dns'`