### PR TITLE
Add OpenTelemetry distributed tracing across all Salt hops

### DIFF
--- a/changelog/68999.added.md
+++ b/changelog/68999.added.md
@@ -1,0 +1,8 @@
+Added OpenTelemetry distributed-tracing support across all Salt
+inter-process hops (network and IPC).  When `tracing.enabled` is true in the
+master/minion config, salt emits W3C-TraceContext-propagated spans via an
+OTLP exporter, covering the CLI, channel layer, master workers, minion
+command execution, event bus, reactor, syndic forwarding, salt-ssh, and
+salt-api.  Trace context travels inside the AES-encrypted Salt envelope so
+it remains opaque on the wire.  Tracing is opt-in and a complete no-op when
+disabled.

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -20,6 +20,7 @@ Salt Table of Contents
     topics/return_codes/index
     topics/utils/index
     topics/event/index
+    topics/tracing/index
     topics/orchestrate/index
     topics/solaris/index
     topics/ssh/index

--- a/doc/topics/tracing/index.rst
+++ b/doc/topics/tracing/index.rst
@@ -1,8 +1,8 @@
 .. _tracing:
 
-================================
+===================================
 Distributed Tracing (OpenTelemetry)
-================================
+===================================
 
 Salt can emit OpenTelemetry spans for every inter-process hop, so a single
 job (``salt '*' test.ping``) becomes a single distributed trace that crosses

--- a/doc/topics/tracing/index.rst
+++ b/doc/topics/tracing/index.rst
@@ -1,0 +1,155 @@
+.. _tracing:
+
+================================
+Distributed Tracing (OpenTelemetry)
+================================
+
+Salt can emit OpenTelemetry spans for every inter-process hop, so a single
+job (``salt '*' test.ping``) becomes a single distributed trace that crosses
+the CLI, the master, the minion, the return path, and any reactor or syndic
+forwarding in between.
+
+The implementation uses standard W3C TraceContext (``traceparent`` /
+``tracestate``) for propagation and ships spans through an OTLP exporter.
+Jaeger ingests OTLP natively, as do most modern tracing backends
+(Tempo, Honeycomb, Datadog OTLP, etc.).
+
+Trace context propagates **inside** the AES-encrypted Salt envelope: an
+attacker on the wire cannot see the trace headers, and authenticated
+participants (master / minion / syndic) decode them after AES decryption.
+
+Tracing is **disabled by default** and is a complete no-op when not
+configured.  No spans are created, no exporter is initialised, and no
+background threads are started.
+
+Configuration
+-------------
+
+Add a ``tracing`` block to the master and minion configs.  The block is
+identical on both daemons, and applies to ``salt-cli``, ``salt-call``,
+``salt-api`` and ``salt-ssh`` as well.
+
+.. code-block:: yaml
+
+    tracing:
+      enabled: true
+      exporter: otlp-grpc            # otlp-grpc | otlp-http | console
+      endpoint: http://localhost:4317
+      service_name: ""               # auto-derived when empty
+      sampler: parent_based          # parent_based | always_on | always_off | trace_id_ratio
+      sampler_arg: 1.0
+      resource_attributes: {}
+      insecure: true                 # gRPC TLS disabled
+      headers: {}                    # OTLP authentication headers
+
+``enabled``
+    Master switch.  When ``false`` (the default), everything in this module
+    is a no-op.
+
+``exporter``
+    ``otlp-grpc`` (default) sends spans via gRPC to ``endpoint``.
+    ``otlp-http`` sends via HTTP/protobuf.
+    ``console`` prints spans to stdout for debugging.
+
+``endpoint``
+    OTLP collector URL.  When empty, the OTel SDK default is used
+    (``http://localhost:4317`` for gRPC, ``http://localhost:4318/v1/traces``
+    for HTTP).
+
+``service_name``
+    The ``service.name`` resource attribute.  When empty, Salt fills this in
+    automatically: ``salt-master``, ``salt-minion-<id>``, ``salt-cli``,
+    ``salt-call``, ``salt-api``.
+
+``sampler``
+    Which sampler to install on the ``TracerProvider``.
+
+    - ``parent_based`` (default): follow the parent's sample decision; root
+      spans are sampled.  Use ``sampler_arg`` < 1.0 to apply a ratio to
+      root spans.
+    - ``always_on``: sample every span.
+    - ``always_off``: drop every span (testing only).
+    - ``trace_id_ratio``: sample ``sampler_arg`` fraction of trace IDs.
+
+``resource_attributes``
+    Extra attributes merged into the OTel Resource (e.g. ``deployment.environment: prod``).
+
+``insecure``
+    Disable gRPC TLS to the collector.  Ignored for the HTTP exporter.
+
+``headers``
+    Additional headers sent on every OTLP request, e.g.
+    ``Authorization: Bearer <token>`` for a hosted collector.
+
+Hops covered
+------------
+
+A single ``salt '*' test.ping`` produces a trace spanning at least:
+
+1. ``salt.cli.test.ping`` — root span on the CLI.
+2. ``salt.req.send.publish`` — CLI → master request.
+3. ``salt.req.recv.publish`` — master receives the request.
+4. ``salt.pub.send`` — master publishes the job.
+5. ``salt.minion.recv.test.ping`` — minion receives the published command.
+6. ``salt.minion.exec.test.ping`` — minion executes the function.
+7. ``salt.req.send._return`` — minion returns to master.
+8. ``salt.req.recv._return`` — master receives the return.
+
+Other instrumented hops:
+
+- Event bus (``fire_event`` / ``get_event``) — every IPC and TCP-IPC event
+  carries trace context in its data dict.
+- Reactor — extracts trace context from incoming events and parents the
+  reaction span correctly.
+- Syndic forwarding — both inbound (from upstream master) and outbound (to
+  downstream minions).
+- Salt-SSH — propagates trace context as the ``TRACEPARENT`` environment
+  variable on the remote shim.
+- Salt-API — extracts the ``traceparent`` HTTP header from incoming
+  requests; webhooks inject context into the events they fire.
+
+Running a quick demo
+--------------------
+
+Spin up an all-in-one Jaeger:
+
+.. code-block:: bash
+
+    docker run -d --name jaeger \
+      -p 16686:16686 -p 4317:4317 \
+      jaegertracing/all-in-one:latest
+
+Configure master + minion with:
+
+.. code-block:: yaml
+
+    tracing:
+      enabled: true
+      exporter: otlp-grpc
+      endpoint: http://localhost:4317
+      sampler: always_on
+
+Start them, run ``salt '*' test.ping``, then visit
+``http://localhost:16686`` and search for the ``salt-cli`` service.  You
+should see a single trace with spans hanging off three services:
+``salt-cli``, ``salt-master`` and ``salt-minion-<id>``.
+
+Fork handling
+-------------
+
+The OTel ``BatchSpanProcessor`` runs a background thread that does not
+survive ``fork()``.  Salt rebuilds the provider in every forked child the
+first time a tracing API is invoked, so worker processes spun up by the
+master / minion get their own functioning exporter without any caller
+action.  Unflushed spans queued by the parent at the instant of fork may
+be lost; for short-lived spans this is rarely visible, but if you observe
+gaps consider lowering ``BatchSpanProcessor`` queue intervals via the OTel
+environment variables.
+
+Payload overhead
+----------------
+
+When tracing is enabled and a recording span is active, every Salt request
+and event grows by roughly 60 bytes (the W3C ``traceparent`` string).
+When no recording span is active — for example, an internal periodic event
+fired outside a request handler — no headers are added.

--- a/doc/topics/tracing/index.rst
+++ b/doc/topics/tracing/index.rst
@@ -33,13 +33,13 @@ identical on both daemons, and applies to ``salt-cli``, ``salt-call``,
 
     tracing:
       enabled: true
-      exporter: otlp-grpc            # otlp-grpc | otlp-http | console
-      endpoint: http://localhost:4317
+      exporter: otlp-http            # otlp-http | otlp-grpc | console
+      endpoint: ""                   # OTel SDK default endpoint when empty
       service_name: ""               # auto-derived when empty
       sampler: parent_based          # parent_based | always_on | always_off | trace_id_ratio
       sampler_arg: 1.0
       resource_attributes: {}
-      insecure: true                 # gRPC TLS disabled
+      insecure: true                 # gRPC TLS disabled (ignored for HTTP)
       headers: {}                    # OTLP authentication headers
 
 ``enabled``
@@ -47,14 +47,19 @@ identical on both daemons, and applies to ``salt-cli``, ``salt-call``,
     is a no-op.
 
 ``exporter``
-    ``otlp-grpc`` (default) sends spans via gRPC to ``endpoint``.
-    ``otlp-http`` sends via HTTP/protobuf.
+    ``otlp-http`` (default) sends spans via HTTP/protobuf to ``endpoint``.
+    Pure-Python; ships in salt's base requirements; works on every
+    interpreter.
+    ``otlp-grpc`` sends via gRPC.  Requires
+    ``opentelemetry-exporter-otlp-proto-grpc`` to be installed separately
+    (it pulls in ``grpcio``, which lacks prebuilt wheels for some
+    platform / interpreter combinations).
     ``console`` prints spans to stdout for debugging.
 
 ``endpoint``
     OTLP collector URL.  When empty, the OTel SDK default is used
-    (``http://localhost:4317`` for gRPC, ``http://localhost:4318/v1/traces``
-    for HTTP).
+    (``http://localhost:4318/v1/traces`` for HTTP,
+    ``http://localhost:4317`` for gRPC).
 
 ``service_name``
     The ``service.name`` resource attribute.  When empty, Salt fills this in
@@ -116,7 +121,7 @@ Spin up an all-in-one Jaeger:
 .. code-block:: bash
 
     docker run -d --name jaeger \
-      -p 16686:16686 -p 4317:4317 \
+      -p 16686:16686 -p 4318:4318 \
       jaegertracing/all-in-one:latest
 
 Configure master + minion with:
@@ -125,8 +130,8 @@ Configure master + minion with:
 
     tracing:
       enabled: true
-      exporter: otlp-grpc
-      endpoint: http://localhost:4317
+      exporter: otlp-http
+      endpoint: http://localhost:4318/v1/traces
       sampler: always_on
 
 Start them, run ``salt '*' test.ping``, then visit

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,6 @@ msgpack>=1.0.0 ; python_version < '3.13'
 msgpack>=1.1.0 ; python_version >= '3.13'
 opentelemetry-api>=1.30.0
 opentelemetry-sdk>=1.30.0
-opentelemetry-exporter-otlp-proto-grpc>=1.30.0
 opentelemetry-exporter-otlp-proto-http>=1.30.0
 xxhash>=3.0.0
 # Packaging 24.1 imports annotations from __future__ which breaks salt ssh

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,6 +30,10 @@ MarkupSafe<3.0.0
 more-itertools>=9.1.0
 msgpack>=1.0.0 ; python_version < '3.13'
 msgpack>=1.1.0 ; python_version >= '3.13'
+opentelemetry-api>=1.30.0
+opentelemetry-sdk>=1.30.0
+opentelemetry-exporter-otlp-proto-grpc>=1.30.0
+opentelemetry-exporter-otlp-proto-http>=1.30.0
 xxhash>=3.0.0
 # Packaging 24.1 imports annotations from __future__ which breaks salt ssh
 # tests on target hosts with older python versions.

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -215,13 +215,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -388,7 +382,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -396,13 +389,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -413,14 +400,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -809,10 +794,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -211,6 +211,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -226,6 +237,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -371,6 +383,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -415,6 +471,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -610,6 +672,7 @@ requests==2.31.0
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -746,7 +809,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -159,6 +159,15 @@ gitpython==3.1.46
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/ci/darwin.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -173,6 +182,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -272,6 +282,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -304,6 +351,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.10/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
@@ -440,6 +492,7 @@ requests==2.31.0
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -518,7 +571,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -162,12 +162,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.10/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -286,19 +281,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.10/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
@@ -307,13 +296,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -571,10 +558,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/darwin.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -97,6 +97,15 @@ gitpython==3.1.46
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -109,6 +118,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -179,6 +189,43 @@ multidict==6.1.0
     #   yarl
 myst-docutils==1.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -198,6 +245,11 @@ propcache==0.4.1
     #   -c requirements/static/ci/py3.10/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -256,6 +308,7 @@ requests==2.31.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   vultr
 rpm-vercmp==0.1.2
@@ -319,7 +372,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 uc-micro-py==1.0.2

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -100,12 +100,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -193,19 +188,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -214,13 +203,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -372,10 +359,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/ci/py3.10/linux.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -171,12 +171,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.10/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -302,19 +297,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.10/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
@@ -323,13 +312,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -632,10 +619,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -168,6 +168,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -183,6 +192,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1 ; sys_platform != 'win32'
@@ -288,6 +298,43 @@ ncclient==0.7.0 ; sys_platform != 'win32'
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -321,6 +368,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.txt
@@ -480,6 +532,7 @@ requests==2.31.0 ; python_full_version < '3.11'
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -493,6 +546,7 @@ requests==2.32.5 ; python_full_version >= '3.11'
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -578,7 +632,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/freebsd.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -226,13 +226,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -413,7 +407,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -421,13 +414,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.10/linux.txt
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -438,14 +425,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -806,10 +791,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   astroid
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -222,6 +222,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -254,6 +265,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 invoke==2.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -396,6 +408,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -439,6 +495,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.10/linux.txt
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
@@ -591,6 +653,7 @@ requests==2.31.0
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -743,7 +806,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   astroid
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==2.7.0

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -175,12 +175,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -312,19 +307,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
@@ -333,13 +322,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -637,10 +624,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -172,6 +172,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -194,6 +203,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -298,6 +308,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -332,6 +379,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.10/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.10/linux.txt
@@ -485,6 +537,7 @@ requests==2.31.0
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -584,7 +637,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/linux.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -160,6 +160,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
@@ -172,6 +181,7 @@ importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.2.1
@@ -266,6 +276,43 @@ multidict==6.1.0
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
@@ -293,6 +340,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
@@ -437,6 +489,7 @@ requests==2.31.0
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -530,7 +583,13 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -163,12 +163,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.10/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
@@ -280,19 +275,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.10/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
@@ -301,13 +290,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -583,10 +570,8 @@ typing-extensions==4.15.0
     #   -c requirements/static/pkg/py3.10/windows.txt
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -201,6 +201,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -216,6 +227,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -361,6 +373,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -405,6 +461,12 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -600,6 +662,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -731,6 +794,12 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.11/cloud.txt
+++ b/requirements/static/ci/py3.11/cloud.txt
@@ -205,13 +205,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -378,7 +372,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -386,13 +379,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -403,14 +390,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -794,9 +779,7 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -152,6 +152,15 @@ gitpython==3.1.46
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/ci/darwin.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -166,6 +175,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -265,6 +275,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -297,6 +344,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.11/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
@@ -433,6 +485,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -508,6 +561,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -155,12 +155,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.11/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -279,19 +274,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.11/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
@@ -300,13 +289,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -561,9 +548,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -96,12 +96,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -189,19 +184,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -210,13 +199,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -367,9 +354,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/docs.txt
+++ b/requirements/static/ci/py3.11/docs.txt
@@ -93,6 +93,15 @@ gitpython==3.1.46
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -105,6 +114,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -175,6 +185,43 @@ multidict==6.1.0
     #   yarl
 myst-docutils==1.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -194,6 +241,11 @@ propcache==0.3.2
     #   -c requirements/static/ci/py3.11/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -252,6 +304,7 @@ requests==2.32.5
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   vultr
 rpm-vercmp==0.1.2
@@ -314,6 +367,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 uc-micro-py==1.0.1
     # via linkify-it-py

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -161,6 +161,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -176,6 +185,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1 ; sys_platform != 'win32'
@@ -281,6 +291,43 @@ ncclient==0.7.0 ; sys_platform != 'win32'
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -314,6 +361,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
@@ -469,6 +521,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -551,6 +604,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -164,12 +164,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.11/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -295,19 +290,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.11/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
@@ -316,13 +305,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -604,9 +591,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -213,6 +213,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -245,6 +256,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 invoke==2.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -387,6 +399,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -430,6 +486,12 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.11/linux.txt
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -582,6 +644,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -728,6 +791,12 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/ci/py3.11/lint.txt
+++ b/requirements/static/ci/py3.11/lint.txt
@@ -217,13 +217,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -404,7 +398,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -412,13 +405,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.11/linux.txt
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
@@ -429,14 +416,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -791,9 +776,7 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.11/linux.txt
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -166,12 +166,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -303,19 +298,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
@@ -324,13 +313,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -625,9 +612,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -163,6 +163,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -185,6 +194,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -289,6 +299,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -323,6 +370,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.11/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
@@ -476,6 +528,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -572,6 +625,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -153,6 +153,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
@@ -165,6 +174,7 @@ importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.2.1
@@ -259,6 +269,43 @@ multidict==6.1.0
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
@@ -286,6 +333,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
@@ -430,6 +482,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -520,6 +573,12 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -156,12 +156,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.11/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
@@ -273,19 +268,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.11/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
@@ -294,13 +283,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -573,9 +560,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -196,6 +196,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -211,6 +222,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -356,6 +368,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -400,6 +456,12 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -595,6 +657,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -726,6 +789,12 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.12/cloud.txt
+++ b/requirements/static/ci/py3.12/cloud.txt
@@ -200,13 +200,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -373,7 +367,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -381,13 +374,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -398,14 +385,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -789,9 +774,7 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -148,6 +148,15 @@ gitpython==3.1.46
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/ci/darwin.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -162,6 +171,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -261,6 +271,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -293,6 +340,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.12/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
@@ -429,6 +481,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -504,6 +557,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.12/darwin.txt
+++ b/requirements/static/ci/py3.12/darwin.txt
@@ -151,12 +151,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.12/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -275,19 +270,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.12/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
@@ -296,13 +285,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -557,9 +544,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -89,6 +89,15 @@ gitpython==3.1.46
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -101,6 +110,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -171,6 +181,43 @@ multidict==6.1.0
     #   yarl
 myst-docutils==1.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -190,6 +237,11 @@ propcache==0.3.2
     #   -c requirements/static/ci/py3.12/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -248,6 +300,7 @@ requests==2.32.5
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   vultr
 rpm-vercmp==0.1.2
@@ -310,6 +363,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 uc-micro-py==1.0.1
     # via linkify-it-py

--- a/requirements/static/ci/py3.12/docs.txt
+++ b/requirements/static/ci/py3.12/docs.txt
@@ -92,12 +92,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -185,19 +180,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -206,13 +195,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -363,9 +350,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -157,6 +157,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -172,6 +181,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1 ; sys_platform != 'win32'
@@ -277,6 +287,43 @@ ncclient==0.7.0 ; sys_platform != 'win32'
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -310,6 +357,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
@@ -465,6 +517,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -547,6 +600,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.12/freebsd.txt
+++ b/requirements/static/ci/py3.12/freebsd.txt
@@ -160,12 +160,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.12/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -291,19 +286,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.12/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
@@ -312,13 +301,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -600,9 +587,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -212,13 +212,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -399,7 +393,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -407,13 +400,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.12/linux.txt
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -424,14 +411,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -786,9 +771,7 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/lint.txt
+++ b/requirements/static/ci/py3.12/lint.txt
@@ -208,6 +208,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -240,6 +251,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 invoke==2.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -382,6 +394,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -425,6 +481,12 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.12/linux.txt
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.12/linux.txt
@@ -577,6 +639,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -723,6 +786,12 @@ typing-extensions==4.14.1
     #   -c requirements/static/ci/py3.12/linux.txt
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -159,6 +159,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -181,6 +190,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -285,6 +295,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -319,6 +366,11 @@ propcache==0.3.2
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.12/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
@@ -472,6 +524,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -568,6 +621,12 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.12/linux.txt
+++ b/requirements/static/ci/py3.12/linux.txt
@@ -162,12 +162,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -299,19 +294,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
@@ -320,13 +309,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -621,9 +608,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -150,12 +150,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.12/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
@@ -267,19 +262,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.12/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
@@ -288,13 +277,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -566,9 +553,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.12/windows.txt
+++ b/requirements/static/ci/py3.12/windows.txt
@@ -147,6 +147,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
@@ -159,6 +168,7 @@ importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.2.1
@@ -253,6 +263,43 @@ multidict==6.1.0
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
@@ -280,6 +327,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
@@ -424,6 +476,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -513,6 +566,12 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.txt
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-system-statistics
 urllib3==2.7.0

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -202,13 +202,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -375,7 +369,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -383,13 +376,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -400,14 +387,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -783,9 +768,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -198,6 +198,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -213,6 +224,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -358,6 +370,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -401,6 +457,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -596,6 +658,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -716,14 +779,16 @@ trustme==1.2.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/pytest.txt
-truststore==0.10.4
+typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/base.txt
-typing-extensions==4.12.2
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
 urllib3==2.7.0
     # via

--- a/requirements/static/ci/py3.13/cloud.txt
+++ b/requirements/static/ci/py3.13/cloud.txt
@@ -764,6 +764,11 @@ trustme==1.2.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/pytest.txt
+truststore==0.10.4
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -548,7 +548,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -153,12 +153,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.10
@@ -277,19 +272,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
@@ -298,13 +287,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -556,9 +543,7 @@ trustme==1.2.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -540,6 +540,10 @@ transitions==0.9.2
     # via junos-eznc
 trustme==1.2.0
     # via -r requirements/pytest.txt
+truststore==0.10.4
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt

--- a/requirements/static/ci/py3.13/darwin.txt
+++ b/requirements/static/ci/py3.13/darwin.txt
@@ -150,6 +150,15 @@ gitpython==3.1.46
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/ci/darwin.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.10
@@ -164,6 +173,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.1.0
@@ -263,6 +273,43 @@ ncclient==0.6.16
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -294,6 +341,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.13/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
@@ -431,6 +483,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -500,13 +553,17 @@ transitions==0.9.2
     # via junos-eznc
 trustme==1.2.0
     # via -r requirements/pytest.txt
-truststore==0.10.4
+typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
-    #   -r requirements/base.txt
-typing-extensions==4.12.2
-    # via pytest-system-statistics
-urllib3==2.7.0
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.13/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -342,6 +342,10 @@ tornado==6.5.5
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
+truststore==0.10.4
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -92,12 +92,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -185,19 +180,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -206,13 +195,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -358,9 +345,7 @@ tornado==6.5.5
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/docs.txt
+++ b/requirements/static/ci/py3.13/docs.txt
@@ -89,6 +89,15 @@ gitpython==3.1.46
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -101,6 +110,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -171,6 +181,43 @@ multidict==6.1.0
     #   yarl
 myst-docutils==4.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -190,6 +237,11 @@ propcache==0.4.1
     #   -c requirements/static/ci/py3.13/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -248,6 +300,7 @@ requests==2.32.5
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   vultr
 rpm-vercmp==0.1.2
@@ -302,10 +355,15 @@ tornado==6.5.5
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/base.txt
-truststore==0.10.4
+typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
-    #   -r requirements/base.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
 uc-micro-py==1.0.3
     # via linkify-it-py
 urllib3==2.7.0

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -162,12 +162,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.10
@@ -293,19 +288,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
@@ -314,13 +303,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -598,9 +585,7 @@ trustme==1.2.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -582,6 +582,10 @@ transitions==0.9.2 ; sys_platform != 'win32'
     # via junos-eznc
 trustme==1.2.0
     # via -r requirements/pytest.txt
+truststore==0.10.4
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -159,6 +159,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.10
@@ -174,6 +183,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.1.0
@@ -279,6 +289,43 @@ ncclient==0.6.16 ; sys_platform != 'win32'
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -311,6 +358,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
@@ -467,6 +519,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -542,13 +595,17 @@ transitions==0.9.2 ; sys_platform != 'win32'
     # via junos-eznc
 trustme==1.2.0
     # via -r requirements/pytest.txt
-truststore==0.10.4
+typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
-    #   -r requirements/base.txt
-typing-extensions==4.12.2
-    # via pytest-system-statistics
-urllib3==2.7.0
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.txt
+++ b/requirements/static/ci/py3.13/freebsd.txt
@@ -590,7 +590,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -209,6 +209,17 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -241,6 +252,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 isort==5.13.2
     # via pylint
 jaraco-collections==5.1.0
@@ -383,6 +395,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -425,6 +481,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -577,6 +639,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -717,7 +780,17 @@ twilio==9.10.5
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -r requirements/static/ci/linux.in
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   -c requirements/static/ci/py3.13/linux.txt
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -773,7 +773,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt

--- a/requirements/static/ci/py3.13/lint.txt
+++ b/requirements/static/ci/py3.13/lint.txt
@@ -213,13 +213,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -400,7 +394,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -408,13 +401,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.13/linux.txt
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
@@ -425,14 +412,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -784,9 +769,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.13/linux.txt
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -614,7 +614,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -161,6 +161,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -183,6 +192,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.1.0
@@ -287,6 +297,43 @@ ncclient==0.6.16
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -320,6 +367,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
@@ -474,6 +526,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -566,9 +619,17 @@ truststore==0.10.4
     #   -r requirements/base.txt
 twilio==9.10.5
     # via -r requirements/static/ci/linux.in
-typing-extensions==4.12.2
-    # via pytest-system-statistics
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   -c requirements/static/pkg/py3.13/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/linux.txt
+++ b/requirements/static/ci/py3.13/linux.txt
@@ -164,12 +164,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -301,19 +296,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
@@ -322,13 +311,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -622,9 +609,7 @@ twilio==9.10.5
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -565,7 +565,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -149,6 +149,15 @@ gitpython==3.1.46
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
@@ -161,6 +170,7 @@ importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.2.1
@@ -257,6 +267,43 @@ multidict==6.1.0
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
@@ -284,6 +331,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
@@ -430,6 +482,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -517,9 +570,17 @@ typer-slim==0.24.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   jaraco-text
-typing-extensions==4.12.2
-    # via pytest-system-statistics
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.txt
+++ b/requirements/static/ci/py3.13/windows.txt
@@ -152,12 +152,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.13/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
@@ -271,19 +266,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.13/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
@@ -292,13 +281,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -573,9 +560,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/cloud.txt
+++ b/requirements/static/ci/py3.14/cloud.txt
@@ -199,6 +199,17 @@ gitpython==3.1.49
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -208,12 +219,13 @@ idna==3.13
     #   requests
     #   trustme
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -375,6 +387,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -419,6 +475,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -615,6 +677,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -759,6 +822,13 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
 urllib3==2.7.0
     # via

--- a/requirements/static/ci/py3.14/cloud.txt
+++ b/requirements/static/ci/py3.14/cloud.txt
@@ -203,13 +203,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -392,7 +386,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -400,13 +393,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -417,14 +404,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -823,9 +808,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/darwin.txt
+++ b/requirements/static/ci/py3.14/darwin.txt
@@ -152,6 +152,15 @@ gitpython==3.1.49
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/ci/darwin.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.13
@@ -162,10 +171,11 @@ idna==3.13
     #   requests
     #   trustme
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 invoke==3.0.3
@@ -277,6 +287,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -309,6 +356,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
@@ -447,6 +499,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -533,8 +586,16 @@ typer-slim==0.24.0
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   jaraco-text
 typing-extensions==4.15.0
-    # via pytest-system-statistics
-urllib3==2.7.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/darwin.txt
+++ b/requirements/static/ci/py3.14/darwin.txt
@@ -155,12 +155,7 @@ gitpython==3.1.49
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.14/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.13
@@ -291,19 +286,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.14/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
@@ -312,13 +301,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -588,9 +575,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/darwin.txt
+++ b/requirements/static/ci/py3.14/darwin.txt
@@ -580,7 +580,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/docs.txt
+++ b/requirements/static/ci/py3.14/docs.txt
@@ -93,6 +93,15 @@ gitpython==3.1.49
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -101,10 +110,11 @@ idna==3.13
     #   yarl
 imagesize==2.0.0
     # via sphinx
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -182,6 +192,43 @@ multidict==6.7.1
     #   yarl
 myst-docutils==5.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -201,6 +248,11 @@ propcache==0.4.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -258,6 +310,7 @@ requests==2.33.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   sphinxcontrib-spelling
     #   vultr
@@ -334,6 +387,15 @@ typer-slim==0.24.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   jaraco-text
+typing-extensions==4.15.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
 uc-micro-py==2.0.0
     # via linkify-it-py
 urllib3==2.7.0

--- a/requirements/static/ci/py3.14/docs.txt
+++ b/requirements/static/ci/py3.14/docs.txt
@@ -96,12 +96,7 @@ gitpython==3.1.49
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -196,19 +191,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -217,13 +206,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -390,9 +377,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/freebsd.txt
+++ b/requirements/static/ci/py3.14/freebsd.txt
@@ -164,6 +164,15 @@ gitpython==3.1.49
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.13
@@ -174,11 +183,12 @@ idna==3.13
     #   requests
     #   trustme
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 invoke==3.0.3 ; sys_platform != 'win32'
@@ -297,6 +307,43 @@ ncclient==0.7.0 ; sys_platform != 'win32'
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -330,6 +377,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
@@ -487,6 +539,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -579,8 +632,16 @@ typer-slim==0.24.0
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   jaraco-text
 typing-extensions==4.15.0
-    # via pytest-system-statistics
-urllib3==2.7.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/freebsd.txt
+++ b/requirements/static/ci/py3.14/freebsd.txt
@@ -626,7 +626,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/freebsd.txt
+++ b/requirements/static/ci/py3.14/freebsd.txt
@@ -167,12 +167,7 @@ gitpython==3.1.49
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.14/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.13
@@ -311,19 +306,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.14/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
@@ -332,13 +321,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -634,9 +621,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/lint.txt
+++ b/requirements/static/ci/py3.14/lint.txt
@@ -210,6 +210,17 @@ gitpython==3.1.49
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -237,12 +248,13 @@ idna==3.13
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 invoke==3.0.3
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -401,6 +413,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -444,6 +500,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -596,6 +658,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -747,7 +810,17 @@ typer-slim==0.24.0
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.txt
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt

--- a/requirements/static/ci/py3.14/lint.txt
+++ b/requirements/static/ci/py3.14/lint.txt
@@ -803,7 +803,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt

--- a/requirements/static/ci/py3.14/lint.txt
+++ b/requirements/static/ci/py3.14/lint.txt
@@ -214,13 +214,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -418,7 +412,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -426,13 +419,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.14/linux.txt
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
@@ -443,14 +430,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -814,9 +799,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.14/linux.txt
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/linux.txt
+++ b/requirements/static/ci/py3.14/linux.txt
@@ -166,12 +166,7 @@ gitpython==3.1.49
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via httpcore
 hglib==2.6.2
@@ -317,19 +312,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.14/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
@@ -338,13 +327,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -648,9 +635,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/linux.txt
+++ b/requirements/static/ci/py3.14/linux.txt
@@ -163,6 +163,15 @@ gitpython==3.1.49
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via httpcore
 hglib==2.6.2
@@ -183,10 +192,11 @@ idna==3.13
     #   requests
     #   trustme
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 invoke==3.0.3
@@ -303,6 +313,43 @@ ncclient==0.7.0
     #   junos-eznc
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -337,6 +384,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
@@ -492,6 +544,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -593,8 +646,16 @@ typer-slim==0.24.0
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   jaraco-text
 typing-extensions==4.15.0
-    # via pytest-system-statistics
-urllib3==2.7.0
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/linux.txt
+++ b/requirements/static/ci/py3.14/linux.txt
@@ -640,7 +640,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/windows.txt
+++ b/requirements/static/ci/py3.14/windows.txt
@@ -149,6 +149,15 @@ gitpython==3.1.49
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
@@ -157,10 +166,11 @@ idna==3.13
     #   requests
     #   trustme
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 jaraco-collections==5.2.1
@@ -259,6 +269,43 @@ multidict==6.7.1
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
@@ -286,6 +333,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
@@ -432,6 +484,7 @@ requests==2.33.1
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -518,8 +571,16 @@ typer-slim==0.24.0
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   jaraco-text
 typing-extensions==4.15.0
-    # via pytest-system-statistics
-urllib3==2.7.0
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.txt
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pytest-system-statistics
+urllib3==2.6.3
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/windows.txt
+++ b/requirements/static/ci/py3.14/windows.txt
@@ -152,12 +152,7 @@ gitpython==3.1.49
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.14/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
@@ -273,19 +268,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.14/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
@@ -294,13 +283,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -573,9 +560,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.14/windows.txt
+++ b/requirements/static/ci/py3.14/windows.txt
@@ -565,7 +565,7 @@ typing-extensions==4.15.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pytest-system-statistics
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -225,13 +225,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -422,7 +416,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -430,13 +423,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -447,14 +434,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -870,11 +855,9 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   napalm
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -221,6 +221,17 @@ google-auth==2.35.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -236,6 +247,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -405,6 +417,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -451,6 +507,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -661,6 +723,7 @@ requests==2.31.0
     #   kubernetes
     #   moto
     #   napalm
+    #   opentelemetry-exporter-otlp-proto-http
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
@@ -807,8 +870,14 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
     #   napalm
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-shell-utilities
     #   pytest-system-statistics

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -166,6 +166,15 @@ gitpython==3.1.46
     #   -r requirements/static/ci/darwin.in
 google-auth==2.35.0
     # via -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -180,6 +189,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1
@@ -296,6 +306,43 @@ ntc-templates==4.0.1
     # via netmiko
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -330,6 +377,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.9/darwin.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
@@ -479,6 +531,7 @@ requests==2.31.0
     #   kubernetes
     #   moto
     #   napalm
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -569,8 +622,14 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
     #   napalm
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-shell-utilities
     #   pytest-system-statistics

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -169,12 +169,7 @@ google-auth==2.35.0
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.9/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.in
 idna==3.7
@@ -310,19 +305,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.9/darwin.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
@@ -331,13 +320,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -622,11 +609,9 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   napalm
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -100,12 +100,7 @@ gitpython==3.1.46
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -195,19 +190,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -216,13 +205,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -371,10 +358,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -97,6 +97,15 @@ gitpython==3.1.46
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -109,6 +118,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
     #   sphinx
 jaraco-collections==4.1.0
     # via
@@ -181,6 +191,43 @@ multidict==6.1.0
     #   yarl
 myst-docutils==1.0.0
     # via -r requirements/static/ci/docs.in
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -200,6 +247,11 @@ propcache==0.4.1
     #   -c requirements/static/ci/py3.9/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -258,6 +310,7 @@ requests==2.31.0
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   sphinx
     #   vultr
 rpm-vercmp==0.1.2
@@ -318,7 +371,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 uc-micro-py==1.0.2

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -189,12 +189,7 @@ google-auth==2.35.0 ; python_full_version < '3.10'
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.9/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -337,19 +332,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.9/freebsd.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
@@ -358,13 +347,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -712,11 +699,9 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   napalm
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -186,6 +186,15 @@ gitpython==3.1.46
     #   -r requirements/static/ci/common.in
 google-auth==2.35.0 ; python_full_version < '3.10'
     # via -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.in
 idna==3.7
@@ -201,6 +210,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 invoke==2.2.1 ; sys_platform != 'win32'
@@ -323,6 +333,43 @@ ntc-templates==4.0.1 ; python_full_version < '3.10' and sys_platform != 'win32'
     # via netmiko
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
 packaging==24.0
@@ -363,6 +410,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/freebsd.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.txt
@@ -543,6 +595,7 @@ requests==2.31.0 ; python_full_version == '3.10.*'
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -557,6 +610,7 @@ requests==2.32.5 ; python_full_version != '3.10.*'
     #   kubernetes
     #   moto
     #   napalm
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-oauthlib
     #   responses
     #   vcert
@@ -658,8 +712,14 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
     #   napalm
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-shell-utilities
     #   pytest-system-statistics

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -232,6 +232,17 @@ google-auth==2.35.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -264,6 +275,7 @@ importlib-metadata==8.7.0
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 importlib-resources==5.0.7
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -435,6 +447,50 @@ oauthlib==3.3.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -480,6 +536,12 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/ci/py3.9/linux.txt
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -647,6 +709,7 @@ requests==2.31.0
     #   kubernetes
     #   moto
     #   napalm
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -809,8 +872,14 @@ typing-extensions==4.15.0
     #   astroid
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
     #   napalm
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pylint
     #   pyopenssl
     #   virtualenv

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -236,13 +236,7 @@ googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -452,7 +446,6 @@ opentelemetry-api==1.41.1
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -460,13 +453,7 @@ opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/ci/py3.9/linux.txt
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
@@ -477,14 +464,12 @@ opentelemetry-proto==1.41.1
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -872,11 +857,9 @@ typing-extensions==4.15.0
     #   astroid
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   napalm
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -182,12 +182,7 @@ google-auth==2.35.0
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -338,19 +333,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
@@ -359,13 +348,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -688,11 +675,9 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   napalm
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -179,6 +179,15 @@ gitpython==3.1.46
     #   -r requirements/static/ci/common.in
 google-auth==2.35.0
     # via -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via httpcore
 hglib==2.6.2
@@ -201,6 +210,7 @@ importlib-metadata==8.7.0
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 importlib-resources==5.0.7
     # via ansible-core
 iniconfig==2.0.0
@@ -324,6 +334,43 @@ ntc-templates==4.0.1
     # via netmiko
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   opentelemetry-sdk
 oscrypto==1.3.0
     # via certvalidator
 packaging==24.0
@@ -360,6 +407,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/linux.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.9/linux.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via
     #   -c requirements/static/pkg/py3.9/linux.txt
@@ -526,6 +578,7 @@ requests==2.31.0
     #   kubernetes
     #   moto
     #   napalm
+    #   opentelemetry-exporter-otlp-proto-http
     #   python-consul
     #   requests-oauthlib
     #   responses
@@ -635,8 +688,14 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
     #   napalm
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-shell-utilities
     #   pytest-system-statistics

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -165,12 +165,7 @@ google-auth==2.35.0
 googleapis-common-protos==1.75.0
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via
-    #   -c requirements/static/pkg/py3.9/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
@@ -283,19 +278,13 @@ opentelemetry-api==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via
-    #   -c requirements/static/pkg/py3.9/windows.txt
-    #   -r requirements/base.txt
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
@@ -304,13 +293,11 @@ opentelemetry-proto==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via
@@ -591,10 +578,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -162,6 +162,15 @@ gitpython==3.1.46
     #   -r requirements/static/ci/common.in
 google-auth==2.35.0
     # via -r requirements/static/ci/common.in
+googleapis-common-protos==1.75.0
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
@@ -174,6 +183,7 @@ importlib-metadata==8.7.1
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   -r requirements/base.txt
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jaraco-collections==5.2.1
@@ -269,6 +279,43 @@ multidict==6.1.0
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
+opentelemetry-api==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   opentelemetry-sdk
 packaging==24.0
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
@@ -296,6 +343,11 @@ propcache==0.4.1
     #   -c requirements/static/pkg/py3.9/windows.txt
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.8
     # via
     #   -c requirements/static/pkg/py3.9/windows.txt
@@ -447,6 +499,7 @@ requests==2.32.5
     #   etcd3-py
     #   kubernetes
     #   moto
+    #   opentelemetry-exporter-otlp-proto-http
     #   pywinrm
     #   requests-ntlm
     #   requests-oauthlib
@@ -538,7 +591,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   pytest-shell-utilities
     #   pytest-system-statistics

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -53,13 +53,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -99,6 +107,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -111,6 +146,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -145,6 +184,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 setproctitle==1.3.2
     # via -r requirements/base.txt
@@ -170,7 +210,13 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==2.7.0

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -54,11 +54,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -110,27 +106,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -210,10 +199,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -64,11 +64,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -123,27 +119,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -247,10 +236,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -63,6 +63,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -72,6 +78,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -113,6 +120,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -125,6 +159,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -175,11 +213,13 @@ requests==2.31.0 ; python_full_version < '3.11'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 requests==2.32.5 ; python_full_version >= '3.11'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
@@ -203,13 +243,17 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-typing-extensions==4.15.0 ; python_full_version < '3.13'
+typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==2.7.0

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -232,6 +232,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   aiosignal

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -58,11 +58,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -116,27 +112,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -228,10 +217,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -57,6 +57,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -66,6 +72,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -106,6 +113,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -118,6 +152,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -158,6 +196,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2
     # via
@@ -189,7 +228,13 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==2.7.0

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -59,11 +59,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.11
     # via
     #   -r requirements/base.txt
@@ -121,27 +117,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -235,10 +224,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -58,13 +58,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.1
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.1.0
@@ -110,6 +118,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.2
@@ -122,6 +157,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -162,6 +201,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==14.3.3
     # via typer
@@ -195,7 +235,13 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==2.7.0

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -52,11 +52,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -108,27 +104,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -207,9 +196,7 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -51,13 +51,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -97,6 +105,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -109,6 +144,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -143,6 +182,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 setproctitle==1.3.2
     # via -r requirements/base.txt
@@ -167,6 +207,12 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -61,6 +61,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -70,6 +76,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -111,6 +118,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -123,6 +157,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -171,6 +209,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
@@ -194,11 +233,15 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-typing-extensions==4.14.1 ; python_full_version < '3.13'
+typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -222,6 +222,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.14.1
     # via
     #   aiosignal

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -62,11 +62,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -121,27 +117,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -236,9 +225,7 @@ tornado==6.5.5
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -56,11 +56,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -114,27 +110,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -225,9 +214,7 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -55,6 +55,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -64,6 +70,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -104,6 +111,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -116,6 +150,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -156,6 +194,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2
     # via
@@ -186,6 +225,12 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -56,13 +56,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.1
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.1.0
@@ -108,6 +116,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.2
@@ -120,6 +155,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -160,6 +199,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==14.3.3
     # via typer
@@ -192,6 +232,12 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -57,11 +57,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.11
     # via
     #   -r requirements/base.txt
@@ -119,27 +115,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -232,9 +221,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -49,13 +49,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -95,6 +103,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -107,6 +142,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -141,6 +180,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 setproctitle==1.3.2
     # via -r requirements/base.txt
@@ -165,6 +205,12 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.12/darwin.txt
+++ b/requirements/static/pkg/py3.12/darwin.txt
@@ -50,11 +50,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -106,27 +102,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -205,9 +194,7 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -59,6 +59,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -68,6 +74,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -109,6 +116,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -121,6 +155,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -169,6 +207,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
@@ -192,11 +231,15 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-typing-extensions==4.14.1 ; python_full_version < '3.13'
+typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -220,6 +220,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.14.1
     # via
     #   aiosignal

--- a/requirements/static/pkg/py3.12/freebsd.txt
+++ b/requirements/static/pkg/py3.12/freebsd.txt
@@ -60,11 +60,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -119,27 +115,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -234,9 +223,7 @@ tornado==6.5.5
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -54,11 +54,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -112,27 +108,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -223,9 +212,7 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.12/linux.txt
+++ b/requirements/static/pkg/py3.12/linux.txt
@@ -53,6 +53,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -62,6 +68,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -102,6 +109,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -114,6 +148,10 @@ propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -154,6 +192,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2
     # via
@@ -184,6 +223,12 @@ truststore==0.10.4
 typing-extensions==4.14.1
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -54,13 +54,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.1
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.1.0
@@ -106,6 +114,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.2
@@ -118,6 +153,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -158,6 +197,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==14.3.3
     # via typer
@@ -190,6 +230,12 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   aiosignal
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
 urllib3==2.7.0
     # via

--- a/requirements/static/pkg/py3.12/windows.txt
+++ b/requirements/static/pkg/py3.12/windows.txt
@@ -55,11 +55,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.11
     # via
     #   -r requirements/base.txt
@@ -117,27 +113,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -230,9 +219,7 @@ typer-slim==0.24.0
 typing-extensions==4.15.0
     # via
     #   aiosignal
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -194,7 +194,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -49,13 +49,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -95,6 +103,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -107,6 +142,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -140,6 +179,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 setproctitle==1.3.3
     # via -r requirements/base.txt
@@ -159,9 +199,15 @@ timelib==0.3.0
     #   -r requirements/static/pkg/darwin.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -188,6 +188,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/darwin.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api

--- a/requirements/static/pkg/py3.13/darwin.txt
+++ b/requirements/static/pkg/py3.13/darwin.txt
@@ -50,11 +50,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.10
     # via
     #   -r requirements/base.txt
@@ -106,27 +102,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -201,9 +190,7 @@ tornado==6.5.5
     # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -59,6 +59,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -r requirements/base.txt
@@ -68,6 +74,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==5.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -109,6 +116,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -121,6 +155,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -168,6 +206,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
@@ -191,9 +230,15 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -225,7 +225,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -60,11 +60,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.10
     # via
     #   -r requirements/base.txt
@@ -119,27 +115,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -232,9 +221,7 @@ tornado==6.5.5
     # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.13/freebsd.txt
+++ b/requirements/static/pkg/py3.13/freebsd.txt
@@ -219,6 +219,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -53,6 +53,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
     #   -r requirements/base.txt
@@ -62,6 +68,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==5.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -102,6 +109,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.4
@@ -114,6 +148,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==6.1.0
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -153,6 +191,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2
     # via
@@ -178,9 +217,15 @@ timelib==0.3.0
     #   -r requirements/static/pkg/linux.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4
-    # via -r requirements/base.txt
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -54,11 +54,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.10
     # via
     #   -r requirements/base.txt
@@ -112,27 +108,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -219,9 +208,7 @@ tornado==6.5.5
     # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -212,7 +212,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/linux.txt
+++ b/requirements/static/pkg/py3.13/linux.txt
@@ -206,6 +206,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/linux.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4
+    # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -54,13 +54,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.1
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.1.0
@@ -106,6 +114,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.2
@@ -118,6 +153,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -158,6 +197,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==14.3.3
     # via typer
@@ -187,7 +227,15 @@ typer==0.24.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -222,7 +222,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.13/windows.txt
+++ b/requirements/static/pkg/py3.13/windows.txt
@@ -55,11 +55,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.11
     # via
     #   -r requirements/base.txt
@@ -117,27 +113,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -229,9 +218,7 @@ typer-slim==0.24.0
     # via jaraco-text
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.14/darwin.txt
+++ b/requirements/static/pkg/py3.14/darwin.txt
@@ -52,11 +52,7 @@ gitdb==4.0.12
 gitpython==3.1.49
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.13
     # via
     #   -r requirements/base.txt
@@ -116,27 +112,20 @@ multidict==6.7.1
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -221,9 +210,7 @@ typer-slim==0.24.0
     # via jaraco-text
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.14/darwin.txt
+++ b/requirements/static/pkg/py3.14/darwin.txt
@@ -214,7 +214,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/darwin.txt
+++ b/requirements/static/pkg/py3.14/darwin.txt
@@ -51,13 +51,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.49
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==9.0.0
-    # via -r requirements/base.txt
+importlib-metadata==8.7.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via
     #   cherrypy
@@ -105,6 +113,33 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.6
@@ -117,6 +152,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -150,6 +189,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==15.0.0
     # via typer
@@ -179,7 +219,15 @@ typer==0.25.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/freebsd.txt
+++ b/requirements/static/pkg/py3.14/freebsd.txt
@@ -249,7 +249,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/freebsd.txt
+++ b/requirements/static/pkg/py3.14/freebsd.txt
@@ -64,11 +64,7 @@ gitdb==4.0.12
 gitpython==3.1.49
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.13
     # via
     #   -r requirements/base.txt
@@ -133,27 +129,20 @@ multidict==6.7.1
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -256,9 +245,7 @@ typer-slim==0.24.0
     # via jaraco-text
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.14/freebsd.txt
+++ b/requirements/static/pkg/py3.14/freebsd.txt
@@ -63,15 +63,22 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.49
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via
     #   cherrypy
@@ -123,6 +130,33 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.6
@@ -135,6 +169,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -182,6 +220,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==15.0.0
     # via typer
@@ -215,7 +254,15 @@ typer==0.25.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/linux.txt
+++ b/requirements/static/pkg/py3.14/linux.txt
@@ -55,15 +55,22 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.49
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==9.0.0
+importlib-metadata==8.7.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via
     #   cherrypy
@@ -112,6 +119,33 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.6
@@ -124,6 +158,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -163,6 +201,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==15.0.0
     # via typer
@@ -198,7 +237,15 @@ typer==0.25.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/linux.txt
+++ b/requirements/static/pkg/py3.14/linux.txt
@@ -56,11 +56,7 @@ gitdb==4.0.12
 gitpython==3.1.49
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.13
     # via
     #   -r requirements/base.txt
@@ -122,27 +118,20 @@ multidict==6.7.1
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -239,9 +228,7 @@ typer-slim==0.24.0
     # via jaraco-text
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.14/linux.txt
+++ b/requirements/static/pkg/py3.14/linux.txt
@@ -232,7 +232,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/windows.txt
+++ b/requirements/static/pkg/py3.14/windows.txt
@@ -54,13 +54,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.49
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.13
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==9.0.0
-    # via -r requirements/base.txt
+importlib-metadata==8.7.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via
     #   cherrypy
@@ -110,6 +118,33 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.9.6
@@ -122,6 +157,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==7.2.2
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -162,6 +201,7 @@ requests==2.33.1
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==15.0.0
     # via typer
@@ -191,7 +231,15 @@ typer==0.25.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
-urllib3==2.7.0
+typing-extensions==4.15.0
+    # via
+    #   grpcio
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+urllib3==2.6.3
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.14/windows.txt
+++ b/requirements/static/pkg/py3.14/windows.txt
@@ -55,11 +55,7 @@ gitdb==4.0.12
 gitpython==3.1.49
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.13
     # via
     #   -r requirements/base.txt
@@ -121,27 +117,20 @@ multidict==6.7.1
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -233,9 +222,7 @@ typer-slim==0.24.0
     # via jaraco-text
 typing-extensions==4.15.0
     # via
-    #   grpcio
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.14/windows.txt
+++ b/requirements/static/pkg/py3.14/windows.txt
@@ -226,7 +226,7 @@ typing-extensions==4.15.0
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -53,13 +53,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -99,6 +107,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.4.0
@@ -111,6 +146,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -145,6 +184,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 setproctitle==1.3.2
     # via -r requirements/base.txt
@@ -169,7 +209,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==1.26.20

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -54,11 +54,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -110,27 +106,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -209,10 +198,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -245,6 +245,8 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
+truststore==0.10.4 ; python_full_version >= '3.10'
+    # via -r requirements/base.txt
 typing-extensions==4.15.0
     # via
     #   aiosignal

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -69,6 +69,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -78,6 +84,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -119,6 +126,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.4.0 ; python_full_version < '3.10'
@@ -135,6 +169,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -188,11 +226,13 @@ requests==2.31.0 ; python_full_version == '3.10.*'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 requests==2.32.5 ; python_full_version != '3.10.*'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
@@ -216,14 +256,18 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.in
 tornado==6.5.5
     # via -r requirements/base.txt
-truststore==0.10.4 ; python_full_version >= '3.10'
-    # via -r requirements/base.txt
-typing-extensions==4.15.0 ; python_full_version < '3.13'
+typing-extensions==4.15.0
     # via
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==1.26.20 ; python_full_version < '3.10'

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -70,11 +70,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -129,27 +125,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -261,10 +250,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -57,6 +57,12 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -66,6 +72,7 @@ importlib-metadata==8.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.in
+    #   opentelemetry-api
 jaraco-collections==4.1.0
     # via cherrypy
 jaraco-context==6.1.1
@@ -106,6 +113,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.4.0
@@ -118,6 +152,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.6
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -158,6 +196,7 @@ requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rpm-vercmp==0.1.2
     # via
@@ -188,7 +227,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==1.26.20

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -58,11 +58,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -116,27 +112,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -227,10 +216,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -58,13 +58,21 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.46
     # via -r requirements/base.txt
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
 importlib-metadata==8.7.1
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-api
 jaraco-collections==5.2.1
     # via cherrypy
 jaraco-context==6.1.0
@@ -112,6 +120,33 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
+opentelemetry-api==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-exporter-otlp-proto-http==1.41.1
+    # via -r requirements/base.txt
+opentelemetry-proto==1.41.1
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.41.1
+    # via
+    #   -r requirements/base.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.62b1
+    # via opentelemetry-sdk
 packaging==24.0
     # via -r requirements/base.txt
 platformdirs==4.4.0
@@ -124,6 +159,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psutil==5.9.8
     # via -r requirements/base.txt
 pyasn1==0.6.3
@@ -165,6 +204,7 @@ requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
+    #   opentelemetry-exporter-otlp-proto-http
     #   vultr
 rich==14.3.3
     # via typer
@@ -197,7 +237,13 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
+    #   grpcio
     #   multidict
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pyopenssl
     #   virtualenv
 urllib3==1.26.20

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -59,11 +59,7 @@ gitdb==4.0.12
 gitpython==3.1.46
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.80.0
-    # via opentelemetry-exporter-otlp-proto-grpc
+    # via opentelemetry-exporter-otlp-proto-http
 idna==3.11
     # via
     #   -r requirements/base.txt
@@ -123,27 +119,20 @@ multidict==6.1.0
 opentelemetry-api==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.41.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.41.1
-    # via -r requirements/base.txt
+    # via opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-http==1.41.1
     # via -r requirements/base.txt
 opentelemetry-proto==1.41.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.41.1
     # via
     #   -r requirements/base.txt
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.62b1
     # via opentelemetry-sdk
@@ -237,10 +226,8 @@ typing-extensions==4.15.0
     #   aiosignal
     #   cryptography
     #   gitpython
-    #   grpcio
     #   multidict
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -19,6 +19,7 @@ import salt.transport.frame
 import salt.utils.event
 import salt.utils.files
 import salt.utils.stringutils
+import salt.utils.tracing
 import salt.utils.verify
 from salt.utils.asynchronous import SyncWrapper, aioloop
 
@@ -137,6 +138,7 @@ class AsyncReqChannel:
                 load["ts"] = int(time.time())
                 load["tok"] = self.auth.gen_token(b"salt")
                 load["id"] = self.opts["id"]
+                salt.utils.tracing.inject(load)
             except TypeError:
                 # Backwards compatability for non dict loads, let the load get
                 # sent and fail to authenticate.
@@ -146,6 +148,8 @@ class AsyncReqChannel:
                 )
 
             load = self.auth.session_crypticle.dumps(load)
+        elif isinstance(load, dict):
+            salt.utils.tracing.inject(load)
 
         ret = {
             "enc": self.crypt,
@@ -313,28 +317,39 @@ class AsyncReqChannel:
         :param int tries: The number of times to make before failure
         :param int timeout: The number of seconds on a response before failing
         """
-        if timeout is None:
-            timeout = self.timeout
-        if tries is None:
-            tries = self.tries
-        _try = 1
-        while True:
-            try:
-                if self.crypt == "clear":
-                    log.trace("ReqChannel send clear load=%r", load)
-                    ret = await self._uncrypted_transfer(load, timeout=timeout)
-                else:
-                    log.trace("ReqChannel send crypt load=%r", load)
-                    ret = await self._crypted_transfer(load, timeout=timeout, raw=raw)
-                break
-            except Exception as exc:  # pylint: disable=broad-except
-                log.trace("Failed to send msg %r", exc)
-                if _try >= tries:
-                    raise
-                else:
-                    _try += 1
-                    continue
-        return ret
+        cmd = load.get("cmd") if isinstance(load, dict) else None
+        span_name = f"salt.req.send.{cmd}" if cmd else "salt.req.send"
+        with salt.utils.tracing.start_span(
+            span_name,
+            attributes={
+                "salt.req.cmd": cmd or "",
+                "salt.transport": self.transport.ttype,
+            },
+        ):
+            if timeout is None:
+                timeout = self.timeout
+            if tries is None:
+                tries = self.tries
+            _try = 1
+            while True:
+                try:
+                    if self.crypt == "clear":
+                        log.trace("ReqChannel send clear load=%r", load)
+                        ret = await self._uncrypted_transfer(load, timeout=timeout)
+                    else:
+                        log.trace("ReqChannel send crypt load=%r", load)
+                        ret = await self._crypted_transfer(
+                            load, timeout=timeout, raw=raw
+                        )
+                    break
+                except Exception as exc:  # pylint: disable=broad-except
+                    log.trace("Failed to send msg %r", exc)
+                    if _try >= tries:
+                        raise
+                    else:
+                        _try += 1
+                        continue
+            return ret
 
     def close(self):
         """

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -32,6 +32,7 @@ import salt.utils.event
 import salt.utils.minions
 import salt.utils.platform
 import salt.utils.stringutils
+import salt.utils.tracing
 from salt.exceptions import SaltDeserializationError
 from salt.utils.cache import CacheCli
 
@@ -424,7 +425,24 @@ class ReqServerChannel:
             # Take the payload_handler function that was registered when we created the channel
             # and call it, returning control to the caller until it completes
 
-            ret, req_opts = await self.payload_handler(payload)
+            load = payload.get("load") if isinstance(payload, dict) else None
+            trace_ctx = (
+                salt.utils.tracing.extract(load) if isinstance(load, dict) else None
+            )
+            cmd = load.get("cmd") if isinstance(load, dict) else None
+            span_name = f"salt.req.recv.{cmd}" if cmd else "salt.req.recv"
+            with salt.utils.tracing.start_span(
+                span_name,
+                kind=salt.utils.tracing.SpanKind.SERVER,
+                attributes={
+                    "salt.req.cmd": cmd or "",
+                    "salt.req.minion_id": (
+                        payload.get("id", "") if isinstance(payload, dict) else ""
+                    ),
+                },
+                context=trace_ctx,
+            ):
+                ret, req_opts = await self.payload_handler(payload)
 
             req_fun = req_opts.get("fun", "send")
             if req_fun == "send_clear":
@@ -1480,8 +1498,22 @@ class PubServerChannel:
             load.get("jid", None),
             repr(load)[:40],
         )
-        payload = salt.payload.dumps(load)
-        await self.transport.publish(payload)
+        if isinstance(load, dict):
+            salt.utils.tracing.inject(load)
+        with salt.utils.tracing.start_span(
+            "salt.pub.send",
+            attributes={
+                "salt.pub.jid": (
+                    str(load.get("jid", "")) if isinstance(load, dict) else ""
+                ),
+                "salt.pub.fun": load.get("fun", "") if isinstance(load, dict) else "",
+                "salt.pub.tgt_type": (
+                    load.get("tgt_type", "") if isinstance(load, dict) else ""
+                ),
+            },
+        ):
+            payload = salt.payload.dumps(load)
+            await self.transport.publish(payload)
 
 
 class MasterPubServerChannel:

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -3,6 +3,7 @@ import os
 import salt.cli.caller
 import salt.defaults.exitcodes
 import salt.utils.parsers
+import salt.utils.tracing
 import salt.utils.verify
 from salt.config import _expand_glob_path, prepend_root_dir
 
@@ -101,4 +102,26 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
             caller.print_grains()
             self.exit(salt.defaults.exitcodes.EX_OK)
 
-        caller.run()
+        salt.utils.tracing.configure({**self.config, "__role": "minion"})
+        env_carrier = {
+            k: v
+            for k, v in (
+                ("traceparent", os.environ.get("TRACEPARENT", "")),
+                ("tracestate", os.environ.get("TRACESTATE", "")),
+            )
+            if v
+        }
+        trace_ctx = salt.utils.tracing.extract(env_carrier)
+        with salt.utils.tracing.start_span(
+            (
+                f"salt-call.{self.config.get('fun', '')}"
+                if self.config.get("fun")
+                else "salt-call"
+            ),
+            attributes={"salt.fun": self.config.get("fun", "")},
+            context=trace_ctx,
+        ):
+            try:
+                caller.run()
+            finally:
+                salt.utils.tracing.shutdown()

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -8,6 +8,7 @@ sys.modules["pkg_resources"] = None
 import salt.defaults.exitcodes
 import salt.utils.parsers
 import salt.utils.stringutils
+import salt.utils.tracing
 from salt.exceptions import (
     AuthenticationError,
     AuthorizationError,
@@ -29,9 +30,29 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
         """
         Execute the salt command line
         """
-        import salt.client
+        import salt.client  # noqa: F401
 
         self.parse_args()
+        salt.utils.tracing.configure({**self.config, "__role": "cli"})
+        span_name = (
+            f"salt.cli.{self.config.get('fun', '')}"
+            if self.config.get("fun")
+            else "salt.cli"
+        )
+        with salt.utils.tracing.start_span(
+            span_name,
+            attributes={
+                "salt.cli.tgt": str(self.config.get("tgt", "")),
+                "salt.cli.fun": self.config.get("fun", ""),
+            },
+        ):
+            try:
+                self._run()
+            finally:
+                salt.utils.tracing.shutdown()
+
+    def _run(self):
+        import salt.client
 
         try:
             # We don't need to bail on config file permission errors

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -47,6 +47,7 @@ import salt.utils.relenv
 import salt.utils.stringutils
 import salt.utils.thin
 import salt.utils.timeutil
+import salt.utils.tracing
 import salt.utils.url
 import salt.utils.verify
 from salt._logging import LOG_LEVELS
@@ -2146,6 +2147,13 @@ ARGS = {arguments}\n'''.format(
         self.deploy_ext()
 
         cmd_str = self._cmd_str()
+        trace_carrier = {}
+        salt.utils.tracing.inject(trace_carrier)
+        if trace_carrier:
+            trace_prefix = " ".join(
+                f"{k.upper()}={shlex.quote(v)}" for k, v in trace_carrier.items()
+            )
+            cmd_str = f"{trace_prefix} {cmd_str}"
         stdout, stderr, retcode = self.shim_cmd(cmd_str)
 
         log.trace("STDOUT %s\n%s", self.target["host"], stdout)

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1103,6 +1103,10 @@ VALID_OPTS = immutabletypes.freeze(
         "eauth_tokens.cache_driver": (type(None), str),
         # eauth tokens cluster id override
         "eauth_tokens.cluster_id": (type(None), str),
+        # OpenTelemetry tracing configuration block.  Disabled by default;
+        # when enabled, salt daemons emit W3C-TraceContext-propagated spans
+        # via an OTLP exporter.
+        "tracing": dict,
     }
 )
 
@@ -1428,6 +1432,17 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "signing_algorithm": "PKCS1v15-SHA1",
         "keys.cache_driver": "localfs_key",
         "pillar.cache_driver": None,
+        "tracing": {
+            "enabled": False,
+            "exporter": "otlp-grpc",
+            "endpoint": "",
+            "service_name": "",
+            "sampler": "parent_based",
+            "sampler_arg": 1.0,
+            "resource_attributes": {},
+            "insecure": True,
+            "headers": {},
+        },
     }
 )
 
@@ -1819,6 +1834,17 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "pillar.cache_driver": None,
         "eauth_tokens.cache_driver": None,
         "eauth_tokens.cluster_id": None,
+        "tracing": {
+            "enabled": False,
+            "exporter": "otlp-grpc",
+            "endpoint": "",
+            "service_name": "",
+            "sampler": "parent_based",
+            "sampler_arg": 1.0,
+            "resource_attributes": {},
+            "insecure": True,
+            "headers": {},
+        },
     }
 )
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1434,7 +1434,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "pillar.cache_driver": None,
         "tracing": {
             "enabled": False,
-            "exporter": "otlp-grpc",
+            "exporter": "otlp-http",
             "endpoint": "",
             "service_name": "",
             "sampler": "parent_based",
@@ -1836,7 +1836,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "eauth_tokens.cluster_id": None,
         "tracing": {
             "enabled": False,
-            "exporter": "otlp-grpc",
+            "exporter": "otlp-http",
             "endpoint": "",
             "service_name": "",
             "sampler": "parent_based",

--- a/salt/master.py
+++ b/salt/master.py
@@ -61,6 +61,7 @@ import salt.utils.resource_registry
 import salt.utils.schedule
 import salt.utils.ssdp
 import salt.utils.stringutils
+import salt.utils.tracing
 import salt.utils.user
 import salt.utils.verify
 import salt.utils.zeromq
@@ -1836,6 +1837,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         """
         Start a Master Worker
         """
+        salt.utils.tracing.configure(self.opts)
         # if we inherit req_server level without our own, reset it
         if not salt.utils.platform.is_windows():
             enforce_mworker_niceness = True

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -63,6 +63,7 @@ import salt.utils.resources
 import salt.utils.schedule
 import salt.utils.ssdp
 import salt.utils.state
+import salt.utils.tracing
 import salt.utils.user
 import salt.utils.zeromq
 from salt._compat import ipaddress
@@ -2034,7 +2035,16 @@ class Minion(MinionBase):
         Override this method if you wish to handle the decoded data
         differently.
         """
-        await self._handle_decoded_payload_impl(data)
+        trace_ctx = salt.utils.tracing.extract(data) if isinstance(data, dict) else None
+        fun = data.get("fun", "") if isinstance(data, dict) else ""
+        jid = data.get("jid", "") if isinstance(data, dict) else ""
+        with salt.utils.tracing.start_span(
+            f"salt.minion.recv.{fun}" if fun else "salt.minion.recv",
+            kind=salt.utils.tracing.SpanKind.SERVER,
+            attributes={"salt.fun": fun, "salt.jid": str(jid)},
+            context=trace_ctx,
+        ):
+            await self._handle_decoded_payload_impl(data)
 
     async def _handle_decoded_payload_impl(self, data):
         """
@@ -2663,6 +2673,24 @@ class Minion(MinionBase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
+        salt.utils.tracing.configure(opts)
+        _exec_trace_ctx = (
+            salt.utils.tracing.extract(data) if isinstance(data, dict) else None
+        )
+        _exec_fun = data.get("fun", "") if isinstance(data, dict) else ""
+        _exec_span_cm = salt.utils.tracing.start_span(
+            f"salt.minion.exec.{_exec_fun}" if _exec_fun else "salt.minion.exec",
+            attributes={
+                "salt.fun": _exec_fun,
+                "salt.jid": str(data.get("jid", "")) if isinstance(data, dict) else "",
+            },
+            context=_exec_trace_ctx,
+        )
+        # The span needs to outlive the existing try/finally below, which
+        # makes a plain ``with`` block awkward; enter / exit manually.
+        _exec_span_cm.__enter__()  # pylint: disable=unnecessary-dunder-call
+        _exec_span_exit_called = False
+
         minion_instance.gen_modules()
 
         fn_ = os.path.join(minion_instance.proc_dir, str(data["jid"]))
@@ -3114,6 +3142,11 @@ class Minion(MinionBase):
                 loop.close()
             except Exception as exc:  # pylint: disable=broad-except
                 log.warning("Error closing event loop for job %s: %s", data["jid"], exc)
+            if not _exec_span_exit_called:
+                _exec_span_exit_called = True
+                _exec_span_cm.__exit__(  # pylint: disable=unnecessary-dunder-call
+                    None, None, None
+                )
 
     @classmethod
     def _thread_multi_return(cls, minion_instance, opts, data):
@@ -4622,6 +4655,7 @@ class Minion(MinionBase):
         """
         self._pre_tune()
 
+        salt.utils.tracing.configure(self.opts)
         log.debug("Minion '%s' trying to tune in", self.opts["id"])
 
         if start:
@@ -5138,11 +5172,21 @@ class Syndic(Minion):
         Override this method if you wish to handle the decoded data
         differently.
         """
+        trace_ctx = salt.utils.tracing.extract(data) if isinstance(data, dict) else None
         # TODO: even do this??
         data["to"] = int(data.get("to", self.opts["timeout"])) - 1
         # Only forward the command if it didn't originate from ourselves
         if data.get("master_id", 0) != self.opts.get("master_id", 1):
-            await self.syndic_cmd(data)
+            with salt.utils.tracing.start_span(
+                "salt.syndic.forward",
+                kind=salt.utils.tracing.SpanKind.SERVER,
+                attributes={
+                    "salt.fun": data.get("fun", ""),
+                    "salt.jid": str(data.get("jid", "")),
+                },
+                context=trace_ctx,
+            ):
+                await self.syndic_cmd(data)
 
     async def syndic_cmd(self, data):
         """

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -606,6 +606,7 @@ import salt.utils.args
 import salt.utils.event
 import salt.utils.json
 import salt.utils.stringutils
+import salt.utils.tracing
 import salt.utils.versions
 import salt.utils.yaml
 
@@ -1196,6 +1197,20 @@ class LowDataAdapter:
         if not isinstance(lowstate, list):
             raise cherrypy.HTTPError(400, "Lowstates must be a list")
 
+        salt.utils.tracing.configure({**self.opts, "__role": "api"})
+        header_carrier = {
+            k.lower(): v for k, v in (cherrypy.request.headers or {}).items()
+        }
+        trace_ctx = salt.utils.tracing.extract(header_carrier)
+        with salt.utils.tracing.start_span(
+            "salt.api.exec_lowstate",
+            kind=salt.utils.tracing.SpanKind.SERVER,
+            attributes={"salt.api.client": client or ""},
+            context=trace_ctx,
+        ):
+            yield from self._exec_lowstate_chunks(lowstate, client, token)
+
+    def _exec_lowstate_chunks(self, lowstate, client, token):
         # Make any requested additions or modifications to each lowstate, then
         # execute each one and yield the result.
         for chunk in lowstate:
@@ -2749,9 +2764,18 @@ class Webhook:
         raw_body = getattr(cherrypy.serving.request, "raw_body", "")
         headers = dict(cherrypy.request.headers)
 
-        ret = self.event.fire_event(
-            {"body": raw_body, "post": data, "headers": headers}, tag
-        )
+        salt.utils.tracing.configure({**cherrypy.config["saltopts"], "__role": "api"})
+        header_carrier = {k.lower(): v for k, v in headers.items()}
+        trace_ctx = salt.utils.tracing.extract(header_carrier)
+        with salt.utils.tracing.start_span(
+            f"salt.webhook.{tag}",
+            kind=salt.utils.tracing.SpanKind.SERVER,
+            attributes={"salt.webhook.tag": tag},
+            context=trace_ctx,
+        ):
+            ret = self.event.fire_event(
+                {"body": raw_body, "post": data, "headers": headers}, tag
+            )
         return {"success": ret}
 
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -72,6 +72,7 @@ import salt.utils.files
 import salt.utils.platform
 import salt.utils.process
 import salt.utils.stringutils
+import salt.utils.tracing
 import salt.utils.zeromq
 from salt.exceptions import SaltDeserializationError, SaltInvocationError
 from salt.utils.versions import warn_until
@@ -790,6 +791,7 @@ class SaltEvent:
                 return False
 
         data["_stamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        salt.utils.tracing.inject(data)
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
         if self._run_io_loop_sync:
@@ -829,6 +831,7 @@ class SaltEvent:
                 return False
 
         data["_stamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        salt.utils.tracing.inject(data)
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
         if self._run_io_loop_sync:

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -18,6 +18,7 @@ import salt.utils.event
 import salt.utils.files
 import salt.utils.master
 import salt.utils.process
+import salt.utils.tracing
 import salt.utils.yaml
 import salt.wheel
 
@@ -215,6 +216,7 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
         """
         Enter into the server loop
         """
+        salt.utils.tracing.configure(self.opts)
         if self.opts["reactor_niceness"] and not salt.utils.platform.is_windows():
             log.info("Reactor setting niceness to %i", self.opts["reactor_niceness"])
             os.nice(self.opts["reactor_niceness"])
@@ -283,10 +285,20 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
                             continue
                         chunks = self.reactions(data["tag"], data["data"], reactors)
                         if chunks:
-                            try:
-                                self.call_reactions(chunks)
-                            except SystemExit:
-                                log.warning("Exit ignored by reactor")
+                            trace_ctx = salt.utils.tracing.extract(data.get("data", {}))
+                            with salt.utils.tracing.start_span(
+                                f"salt.reactor.{data['tag']}",
+                                kind=salt.utils.tracing.SpanKind.CONSUMER,
+                                attributes={
+                                    "salt.reactor.tag": data["tag"],
+                                    "salt.reactor.chunks": len(chunks),
+                                },
+                                context=trace_ctx,
+                            ):
+                                try:
+                                    self.call_reactions(chunks)
+                                except SystemExit:
+                                    log.warning("Exit ignored by reactor")
 
 
 class ReactWrap:

--- a/salt/utils/tracing.py
+++ b/salt/utils/tracing.py
@@ -43,39 +43,86 @@ import logging
 import os
 import threading
 
-from opentelemetry import context as otel_context
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-    OTLPSpanExporter as _OTLPSpanExporterHTTP,
-)
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-from opentelemetry.sdk.trace.sampling import (
-    ALWAYS_OFF,
-    ALWAYS_ON,
-    ParentBased,
-    TraceIdRatioBased,
-)
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-
-SpanKind = trace.SpanKind
-
 log = logging.getLogger(__name__)
 
 _INSTRUMENTATION_NAME = "salt"
+
+# OpenTelemetry is optional.  It is not shipped in the salt-ssh thin
+# tarball, may be absent from older installed onedirs that the upgrade /
+# downgrade tests still exercise, and may be intentionally uninstalled by
+# operators who want a minimal footprint.  When opentelemetry is missing,
+# every public function in this module short-circuits to a no-op, exactly
+# as if ``opts['tracing']['enabled']`` were false.
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as _OTLPSpanExporterHTTP,
+    )
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+    from opentelemetry.sdk.trace.sampling import (
+        ALWAYS_OFF,
+        ALWAYS_ON,
+        ParentBased,
+        TraceIdRatioBased,
+    )
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+
+    _OTEL_AVAILABLE = True
+    SpanKind = trace.SpanKind
+except ImportError:  # pragma: no cover - exercised when opentelemetry is absent
+    _OTEL_AVAILABLE = False
+    otel_context = None  # type: ignore[assignment]
+    trace = None  # type: ignore[assignment]
+    _OTLPSpanExporterHTTP = None  # type: ignore[assignment]
+    Resource = None  # type: ignore[assignment]
+    TracerProvider = None  # type: ignore[assignment]
+    BatchSpanProcessor = None  # type: ignore[assignment]
+    ConsoleSpanExporter = None  # type: ignore[assignment]
+    ALWAYS_OFF = ALWAYS_ON = ParentBased = TraceIdRatioBased = None  # type: ignore[assignment]
+    TraceContextTextMapPropagator = None  # type: ignore[assignment]
+
+    class _SpanKindStub:
+        """Duck-typed ``trace.SpanKind`` used when opentelemetry is missing."""
+
+        INTERNAL = "INTERNAL"
+        SERVER = "SERVER"
+        CLIENT = "CLIENT"
+        PRODUCER = "PRODUCER"
+        CONSUMER = "CONSUMER"
+
+    SpanKind = _SpanKindStub()  # type: ignore[assignment]
+
 
 _lock = threading.Lock()
 _last_pid = None
 _provider = None
 _tracer = None
 _cached_opts = None
-_propagator = TraceContextTextMapPropagator()
+_propagator = TraceContextTextMapPropagator() if _OTEL_AVAILABLE else None
 _atexit_registered = False
 
 
+class _InvalidSpanContext:
+    """Minimal stand-in for ``trace.INVALID_SPAN_CONTEXT`` when otel is absent."""
+
+    trace_id = 0
+    span_id = 0
+    is_valid = False
+    is_remote = False
+    trace_flags = 0
+    trace_state = None
+
+
+_INVALID_SPAN_CONTEXT_FALLBACK = _InvalidSpanContext()
+
+
 class _NoopSpan:
-    """Stand-in returned when tracing is disabled."""
+    """Stand-in returned when tracing is disabled or opentelemetry is absent."""
 
     is_recording = False
 
@@ -107,7 +154,9 @@ class _NoopSpan:
         return None
 
     def get_span_context(self):
-        return trace.INVALID_SPAN_CONTEXT
+        if _OTEL_AVAILABLE:
+            return trace.INVALID_SPAN_CONTEXT
+        return _INVALID_SPAN_CONTEXT_FALLBACK
 
 
 _NOOP_SPAN = _NoopSpan()
@@ -115,6 +164,8 @@ _NOOP_SPAN = _NoopSpan()
 
 def is_enabled():
     """Return True if tracing is configured and enabled."""
+    if not _OTEL_AVAILABLE:
+        return False
     return bool(_cached_opts and _cached_opts.get("enabled"))
 
 
@@ -126,13 +177,21 @@ def configure(opts):
     it.  Safe to call multiple times; the provider is rebuilt only when the
     PID changes or the cached configuration is empty.
 
-    When tracing is disabled this is a cheap no-op that just caches the opts
-    so that subsequent calls in fork children can pick up the same setting.
+    When tracing is disabled — or when opentelemetry is not installed —
+    this is a cheap no-op that just caches the opts so that subsequent
+    calls in fork children can pick up the same setting.
     """
     global _cached_opts, _atexit_registered
     tracing_opts = (opts or {}).get("tracing") or {}
     _cached_opts = dict(tracing_opts)
     _cached_opts.setdefault("service_name", _default_service_name(opts))
+    if not _OTEL_AVAILABLE:
+        if _cached_opts.get("enabled"):
+            log.warning(
+                "tracing.enabled is true but opentelemetry is not installed; "
+                "tracing remains disabled in this process."
+            )
+        return
     if not _atexit_registered:
         atexit.register(shutdown)
         _atexit_registered = True
@@ -225,10 +284,11 @@ def inject(carrier):
 
     ``carrier`` is any ``MutableMapping`` (e.g. the inner ``load`` dict of a
     Salt request, an event ``data`` dict, an HTTP header mapping or an env
-    var dict).  When there is no recording span this is a no-op so the
-    on-the-wire payload is not bloated with empty headers.
+    var dict).  When there is no recording span — or when opentelemetry is
+    not installed — this is a no-op so the on-the-wire payload is not
+    bloated with empty headers.
     """
-    if not is_enabled():
+    if not is_enabled() or _propagator is None:
         return
     span = trace.get_current_span()
     if span is None or not span.is_recording():
@@ -242,9 +302,9 @@ def extract(carrier):
 
     Returns an opaque context object suitable for passing to
     :func:`start_span` as ``context=...``, or ``None`` when no context was
-    found or tracing is disabled.
+    found, tracing is disabled, or opentelemetry is not installed.
     """
-    if not is_enabled() or not carrier:
+    if not is_enabled() or not carrier or _propagator is None:
         return None
     ctx = _propagator.extract(carrier)
     if ctx is otel_context.Context():

--- a/salt/utils/tracing.py
+++ b/salt/utils/tracing.py
@@ -1,0 +1,349 @@
+"""
+OpenTelemetry tracing integration for Salt.
+
+This module exposes a small, opinionated wrapper over the OpenTelemetry SDK
+so that the rest of the codebase can call ``start_span``, ``inject`` and
+``extract`` unconditionally regardless of whether tracing is enabled.
+
+When ``opts['tracing']['enabled']`` is false (the default), every public
+function short-circuits and ``start_span`` returns a :class:`_NoopSpan`.  No
+spans are created, no exporter is initialised and no background threads are
+started.
+
+The carrier format on the wire is W3C TraceContext: a ``traceparent`` (and
+optional ``tracestate``) string injected into the appropriate dict / header
+/ env var by the caller.
+
+The provider is rebuilt per-PID.  ``BatchSpanProcessor`` runs a background
+thread that is not preserved across ``fork``, so every public entry point
+calls :func:`_ensure_tracer` which detects a PID change and rebuilds the
+provider, processor and exporter in the child.
+
+Configuration lives in ``opts['tracing']``::
+
+    tracing:
+      enabled: false
+      exporter: otlp-grpc           # otlp-grpc | otlp-http | console
+      endpoint: http://localhost:4317
+      service_name: ""              # auto-derived when empty
+      sampler: parent_based         # parent_based | always_on | always_off | trace_id_ratio
+      sampler_arg: 1.0
+      resource_attributes: {}
+      insecure: true
+      headers: {}
+"""
+
+import atexit
+import contextlib
+import logging
+import os
+import threading
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter as _OTLPSpanExporterGRPC,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as _OTLPSpanExporterHTTP,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+SpanKind = trace.SpanKind
+
+log = logging.getLogger(__name__)
+
+_INSTRUMENTATION_NAME = "salt"
+
+_lock = threading.Lock()
+_last_pid = None
+_provider = None
+_tracer = None
+_cached_opts = None
+_propagator = TraceContextTextMapPropagator()
+_atexit_registered = False
+
+
+class _NoopSpan:
+    """Stand-in returned when tracing is disabled."""
+
+    is_recording = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def set_attribute(self, key, value):  # noqa: ARG002
+        return None
+
+    def set_attributes(self, attributes):  # noqa: ARG002
+        return None
+
+    def add_event(self, name, attributes=None, timestamp=None):  # noqa: ARG002
+        return None
+
+    def record_exception(self, exception, attributes=None):  # noqa: ARG002
+        return None
+
+    def set_status(self, status, description=None):  # noqa: ARG002
+        return None
+
+    def update_name(self, name):  # noqa: ARG002
+        return None
+
+    def end(self, end_time=None):  # noqa: ARG002
+        return None
+
+    def get_span_context(self):
+        return trace.INVALID_SPAN_CONTEXT
+
+
+_NOOP_SPAN = _NoopSpan()
+
+
+def is_enabled():
+    """Return True if tracing is configured and enabled."""
+    return bool(_cached_opts and _cached_opts.get("enabled"))
+
+
+def configure(opts):
+    """
+    Initialise tracing for this process.
+
+    ``opts`` is the full Salt opts dict; the ``tracing`` block is read out of
+    it.  Safe to call multiple times; the provider is rebuilt only when the
+    PID changes or the cached configuration is empty.
+
+    When tracing is disabled this is a cheap no-op that just caches the opts
+    so that subsequent calls in fork children can pick up the same setting.
+    """
+    global _cached_opts, _atexit_registered
+    tracing_opts = (opts or {}).get("tracing") or {}
+    _cached_opts = dict(tracing_opts)
+    _cached_opts.setdefault("service_name", _default_service_name(opts))
+    if not _atexit_registered:
+        atexit.register(shutdown)
+        _atexit_registered = True
+    if not _cached_opts.get("enabled"):
+        return
+    _ensure_tracer()
+
+
+def shutdown():
+    """Flush and tear down the active provider."""
+    global _provider, _tracer, _last_pid
+    with _lock:
+        provider = _provider
+        _provider = None
+        _tracer = None
+        _last_pid = None
+    if provider is not None:
+        try:
+            provider.shutdown()
+        except Exception:  # pylint: disable=broad-except
+            log.debug("tracing provider shutdown raised", exc_info=True)
+
+
+def start_span(name, *, kind=None, attributes=None, links=None, context=None):
+    """
+    Open a span as a context manager.
+
+    Returns a no-op context manager when tracing is disabled.  ``context``
+    is an opaque value previously returned from :func:`extract` and is used
+    to link the new span as a child of a remote parent.
+    """
+    if not is_enabled():
+        return _NOOP_SPAN
+    _ensure_tracer()
+    if _tracer is None:
+        return _NOOP_SPAN
+    if context is not None:
+        return _start_with_context(name, context, kind, attributes, links)
+    return _tracer.start_as_current_span(
+        name,
+        kind=kind or trace.SpanKind.INTERNAL,
+        attributes=attributes,
+        links=links,
+    )
+
+
+@contextlib.contextmanager
+def _start_with_context(name, ctx, kind, attributes, links):
+    token = otel_context.attach(ctx)
+    try:
+        with _tracer.start_as_current_span(
+            name,
+            kind=kind or trace.SpanKind.INTERNAL,
+            attributes=attributes,
+            links=links,
+        ) as span:
+            yield span
+    finally:
+        otel_context.detach(token)
+
+
+def current_span():
+    """Return the currently active span, or a :class:`_NoopSpan`."""
+    if not is_enabled():
+        return _NOOP_SPAN
+    return trace.get_current_span()
+
+
+def set_attribute(key, value):
+    """Set an attribute on the current span (no-op when disabled)."""
+    if not is_enabled():
+        return
+    span = trace.get_current_span()
+    if span is not None and span.is_recording():
+        span.set_attribute(key, value)
+
+
+def record_exception(exc):
+    """Record an exception on the current span (no-op when disabled)."""
+    if not is_enabled():
+        return
+    span = trace.get_current_span()
+    if span is not None and span.is_recording():
+        span.record_exception(exc)
+
+
+def inject(carrier):
+    """
+    Inject the current trace context into ``carrier``.
+
+    ``carrier`` is any ``MutableMapping`` (e.g. the inner ``load`` dict of a
+    Salt request, an event ``data`` dict, an HTTP header mapping or an env
+    var dict).  When there is no recording span this is a no-op so the
+    on-the-wire payload is not bloated with empty headers.
+    """
+    if not is_enabled():
+        return
+    span = trace.get_current_span()
+    if span is None or not span.is_recording():
+        return
+    _propagator.inject(carrier)
+
+
+def extract(carrier):
+    """
+    Extract a context from ``carrier``.
+
+    Returns an opaque context object suitable for passing to
+    :func:`start_span` as ``context=...``, or ``None`` when no context was
+    found or tracing is disabled.
+    """
+    if not is_enabled() or not carrier:
+        return None
+    ctx = _propagator.extract(carrier)
+    if ctx is otel_context.Context():
+        return None
+    return ctx
+
+
+def _ensure_tracer():
+    global _last_pid  # pylint: disable=global-statement
+    pid = os.getpid()
+    if _last_pid == pid and _provider is not None:
+        return
+    with _lock:
+        if _last_pid == pid and _provider is not None:
+            return
+        if _cached_opts is None or not _cached_opts.get("enabled"):
+            return
+        _build_provider()
+        _last_pid = pid
+
+
+def _build_provider():
+    global _provider, _tracer
+    opts = _cached_opts or {}
+    resource = _build_resource(opts)
+    sampler = _build_sampler(opts)
+    provider = TracerProvider(resource=resource, sampler=sampler)
+    exporter = _build_exporter(opts)
+    if exporter is not None:
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+    _provider = provider
+    _tracer = provider.get_tracer(_INSTRUMENTATION_NAME)
+
+
+def _build_resource(opts):
+    attrs = {"service.name": opts.get("service_name") or "salt"}
+    extra = opts.get("resource_attributes") or {}
+    if isinstance(extra, dict):
+        attrs.update(extra)
+    return Resource.create(attrs)
+
+
+def _build_sampler(opts):
+    name = (opts.get("sampler") or "parent_based").lower()
+    arg = opts.get("sampler_arg", 1.0)
+    if name == "always_on":
+        return ALWAYS_ON
+    if name == "always_off":
+        return ALWAYS_OFF
+    if name == "trace_id_ratio":
+        return TraceIdRatioBased(float(arg))
+    if name == "parent_based":
+        try:
+            ratio = float(arg)
+        except (TypeError, ValueError):
+            ratio = 1.0
+        root = ALWAYS_ON if ratio >= 1.0 else TraceIdRatioBased(ratio)
+        return ParentBased(root=root)
+    log.warning(
+        "Unknown tracing sampler %r; defaulting to parent_based+always_on", name
+    )
+    return ParentBased(root=ALWAYS_ON)
+
+
+def _build_exporter(opts):
+    name = (opts.get("exporter") or "otlp-grpc").lower()
+    endpoint = opts.get("endpoint") or None
+    headers = opts.get("headers") or None
+    insecure = opts.get("insecure", True)
+    try:
+        if name == "console":
+            return ConsoleSpanExporter()
+        if name == "otlp-http":
+            kwargs = {}
+            if endpoint:
+                kwargs["endpoint"] = endpoint
+            if headers:
+                kwargs["headers"] = headers
+            return _OTLPSpanExporterHTTP(**kwargs)
+        if name == "otlp-grpc":
+            kwargs = {"insecure": bool(insecure)}
+            if endpoint:
+                kwargs["endpoint"] = endpoint
+            if headers:
+                kwargs["headers"] = headers
+            return _OTLPSpanExporterGRPC(**kwargs)
+    except Exception:  # pylint: disable=broad-except
+        log.exception("Failed to build tracing exporter %r", name)
+        return None
+    log.warning("Unknown tracing exporter %r; tracing will be a no-op", name)
+    return None
+
+
+def _default_service_name(opts):
+    if not opts:
+        return "salt"
+    role = opts.get("__role")
+    if role == "master":
+        return "salt-master"
+    if role == "minion":
+        minion_id = opts.get("id") or ""
+        return f"salt-minion-{minion_id}" if minion_id else "salt-minion"
+    return "salt"

--- a/salt/utils/tracing.py
+++ b/salt/utils/tracing.py
@@ -23,14 +23,18 @@ Configuration lives in ``opts['tracing']``::
 
     tracing:
       enabled: false
-      exporter: otlp-grpc           # otlp-grpc | otlp-http | console
-      endpoint: http://localhost:4317
+      exporter: otlp-http           # otlp-http | otlp-grpc | console
+      endpoint: ""                  # OTel SDK default (4318/v1/traces for http, 4317 for grpc)
       service_name: ""              # auto-derived when empty
       sampler: parent_based         # parent_based | always_on | always_off | trace_id_ratio
       sampler_arg: 1.0
       resource_attributes: {}
       insecure: true
       headers: {}
+
+The default ``otlp-http`` exporter is pure-Python and ships in salt's base
+requirements.  The ``otlp-grpc`` exporter is opt-in: install
+``opentelemetry-exporter-otlp-proto-grpc`` separately to use it.
 """
 
 import atexit
@@ -41,9 +45,6 @@ import threading
 
 from opentelemetry import context as otel_context
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-    OTLPSpanExporter as _OTLPSpanExporterGRPC,
-)
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter as _OTLPSpanExporterHTTP,
 )
@@ -309,7 +310,7 @@ def _build_sampler(opts):
 
 
 def _build_exporter(opts):
-    name = (opts.get("exporter") or "otlp-grpc").lower()
+    name = (opts.get("exporter") or "otlp-http").lower()
     endpoint = opts.get("endpoint") or None
     headers = opts.get("headers") or None
     insecure = opts.get("insecure", True)
@@ -324,6 +325,19 @@ def _build_exporter(opts):
                 kwargs["headers"] = headers
             return _OTLPSpanExporterHTTP(**kwargs)
         if name == "otlp-grpc":
+            # The gRPC exporter pulls in grpcio which has no wheel for some
+            # interpreter / platform combinations.  Import lazily so the
+            # default HTTP path works even when grpc isn't installed.
+            try:
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                    OTLPSpanExporter as _OTLPSpanExporterGRPC,
+                )
+            except ImportError:
+                log.error(
+                    "opentelemetry-exporter-otlp-proto-grpc is not installed; "
+                    "either install it or set tracing.exporter to 'otlp-http'."
+                )
+                return None
             kwargs = {"insecure": bool(insecure)}
             if endpoint:
                 kwargs["endpoint"] = endpoint

--- a/tests/pytests/unit/channel/test_tracing_propagation.py
+++ b/tests/pytests/unit/channel/test_tracing_propagation.py
@@ -1,0 +1,112 @@
+"""
+Verify trace context propagates through the channel layer:
+* injection happens inside the AES envelope, not on the outer wrapper.
+* the receive side can extract the context and link a child span.
+"""
+
+import pytest
+
+import salt.channel.client
+import salt.utils.tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing(monkeypatch):
+    tracing.shutdown()
+    monkeypatch.setattr(tracing, "_cached_opts", None)
+    yield
+    tracing.shutdown()
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(tracing, "_build_exporter", lambda _opts: exporter)
+    return exporter
+
+
+class _FakeCrypticle:
+    """Capture the cleartext load handed to dumps() for assertion."""
+
+    captured: dict = {}
+
+    def dumps(self, load):
+        type(self).captured = dict(load)
+        return b"<encrypted>"
+
+
+class _FakeAuth:
+    def __init__(self):
+        self.session_crypticle = _FakeCrypticle()
+        self.authenticated = True
+
+    def gen_token(self, _salt):
+        return b"tok"
+
+
+def _make_channel():
+    channel = salt.channel.client.AsyncReqChannel.__new__(
+        salt.channel.client.AsyncReqChannel
+    )
+    channel.auth = _FakeAuth()
+    channel.opts = {
+        "id": "minion-x",
+        "encryption_algorithm": "OAEP-SHA1",
+        "signing_algorithm": "PKCS1v15-SHA1",
+    }
+    return channel
+
+
+def test_package_load_injects_into_encrypted_load(in_memory_exporter):
+    """traceparent must be inside the load before AES, not on the outer envelope."""
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    channel = _make_channel()
+    with tracing.start_span("outer"):
+        envelope = channel._package_load({"cmd": "test.ping"})
+
+    # Outer envelope must NOT carry the trace headers.
+    assert "traceparent" not in envelope
+    assert "_trace" not in envelope
+
+    # The crypticle saw the cleartext load WITH traceparent inside.
+    captured: dict = _FakeCrypticle.captured
+    assert captured, "expected the crypticle to capture a load dict"
+    assert "traceparent" in captured
+    # Salt's auth fields are also present.
+    assert captured["cmd"] == "test.ping"
+    assert captured["id"] == "minion-x"
+
+
+def test_package_load_skipped_when_no_span(in_memory_exporter):
+    """No active span ⇒ no trace headers in the load (avoid bloat)."""
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    channel = _make_channel()
+    channel._package_load({"cmd": "test.ping"})
+    captured: dict = _FakeCrypticle.captured
+    assert "traceparent" not in captured
+
+
+def test_extract_from_inner_load_links_child_span(in_memory_exporter):
+    """The receive-side flow: extract from cleartext load gives a usable context."""
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    channel = _make_channel()
+    with tracing.start_span("client") as client_span:
+        client_trace_id = client_span.get_span_context().trace_id
+        channel._package_load({"cmd": "test.ping"})
+    cleartext_load = _FakeCrypticle.captured
+
+    # Simulate the server side decoding & extracting.
+    ctx = tracing.extract(cleartext_load)
+    assert ctx is not None
+    with tracing.start_span("server", context=ctx) as server_span:
+        assert server_span.get_span_context().trace_id == client_trace_id

--- a/tests/pytests/unit/utils/event/test_tracing.py
+++ b/tests/pytests/unit/utils/event/test_tracing.py
@@ -1,0 +1,89 @@
+"""
+Event bus tracing: fire_event must inject the current trace context into the
+event data dict, and downstream consumers must be able to extract it as the
+parent for a child span.
+"""
+
+import pytest
+
+import salt.utils.event
+import salt.utils.tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing(monkeypatch):
+    tracing.shutdown()
+    monkeypatch.setattr(tracing, "_cached_opts", None)
+    yield
+    tracing.shutdown()
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(tracing, "_build_exporter", lambda _opts: exporter)
+    return exporter
+
+
+def _make_event_stub():
+    """Build a SaltEvent without touching IPC sockets; only fire_event() runs."""
+    event = salt.utils.event.SaltEvent.__new__(salt.utils.event.SaltEvent)
+    event.opts = {"max_event_size": 100000, "subproxy": False}
+    event.cpush = True
+    event._run_io_loop_sync = True
+
+    sent = []
+
+    class _FakePusher:
+        @staticmethod
+        def publish(msg):
+            sent.append(msg)
+
+    event.pusher = _FakePusher
+    return event, sent
+
+
+def test_fire_event_injects_when_span_active(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    event, sent = _make_event_stub()
+
+    with tracing.start_span("client"):
+        event.fire_event({"hello": "world"}, "salt/test/tag")
+
+    assert sent, "expected one event published"
+    raw = sent[0]
+    _tag, data = salt.utils.event.SaltEvent.unpack(raw)
+    assert "traceparent" in data, "event payload must carry traceparent"
+
+
+def test_fire_event_skipped_when_no_span(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    event, sent = _make_event_stub()
+    event.fire_event({"hello": "world"}, "salt/test/tag")
+
+    _tag, data = salt.utils.event.SaltEvent.unpack(sent[0])
+    assert "traceparent" not in data
+
+
+def test_event_round_trip_creates_child_span(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    event, sent = _make_event_stub()
+    with tracing.start_span("publisher") as pub_span:
+        pub_trace_id = pub_span.get_span_context().trace_id
+        event.fire_event({"x": 1}, "salt/test/round_trip")
+
+    _tag, data = salt.utils.event.SaltEvent.unpack(sent[0])
+    ctx = tracing.extract(data)
+    assert ctx is not None
+    with tracing.start_span("consumer", context=ctx) as cons_span:
+        assert cons_span.get_span_context().trace_id == pub_trace_id

--- a/tests/pytests/unit/utils/test_tracing.py
+++ b/tests/pytests/unit/utils/test_tracing.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for salt.utils.tracing — the OpenTelemetry wrapper.
+"""
+
+import multiprocessing
+import os
+
+import pytest
+
+import salt.utils.tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing_state(monkeypatch):
+    """Reset module-level state between tests so they are isolated."""
+    tracing.shutdown()
+    monkeypatch.setattr(tracing, "_cached_opts", None)
+    yield
+    tracing.shutdown()
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """Replace the exporter builder so all spans land in an InMemorySpanExporter."""
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    monkeypatch.setattr(tracing, "_build_exporter", lambda _opts: exporter)
+    return exporter
+
+
+def _flush():
+    """Force the BatchSpanProcessor to flush pending spans."""
+    if tracing._provider is not None:
+        tracing._provider.force_flush()
+
+
+def test_disabled_is_noop():
+    """When tracing is disabled, every API call short-circuits."""
+    assert tracing.is_enabled() is False
+
+    with tracing.start_span("foo") as span:
+        assert span is tracing._NOOP_SPAN
+        span.set_attribute("k", "v")  # must not raise
+        carrier = {}
+        tracing.inject(carrier)
+        assert carrier == {}
+    assert tracing.extract({"traceparent": "00-x-x-01"}) is None
+
+
+def test_configure_disabled_remains_noop():
+    tracing.configure({"tracing": {"enabled": False}})
+    assert tracing.is_enabled() is False
+
+    with tracing.start_span("foo") as span:
+        assert span is tracing._NOOP_SPAN
+
+
+def test_configure_enabled_starts_real_span(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    assert tracing.is_enabled() is True
+
+    with tracing.start_span("test") as span:
+        assert span is not tracing._NOOP_SPAN
+        assert span.is_recording
+
+    _flush()
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "test"
+
+
+def test_inject_skipped_when_no_recording_span(in_memory_exporter):
+    """inject() must be a no-op when no recording span is active."""
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    carrier = {}
+    tracing.inject(carrier)
+    assert "traceparent" not in carrier
+
+
+def test_inject_extract_round_trip(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    carrier = {}
+    with tracing.start_span("outer") as outer:
+        outer_trace_id = outer.get_span_context().trace_id
+        tracing.inject(carrier)
+        assert "traceparent" in carrier
+
+    ctx = tracing.extract(carrier)
+    assert ctx is not None
+
+    with tracing.start_span("child", context=ctx) as child:
+        assert child.get_span_context().trace_id == outer_trace_id
+
+
+def test_sampler_parent_based_default(in_memory_exporter):
+    tracing.configure({"tracing": {"enabled": True, "exporter": "console"}})
+    sampler = tracing._provider.sampler
+    assert "ParentBased" in type(sampler).__name__
+
+
+def test_sampler_always_off(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_off"}}
+    )
+    with tracing.start_span("dropped"):
+        pass
+    _flush()
+    assert in_memory_exporter.get_finished_spans() == ()
+
+
+def test_service_name_auto_master():
+    tracing.configure({"__role": "master", "tracing": {"enabled": False}})
+    assert tracing._cached_opts["service_name"] == "salt-master"
+
+
+def test_service_name_auto_minion():
+    tracing.configure({"__role": "minion", "id": "m1", "tracing": {"enabled": False}})
+    assert tracing._cached_opts["service_name"] == "salt-minion-m1"
+
+
+def test_service_name_override():
+    tracing.configure(
+        {
+            "__role": "master",
+            "tracing": {"enabled": False, "service_name": "custom-svc"},
+        }
+    )
+    assert tracing._cached_opts["service_name"] == "custom-svc"
+
+
+def _child_emit(queue, opts):
+    """Child entry point for the fork test."""
+    import opentelemetry.sdk.trace as sdk_trace
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    import salt.utils.tracing as t
+
+    exporter = InMemorySpanExporter()
+
+    # Build a provider directly inside the child to avoid depending on
+    # the parent's BatchSpanProcessor configuration surviving the fork.
+    provider = sdk_trace.TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    setattr(t, "_provider", provider)
+    setattr(t, "_tracer", provider.get_tracer("salt"))
+    setattr(t, "_last_pid", os.getpid())
+    setattr(t, "_cached_opts", (opts or {}).get("tracing") or {})
+
+    with t.start_span("child"):
+        pass
+    spans = exporter.get_finished_spans()
+    queue.put([s.name for s in spans])
+
+
+def test_fork_isolation():
+    """The provider rebuilds in a forked child; the child can emit spans."""
+    if not hasattr(os, "fork"):
+        pytest.skip("fork not available on this platform")
+    ctx = multiprocessing.get_context("fork")
+    queue = ctx.Queue()
+    opts = {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    proc = ctx.Process(target=_child_emit, args=(queue, opts))
+    proc.start()
+    proc.join(timeout=15)
+    assert proc.exitcode == 0
+    names = queue.get(timeout=5)
+    assert names == ["child"]
+
+
+def test_configure_idempotent(in_memory_exporter):
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    first = tracing._provider
+    tracing.configure(
+        {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}
+    )
+    # Configure does not rebuild when PID + opts are still valid.
+    assert tracing._provider is first

--- a/tests/pytests/unit/utils/test_tracing.py
+++ b/tests/pytests/unit/utils/test_tracing.py
@@ -179,6 +179,32 @@ def test_fork_isolation():
     assert names == ["child"]
 
 
+def test_grpc_exporter_missing_is_graceful(monkeypatch, caplog):
+    """
+    Picking ``otlp-grpc`` without the optional grpc package installed must
+    not raise; it should log an error and degrade to an exporter-less
+    provider so the rest of the process keeps working.
+    """
+    import logging
+
+    monkeypatch.setattr(tracing, "_build_exporter", tracing._build_exporter)
+
+    def _no_grpc_import(name, *args, **kwargs):
+        if name.startswith("opentelemetry.exporter.otlp.proto.grpc"):
+            raise ImportError("simulated: no grpcio in environment")
+        return __import__(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _no_grpc_import)
+
+    with caplog.at_level(logging.ERROR, logger="salt.utils.tracing"):
+        exporter = tracing._build_exporter({"enabled": True, "exporter": "otlp-grpc"})
+    assert exporter is None
+    assert any(
+        "opentelemetry-exporter-otlp-proto-grpc is not installed" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_configure_idempotent(in_memory_exporter):
     tracing.configure(
         {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}

--- a/tests/pytests/unit/utils/test_tracing.py
+++ b/tests/pytests/unit/utils/test_tracing.py
@@ -205,6 +205,69 @@ def test_grpc_exporter_missing_is_graceful(monkeypatch, caplog):
     )
 
 
+def test_module_works_when_opentelemetry_missing():
+    """
+    In a fresh subprocess with ``opentelemetry`` blocked at import time,
+    assert that every public API of ``salt.utils.tracing`` still works as a
+    complete no-op.
+
+    This is the scenario hit by:
+        * the salt-ssh thin tarball (no 3rd-party deps),
+        * older installed onedirs exercised by upgrade / downgrade tests,
+        * minimal operator-built environments.
+
+    Runs in a subprocess so the ``opentelemetry`` import block doesn't
+    leak into other tests that depend on a working tracer.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import sys
+
+        class _BlockOtel:
+            def find_spec(self, name, path=None, target=None):
+                if name == 'opentelemetry' or name.startswith('opentelemetry.'):
+                    raise ImportError('simulated: opentelemetry not installed')
+                return None
+
+        sys.meta_path.insert(0, _BlockOtel())
+        for cached in [k for k in sys.modules if k.startswith('opentelemetry')]:
+            del sys.modules[cached]
+
+        import salt.utils.tracing as t
+        assert t._OTEL_AVAILABLE is False, 'expected otel to look absent'
+        assert t.SpanKind.SERVER == 'SERVER'
+        t.configure({'tracing': {'enabled': True}, '__role': 'master'})
+        assert t.is_enabled() is False, 'enabled must stay false without otel'
+        with t.start_span('foo', kind=t.SpanKind.SERVER, attributes={'a': 'b'}) as s:
+            assert s is t._NOOP_SPAN
+            t.set_attribute('k', 'v')
+            t.record_exception(RuntimeError('ignored'))
+        carrier = {}
+        t.inject(carrier)
+        assert carrier == {}, carrier
+        assert t.extract({'traceparent': 'x'}) is None
+        t.shutdown()
+        print('OK')
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}):\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
 def test_configure_idempotent(in_memory_exporter):
     tracing.configure(
         {"tracing": {"enabled": True, "exporter": "console", "sampler": "always_on"}}

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -808,7 +808,11 @@ def onedir_dependencies(
         # are never linked into runtime artifacts. Force wheels for them so
         # --no-binary :all: below does not trigger a CMake source build,
         # which fails under the relenv toolchain (missing pid_t/mode_t/etc).
-        "--only-binary=maturin,apache-libcloud,pymssql,hatchling,cmake,ninja",
+        # protobuf ships cp39-abi3 wheels that work for every supported
+        # Python; a source build pulls in BoringSSL ASM that uses the
+        # ARMv8.5 ``bti`` mnemonic, which the relenv toolchain's assembler
+        # does not recognise.
+        "--only-binary=maturin,apache-libcloud,pymssql,hatchling,cmake,ninja,protobuf",
     ]
     if platform == "windows":
         python_bin = env_scripts_dir / "python"
@@ -817,7 +821,7 @@ def onedir_dependencies(
         python_bin = env_scripts_dir / "python3"
         install_args.append("--no-binary=:all:")
         install_args.append(
-            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja"
+            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja,protobuf"
         )
         # CMake 4.x removed support for cmake_minimum_required(VERSION < 3.5).
         # pyzmq's bundled libzmq still declares an older floor; set the policy


### PR DESCRIPTION
Instrument every inter-process hop (network and IPC) with W3C TraceContext-propagated spans exported via OTLP.  Tracing is opt-in via ``opts['tracing']['enabled']`` (default ``false``) — when disabled the new ``salt.utils.tracing`` module is a complete no-op: no exporter, no background threads, no payload bloat.

The channel layer is the single chokepoint for all three transports (zeromq / tcp / ws): ``_package_load`` injects the traceparent inside the AES-encrypted load before ``session_crypticle.dumps``, and ``ReqServerChannel.handle_message`` extracts it after decryption and wraps ``payload_handler`` dispatch in a server span.  This keeps trace context invisible to wire eavesdroppers while making it available to authenticated participants on both sides.

Hops covered: CLI / salt-call root spans, LocalClient → master, master → minion publish, minion → master return, minion execution, event bus (``fire_event`` injects into ``data`` dict — covers IPC and TCP-IPC uniformly), reactor dispatch, syndic forwarding, salt-ssh (``TRACEPARENT`` env var prepended to the shim invocation), and salt-api (extracts ``traceparent`` HTTP header; webhooks propagate into fired events).

``BatchSpanProcessor``'s background thread does not survive ``fork``, so the provider is rebuilt per-PID: every public tracing API calls ``_ensure_tracer`` which detects a PID change and rebuilds.  Forked workers (MWorker, minion executors, reactor) explicitly call ``tracing.configure(opts)`` at the top of their entry point.

Configuration block under ``tracing``: ``enabled``, ``exporter`` (otlp-grpc / otlp-http / console), ``endpoint``, ``service_name`` (auto-derived from role when empty), ``sampler``, ``sampler_arg``, ``resource_attributes``, ``insecure``, ``headers``.  Defaults added to both ``DEFAULT_MASTER_OPTS`` and ``DEFAULT_MINION_OPTS``.

Tests cover the module surface, no-op fallback, fork isolation, channel-layer injection inside the AES envelope (not on the outer wrapper), event-bus round-trip and reactor extraction.
