### PR TITLE
Bump urllib3 to 2.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ requests>=2.33.1 ; python_version >= '3.10'
 rpm-vercmp; sys_platform == 'linux'
 setproctitle>=1.2.3
 urllib3>=1.26.20,<2.0.0; python_version < '3.10'
-urllib3>=2.6.3; python_version >= '3.10'
+urllib3>=2.7.0; python_version >= '3.10'
 virtualenv
 wmi>=1.5.1; sys_platform == 'win32'
 xmltodict>=0.13.0; sys_platform == 'win32'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -728,7 +728,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -500,7 +500,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -316,7 +316,7 @@ typing-extensions==4.14.1
     #   virtualenv
 uc-micro-py==1.0.2
     # via linkify-it-py
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -551,7 +551,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -735,7 +735,7 @@ typing-extensions==4.14.1
     #   pyjwt
     #   pyopenssl
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -568,7 +568,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -527,7 +527,7 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -711,7 +711,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -490,7 +490,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -310,7 +310,7 @@ typing-extensions==4.14.1
     #   pyopenssl
 uc-micro-py==1.0.1
     # via linkify-it-py
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -540,7 +540,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -716,7 +716,7 @@ typing-extensions==4.14.1
     #   aiosignal
     #   pyopenssl
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -554,7 +554,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -517,7 +517,7 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -706,7 +706,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -486,7 +486,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -306,7 +306,7 @@ typing-extensions==4.14.1
     #   pyopenssl
 uc-micro-py==1.0.1
     # via linkify-it-py
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -536,7 +536,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -711,7 +711,7 @@ typing-extensions==4.14.1
     #   aiosignal
     #   pyopenssl
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -550,7 +550,7 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -513,7 +513,7 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -706,7 +706,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -484,7 +484,7 @@ trustme==1.2.1
     # via -r requirements/pytest.txt
 typing-extensions==4.14.1
     # via pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -306,7 +306,7 @@ tempora==5.8.1
     #   portend
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -534,7 +534,7 @@ trustme==1.2.1
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -698,7 +698,7 @@ twilio==9.10.4
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/linux.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -543,7 +543,7 @@ twilio==9.10.4
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.15.0
     # via pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -510,7 +510,7 @@ typer-slim==0.24.0
     #   jaraco-text
 typing-extensions==4.15.0
     # via pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -659,7 +659,7 @@ urllib3==1.26.20 ; python_full_version < '3.10'
     #   python-etcd
     #   requests
     #   responses
-urllib3==2.6.3 ; python_full_version >= '3.10'
+urllib3==2.7.0 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -168,7 +168,7 @@ typing-extensions==4.14.1
     #   cryptography
     #   pyopenssl
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -202,7 +202,7 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     #   cryptography
     #   pyopenssl
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -189,7 +189,7 @@ typing-extensions==4.14.1
     #   cryptography
     #   pyopenssl
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -202,7 +202,7 @@ typing-extensions==4.15.0
     #   multidict
     #   pyopenssl
     #   virtualenv
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -164,7 +164,7 @@ typing-extensions==4.14.1
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -198,7 +198,7 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -185,7 +185,7 @@ typing-extensions==4.14.1
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -197,7 +197,7 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -162,7 +162,7 @@ typing-extensions==4.14.1
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -196,7 +196,7 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -183,7 +183,7 @@ typing-extensions==4.14.1
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -195,7 +195,7 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   pyopenssl
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -157,7 +157,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/darwin.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -191,7 +191,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/freebsd.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -178,7 +178,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/linux.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -191,7 +191,7 @@ typer==0.24.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/darwin.txt
+++ b/requirements/static/pkg/py3.14/darwin.txt
@@ -157,7 +157,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/darwin.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/freebsd.txt
+++ b/requirements/static/pkg/py3.14/freebsd.txt
@@ -191,7 +191,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/freebsd.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/linux.txt
+++ b/requirements/static/pkg/py3.14/linux.txt
@@ -178,7 +178,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/linux.in
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/windows.txt
+++ b/requirements/static/pkg/py3.14/windows.txt
@@ -191,7 +191,7 @@ typer==0.24.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -217,7 +217,7 @@ urllib3==1.26.20 ; python_full_version < '3.10'
     # via
     #   -r requirements/base.txt
     #   requests
-urllib3==2.6.3 ; python_full_version >= '3.10'
+urllib3==2.7.0 ; python_full_version >= '3.10'
     # via
     #   -r requirements/base.txt
     #   requests


### PR DESCRIPTION
### What does this PR do?
Bumps urllib3 to version 2.7.0

### What issues does this PR fix or reference?
Fixes [Dependabot](https://github.com/saltstack/salt/security/dependabot/6149)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
