### PR TITLE
Add win_lgpo AdministratorLockout policy

### DIFF
--- a/changelog/69132.added.md
+++ b/changelog/69132.added.md
@@ -1,0 +1,4 @@
+Added support for the ``AdministratorLockout`` (Allow Administrator account
+lockout) policy in ``salt.modules.win_lgpo``, allowing the built-in
+Administrator account lockout behaviour to be enabled or disabled via
+Local Group Policy on Windows.

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2941,6 +2941,16 @@ class _policy_info:
                         },
                         "NetUserModal": {"Modal": 3, "Option": "lockout_threshold"},
                     },
+                    "AdministratorLockout": {
+                        "Policy": "Allow Administrator account lockout",
+                        "lgpo_section": self.account_lockout_policy_gpedit_path,
+                        "Settings": self.enabled_one_disabled_zero_no_not_defined.keys(),
+                        "Secedit": {
+                            "Option": "AllowAdministratorLockout",
+                            "Section": "System Access",
+                        },
+                        "Transform": self.enabled_one_disabled_zero_no_not_defined_transform,
+                    },
                     "LockoutWindow": {
                         "Policy": "Reset account lockout counter after",
                         "lgpo_section": self.account_lockout_policy_gpedit_path,

--- a/tests/pytests/functional/modules/win_lgpo/test_account_lockout_policy.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_account_lockout_policy.py
@@ -1,0 +1,44 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.destructive_test,
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module")
+def lgpo(modules):
+    return modules.lgpo
+
+
+@pytest.fixture
+def reset_administrator_lockout(lgpo):
+    original = lgpo.get_policy("AdministratorLockout", "machine")
+    try:
+        yield
+    finally:
+        if original in ("Enabled", "Disabled"):
+            lgpo.set_computer_policy("AdministratorLockout", original)
+
+
+@pytest.mark.parametrize("setting", ["Enabled", "Disabled"])
+def test_administrator_lockout(lgpo, setting, reset_administrator_lockout):
+    """
+    Test setting AdministratorLockout by short name and reading it back.
+    """
+    lgpo.set_computer_policy("AdministratorLockout", setting)
+    result = lgpo.get_policy("AdministratorLockout", "machine")
+    assert result == setting
+
+
+@pytest.mark.parametrize("setting", ["Enabled", "Disabled"])
+def test_administrator_lockout_full_name(lgpo, setting, reset_administrator_lockout):
+    """
+    Test setting AdministratorLockout by its full policy name and reading it
+    back, confirming that the long name resolves to the same policy.
+    """
+    lgpo.set_computer_policy("Allow Administrator account lockout", setting)
+    result = lgpo.get_policy("Allow Administrator account lockout", "machine")
+    assert result == setting


### PR DESCRIPTION
### What does this PR do?
Add the AdministratorLockout (Allow Administrator account lockout) entry to the account lockout policy dictionary in win_lgpo, backed by the AllowAdministratorLockout secedit option in the System Access section. Add functional tests in tests/pytests/functional/modules/win_lgpo/ test_account_lockout_policy.py covering Enabled/Disabled via both the short name and the full policy name, with per-test save/restore of the original setting.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/69132

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
