### PR TITLE
[3008.x] Add 'show_changes' to "file.append" and "file.prepend" state functions

### DIFF
--- a/changelog/59329.added.md
+++ b/changelog/59329.added.md
@@ -1,0 +1,1 @@
+Add 'show_changes' arg for file.append and file.prepend states to hide output

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7014,7 +7014,7 @@ def append(
         .. versionadded:: 3008.0
 
         Output a unified diff of the old file and the new file.
-        Set this option to  ``False` to disable this.
+        Set this option to  ``False`` to disable this.
 
     Multi-line example:
 
@@ -7302,7 +7302,7 @@ def prepend(
         .. versionadded:: 3008.0
 
         Output a unified diff of the old file and the new file.
-        Set this option to  ``False` to disable this.
+        Set this option to  ``False`` to disable this.
 
     Multi-line example:
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6918,6 +6918,7 @@ def append(
     defaults=None,
     context=None,
     ignore_whitespace=True,
+    show_changes=True,
 ):
     """
     Ensure that some text appears at the end of a file.
@@ -7008,6 +7009,12 @@ def append(
         Spaces and Tabs in text are ignored by default, when searching for the
         appending content, one space or multiple tabs are the same for salt.
         Set this option to ``False`` if you want to change this behavior.
+
+    show_changes
+        .. versionadded:: 3008.0
+
+        Output a unified diff of the old file and the new file.
+        Set this option to  ``False` to disable this.
 
     Multi-line example:
 
@@ -7148,6 +7155,8 @@ def append(
         if slines != nlines:
             if not __utils__["files.is_text"](name):
                 ret["changes"]["diff"] = "Replace binary file"
+            elif not show_changes:
+                ret["changes"]["diff"] = "<show_changes=False>"
             else:
                 # Changes happened, add them
                 ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
@@ -7170,6 +7179,8 @@ def append(
     if slines != nlines:
         if not __utils__["files.is_text"](name):
             ret["changes"]["diff"] = "Replace binary file"
+        elif not show_changes:
+            ret["changes"]["diff"] = "<show_changes=False>"
         else:
             # Changes happened, add them
             ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
@@ -7191,6 +7202,7 @@ def prepend(
     defaults=None,
     context=None,
     header=None,
+    show_changes=True,
 ):
     """
     Ensure that some text appears at the beginning of a file
@@ -7285,6 +7297,12 @@ def prepend(
     header
         Forces the text to be prepended. If it exists in the file but not at
         the beginning, then it prepends a duplicate.
+
+    show_changes
+        .. versionadded:: 3008.0
+
+        Output a unified diff of the old file and the new file.
+        Set this option to  ``False` to disable this.
 
     Multi-line example:
 
@@ -7441,6 +7459,8 @@ def prepend(
         if slines != nlines:
             if not __utils__["files.is_text"](name):
                 ret["changes"]["diff"] = "Replace binary file"
+            elif not show_changes:
+                ret["changes"]["diff"] = "<show_changes=False>"
             else:
                 # Changes happened, add them
                 ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
@@ -7480,6 +7500,8 @@ def prepend(
     if slines != nlines:
         if not __utils__["files.is_text"](name):
             ret["changes"]["diff"] = "Replace binary file"
+        elif not show_changes:
+            ret["changes"]["diff"] = "<show_changes=False>"
         else:
             # Changes happened, add them
             ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))

--- a/tests/pytests/functional/states/file/test_append.py
+++ b/tests/pytests/functional/states/file/test_append.py
@@ -160,3 +160,26 @@ def test_file_append_check_cmd(modules, state_tree, tmp_path):
         for state_run in ret:
             assert state_run.result is False
             assert state_run.comment == "check_cmd determined the state failed"
+
+
+@pytest.mark.parametrize("show_changes", (None, True, False))
+def test_append_show_changes(file, show_changes, tmp_path):
+    """
+    Test show_changes argument for file.append
+    """
+
+    name = tmp_path / "testfile-show_changes"
+    name.write_text("#salty!")
+    if show_changes is None:
+        ret = file.append(name=str(name), text="cheese")
+    else:
+        ret = file.append(name=str(name), text="cheese", show_changes=show_changes)
+
+    assert ret.result is True
+    assert name.exists()
+
+    if show_changes in [True, None]:
+        assert "diff" in ret.changes
+        assert "cheese" in ret.changes["diff"]
+    else:
+        assert ret.changes["diff"] == "<show_changes=False>"

--- a/tests/pytests/functional/states/file/test_prepend.py
+++ b/tests/pytests/functional/states/file/test_prepend.py
@@ -34,3 +34,26 @@ def test_prepend_issue_27401_makedirs(file, tmp_path):
     assert name.is_file()
     assert name.read_text() == "cheese\n"
     assert name.parent.is_dir()
+
+
+@pytest.mark.parametrize("show_changes", (None, True, False))
+def test_prepend_show_changes(file, show_changes, tmp_path):
+    """
+    Test show_changes argument for file.prepend
+    """
+
+    name = tmp_path / "testfile-prepend-show_changes"
+    name.write_text("#salty!")
+    if show_changes is None:
+        ret = file.prepend(name=str(name), text="cheese")
+    else:
+        ret = file.prepend(name=str(name), text="cheese", show_changes=show_changes)
+
+    assert ret.result is True
+    assert name.exists()
+
+    if show_changes in [True, None]:
+        assert "diff" in ret.changes
+        assert "cheese" in ret.changes["diff"]
+    else:
+        assert ret.changes["diff"] == "<show_changes=False>"


### PR DESCRIPTION
### What does this PR do?

This PR adds the `show_changes` argument to `file.append` and `file.prepend` state functions in order to allow hiding the diff of the content as part of the output. Same behavior that `file.managed` state and others.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/59329 and https://github.com/saltstack/salt/discussions/67533

### Previous Behavior
The output from `file.append` and `file.prepend` executions always contains a "diff" when files are text files.

### New Behavior
By default, the "diff" is included, but this can be skipped when `show_changes` is set to `False`.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
