### PR TITLE
Master startup with presence_events

### DIFF
--- a/changelog/69146.fixed.md
+++ b/changelog/69146.fixed.md
@@ -1,0 +1,1 @@
+Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy.

--- a/salt/utils/channel.py
+++ b/salt/utils/channel.py
@@ -8,9 +8,16 @@ def iter_transport_opts(opts):
     Yield transport, opts for all master configured transports
     """
     transports = set()
+    # Never deepcopy secrets: SMaster.secrets holds SynchronizedString objects
+    # (multiprocessing sharedctypes) that Python 3.14 refuses to deepcopy outside
+    # a spawning context — assert_spawning() raises even when the start method is
+    # "fork".  Exclude the key before copying and re-attach a live reference after,
+    # so callers that pass opts already enriched by a previous iter_transport_opts
+    # call (e.g. PubServerChannel.factory called from ClearFuncs.connect) are safe.
+    opts_nosecrets = {k: v for k, v in opts.items() if k != "secrets"}
 
-    for transport, opts_overrides in opts.get("transport_opts", {}).items():
-        t_opts = copy.deepcopy(opts)
+    for transport, opts_overrides in opts_nosecrets.get("transport_opts", {}).items():
+        t_opts = copy.deepcopy(opts_nosecrets)
         t_opts.update(opts_overrides)
         t_opts["transport"] = transport
         # Ensure secrets are available
@@ -18,9 +25,9 @@ def iter_transport_opts(opts):
         transports.add(transport)
         yield transport, t_opts
 
-    transport = opts.get("transport", "zeromq")
+    transport = opts_nosecrets.get("transport", "zeromq")
     if transport not in transports:
-        t_opts = copy.deepcopy(opts)
+        t_opts = copy.deepcopy(opts_nosecrets)
         t_opts["secrets"] = salt.master.SMaster.secrets
         yield transport, t_opts
 

--- a/tests/pytests/scenarios/reauth/conftest.py
+++ b/tests/pytests/scenarios/reauth/conftest.py
@@ -14,6 +14,8 @@ def salt_master_factory(salt_factories):
             "publish_signing_algorithm": (
                 "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
             ),
+            "presence_events": True,
+            "loop_interval": 1,
             "worker_pools_enabled": True,
             "worker_pools": {
                 "fast": {

--- a/tests/pytests/scenarios/reauth/test_reauth.py
+++ b/tests/pytests/scenarios/reauth/test_reauth.py
@@ -94,3 +94,16 @@ def test_reauth(salt_cli, salt_minion, salt_master, timeout, event_listener):
     log.debug("Ping successful, stopping minion thread")
     stop_event.set()
     minion_proc.join()
+
+
+def test_presence_events(salt_cli, salt_minion, salt_master, event_listener):
+    assert salt_cli.run("test.ping", minion_tgt=salt_minion.id).data is True
+    start = time.time()
+    matched = event_listener.wait_for_events(
+        [(salt_master.id, "salt/presence/present")],
+        after_time=start,
+        timeout=120,
+    )
+    assert matched.found_all_events, f"missed={matched.missed}"
+    for event in matched:
+        assert salt_minion.id in event.data["present"]


### PR DESCRIPTION
### What does this PR do?

Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy.

### What issues does this PR fix or reference?
Fixes #69146
