### PR TITLE
Distributed cluster cache

### DIFF
--- a/MULTI_RING_DESIGN.md
+++ b/MULTI_RING_DESIGN.md
@@ -1,0 +1,446 @@
+# Multi-Ring / Multi-Raft Cluster Design
+
+Working notes for the evolution from "single global ring, single Raft
+group, every master votes" to "named rings per cache type, per-ring
+Raft groups, capped voter and ring-member counts".
+
+The original sketch (preserved below as historical context) is now
+mostly **landed**.  This top section describes the shipping shape;
+read it first if you want operational context, and consult the
+"Original design sketch" section if you're tracing decisions.
+
+## Shipping shape (2026-05-16)
+
+Multi-ring landed across seven slices.  All 722 tests in the cluster
+suites pass.  Operator surface and on-the-wire shape are stable from
+here.
+
+### Architecture
+
+```
+            cluster Raft log (single group, "cluster" id)
+            ┌──────────────────────────────────────────┐
+            │ MembershipStateMachine        (CONFIG)   │
+            │ RingRegistryStateMachine      (RING_REGISTRY) │
+            │ RoutingStateMachine           (ROUTE)    │
+            │ RingConfigStateMachine        (RING_CONFIG, legacy) │
+            └──────────────────────────────────────────┘
+                                │
+              spawns per-founder
+                                v
+       ring_X Raft log (own group, own log/term/leader)
+       ┌─────────────────────────────────────┐
+       │ MembershipStateMachine  (per-ring CONFIG) │
+       │ RingConfigStateMachine  (per-ring policy) │
+       └─────────────────────────────────────┘
+```
+
+The cluster log is the only consensus state every master needs to
+agree on; per-ring logs handle their own membership and policy
+churn so a ring outage doesn't take down other rings or the cluster.
+
+### Substrate
+
+* `SaltStorage(node_id, opts, ring_id="cluster")` — on-disk path
+  scheme: `cachedir/cluster/consensus/<node_id>/<ring_id>/`.
+* RPC envelope carries `raft_group_id` (default `"cluster"`).
+  `salt/cluster/consensus/rpc.py:pack/unpack` handle it; pre-multi-ring
+  envelopes default to the cluster group on decode.
+* `salt/cluster/consensus/peer.py:RaftDispatcher` accepts either a
+  single `Node` (treated as cluster) or `dict[str, Node]`; routes
+  inbound RPCs by `raft_group_id`.  `register_node`/`unregister_node`
+  let `RaftService` mutate the routing table at runtime.
+* `salt/cluster/consensus/service.py:RaftService` keeps `self._node`
+  for backward compat and `self._nodes = {"cluster": self._node}` as
+  the multi-ring registry.  `_heartbeat_tick` iterates all groups.
+
+### Cluster-log state machines
+
+* `RingRegistryStateMachine` (`raft/log.py`) — registry of named
+  rings.  Each entry: `{ring_id, founding_voters, status}`.  Snapshot
+  round-trips; `on_change` fires per commit.
+* `RoutingStateMachine` (`raft/log.py`) — data-type → ring mapping
+  (or `None` for broadcast).  Snapshot round-trips; `on_change`
+  populates the per-process routing snapshot.
+* New `LogEntryType.RING_REGISTRY = 4` and `LogEntryType.ROUTE = 5`;
+  the legacy `RING_CONFIG = 3` continues to drive the single-ring
+  fallback that pre-multi-ring callers use.
+
+### Per-ring lifecycle
+
+`RaftService._on_ring_registry_change` brings up a per-ring `Node`
+(with its own `SaltStorage(ring_id=...)`, `MembershipStateMachine`,
+and `RingConfigStateMachine`) whenever a registry entry commits and
+this master is in the founder list.  `status="destroyed"` tears down
+the local `Node` and drops it from the dispatcher; on-disk state is
+preserved so re-create with the same id recovers state.
+
+### Ring registry / routing surface
+
+`salt/cluster/ring_membership.py` is now a registry of named rings.
+
+* `get_ring(name)` lazily creates an empty `HashRing` per name.
+* `rebuild(name, voters, replicas=1)` keyed by name; legacy
+  `rebuild(voters)` keeps targeting the `"cluster"` ring.
+* `owns_for(opts, data_type, key)` consults `_ROUTING` first: no
+  route ⇒ broadcast (True); routed to an unknown/empty ring ⇒ False;
+  routed to a populated ring ⇒ defers to `ring.owns()`.
+* `set_route(data_type, ring_id)` / `drop_ring(name)` are called by
+  `RaftService` on commits to keep the per-process snapshot in sync.
+
+### Gate sites
+
+`salt/master.py:1171,1187` (job submission + job return mirroring)
+call `ring_membership.owns_for(self.opts, "jobs", jid)`.  No routing
+entry for `"jobs"` keeps today's broadcast behaviour; an operator
+flips it to a ring with `cluster.route_set`.
+
+### Operator runners
+
+All in `salt/runners/cluster.py`:
+
+| Runner | Purpose |
+|---|---|
+| `cluster.ring_create name=X voters=[…]` | Propose `RING_REGISTRY` entry creating ring X |
+| `cluster.ring_destroy name=X` | Propose destroy (status="destroyed") |
+| `cluster.route_set data_type=… ring=…` | Propose `ROUTE` entry binding data_type to ring |
+| `cluster.route_clear data_type=…` | Propose route → `None` (back to broadcast) |
+| `cluster.ring_set name=X members=voters replicas=N` | Propose `RING_CONFIG` on ring X's *own* log (per-ring policy) |
+| `cluster.shed_unowned ring=X banks=[…] dry_run=…` | Local: drop cache entries this master no longer owns |
+| `cluster.collect_from_peers channels=[…]` | Pull keys/denied_keys from every peer via the existing state-sync chunk transport |
+| `cluster.members` | Read-only membership + leader + health |
+| `cluster.ring_info` | Read-only ring snapshot |
+| `cluster.sync_roots` | Pre-existing: push file_roots/pillar_roots to peers |
+
+Each runner that proposes a Raft entry fires a `cluster/runner/*`
+local event; `salt/channel/server.py:publish_payload` intercepts and
+dispatches to the `RaftService` propose helpers in the publish
+daemon.  Same pattern as `cluster.sync_roots`.
+
+### Reversible migration flow
+
+Going in (broadcast → ring=jobs):
+
+1. `salt-run cluster.ring_create name=jobs voters='[m1,m2,m3]'`
+2. (Registry commits; founders spin up the ring.)
+3. `salt-run cluster.route_set data_type=jobs ring=jobs`
+4. (Routing commits; gates start filtering writes.)
+5. `salt-run cluster.shed_unowned ring=jobs dry_run=True` (preview)
+6. `salt-run cluster.shed_unowned ring=jobs` (commit drops)
+
+Going out (ring=jobs → broadcast):
+
+1. `salt-run cluster.collect_from_peers` (each master gathers full set)
+2. (Operator confirms every master succeeded.)
+3. `salt-run cluster.route_clear data_type=jobs`
+4. (Routing commits; gates broadcast again.)
+5. (Optional) `salt-run cluster.ring_destroy name=jobs`
+
+The asymmetry — drop **after** policy flip going in, collect
+**before** policy flip going out — is what keeps the window safe.
+
+### Recommended production opts
+
+A fresh cluster that wants the multi-ring job-cache sharding from
+day one sets:
+
+```yaml
+# salt/master.d/cluster.conf — same on every master
+
+cluster_id: my-cluster
+cluster_peers:
+  - 10.0.0.1
+  - 10.0.0.2
+  - 10.0.0.3
+interface: 10.0.0.1       # this master's address; differs per master
+
+# Job cache through salt.cache.Cache so the ring gate can shard it.
+master_job_cache: salt_cache
+cache: mmap_cache         # or localfs if mmap_cache is unavailable
+
+# Optional but recommended: cap the cluster's voter pool and let the
+# watchdog auto-replace failed voters.  Defaults are
+# unlimited/disabled to preserve pre-multi-ring behaviour.
+cluster_max_voters: 5
+cluster_min_voters: 3
+cluster_auto_replace_voters: true
+cluster_voter_timeout: 10.0
+```
+
+After the master daemon is running with these opts, create a ring
+and route the jobs data type to it from any master:
+
+```bash
+salt-run cluster.ring_create name=jobs \
+    voters='["10.0.0.1","10.0.0.2","10.0.0.3"]'
+salt-run cluster.route_set data_type=jobs ring=jobs
+```
+
+Operators upgrading an existing ``master_job_cache: local_cache``
+cluster should:
+
+```bash
+# 1. Drain incoming jobs (operator-specific).
+# 2. Stop every master.
+# 3. On each master, migrate the on-disk job cache into the salt_cache
+#    bank layout.  --dry-run first to preview the count.
+salt-run cluster.migrate_jobs_to_cache dry_run=True
+salt-run cluster.migrate_jobs_to_cache
+
+# 4. Flip master_job_cache + cache opts as shown above.
+# 5. Restart every master.
+# 6. Verify with cluster.rings / cluster.routes / cluster.members.
+```
+
+### Known limitations / follow-ups
+
+* **`cluster.collect_from_peers` v1 covers the four state-sync
+  channels and any ``bank:<bank>`` channel.**  The default targets
+  the four ``jobs/*`` banks the salt_cache returner writes through;
+  operators routing other caches name them explicitly via the
+  ``banks=`` parameter.  PKI keys (``keys`` / ``denied_keys``) stay
+  broadcast — see the ``master.py:1195-1208`` comment.
+* **Non-member writes are no-ops in v1.**  A master that is not a
+  ring member but receives a job event for that ring's data type
+  drops the write rather than delegating to a ring member over RPC.
+  ``ring_membership.drop_stats`` records ``not_a_member`` counts so
+  operators can spot a misconfigured load balancer; the rate-limited
+  WARN log line is the loud signal.  Delegate-on-miss is a future
+  RPC.
+* **Legacy `RingConfigStateMachine` still lives on the cluster log.**
+  Functionally inert in multi-ring deployments — per-ring policy is
+  on per-ring logs.  Removing the cluster-log registration is a
+  cleanup follow-up, not a blocker.
+
+---
+
+## Original design sketch
+
+The rest of this document is the pre-implementation design sketch.
+It's preserved for context on the decisions that shaped the shipped
+code.  Open questions noted in the sketch have all been resolved:
+
+* Q1 (ring lifecycle): dynamic via `cluster.ring_create` / `ring_destroy`.
+* Q2 (default rings): pre-multi-ring callers default to the `"cluster"`
+  ring; new code uses named rings via `route_set`.
+* Q3 / Q9 (voter selection): operator-specified in the create call.
+* Q4 (decommissioning): tear down local Raft group; on-disk state
+  preserved for recovery; routes that pointed there are operator's
+  responsibility to clear via `route_clear` first.
+* Q5 (snapshot scope): each ring's `SaltStorage(ring_id=…)` snapshots
+  independently into its own on-disk path.
+* Q6 / Q7 / Q8 (voter caps, operator overrides, auto-replacement):
+  landed in earlier slices (`cluster_max_voters`,
+  `cluster.promote`/`demote`, voter-health watchdog).
+* Q10 (persistence of voter-vs-ring-member status): per-ring
+  `MembershipStateMachine` persisted via the multi-SM envelope, same
+  treatment as the cluster log.
+
+(Working notes for the proposed evolution from "single global ring,
+single Raft group, every master votes" to "named rings per cache type,
+per-ring Raft groups, capped voter and ring-member counts".)
+
+## Today (baseline)
+
+* **One Raft group per cluster.** Every master in `cluster_peers`
+  starts as a voter (`voting=True` is the default in
+  `salt/cluster/consensus/raft/node.py:62` and
+  `salt/cluster/consensus/service.py:69`).
+* **Late joiners become non-voting learners** via
+  `RaftService.notify_peer_joined` (`service.py:359`).  The leader
+  replicates the log to them; once `match_index >= log.index`
+  (`node.py:703-722`) it proposes a CONFIG entry promoting them to
+  voter.  No permanent observer/learner role.
+* **One global ring.**  `_on_membership_change` calls
+  `salt.cluster.ring_membership.rebuild(voters)` at `service.py:218`.
+  The ring is a singleton (`salt/cluster/ring_membership.py`), so every
+  cache type that wants ring routing shares the same node set.
+* **Ring config entries already exist.**
+  `LogEntryType.RING_CONFIG = 3` and `RingConfigStateMachine` were
+  added in `212c6d97bb2`.  Today they ride the single cluster Raft log;
+  the runner `cluster.ring_set` raises `NotImplementedError` because
+  the runner→master propose path was deferred (see `GAPS.md`).
+* **Heap segment cap.**  `mmap_cache.DEFAULT_MAX_SEGMENT_BYTES = 1
+  GiB` (`salt/utils/mmap_cache.py:79`).  Tunable via
+  `mmap_cache_max_segment_bytes` / `mmap_key_max_segment_bytes`.  Not
+  driven by ring config.
+
+## Decisions locked in
+
+1. **Voter count is bounded** per Raft group.  Default unlimited
+   (preserve current behaviour); operator opts in via a cap.
+2. **Ring-member count is bounded** per ring.  Independent cap.
+3. **Voter set and ring-member set are decoupled.**  A master can be a
+   voter without owning ring work, or a ring member without voting.
+   They are not subset-related.
+4. **First-pass behaviour on member loss may halt.**  Auto-replacement
+   of a dead voter / dead ring node by promoting a learner / catching-
+   up peer is a follow-up.  Acceptable because log replication reaches
+   non-voting peers, so eventual promotion is always possible.
+5. **A separate Raft log per ring.**  Multi-Raft architecture — each
+   ring is its own Raft group with its own log, term, leader, commit
+   index, and voter set.
+6. **Multiple rings per cluster, one per cache type.**  Examples: a
+   `minion-keys` ring, a `jobs` ring, a `pillars` ring.  Each cache
+   backend declares which ring it uses.
+7. **Ring-group voters can be any cluster node.**  Not constrained to
+   cluster-Raft voters.
+
+## Architecture that falls out
+
+### Cluster Raft (singular) — control plane
+
+Owns everything cluster-wide that isn't per-ring:
+
+* Cluster-wide voter/learner membership (today's
+  `MembershipStateMachine`).
+* **Ring definitions.**  A registry of
+  `{ring_name → {voter_cap, node_cap, cache_types, initial_voters}}`.
+  Either a new entry type or a new SM that every node replays so
+  every node learns which rings exist.
+
+### Ring Raft groups (N) — data-plane routers
+
+One per logical ring / cache type.  Each one owns:
+
+* Its own `LogStorage` file (independent snapshot / compaction).
+* Its own term, leader, commit index, voted-for.
+* Its own voter set (subset of cluster nodes, bounded by `voter_cap`).
+* Its own ring-member set (the masters that actually own work for
+  this cache; bounded by `node_cap`).  Independent of voters.
+* A `RingMembershipSM` whose `on_change` hook calls
+  `ring_membership[ring_name].rebuild(members)` locally.
+
+### Cache → ring binding
+
+Each cache driver declares its ring name in config:
+
+```yaml
+keys.cache_driver_ring: minion-keys
+jobs.cache_driver_ring: jobs
+pillars.cache_driver_ring: pillars
+```
+
+Ownership queries become
+`ring_membership.get_ring(name).owns(opts, key)`.  The
+`salt/cluster/ring_membership.py` singleton becomes a registry keyed
+by ring name.  Cache types that don't opt into a named ring use a
+`default` ring for backwards compatibility.
+
+### Bootstrap order
+
+1. Cluster Raft commits a `RING_DEFINITION` entry: "create ring X
+   with these caps and initial voters".
+2. On apply, every node instantiates a local Raft `Node` for ring X
+   bound to a new log file, peers configured from the entry's voter
+   list.
+3. Multiplexed transport tags each AppendEntries / RequestVote /
+   InstallSnapshot with `raft_group_id` (cluster-id or ring-name);
+   `SaltPeer` dispatches to the right group.
+4. Ring X's leader emits its own membership entries; each apply
+   fires `ring_membership["X"].rebuild`.
+
+### Cost shape
+
+N ring groups × per-group heartbeats, timers, log files.  With ~5
+cache types and 3-voter rings, well below what etcd / CockroachDB
+live with.  Standard mitigations (group ticking, batched AppendEntries
+over the shared transport) available later if N grows.
+
+## Implementation surface (where it touches today's code)
+
+* `salt/cluster/consensus/service.py` — `RaftService` becomes a
+  manager of multiple `Node` instances rather than owning one.
+  `_on_membership_change` for the cluster group still updates
+  cluster membership; new per-ring callbacks update each ring's
+  membership.
+* `salt/cluster/consensus/raft/node.py` — gains a `raft_group_id`
+  field on every RPC.  `notify_peer_joined`'s promotion gate at
+  `node.py:703-722` reads its group's `voter_cap` before proposing
+  promotion.
+* `salt/cluster/consensus/peer.py` / transport — dispatches incoming
+  RPCs to the addressed group.
+* `salt/cluster/ring_membership.py` — becomes a registry of named
+  rings; `get_ring(name)` replaces the singleton accessor; `rebuild`
+  takes a ring name.
+* `salt/cluster/consensus/storage.py` — supports multiple
+  `SaltStorage` instances, one per group, each with its own
+  persistent path.
+* `salt/runners/cluster.py` — `ring_set` becomes a per-ring propose
+  call; new `ring_create` / `ring_drop` runners for the cluster Raft.
+* `salt/master.py` — gate sites use `ring_membership.get_ring(name)`
+  with the cache's declared ring name instead of the global ring.
+
+## Open questions
+
+1. **Ring definition lifecycle.**  Are rings created at cluster init
+   via static config, or dynamically via a runner
+   (`cluster.ring_create name=jobs voter_cap=3 node_cap=10
+   cache_types=[jobs]`)?  Static is simpler.  Dynamic matches how
+   `ring_set` is shaped today.
+
+2. **Default rings.**  Ship with a default `default` ring that all
+   cache types use unless they opt into a named ring?  Keeps the
+   migration path from "today's one ring" to "many rings" trivial.
+
+3. **Voter selection for new ring groups.**  When the cluster commits
+   "create ring X", who are X's *initial* voters?  Operator-specified
+   in the create call, lowest-N-by-node-id from current cluster
+   voters, or random-N?
+
+4. **Decommissioning a ring.**  Drop a `RING_DEFINITION` entry →
+   every node tears down that local Raft group, deletes its log
+   file.  Cache callers that were routing via it fall back to…
+   what?  Single-node ownership?  Reject?  Worth a contract
+   decision.
+
+5. **Snapshot scope.**  Each ring group snapshots independently.
+   Cluster Raft snapshots independently.  The snapshot envelope
+   `raft.snapshot.v1` already does multi-SM serialisation, so this
+   works — but the envelope writer per group becomes one-of-its-own-
+   SMs, not the global multi-SM bundle.
+
+6. **Voter cap enforcement at static startup.**  Today every address
+   in `cluster_peers` becomes a voter.  With a cap, if
+   `len(cluster_peers) + 1 > max_voters` we need a deterministic
+   voter-subset selection rule (lowest-id-wins, or first N in the
+   configured list) and the rest start as learners.
+
+7. **Operator override.**  A runner like `cluster.promote <id>` /
+   `cluster.demote <id>` so ops can pick who votes when the
+   deterministic rule picks wrong.
+
+8. **Auto-replacement on member loss.**  Today a dead voter stays in
+   `voters` until manually removed.  With caps, the leader should
+   want to demote a missing voter / ring node and promote a healthy
+   learner — otherwise a single death stalls the group forever.  New
+   state machine.  Locked as a follow-up, not first-pass.
+
+9. **Voter set of each ring group.**  Decided: "any node in the
+   cluster, bounded by per-ring cap".  How are they chosen at ring-
+   create time?  Same answer as Q3.
+
+10. **Persistence of voter-vs-ring-member status.**  The membership
+    state machine is already snapshot-persisted across log
+    compaction (`c53e9bec3dd`).  Each ring group's SM needs the same
+    treatment so restart doesn't re-promote everyone.
+
+## Smallest shippable subset
+
+If the above is the long-term shape, a sensible first slice that
+preserves today's behaviour by default:
+
+* `cluster_max_voters` opt (default unlimited).  Gate
+  `notify_peer_joined` promotion (`raft/node.py:708`) on it.  Don't
+  touch static `cluster_peers` startup — operator's responsibility to
+  keep that ≤ cap.
+* `cluster_max_ring_nodes` opt (default unlimited).
+  `_on_membership_change` clamps `voters` → first N (sorted node id)
+  when calling `ring_membership.rebuild`.
+* No multi-Raft yet; no per-cache-type rings yet.  Single global
+  ring continues to ride the cluster Raft via `RING_CONFIG` entries.
+* Auto-replacement deferred; halting on member loss is the
+  first-pass contract.
+
+Multi-Raft and named rings come in follow-ups, gated on the open
+questions above.

--- a/doc/ref/returners/all/index.rst
+++ b/doc/ref/returners/all/index.rst
@@ -18,4 +18,5 @@ returner modules
     postgres
     postgres_local_cache
     rawfile_json
+    salt_cache
     syslog_return

--- a/doc/ref/returners/all/salt.returners.salt_cache.rst
+++ b/doc/ref/returners/all/salt.returners.salt_cache.rst
@@ -1,0 +1,5 @@
+salt.returners.salt_cache
+=========================
+
+.. automodule:: salt.returners.salt_cache
+    :members:

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1681,6 +1681,157 @@ class MasterPubServerChannel:
     def gen_token(self):
         return "".join(random.choices(string.ascii_letters + string.digits, k=32))
 
+    async def _run_root_sync_to_peers(self, channels):
+        """
+        Operator-driven push of ``file_roots`` and/or ``pillar_roots`` to
+        every peer in the cluster.  Triggered by the ``cluster.sync_roots``
+        runner via the ``cluster/runner/sync_roots`` local event.
+
+        For each peer:
+
+        1. Allocate a fresh session id.
+        2. Emit a ``cluster/peer/sync-roots-begin`` event to the peer so
+           the receiver pre-registers a state-sync session — same
+           contract as the join-reply flow, but the receiver's
+           ``on_complete`` is a no-op (this is an ad-hoc push, not a
+           Raft-learner bootstrap).
+        3. Stream the requested channels to that peer via the standard
+           state-sync chunk format.
+
+        Errors per-peer are logged but do not stop the fan-out — a
+        partially-online cluster can still receive the update on
+        reachable peers.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            FILE_ROOTS_CHANNEL,
+            PILLAR_ROOTS_CHANNEL,
+            new_session_id,
+        )
+
+        roots_for = {
+            FILE_ROOTS_CHANNEL: self.opts.get("file_roots"),
+            PILLAR_ROOTS_CHANNEL: self.opts.get("pillar_roots"),
+        }
+        # Honour the channel filter — operator may want only one of the
+        # two trees synced.
+        active_channels = [
+            ch for ch in (FILE_ROOTS_CHANNEL, PILLAR_ROOTS_CHANNEL) if ch in channels
+        ]
+        if not active_channels:
+            log.warning(
+                "cluster.sync_roots: no valid channels (got %r), skipping",
+                channels,
+            )
+            return
+
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+
+        for pusher in self.pushers:
+            await self._send_sync_roots_to_peer(
+                pusher,
+                active_channels,
+                roots_for,
+                crypticle,
+                new_session_id(),
+            )
+
+    async def _send_sync_roots_to_peer(
+        self, pusher, active_channels, roots_for, crypticle, session_id
+    ):
+        """
+        Push one ``cluster.sync_roots`` session to a single peer.
+
+        Split out of :meth:`_run_root_sync_to_peers` so the per-peer
+        loop variables are explicit method arguments — avoids
+        cell-var-from-loop closure captures on the per-channel send.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            iter_root_chunks,
+        )
+
+        peer_id = pusher.pull_host
+        log.info(
+            "cluster.sync_roots: starting %s to peer %s (session %s)",
+            active_channels,
+            peer_id,
+            session_id,
+        )
+
+        # Pre-announce the session to the receiver.  Encrypted under
+        # cluster_aes; the receiver decrypts and registers the session
+        # with an on_complete that tears down the registry entry (vs.
+        # join-reply's ``_start_raft_as_learner``).
+        begin_payload = {"session": session_id, "channels": active_channels}
+        begin_event = salt.utils.event.SaltEvent.pack(
+            salt.utils.event.tagify("sync-roots-begin", "peer", "cluster"),
+            crypticle.dumps(begin_payload),
+        )
+        try:
+            await pusher.publish(begin_event)
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "cluster.sync_roots: failed to send sync-roots-begin to %s",
+                peer_id,
+            )
+            return
+
+        for channel in active_channels:
+            await self._send_sync_roots_channel(
+                pusher,
+                crypticle,
+                session_id,
+                peer_id,
+                channel,
+                iter_root_chunks(roots_for[channel]),
+            )
+
+    async def _send_sync_roots_channel(
+        self, pusher, crypticle, session_id, peer_id, channel, chunks
+    ):
+        """
+        Stream one state-sync channel's chunks to a single peer for an
+        operator-driven ``cluster.sync_roots`` session.
+        """
+        chunks = list(chunks)
+        if not chunks:
+            chunks = [[]]
+        total = len(chunks)
+        for seq, items in enumerate(chunks):
+            payload = {
+                "session": session_id,
+                "channel": channel,
+                "seq": seq,
+                "total": total,
+                "eof": seq == total - 1,
+                "items": items,
+            }
+            chunk_event = salt.utils.event.SaltEvent.pack(
+                salt.utils.event.tagify("state-sync-chunk", "peer", "cluster"),
+                crypticle.dumps(payload),
+            )
+            try:
+                await pusher.publish(chunk_event)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "cluster.sync_roots: chunk %s/%s seq=%d to %s failed",
+                    session_id,
+                    channel,
+                    seq,
+                    peer_id,
+                )
+                return
+        log.info(
+            "cluster.sync_roots: %s/%s sent %d chunks (%d items) to %s",
+            session_id,
+            channel,
+            total,
+            sum(len(c) for c in chunks),
+            peer_id,
+        )
+
     async def _send_state_sync_chunks(self, session_id, peer_id):
         """
         Stream the four state-sync channels (keys, denied_keys,
@@ -1905,6 +2056,75 @@ class MasterPubServerChannel:
             # so this branch should not execute in production).
             log.warning(
                 "state-sync %s: no event loop for watchdog; running without timeout",
+                session_id,
+            )
+
+    def _begin_root_sync_session(self, session_id, channels):
+        """
+        Pre-register a state-sync session for an operator-driven
+        ``cluster.sync_roots`` push.
+
+        Mirrors ``_begin_state_sync_session`` but the on-complete is a
+        plain teardown (no Raft-learner bootstrap, no discover_event to
+        set).  Idempotent: a duplicate ``sync-roots-begin`` for an
+        already-registered session is logged and ignored.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            ALL_CHANNELS,
+            DEFAULT_RECEIVE_TIMEOUT,
+            StateSyncSession,
+        )
+
+        if not session_id:
+            log.warning("sync-roots-begin without session_id; dropping")
+            return
+        if not hasattr(self, "_state_sync_sessions"):
+            self._state_sync_sessions = {}
+        if session_id in self._state_sync_sessions:
+            log.warning(
+                "Duplicate sync-roots-begin session id %s; ignoring", session_id
+            )
+            return
+
+        # Defensive: empty channels list defaults to all four (matches
+        # join-time semantics).
+        if not channels:
+            channels = list(ALL_CHANNELS)
+
+        completed_holder = {"done": False}
+
+        def _on_complete():
+            if completed_holder["done"]:
+                return
+            completed_holder["done"] = True
+            log.info(
+                "cluster.sync_roots: session %s complete (channels=%s)",
+                session_id,
+                channels,
+            )
+            handle = session.watchdog_handle
+            if handle is not None:
+                try:
+                    handle.cancel()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            self._state_sync_sessions.pop(session_id, None)
+
+        # The StateSyncSession state machine tracks per-channel eof.  We
+        # tell it about only the channels we expect — when each fires
+        # eof, the session triggers on_complete.
+        session = StateSyncSession(session_id, _on_complete, channels=channels)
+        session.watchdog_handle = None
+        self._state_sync_sessions[session_id] = session
+
+        try:
+            loop = asyncio.get_event_loop()
+            session.watchdog_handle = loop.call_later(
+                DEFAULT_RECEIVE_TIMEOUT, session.force_complete
+            )
+        except RuntimeError:
+            log.warning(
+                "cluster.sync_roots: no event loop for watchdog on session %s",
                 session_id,
             )
 
@@ -2281,6 +2501,27 @@ class MasterPubServerChannel:
                     log.exception("Failed to decrypt state-sync-chunk")
                     return
                 self._apply_state_sync_chunk(chunk)
+                return
+            if tag.startswith("cluster/peer/sync-roots-begin"):
+                # Operator-driven push from a peer (via the
+                # ``cluster.sync_roots`` runner).  Pre-register a state-
+                # sync session keyed by the announced session_id so the
+                # subsequent ``state-sync-chunk`` events have somewhere
+                # to land.  ``on_complete`` here is a no-op (just removes
+                # the registry entry) because this is an ad-hoc content
+                # push, not a join-time Raft-learner bootstrap.
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    begin = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt sync-roots-begin")
+                    return
+                self._begin_root_sync_session(
+                    begin.get("session"), begin.get("channels") or []
+                )
                 return
             if tag.startswith("cluster/peer/join-notify"):
                 # join-notify is encrypted with the shared cluster AES key.
@@ -2853,6 +3094,14 @@ class MasterPubServerChannel:
     async def publish_payload(self, load, *args):
         tag, data = salt.utils.event.SaltEvent.unpack(load)
         # log.warning("Event %s %s %r", len(self.pushers), tag, data)
+        # Operator-triggered cluster operations originate as ``cluster/runner/*``
+        # events fired by the runner subprocess.  Intercept them here so the
+        # event is consumed locally rather than broadcast as a regular
+        # cluster event.
+        if tag == "cluster/runner/sync_roots":
+            channels = data.get("channels") or ["file_roots", "pillar_roots"]
+            asyncio.create_task(self._run_root_sync_to_peers(channels))
+            return
         tasks = []
         if not tag.startswith("cluster/peer"):
             tasks = [

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1768,6 +1768,44 @@ class MasterPubServerChannel:
         except Exception:  # pylint: disable=broad-except
             log.exception("Multi-ring runner dispatch failed for %s", tag)
 
+    async def _fanout_multi_ring_request(self, tag, data):
+        """
+        Broadcast a multi-ring runner event to every peer.
+
+        Originator side: when the operator runs ``cluster.ring_create`` /
+        ``ring_destroy`` / ``route_set`` / ``route_clear`` / ``ring_set``
+        on this master, we may not be the Raft leader of the cluster
+        group (or the relevant ring's group).  Wrap the payload in a
+        cluster_aes-encrypted ``cluster/peer/multi-ring-request`` event
+        and push it to every peer; each peer's handler re-dispatches via
+        :meth:`_handle_multi_ring_runner_event`, but only the leader's
+        propose actually appends a log entry — followers log "not
+        leader" and skip.  This makes the runner location-independent
+        without requiring an explicit "who's the leader" lookup.
+        """
+        try:
+            crypticle = salt.crypt.Crypticle(
+                self.opts,
+                salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+            )
+        except Exception:  # pylint: disable=broad-except
+            log.exception("multi-ring fan-out: cluster_aes unavailable")
+            return
+        payload = {"runner_tag": tag, "data": data}
+        event = salt.utils.event.SaltEvent.pack(
+            salt.utils.event.tagify("multi-ring-request", "peer", "cluster"),
+            crypticle.dumps(payload),
+        )
+        for pusher in self.pushers:
+            try:
+                await pusher.publish(event)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "multi-ring fan-out: failed to send %s to %s",
+                    tag,
+                    pusher.pull_host,
+                )
+
     async def _run_delegate_write(self, payload):
         """
         Forward a single delegated write to the named ring owner.
@@ -3112,6 +3150,35 @@ class MasterPubServerChannel:
                 loop = asyncio.get_event_loop()
                 loop.run_in_executor(None, self._handle_shed_request, request_payload)
                 return
+            if tag.startswith("cluster/peer/multi-ring-request"):
+                # Peer forwarded a ``cluster.ring_create`` /
+                # ``ring_destroy`` / ``route_set`` / ``route_clear`` /
+                # ``ring_set`` runner invocation to us because they
+                # didn't know who the leader was.  Decrypt the
+                # payload (cluster_aes) and dispatch through the
+                # same multi-ring handler used for local runner
+                # events.  If this master is the Raft leader the
+                # propose appends a log entry; otherwise it logs
+                # "not leader" and skips.
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    request_payload = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt multi-ring-request")
+                    return
+                runner_tag = request_payload.get("runner_tag")
+                runner_data = request_payload.get("data") or {}
+                if not runner_tag:
+                    log.warning(
+                        "cluster/peer/multi-ring-request missing runner_tag; "
+                        "ignoring"
+                    )
+                    return
+                self._handle_multi_ring_runner_event(runner_tag, runner_data)
+                return
             if tag.startswith("cluster/peer/collect-request"):
                 # Operator-driven pull from a peer (via the
                 # ``cluster.collect_from_peers`` runner on the
@@ -3756,19 +3823,16 @@ class MasterPubServerChannel:
             "cluster/runner/route_clear",
             "cluster/runner/ring_set",
         ):
-            # Multi-ring operator runners.  Each fires a local event
-            # carrying the propose payload; the publish daemon's
-            # ``RaftService`` (running in this process) is the only
-            # place the in-memory ``Node`` is reachable, so the
-            # actual Raft propose happens here.
-            #
-            # Fire-and-forget: the runner subprocess returned to the
-            # operator the moment it fired the event.  If the
-            # propose call fails (not a leader, validation error,
-            # etc.) it logs at WARNING — the operator should check
-            # the master log if a subsequent ``cluster.members`` or
-            # routing query doesn't reflect the change.
+            # Multi-ring operator runners.  ``propose_*`` only works
+            # on the Raft leader, and the operator may have invoked
+            # the runner on any master.  Try locally first (no-op
+            # warning if we're not the leader) and *also* fan out a
+            # cluster_aes-encrypted peer event so whichever master is
+            # currently the leader picks it up.  Followers that
+            # receive the fan-out log "not leader" and skip — no
+            # double-commit because the leader is unique.
             self._handle_multi_ring_runner_event(tag, data)
+            asyncio.create_task(self._fanout_multi_ring_request(tag, data))
             return
         tasks = []
         if not tag.startswith("cluster/peer"):

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -3093,7 +3093,6 @@ class MasterPubServerChannel:
 
     async def publish_payload(self, load, *args):
         tag, data = salt.utils.event.SaltEvent.unpack(load)
-        # log.warning("Event %s %s %r", len(self.pushers), tag, data)
         # Operator-triggered cluster operations originate as ``cluster/runner/*``
         # events fired by the runner subprocess.  Intercept them here so the
         # event is consumed locally rather than broadcast as a regular

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1659,7 +1659,7 @@ class MasterPubServerChannel:
             for peer_id in known_peers:
                 if peer_id not in peer_pushers:
                     pusher = self.pusher(peer_id, port)
-                    self.pushers.append(pusher)
+                    self._add_pusher(pusher)
                     peer_pushers[peer_id] = pusher
 
             self._raft_service = RaftService(
@@ -1680,6 +1680,496 @@ class MasterPubServerChannel:
 
     def gen_token(self):
         return "".join(random.choices(string.ascii_letters + string.digits, k=32))
+
+    def _handle_multi_ring_runner_event(self, tag, data):
+        """
+        Dispatch a ``cluster/runner/*`` event into the local
+        ``RaftService`` propose helpers.
+
+        Called from :meth:`publish_payload` for the multi-ring
+        runners (``ring_create``, ``ring_destroy``, ``route_set``,
+        ``route_clear``, ``ring_set``).  Each runner's payload shape
+        is bespoke; we keep the dispatch table close to the
+        intercept so a new runner is a one-line addition here plus a
+        runner stub in ``salt/runners/cluster.py``.
+        """
+        svc = self._raft_service
+        if svc is None:
+            log.warning(
+                "Multi-ring runner event %s arrived but RaftService is not "
+                "wired up on this master; dropping",
+                tag,
+            )
+            return
+        try:
+            if tag == "cluster/runner/ring_create":
+                svc.propose_ring_create(
+                    data["ring_id"],
+                    data.get("founding_voters") or [],
+                )
+            elif tag == "cluster/runner/ring_destroy":
+                svc.propose_ring_destroy(data["ring_id"])
+            elif tag == "cluster/runner/route_set":
+                svc.propose_route(data["data_type"], data["ring_id"])
+            elif tag == "cluster/runner/route_clear":
+                svc.propose_route(data["data_type"], None)
+            elif tag == "cluster/runner/ring_set":
+                # Per-ring policy commit — proposes RING_CONFIG on
+                # the named ring's *own* log.  The ring's Node must
+                # be the leader of its own group on this master.
+                ring_id = data["ring_id"]
+                ring_node = svc._nodes.get(ring_id)
+                if ring_node is None:
+                    log.warning(
+                        "cluster.ring_set %s: ring not hosted locally, "
+                        "operator must invoke on a ring member",
+                        ring_id,
+                    )
+                    return
+                # Reuse the existing single-ring propose plumbing on
+                # the per-ring Node.  ``RingConfigStateMachine.apply``
+                # merges partial updates so omitted args preserve the
+                # current value.
+                from salt.cluster.consensus.raft.log import (  # pylint: disable=import-outside-toplevel
+                    RING_MEMBERS_VALID,
+                    LogEntryType,
+                )
+                from salt.cluster.consensus.raft.node import (  # pylint: disable=import-outside-toplevel
+                    NodeState,
+                )
+
+                members = data.get("members")
+                replicas = data.get("replicas")
+                if members is not None and members not in RING_MEMBERS_VALID:
+                    log.warning(
+                        "cluster.ring_set %s: unknown members policy %r",
+                        ring_id,
+                        members,
+                    )
+                    return
+                if ring_node.state != NodeState.LEADER:
+                    log.warning(
+                        "cluster.ring_set %s: not the leader of this ring "
+                        "(state=%s)",
+                        ring_id,
+                        ring_node.state,
+                    )
+                    return
+                cmd = {}
+                if members is not None:
+                    cmd["members"] = members
+                if replicas is not None:
+                    cmd["replicas"] = int(replicas)
+                if not cmd:
+                    return
+                ring_node.log_add(cmd, entry_type=LogEntryType.RING_CONFIG)
+            else:
+                log.warning("Unhandled multi-ring runner tag %s", tag)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Multi-ring runner dispatch failed for %s", tag)
+
+    async def _run_delegate_write(self, payload):
+        """
+        Forward a single delegated write to the named ring owner.
+
+        Originator side of delegate-on-miss.  The local
+        ``cluster/runner/delegate_write`` event (fired by
+        ``EventMonitor._delegate_on_miss``) carries a fully-formed
+        write request — we just have to find the owner's pusher and
+        send it.
+        """
+        owner = payload.get("owner")
+        if not owner:
+            return
+        pusher = None
+        for candidate in self.pushers:
+            if candidate.pull_host == owner:
+                pusher = candidate
+                break
+        if pusher is None:
+            log.warning(
+                "delegate-on-miss: no pusher for owner %s; dropping %s write "
+                "for %s/%s",
+                owner,
+                payload.get("write_kind"),
+                payload.get("data_type"),
+                payload.get("ring_id"),
+            )
+            return
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+        event = salt.utils.event.SaltEvent.pack(
+            salt.utils.event.tagify("delegate-write", "peer", "cluster"),
+            crypticle.dumps(payload),
+        )
+        try:
+            await pusher.publish(event)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("delegate-on-miss: failed to forward to %s", owner)
+        else:
+            log.info(
+                "delegate-on-miss: forwarded %s write for %s to %s",
+                payload.get("write_kind"),
+                payload.get("data_type"),
+                owner,
+            )
+
+    def _handle_delegate_write(self, payload):
+        """
+        Peer-side handler for ``cluster/peer/delegate-write``.
+
+        Applies the delegated write directly via
+        :mod:`salt.utils.job` *without* re-running the gate (which
+        would loop the event back through the cluster bus).  The
+        salt_cache returner's replay protection ensures duplicate
+        delegates of the same (jid, minion_id) drop cleanly.
+        """
+        import salt.utils.job  # pylint: disable=import-outside-toplevel
+
+        write_kind = payload.get("write_kind")
+        body = payload.get("payload") or {}
+        try:
+            if write_kind == "store_minions":
+                salt.utils.job.store_minions(
+                    self.opts, body.get("jid"), body.get("minions") or []
+                )
+            elif write_kind == "store_job":
+                salt.utils.job.store_job(self.opts, body)
+            else:
+                log.warning(
+                    "delegate-on-miss: unknown write_kind %r; dropping",
+                    write_kind,
+                )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "delegate-on-miss: failed to apply %s for %s/%s",
+                write_kind,
+                payload.get("data_type"),
+                payload.get("ring_id"),
+            )
+
+    async def _run_shed_unowned_all(self, request_payload):
+        """
+        Fan out a shed-unowned request to every peer.
+
+        Originator side of ``cluster.shed_unowned_all`` — wraps the
+        runner-supplied payload in a ``cluster_aes``-encrypted event
+        and publishes it to every peer's pool channel.  Each peer's
+        :meth:`handle_pool_publish` intercepts the event and runs the
+        same shed code path locally via
+        :func:`salt.cluster.migration.perform_shed`.
+        """
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+        event = salt.utils.event.SaltEvent.pack(
+            salt.utils.event.tagify("shed-request", "peer", "cluster"),
+            crypticle.dumps(request_payload),
+        )
+        for pusher in self.pushers:
+            try:
+                await pusher.publish(event)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "cluster.shed_unowned_all: failed to send shed-request to %s",
+                    pusher.pull_host,
+                )
+            else:
+                log.info(
+                    "cluster.shed_unowned_all: requested shed of %s from %s",
+                    request_payload.get("ring_id"),
+                    pusher.pull_host,
+                )
+
+    def _handle_shed_request(self, request_payload):
+        """
+        Peer-side handler for ``cluster/peer/shed-request``.
+
+        Runs :func:`salt.cluster.migration.perform_shed` with the
+        payload's parameters and writes the result into the local
+        shed sentinel so the originator can poll for it via
+        ``cluster.shed_status``.
+        """
+        from salt.cluster import migration  # pylint: disable=import-outside-toplevel
+
+        try:
+            result = migration.perform_shed(
+                self.opts,
+                request_payload.get("ring_id"),
+                banks=tuple(
+                    request_payload.get("banks")
+                    or migration.perform_shed.__defaults__[0]
+                ),
+                subbank_template=request_payload.get("subbank_template"),
+                driver=request_payload.get("driver"),
+                dry_run=bool(request_payload.get("dry_run")),
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            log.exception(
+                "cluster.shed_unowned_all: peer-side shed failed for ring=%s",
+                request_payload.get("ring_id"),
+            )
+            result = {
+                "status": "error",
+                "ring": request_payload.get("ring_id"),
+                "error": str(exc),
+            }
+        migration.write_shed_status(self.opts, result, source="peer_request")
+
+    async def _run_collect_from_peers(self, channels):
+        """
+        Operator-driven *pull* of cache contents from every peer.
+        Mirror image of :meth:`_run_root_sync_to_peers` — instead of
+        this master being the sender, this master is the receiver
+        and asks each peer to send.
+
+        Accepts both the fixed ``keys`` / ``denied_keys`` channels
+        and any ``bank:<bank_name>`` channel (the multi-ring
+        migration uses the latter for the salt_cache returner's
+        ``jobs/*`` banks).
+
+        Wire shape:
+
+        1. For each peer, emit a ``cluster/peer/collect-request``
+           event tagged with this master's interface as the
+           ``requester`` and the channel list.
+        2. The peer's ``publish_payload`` sees the event, opens an
+           outbound state-sync session pointed back at the
+           requester, and streams the requested channels (same wire
+           format as ``cluster.sync_roots``).
+        3. The requester's existing
+           ``cluster/peer/state-sync-chunk`` receiver applies each
+           chunk to its local cache.  ``bank:`` channels route to
+           :func:`salt.cluster.state_sync.install_bank_chunk`.
+
+        Fire-and-forget: the operator polls for completion by
+        inspecting the local cache or master log.  ``cluster_aes``
+        protects every payload.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            BANK_CHANNEL_PREFIX,
+        )
+
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+        requester = self.opts.get("interface")
+        if requester is None:
+            log.warning(
+                "cluster.collect_from_peers: opts['interface'] not set; aborting"
+            )
+            return
+        valid_channels = [
+            ch
+            for ch in channels
+            if ch in ("keys", "denied_keys") or ch.startswith(BANK_CHANNEL_PREFIX)
+        ]
+        if not valid_channels:
+            log.warning(
+                "cluster.collect_from_peers: no valid channels in %r; aborting",
+                channels,
+            )
+            return
+        request_payload = {"requester": requester, "channels": valid_channels}
+        expected_peers = [p.pull_host for p in self.pushers]
+        self._init_collect_sentinel(valid_channels, expected_peers, requester)
+        for pusher in self.pushers:
+            peer_id = pusher.pull_host
+            event = salt.utils.event.SaltEvent.pack(
+                salt.utils.event.tagify("collect-request", "peer", "cluster"),
+                crypticle.dumps(request_payload),
+            )
+            try:
+                await pusher.publish(event)
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "cluster.collect_from_peers: failed to send "
+                    "collect-request to %s",
+                    peer_id,
+                )
+            else:
+                log.info(
+                    "cluster.collect_from_peers: requested %s from %s",
+                    valid_channels,
+                    peer_id,
+                )
+
+    def _init_collect_sentinel(self, channels, expected_peers, requester):
+        """
+        Initialise the per-process collect-status structure and
+        flush it to disk.  Subsequent
+        :meth:`_record_collect_chunk` calls update the same file
+        as chunks land, so an operator polling
+        ``cachedir/cluster-collect-status.json`` can confirm
+        completion without grepping logs.
+        """
+        import time  # pylint: disable=import-outside-toplevel
+
+        self._collect_status = {
+            "started_at": time.time(),
+            "updated_at": time.time(),
+            "requester": requester,
+            "channels": list(channels),
+            "expected_peers": sorted(expected_peers),
+            "items_installed": 0,
+            "chunks_installed": 0,
+            "per_channel": {
+                ch: {"chunks": 0, "items": 0, "eofs_seen": 0} for ch in channels
+            },
+            "complete": False,
+        }
+        self._write_collect_sentinel()
+
+    def _record_collect_chunk(self, channel, items_installed, eof):
+        """
+        Update the in-memory collect status with one chunk's
+        outcome and flush.
+
+        ``complete`` flips to True when every channel has seen at
+        least ``len(expected_peers)`` eofs — the heuristic for "every
+        peer responded for every requested channel."  Operators
+        watching the file poll for the boolean, not the per-channel
+        counts.
+        """
+        import time  # pylint: disable=import-outside-toplevel
+
+        status = getattr(self, "_collect_status", None)
+        if status is None:
+            return
+        per_ch = status["per_channel"].setdefault(
+            channel, {"chunks": 0, "items": 0, "eofs_seen": 0}
+        )
+        per_ch["chunks"] += 1
+        per_ch["items"] += int(items_installed)
+        if eof:
+            per_ch["eofs_seen"] += 1
+        status["chunks_installed"] += 1
+        status["items_installed"] += int(items_installed)
+        status["updated_at"] = time.time()
+        expected_eofs = len(status["expected_peers"])
+        if expected_eofs > 0 and all(
+            ch_state["eofs_seen"] >= expected_eofs
+            for ch_state in status["per_channel"].values()
+        ):
+            status["complete"] = True
+        self._write_collect_sentinel()
+
+    def _write_collect_sentinel(self):
+        """
+        Persist ``self._collect_status`` to
+        ``cachedir/cluster-collect-status.json``.
+
+        Atomic write — tmp file + rename — so an operator polling
+        the sentinel during a high-rate collect never sees a torn
+        write.  Each chunk-arrival path calls back here, so the
+        write frequency is bounded only by chunk arrival rate.
+        """
+        import json  # pylint: disable=import-outside-toplevel
+        import os  # pylint: disable=import-outside-toplevel
+
+        import salt.utils.atomicfile  # pylint: disable=import-outside-toplevel
+
+        cachedir = self.opts.get("cachedir")
+        if not cachedir:
+            return
+        path = os.path.join(cachedir, "cluster-collect-status.json")
+        try:
+            with salt.utils.atomicfile.atomic_open(path, "w") as fp:
+                json.dump(self._collect_status, fp)
+        except OSError as exc:
+            log.warning(
+                "cluster.collect_from_peers: failed to write status sentinel %s: %s",
+                path,
+                exc,
+            )
+
+    async def _handle_collect_request(self, requester, channels):
+        """
+        Peer-side handler for ``cluster/peer/collect-request``.
+
+        Opens an outbound state-sync session back to *requester* and
+        streams the requested cache channels.  Three channel shapes
+        are accepted:
+
+        * ``keys`` / ``denied_keys`` — minion-keys banks shipped via
+          :func:`salt.cluster.state_sync.iter_keys_chunks`.
+        * ``bank:<bank_name>`` — arbitrary :class:`salt.cache.Cache`
+          banks shipped via
+          :func:`salt.cluster.state_sync.iter_bank_chunks`.  Used by
+          the multi-ring jobs migration.
+
+        The requester's existing
+        ``cluster/peer/state-sync-chunk`` receiver routes installs by
+        the same channel string.
+        """
+        from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+            bank_from_channel,
+            iter_bank_chunks,
+            iter_keys_chunks,
+            new_session_id,
+        )
+
+        pusher = None
+        for candidate in self.pushers:
+            if candidate.pull_host == requester:
+                pusher = candidate
+                break
+        if pusher is None:
+            log.warning(
+                "cluster/peer/collect-request from %s: no pusher for that "
+                "requester; ignoring",
+                requester,
+            )
+            return
+        crypticle = salt.crypt.Crypticle(
+            self.opts,
+            salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+        )
+        session_id = new_session_id()
+
+        # Announce the session so the requester's receiver registers
+        # it before chunks arrive.  Reuse the sync-roots-begin shape
+        # — the on-complete on that path is a plain teardown, which
+        # is what we want here too.  Mark the origin so the
+        # requester's chunk handler updates the collect-status
+        # sentinel and not the sync_roots one.
+        begin_payload = {
+            "session": session_id,
+            "channels": channels,
+            "origin": "collect",
+        }
+        begin_event = salt.utils.event.SaltEvent.pack(
+            salt.utils.event.tagify("sync-roots-begin", "peer", "cluster"),
+            crypticle.dumps(begin_payload),
+        )
+        try:
+            await pusher.publish(begin_event)
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "cluster.collect_from_peers: failed to announce session %s to %s",
+                session_id,
+                requester,
+            )
+            return
+
+        for channel in channels:
+            bank = bank_from_channel(channel)
+            if bank is not None:
+                chunks = iter_bank_chunks(self.opts, bank)
+            else:
+                chunks = iter_keys_chunks(self.opts, channel)
+            await self._send_sync_roots_channel(
+                pusher,
+                crypticle,
+                session_id,
+                requester,
+                channel,
+                chunks,
+            )
 
     async def _run_root_sync_to_peers(self, channels):
         """
@@ -1932,6 +2422,8 @@ class MasterPubServerChannel:
             FILE_ROOTS_CHANNEL,
             KEYS_CHANNEL,
             PILLAR_ROOTS_CHANNEL,
+            bank_from_channel,
+            install_bank_chunk,
             install_keys_chunk,
             install_root_chunk,
         )
@@ -1964,13 +2456,21 @@ class MasterPubServerChannel:
             elif channel == PILLAR_ROOTS_CHANNEL:
                 installed = install_root_chunk(self.opts.get("pillar_roots"), items)
             else:
-                log.warning(
-                    "state-sync chunk for unknown channel %r (session=%s seq=%s)",
-                    channel,
-                    session_id,
-                    seq,
-                )
-                return
+                # ``bank:<bank_name>`` channels carry arbitrary cache
+                # entries — used by ``cluster.collect_from_peers``
+                # for caches outside the four join-time channels.
+                bank = bank_from_channel(channel)
+                if bank:
+                    installed = install_bank_chunk(self.opts, bank, items)
+                else:
+                    log.warning(
+                        "state-sync chunk for unknown channel %r "
+                        "(session=%s seq=%s)",
+                        channel,
+                        session_id,
+                        seq,
+                    )
+                    return
         except Exception:  # pylint: disable=broad-except
             log.exception(
                 "state-sync %s/%s seq=%s install failed",
@@ -1987,6 +2487,11 @@ class MasterPubServerChannel:
             installed,
             " (eof)" if eof else "",
         )
+        # Collect-origin sessions update the operator-visible
+        # status sentinel — bumps a counter the operator polls
+        # while waiting for the runner's fan-out to finish.
+        if getattr(session, "origin", "sync_roots") == "collect":
+            self._record_collect_chunk(channel, installed, eof)
         session.record_chunk(channel, seq, eof, installed)
 
     def _begin_state_sync_session(self, session_id, known_peers, discover_event):
@@ -2059,15 +2564,24 @@ class MasterPubServerChannel:
                 session_id,
             )
 
-    def _begin_root_sync_session(self, session_id, channels):
+    def _begin_root_sync_session(self, session_id, channels, origin="sync_roots"):
         """
         Pre-register a state-sync session for an operator-driven
-        ``cluster.sync_roots`` push.
+        content push.
 
-        Mirrors ``_begin_state_sync_session`` but the on-complete is a
-        plain teardown (no Raft-learner bootstrap, no discover_event to
-        set).  Idempotent: a duplicate ``sync-roots-begin`` for an
-        already-registered session is logged and ignored.
+        *origin* distinguishes between session shapes that share the
+        same wire format:
+
+        * ``"sync_roots"`` (default) — push from
+          ``cluster.sync_roots``; the on-complete only tears down the
+          registry entry.
+        * ``"collect"`` — pull driven by
+          ``cluster.collect_from_peers``; the chunk handler also
+          updates ``cachedir/cluster-collect-status.json`` so an
+          operator can confirm completion without tailing logs.
+
+        Idempotent: a duplicate begin for an already-registered
+        session is logged and ignored.
         """
         from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
             ALL_CHANNELS,
@@ -2115,6 +2629,7 @@ class MasterPubServerChannel:
         # eof, the session triggers on_complete.
         session = StateSyncSession(session_id, _on_complete, channels=channels)
         session.watchdog_handle = None
+        session.origin = origin
         self._state_sync_sessions[session_id] = session
 
         try:
@@ -2309,7 +2824,7 @@ class MasterPubServerChannel:
                     else (peer, self.tcp_master_pool_port)
                 )
                 pusher = self.pusher(host, int(port))
-                self.pushers.append(pusher)
+                self._add_pusher(pusher)
 
             # Set up the cluster pool puller for incoming peer events
             self.pool_puller = salt.transport.tcp.TCPPuller(
@@ -2462,6 +2977,33 @@ class MasterPubServerChannel:
             pull_port=port,
         )
 
+    def _add_pusher(self, pusher):
+        """
+        Append *pusher* to :attr:`self.pushers` only if no existing
+        pusher already targets the same ``(pull_host, pull_port)``.
+
+        The list of pushers is what every fan-out path
+        (publish_payload's cluster-event broadcast, sync_roots,
+        collect_from_peers, shed_unowned_all, delegate-on-miss)
+        iterates over.  A duplicate entry causes every event to ship
+        twice — wasted bandwidth and, more dangerously, non-atomic
+        sentinel writes that interleave under concurrent arrivals on
+        the peer side.  Multiple code paths add pushers (static
+        config, join-reply, discover-reply, late-joiner
+        ``_start_raft_as_learner``); pre-this-fix, a master that
+        statically configured a peer AND saw a join-reply for it
+        ended up with the peer twice in the list.
+        """
+        host = getattr(pusher, "pull_host", None)
+        port = getattr(pusher, "pull_port", None)
+        for existing in self.pushers:
+            if (
+                getattr(existing, "pull_host", None) == host
+                and getattr(existing, "pull_port", None) == port
+            ):
+                return
+        self.pushers.append(pusher)
+
     async def handle_pool_publish(self, payload):
         """
         Handle incoming events from cluster peer.
@@ -2471,11 +3013,15 @@ class MasterPubServerChannel:
             if salt.cluster.consensus.rpc.is_raft_tag(tag):
                 if self._raft_dispatcher is not None:
                     try:
-                        _, src, rpc_id, rpc_payload = salt.cluster.consensus.rpc.unpack(
-                            payload
-                        )
+                        (
+                            _,
+                            src,
+                            rpc_id,
+                            raft_group_id,
+                            rpc_payload,
+                        ) = salt.cluster.consensus.rpc.unpack(payload)
                         await self._raft_dispatcher.dispatch(
-                            tag, src, rpc_id, rpc_payload
+                            tag, src, rpc_id, rpc_payload, raft_group_id=raft_group_id
                         )
                     except Exception:  # pylint: disable=broad-except
                         log.exception("Error dispatching Raft RPC tag %s", tag)
@@ -2520,8 +3066,80 @@ class MasterPubServerChannel:
                     log.exception("Failed to decrypt sync-roots-begin")
                     return
                 self._begin_root_sync_session(
-                    begin.get("session"), begin.get("channels") or []
+                    begin.get("session"),
+                    begin.get("channels") or [],
+                    origin=begin.get("origin", "sync_roots"),
                 )
+                return
+            if tag.startswith("cluster/peer/delegate-write"):
+                # Delegate-on-miss arrival: a peer forwarded a
+                # routed write because it isn't the ring owner.
+                # Apply the write directly without re-running the
+                # gate (which would loop).  Idempotent returners
+                # absorb the rare double-delivery (bus
+                # replication already landed the event here under
+                # symmetric topology).
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    payload = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt delegate-write")
+                    return
+                loop = asyncio.get_event_loop()
+                loop.run_in_executor(None, self._handle_delegate_write, payload)
+                return
+            if tag.startswith("cluster/peer/shed-request"):
+                # Operator-driven shed fan-out from a peer that ran
+                # ``cluster.shed_unowned_all``.  Decrypt the payload
+                # (cluster_aes) and run the local shed in a worker
+                # task so we don't block the publish loop on cache
+                # I/O.  The result lands in the per-master shed
+                # sentinel for ``cluster.shed_status`` to surface.
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    request_payload = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt shed-request")
+                    return
+                # Run the shed in an executor so cache.list/flush
+                # don't block the event loop.
+                loop = asyncio.get_event_loop()
+                loop.run_in_executor(None, self._handle_shed_request, request_payload)
+                return
+            if tag.startswith("cluster/peer/collect-request"):
+                # Operator-driven pull from a peer (via the
+                # ``cluster.collect_from_peers`` runner on the
+                # requester).  The requester names the channels it
+                # wants; we open an outbound state-sync session back
+                # to it and stream those channels.  Reuses the
+                # existing sync-roots-begin + state-sync-chunk wire
+                # format so the requester's existing receiver
+                # handles the chunks unchanged.
+                try:
+                    crypticle = salt.crypt.Crypticle(
+                        self.opts,
+                        salt.master.SMaster.secrets["cluster_aes"]["secret"].value,
+                    )
+                    request = crypticle.loads(data)
+                except Exception:  # pylint: disable=broad-except
+                    log.exception("Failed to decrypt collect-request")
+                    return
+                requester = request.get("requester")
+                channels = request.get("channels") or []
+                if not requester or not channels:
+                    log.warning(
+                        "cluster/peer/collect-request missing requester or "
+                        "channels (got %r); ignoring",
+                        request,
+                    )
+                    return
+                asyncio.create_task(self._handle_collect_request(requester, channels))
                 return
             if tag.startswith("cluster/peer/join-notify"):
                 # join-notify is encrypted with the shared cluster AES key.
@@ -2744,7 +3362,7 @@ class MasterPubServerChannel:
                     )
 
                 self.cluster_peers.append(payload["peer_id"])
-                self.pushers.append(self.pusher(payload["peer_id"]))
+                self._add_pusher(self.pusher(payload["peer_id"]))
 
                 # Add the joining peer to our own Raft state as a learner.
                 # The join-notify broadcast below tells *other* peers about
@@ -2959,7 +3577,7 @@ class MasterPubServerChannel:
                             payload["peer_id"],
                         )
                 pusher = self.pusher(payload["peer_id"])
-                self.pushers.append(pusher)
+                self._add_pusher(pusher)
                 try:
                     await pusher.publish(event_data)
                 except Exception as exc:  # pylint: disable=broad-except
@@ -3100,6 +3718,57 @@ class MasterPubServerChannel:
         if tag == "cluster/runner/sync_roots":
             channels = data.get("channels") or ["file_roots", "pillar_roots"]
             asyncio.create_task(self._run_root_sync_to_peers(channels))
+            return
+        if tag == "cluster/runner/collect_from_peers":
+            # Operator-driven pull of cache contents from peers.  The
+            # runner subprocess on this master fired the event; we
+            # broadcast a collect-request to every peer so each one
+            # initiates an outbound state-sync send to us.  Receiver
+            # side reuses the existing state-sync chunk handler at
+            # ``cluster/peer/state-sync-chunk``.
+            channels = data.get("channels") or ["keys", "denied_keys"]
+            asyncio.create_task(self._run_collect_from_peers(channels))
+            return
+        if tag == "cluster/runner/shed_unowned_all":
+            # Operator-driven fan-out of cluster.shed_unowned.  We
+            # broadcast a cluster_aes-encrypted shed-request to every
+            # peer; each peer's daemon runs the same shed logic and
+            # writes a per-master sentinel.  The originator runner
+            # subprocess (which fired this event) also ran its own
+            # local shed inline — no need to repeat that here.
+            asyncio.create_task(self._run_shed_unowned_all(data))
+            return
+        if tag == "cluster/runner/delegate_write":
+            # Delegate-on-miss: the EventMonitor on this master saw
+            # a routed write it didn't own and looked up the ring's
+            # owner.  Forward the write to that owner via a
+            # cluster_aes-encrypted ``cluster/peer/delegate-write``
+            # event.  In the standard cluster topology bus
+            # replication already delivered the original event to
+            # the owner — this delegate is a safety net for
+            # asymmetric topologies (or a guard against bus drops).
+            asyncio.create_task(self._run_delegate_write(data))
+            return
+        if tag in (
+            "cluster/runner/ring_create",
+            "cluster/runner/ring_destroy",
+            "cluster/runner/route_set",
+            "cluster/runner/route_clear",
+            "cluster/runner/ring_set",
+        ):
+            # Multi-ring operator runners.  Each fires a local event
+            # carrying the propose payload; the publish daemon's
+            # ``RaftService`` (running in this process) is the only
+            # place the in-memory ``Node`` is reachable, so the
+            # actual Raft propose happens here.
+            #
+            # Fire-and-forget: the runner subprocess returned to the
+            # operator the moment it fired the event.  If the
+            # propose call fails (not a leader, validation error,
+            # etc.) it logs at WARNING — the operator should check
+            # the master log if a subsequent ``cluster.members`` or
+            # routing query doesn't reflect the change.
+            self._handle_multi_ring_runner_event(tag, data)
             return
         tasks = []
         if not tag.startswith("cluster/peer"):

--- a/salt/cluster/consensus/peer.py
+++ b/salt/cluster/consensus/peer.py
@@ -105,21 +105,30 @@ class SaltPeer(Peer):
     """
     A ``Peer`` that sends Raft RPCs over the cluster pool channel.
 
-    :param node_id:  The remote master's node-id — its
-                     ``opts["interface"]`` address (matches the entries in
-                     ``opts["cluster_peers"]`` and the ``peer_pushers`` keys
-                     used everywhere else in the cluster code).
-    :param pusher:   The ``PublishServer`` instance already connected to that
-                     master's ``cluster_pool_port``.
-    :param local_id: This master's own node-id (used as ``src`` in envelopes).
-    :param voting:   Whether the peer counts toward quorum.
+    :param node_id:       The remote master's node-id — its
+                          ``opts["interface"]`` address (matches the
+                          entries in ``opts["cluster_peers"]`` and the
+                          ``peer_pushers`` keys used everywhere else
+                          in the cluster code).
+    :param pusher:        The ``PublishServer`` instance already
+                          connected to that master's
+                          ``cluster_pool_port``.
+    :param local_id:      This master's own node-id (used as ``src``
+                          in envelopes).
+    :param voting:        Whether the peer counts toward quorum.
+    :param raft_group_id: Which Raft group this peer belongs to.
+                          ``"cluster"`` (default) is the main cluster
+                          group; per-ring peers carry the ring name so
+                          the dispatcher on the receiving side routes
+                          RPCs to the correct local ``Node``.
     """
 
-    def __init__(self, node_id, pusher, local_id, voting=True):
+    def __init__(self, node_id, pusher, local_id, voting=True, raft_group_id="cluster"):
         # Pass None for the node object; we manage node_id directly.
         super().__init__(None, node_id=node_id, voting=voting)
         self._pusher = pusher
         self._local_id = local_id
+        self._raft_group_id = raft_group_id
 
     @property
     def node_id(self):
@@ -135,7 +144,13 @@ class SaltPeer(Peer):
 
     async def _send(self, tag, payload, rpc_id=None):
         rpc_id = rpc_id or str(uuid.uuid4())
-        raw = rpc.pack(tag, self._local_id, rpc_id, payload)
+        raw = rpc.pack(
+            tag,
+            self._local_id,
+            rpc_id,
+            payload,
+            raft_group_id=self._raft_group_id,
+        )
         try:
             await _publish(self._pusher, raw)
         except Exception:  # pylint: disable=broad-except
@@ -243,9 +258,16 @@ class RaftDispatcher:
     appropriate pusher.
 
     One ``RaftDispatcher`` instance lives inside ``MasterPubServerChannel``
-    alongside the existing pushers.
+    alongside the existing pushers.  When this master hosts multiple
+    Raft groups (the main cluster group plus per-ring groups) it owns
+    one ``Node`` per group; inbound RPCs carry a ``raft_group_id``
+    field that selects the target ``Node``.
 
-    :param node:      The local ``salt.cluster.consensus.raft.Node``.
+    :param node:      Either a single ``Node`` (treated as the
+                      ``"cluster"`` group) or a ``dict[str, Node]``
+                      mapping group-id to its local ``Node``.  Passing
+                      a single Node preserves the pre-multi-ring
+                      constructor signature.
     :param local_id:  This master's node-id (``opts["interface"]``) — used as
                       ``src`` in outbound RPC envelopes.
     :param pushers:   Dict mapping peer node-id (interface address) ->
@@ -253,27 +275,78 @@ class RaftDispatcher:
     """
 
     def __init__(self, node, local_id, pushers):
-        self._node = node
+        # Normalise to a dict keyed by group-id.  Callers that pass a
+        # bare Node (or None) are interpreted as the main cluster
+        # group; the dict-of-nodes form is the multi-ring shape.
+        if isinstance(node, dict):
+            self._nodes = dict(node)
+        else:
+            self._nodes = {"cluster": node}
         self._local_id = local_id
         # pushers keyed by peer node-id for O(1) lookup
         self._pushers = pushers  # dict[str, PublishServer]
 
-    async def _reply(self, dst, tag, payload):
+    @property
+    def _node(self):
+        """
+        Backward-compat accessor for callers that reach in for the
+        single Node (tests primarily).  Returns the cluster group's
+        Node so existing assertions keep working.
+        """
+        return self._nodes.get("cluster")
+
+    @_node.setter
+    def _node(self, node):
+        """
+        Mutating ``dispatcher._node`` (used by some tests to simulate
+        a failed leader losing its Node) maps to the cluster group.
+        Setting ``None`` removes the cluster Node entirely so
+        :meth:`dispatch` drops inbound RPCs.
+        """
+        if node is None:
+            self._nodes.pop("cluster", None)
+        else:
+            self._nodes["cluster"] = node
+
+    def register_node(self, raft_group_id, node):
+        """
+        Add or replace the ``Node`` for *raft_group_id*.
+
+        Used when ``RaftService`` brings up a per-ring Raft group
+        after the dispatcher has already been constructed.
+        """
+        self._nodes[raft_group_id] = node
+
+    def unregister_node(self, raft_group_id):
+        """Remove the ``Node`` registered for *raft_group_id*, if any."""
+        self._nodes.pop(raft_group_id, None)
+
+    async def _reply(self, dst, tag, payload, raft_group_id="cluster"):
         pusher = self._pushers.get(dst)
         if pusher is None:
             log.warning("RaftDispatcher: no pusher for %s, dropping %s reply", dst, tag)
             return
-        raw = rpc.pack(tag, self._local_id, str(uuid.uuid4()), payload)
+        raw = rpc.pack(
+            tag,
+            self._local_id,
+            str(uuid.uuid4()),
+            payload,
+            raft_group_id=raft_group_id,
+        )
         try:
             await _publish(pusher, raw)
         except Exception:  # pylint: disable=broad-except
             log.exception("RaftDispatcher: failed to send %s reply to %s", tag, dst)
 
-    async def dispatch(self, tag, src, rpc_id, payload):
+    async def dispatch(self, tag, src, rpc_id, payload, raft_group_id="cluster"):
         """Route one inbound Raft RPC to the correct Node method."""
-        node = self._node
+        node = self._nodes.get(raft_group_id)
         if node is None:
-            log.debug("RaftDispatcher: node not ready, dropping %s", tag)
+            log.debug(
+                "RaftDispatcher: no node for group %s, dropping %s",
+                raft_group_id,
+                tag,
+            )
             return
 
         try:
@@ -288,6 +361,7 @@ class RaftDispatcher:
                     payload["callback_node"],
                     rpc.REQUEST_VOTE_REPLY,
                     {"granted": granted, "term": term, "voter_id": self._local_id},
+                    raft_group_id=raft_group_id,
                 )
 
             elif tag == rpc.PRE_REQUEST_VOTE:
@@ -301,6 +375,7 @@ class RaftDispatcher:
                     payload["callback_node"],
                     rpc.PRE_REQUEST_VOTE_REPLY,
                     {"granted": granted, "term": term, "voter_id": self._local_id},
+                    raft_group_id=raft_group_id,
                 )
 
             elif tag == rpc.REQUEST_VOTE_REPLY:
@@ -339,6 +414,7 @@ class RaftDispatcher:
                         "conflict_index": last_idx,
                         "conflict_term": conflict_term,
                     },
+                    raft_group_id=raft_group_id,
                 )
 
             elif tag == rpc.APPEND_ENTRIES_REPLY:
@@ -369,6 +445,7 @@ class RaftDispatcher:
                     payload["callback_node"],
                     rpc.INSTALL_SNAPSHOT_REPLY,
                     {"our_term": our_term, "peer_id": self._local_id},
+                    raft_group_id=raft_group_id,
                 )
 
             elif tag == rpc.INSTALL_SNAPSHOT_REPLY:

--- a/salt/cluster/consensus/raft/log.py
+++ b/salt/cluster/consensus/raft/log.py
@@ -60,11 +60,23 @@ class LogEntryType:
     COMMAND = 0
     CONFIG = 1
     SNAPSHOT = 2
-    # Ring policy commit (members source + replication factor).  Driven
-    # by a salt-run cluster.ring runner in stage 1; applied to a
-    # ``RingConfigStateMachine`` registered on the Log so its state
-    # survives compaction in the same envelope as ``membership_sm``.
+    # Ring policy commit (members source + replication factor).  Lives
+    # in a *per-ring* Raft log and drives that ring's
+    # ``RingConfigStateMachine``.  Was originally a cluster-log entry
+    # in the single-ring design; the multi-ring world treats it as
+    # per-ring state.
     RING_CONFIG = 3
+    # Cluster-log registry entry: ``{"ring_id": str,
+    # "founding_voters": [str, ...], "status": "active"|"destroyed"}``.
+    # Applied by ``RingRegistryStateMachine`` on the cluster log; the
+    # daemon brings up (or tears down) the named ring's Raft group
+    # when the entry commits.
+    RING_REGISTRY = 4
+    # Cluster-log data-type routing entry: ``{"data_type": str,
+    # "ring_id": str|None}``.  Applied by ``RoutingStateMachine`` on
+    # the cluster log; gates consult the routing table to decide
+    # which ring (if any) owns a given cache.
+    ROUTE = 5
 
 
 class LogEntry(NamedTuple):
@@ -761,6 +773,263 @@ class RingConfigStateMachine(BaseStateMachine):
         return (
             f"<RingConfigStateMachine members={self._members!r} "
             f"replicas={self._replicas} version={self._version}>"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-ring state machines (live on the cluster Raft log)
+# ---------------------------------------------------------------------------
+
+
+# Valid ring lifecycle states recorded in the registry.
+RING_STATUS_ACTIVE = "active"
+RING_STATUS_DESTROYED = "destroyed"
+RING_STATUS_VALID = (RING_STATUS_ACTIVE, RING_STATUS_DESTROYED)
+
+
+class RingRegistryStateMachine(BaseStateMachine):
+    """
+    Cluster-log registry of named rings.
+
+    For each named Raft "ring" (a separate consensus group used to
+    shard one Salt cache), the registry tracks ``founding_voters``
+    (initial voter list at create time) and ``status`` (``"active"``
+    or ``"destroyed"``).  Once a ring is created and brought up,
+    further membership and policy churn lives in *that ring's own*
+    Raft log — the registry only records the lifecycle moments
+    cluster-wide consensus needs to agree on.
+
+    Command shape applied from a ``LogEntryType.RING_REGISTRY`` entry::
+
+        {"ring_id": "jobs",
+         "founding_voters": ["m1", "m2", "m3"],
+         "status": "active"}
+
+    Or, to destroy::
+
+        {"ring_id": "jobs", "status": "destroyed"}
+
+    On each commit ``on_change(ring_id, founding_voters, status)``
+    fires; ``RaftService`` wires this to bring up or tear down the
+    named ring's per-ring Raft group inside the publish daemon.
+
+    Snapshot/restore round-trip through the same multi-SM envelope
+    used by :class:`MembershipStateMachine`, registered under name
+    ``"ring_registry_sm"``.
+    """
+
+    def __init__(self, on_change=None):
+        # ring_id -> {"founding_voters": [...], "status": "active"|"destroyed"}
+        self._rings = {}
+        self._version = -1
+        self.on_change = on_change
+
+    # ------------------------------------------------------------------
+    # BaseStateMachine interface
+    # ------------------------------------------------------------------
+
+    def apply(self, cmd, client_id=None, sequence_num=None, index=-1):
+        """
+        Apply a committed RING_REGISTRY entry.
+
+        Status defaults to ``"active"`` so the common create case is
+        a two-field commit; founding voters are sorted to canonicalise
+        the on-disk representation.  ``ring_id`` is required.
+        """
+        if not isinstance(cmd, dict):
+            log.warning("RingRegistryStateMachine: ignoring non-dict cmd %r", cmd)
+            return
+        ring_id = cmd.get("ring_id")
+        if not ring_id:
+            log.warning(
+                "RingRegistryStateMachine: ignoring entry without ring_id: %r",
+                cmd,
+            )
+            return
+        status = cmd.get("status", RING_STATUS_ACTIVE)
+        if status not in RING_STATUS_VALID:
+            log.warning(
+                "RingRegistryStateMachine: ignoring unknown status %r "
+                "(expected one of %s)",
+                status,
+                RING_STATUS_VALID,
+            )
+            return
+        existing = self._rings.get(ring_id) or {}
+        # Preserve the existing founding_voters when the incoming
+        # entry omits them — destroy commits ride this path so the
+        # audit trail keeps "who founded this ring."  ``cmd.get`` is
+        # checked against ``None`` rather than truthiness so an
+        # explicit empty list still wins (operator-driven correction).
+        if "founding_voters" in cmd and cmd.get("founding_voters") is not None:
+            founders = sorted(cmd["founding_voters"] or [])
+        else:
+            founders = existing.get("founding_voters", [])
+        # Destruction of a never-registered ring is a no-op write to
+        # the registry — keep the entry so the lifecycle is auditable.
+        self._rings[ring_id] = {
+            "founding_voters": founders,
+            "status": status,
+        }
+        self._version = index
+        if self.on_change is not None:
+            self.on_change(ring_id, founders, status)
+
+    def get_snapshot(self):
+        """Return the JSON-serialisable registry."""
+        return {
+            "rings": {ring_id: dict(entry) for ring_id, entry in self._rings.items()},
+            "version": self._version,
+        }
+
+    def restore_snapshot(self, data):
+        """Restore from a snapshot dict (as produced by :meth:`get_snapshot`)."""
+        if isinstance(data, (bytes, bytearray)):
+            data = json.loads(data.decode())
+        if not isinstance(data, dict):
+            return
+        rings = data.get("rings", {})
+        if isinstance(rings, dict):
+            self._rings = {
+                ring_id: {
+                    "founding_voters": sorted(entry.get("founding_voters", []) or []),
+                    "status": entry.get("status", RING_STATUS_ACTIVE),
+                }
+                for ring_id, entry in rings.items()
+                if isinstance(entry, dict)
+            }
+        self._version = data.get("version", -1)
+
+    # ------------------------------------------------------------------
+    # Query API
+    # ------------------------------------------------------------------
+
+    def rings(self):
+        """Return the full ring_id -> entry dict.  Copy; callers may mutate."""
+        return {ring_id: dict(entry) for ring_id, entry in self._rings.items()}
+
+    def active_rings(self):
+        """Return a sorted list of ring ids whose status is ``"active"``."""
+        return sorted(
+            ring_id
+            for ring_id, entry in self._rings.items()
+            if entry.get("status") == RING_STATUS_ACTIVE
+        )
+
+    def get(self, ring_id):
+        """Return the registry entry for *ring_id*, or ``None`` if unknown."""
+        entry = self._rings.get(ring_id)
+        return dict(entry) if entry is not None else None
+
+    @property
+    def registry_version(self):
+        """Log index of the most recently applied RING_REGISTRY entry, or -1."""
+        return self._version
+
+    def __repr__(self):
+        return (
+            f"<RingRegistryStateMachine rings={sorted(self._rings)} "
+            f"version={self._version}>"
+        )
+
+
+class RoutingStateMachine(BaseStateMachine):
+    """
+    Cluster-log data-type -> ring mapping.
+
+    For each Salt data type that a master writes to a cache (e.g.
+    ``"jobs"``), the routing table answers "which ring owns this
+    data?".  A mapping of ``None`` means *broadcast* — no ring is
+    consulted and every master writes the data unconditionally
+    (the pre-multi-ring default).
+
+    Command shape applied from a ``LogEntryType.ROUTE`` entry::
+
+        {"data_type": "jobs", "ring_id": "jobs_ring"}
+
+    Or, to clear a route back to broadcast::
+
+        {"data_type": "jobs", "ring_id": None}
+
+    On each commit ``on_change(data_type, ring_id)`` fires;
+    ``RaftService`` wires this so the local routing table used by the
+    gate sites in ``salt/master.py`` stays in sync without IPC.
+
+    Snapshot/restore round-trip through the same multi-SM envelope
+    used by :class:`MembershipStateMachine`, registered under name
+    ``"routing_sm"``.
+    """
+
+    def __init__(self, on_change=None):
+        # data_type -> ring_id or None
+        self._routes = {}
+        self._version = -1
+        self.on_change = on_change
+
+    # ------------------------------------------------------------------
+    # BaseStateMachine interface
+    # ------------------------------------------------------------------
+
+    def apply(self, cmd, client_id=None, sequence_num=None, index=-1):
+        """Apply a committed ROUTE entry."""
+        if not isinstance(cmd, dict):
+            log.warning("RoutingStateMachine: ignoring non-dict cmd %r", cmd)
+            return
+        data_type = cmd.get("data_type")
+        if not data_type:
+            log.warning(
+                "RoutingStateMachine: ignoring entry without data_type: %r",
+                cmd,
+            )
+            return
+        # Use a sentinel so we can distinguish "ring_id absent" (treat as
+        # a clear-to-broadcast) from "ring_id explicitly None".  Both
+        # map to broadcast semantically, so we accept either; the more
+        # natural form for an operator is to send ``"ring_id": None``.
+        ring_id = cmd.get("ring_id")
+        self._routes[data_type] = ring_id
+        self._version = index
+        if self.on_change is not None:
+            self.on_change(data_type, ring_id)
+
+    def get_snapshot(self):
+        """Return the JSON-serialisable routing table."""
+        return {
+            "routes": dict(self._routes),
+            "version": self._version,
+        }
+
+    def restore_snapshot(self, data):
+        """Restore from a snapshot dict (as produced by :meth:`get_snapshot`)."""
+        if isinstance(data, (bytes, bytearray)):
+            data = json.loads(data.decode())
+        if not isinstance(data, dict):
+            return
+        routes = data.get("routes", {})
+        if isinstance(routes, dict):
+            self._routes = dict(routes)
+        self._version = data.get("version", -1)
+
+    # ------------------------------------------------------------------
+    # Query API
+    # ------------------------------------------------------------------
+
+    def routes(self):
+        """Return a copy of the data_type -> ring_id mapping."""
+        return dict(self._routes)
+
+    def get(self, data_type, default=None):
+        """Return the ring_id for *data_type*, or *default* if unrouted."""
+        return self._routes.get(data_type, default)
+
+    @property
+    def routing_version(self):
+        """Log index of the most recently applied ROUTE entry, or -1."""
+        return self._version
+
+    def __repr__(self):
+        return (
+            f"<RoutingStateMachine routes={self._routes!r} " f"version={self._version}>"
         )
 
 

--- a/salt/cluster/consensus/raft/node.py
+++ b/salt/cluster/consensus/raft/node.py
@@ -837,6 +837,23 @@ class Node:
                     ring_sm = self.log._extra_state_machines.get("ring_sm")
                     if ring_sm is not None:
                         ring_sm.apply(entry.cmd, index=entry.index)
+                elif entry.type == LogEntryType.RING_REGISTRY:
+                    # Multi-ring registry: the cluster log records
+                    # which rings exist and their founding voters.
+                    # Applied to ``ring_registry_sm`` if registered;
+                    # the SM's on_change fires per-ring lifecycle in
+                    # RaftService (slice 3 of the multi-ring rollout).
+                    registry_sm = self.log._extra_state_machines.get("ring_registry_sm")
+                    if registry_sm is not None:
+                        registry_sm.apply(entry.cmd, index=entry.index)
+                elif entry.type == LogEntryType.ROUTE:
+                    # Data-type -> ring routing.  Applied to
+                    # ``routing_sm`` if registered; the SM's on_change
+                    # drives the local routing table that gate sites
+                    # consult.
+                    routing_sm = self.log._extra_state_machines.get("routing_sm")
+                    if routing_sm is not None:
+                        routing_sm.apply(entry.cmd, index=entry.index)
             self.log.last_applied = new_applied
 
     @lock

--- a/salt/cluster/consensus/rpc.py
+++ b/salt/cluster/consensus/rpc.py
@@ -10,7 +10,14 @@ Each Raft RPC is packed as a plain dict via ``salt.payload`` (msgpack) and
 wrapped inside the event envelope understood by the pool puller:
 
     tag  : "cluster/raft/<kind>"
-    data : {"src": <node_id>, "rpc_id": <str>, "payload": <dict>}
+    data : {"src": <node_id>, "rpc_id": <str>,
+            "raft_group_id": <str>, "payload": <dict>}
+
+``raft_group_id`` identifies which Raft group the RPC belongs to so a
+single master process can host multiple coexisting groups (the main
+cluster group plus per-ring groups).  Older envelopes that pre-date
+multi-ring support omit the field and are interpreted as the
+``"cluster"`` group.
 """
 
 import logging
@@ -57,31 +64,53 @@ def is_raft_tag(tag):
 # ---------------------------------------------------------------------------
 
 
-def pack(tag, src, rpc_id, payload):
+def pack(tag, src, rpc_id, payload, raft_group_id="cluster"):
     """
     Serialise a Raft RPC into the bytes the pool puller expects.
 
-    :param tag:     One of the ``cluster/raft/*`` constants above.
-    :param src:     Sender node-id (``opts["interface"]``) — matches the
-                    cluster-wide identity used by ``RaftService`` and the
-                    ``cluster_peers`` opt; not the daemon's ``opts["id"]``.
-    :param rpc_id:  Opaque correlation string chosen by the caller.
-    :param payload: Dict of RPC-specific fields.
-    :returns:       Raw bytes ready for ``pusher.publish()``.
+    :param tag:           One of the ``cluster/raft/*`` constants above.
+    :param src:           Sender node-id (``opts["interface"]``) —
+                          matches the cluster-wide identity used by
+                          ``RaftService`` and the ``cluster_peers``
+                          opt; not the daemon's ``opts["id"]``.
+    :param rpc_id:        Opaque correlation string chosen by the
+                          caller.
+    :param payload:       Dict of RPC-specific fields.
+    :param raft_group_id: Identifier of the Raft group this RPC
+                          belongs to.  ``"cluster"`` (default) is the
+                          main cluster group; named rings (e.g.
+                          ``"jobs"``) get their own group ids.
+    :returns:             Raw bytes ready for ``pusher.publish()``.
     """
-    data = {"src": src, "rpc_id": rpc_id, "payload": payload}
+    data = {
+        "src": src,
+        "rpc_id": rpc_id,
+        "raft_group_id": raft_group_id,
+        "payload": payload,
+    }
     return salt.utils.event.SaltEvent.pack(tag, data)
 
 
 def unpack(raw):
     """
-    Deserialise raw bytes from the pool puller back into ``(tag, src, rpc_id, payload)``.
+    Deserialise raw bytes from the pool puller back into
+    ``(tag, src, rpc_id, raft_group_id, payload)``.
+
+    Envelopes that pre-date the multi-ring extension omit the
+    ``raft_group_id`` field; those are interpreted as the main
+    cluster group (``"cluster"``).
 
     :raises ValueError: if the envelope is missing required keys.
     """
     tag, data = salt.utils.event.SaltEvent.unpack(raw)
     try:
-        return tag, data["src"], data["rpc_id"], data["payload"]
+        return (
+            tag,
+            data["src"],
+            data["rpc_id"],
+            data.get("raft_group_id", "cluster"),
+            data["payload"],
+        )
     except KeyError as exc:
         raise ValueError(
             f"Malformed Raft RPC envelope (missing {exc}): {data!r}"

--- a/salt/cluster/consensus/service.py
+++ b/salt/cluster/consensus/service.py
@@ -39,10 +39,14 @@ import logging
 from salt.cluster.consensus.peer import RaftDispatcher, SaltPeer
 from salt.cluster.consensus.raft import AsyncTimeoutScheduler, Node
 from salt.cluster.consensus.raft.log import (
-    RING_MEMBERS_SELF,
     RING_MEMBERS_VOTERS,
+    RING_STATUS_ACTIVE,
+    RING_STATUS_DESTROYED,
+    RING_STATUS_VALID,
     LogEntryType,
     RingConfigStateMachine,
+    RingRegistryStateMachine,
+    RoutingStateMachine,
 )
 from salt.cluster.consensus.raft.node import NodeState
 from salt.cluster.consensus.storage import SaltStorage
@@ -112,6 +116,14 @@ class RaftService:
             max_log_size=max_log_size,
             max_voters=max_voters,
         )
+        # ``_nodes`` is the multi-ring registry: keys are Raft group
+        # ids, values are the local ``Node`` instances.  Slice 1 only
+        # carries the main cluster group; later slices spawn per-ring
+        # Nodes here as the cluster log commits RING_REGISTRY entries.
+        # ``self._node`` (singular) stays as a convenience handle to
+        # the cluster Node — every existing call site reads it through
+        # that name.
+        self._nodes = {"cluster": self._node}
         self._scheduler = AsyncTimeoutScheduler(loop=loop)
         self._node.register_schedule_timeout(self._scheduler.schedule)
 
@@ -119,16 +131,53 @@ class RaftService:
         # this node appears in the committed voter set.
         self._node.membership_sm.on_change = self._on_membership_change
 
-        # Ring config SM: tracks the cluster's ring policy (members
-        # source + replication factor).  Registered on the Log so its
-        # state survives compaction.  Default policy ("self", 1) means
-        # the per-process ring contains only this master and writes
-        # broadcast as they do today; an operator flips to ("voters",
-        # N) by committing a RING_CONFIG entry through Raft.
-        self._ring_config_sm = RingConfigStateMachine(
-            on_change=self._on_ring_config_change
+        # Ring registry SM: cluster-log inventory of named rings (one
+        # per shardable cache).  Slice 2 of the multi-ring rollout —
+        # bringing up / tearing down per-ring Raft groups is wired in
+        # slice 3; for now we just track and persist the registry so
+        # an operator can record the desired topology.
+        self._ring_registry_sm = RingRegistryStateMachine(
+            on_change=self._on_ring_registry_change
         )
-        self._node.log.register_state_machine("ring_sm", self._ring_config_sm)
+        self._node.log.register_state_machine(
+            "ring_registry_sm", self._ring_registry_sm
+        )
+
+        # Routing SM: cluster-log data-type -> ring mapping (e.g.
+        # "jobs" -> "jobs_ring", "events" -> None for broadcast).
+        # Gate sites consult the routing table once it's populated;
+        # absent entries mean broadcast, preserving today's behaviour.
+        self._routing_sm = RoutingStateMachine(on_change=self._on_route_change)
+        self._node.log.register_state_machine("routing_sm", self._routing_sm)
+
+        # ``Node.__init__`` already loaded any snapshot, but only the
+        # state machines registered at construction time
+        # (``membership_sm``) saw the restore.  Re-run the restore
+        # now that ``ring_sm`` / ``ring_registry_sm`` / ``routing_sm``
+        # are registered so a master coming back from a snapshot
+        # rebuilds them from disk instead of starting empty (which
+        # would be silently wrong under log compaction).
+        if storage is not None:
+            try:
+                snap = storage.load_snapshot()
+            except Exception:  # pylint: disable=broad-except
+                snap = None
+            if snap and "data" in snap:
+                self._node.log.restore_state_machines_from_data(snap["data"])
+
+        # The snapshot restore above populated the registry but did
+        # not fire its ``on_change`` (``restore_snapshot`` is a pure
+        # store).  Drive bring-up for any active rings that this
+        # master was hosting before the restart so the per-ring
+        # ``Node`` instances reattach to the dispatcher.  Idempotent
+        # — ``_bring_up_ring`` no-ops when the ring is already up.
+        for ring_id in self._ring_registry_sm.active_rings():
+            entry = self._ring_registry_sm.get(ring_id) or {}
+            self._on_ring_registry_change(
+                ring_id,
+                entry.get("founding_voters", []),
+                entry.get("status", RING_STATUS_ACTIVE),
+            )
 
         # Build SaltPeer objects - one per cluster peer (all voting at start).
         peers = [
@@ -141,8 +190,13 @@ class RaftService:
         self._node.register_peer_factory(self._make_peer)
 
         # peer_pushers is keyed by interface address, matching the
-        # callback_node field written into RPC envelopes.
-        self._dispatcher = RaftDispatcher(self._node, node_id, self._peer_pushers)
+        # callback_node field written into RPC envelopes.  Hand the
+        # dispatcher the full ``_nodes`` dict so that inbound RPCs are
+        # routed by ``raft_group_id``; passing ``self._nodes``
+        # (instead of a bare ``self._node``) means subsequent
+        # ``register_ring_node`` calls are visible to the dispatcher
+        # without extra plumbing.
+        self._dispatcher = RaftDispatcher(self._nodes, node_id, self._peer_pushers)
 
         # If Node started from a saved snapshot the membership SM was
         # restored before this on_change wiring existed, so the cluster-
@@ -170,12 +224,22 @@ class RaftService:
         committed voter set, signalling that it is a full participant and may
         begin serving minion/CLI traffic.
 
-        Also reapplies the current ring policy: when ``members=voters`` the
-        ring contents track the new voter set.  In ``members=self`` (default)
-        the ring stays self-only regardless of voters, which preserves the
-        broadcast-everywhere stage-0 behaviour.
+        The default ``"cluster"`` ring is kept in lock-step with the
+        cluster voter set so pre-multi-ring callers
+        (``ring_membership.owns(opts, key)`` with no ring name) see a
+        meaningful answer.  Per-ring sharding is driven separately by
+        each per-ring ``Node``'s own ``MembershipStateMachine``.
         """
-        self._apply_ring_policy()
+        # Lazy import keeps the consensus package independent of the
+        # ring module's load order.
+        import salt.cluster.ring_membership  # pylint: disable=import-outside-toplevel
+
+        # Keep the default "cluster" ring populated with the current
+        # voter set.  Empty ``voters`` shouldn't happen in steady
+        # state but we tolerate it (an empty ring answers True for
+        # every owns() — broadcast semantics).
+        if voters:
+            salt.cluster.ring_membership.rebuild(list(voters))
 
         if self._on_ready is None:
             return
@@ -188,95 +252,345 @@ class RaftService:
             self._on_ready()
             self._on_ready = None  # fire only once
 
-    def _on_ring_config_change(self, members, replicas):
+    def _on_ring_registry_change(self, ring_id, founding_voters, status):
         """
-        Called by ``RingConfigStateMachine`` after every committed
-        RING_CONFIG entry.  Rebuilds this process's ring with the new
-        policy applied to the current voter set.
+        Called by :class:`RingRegistryStateMachine` after each
+        committed ``RING_REGISTRY`` entry.
 
-        Replication factor is tracked in the SM but not yet honoured by
-        the rebuild — stage 1 ships the policy plumbing; stage 2 will
-        teach the ring to use ``replicas > 1`` for fault tolerance.
+        * ``status="active"`` and this master is in ``founding_voters``:
+          bring up the per-ring Raft group inside this process.  The
+          per-ring ``Node`` shares the same asyncio loop, scheduler,
+          and peer transport as the cluster group; only the on-disk
+          state and Raft state machines are independent.
+        * ``status="destroyed"``: tear down the per-ring Node and
+          drop it from the dispatcher's routing table.
+        * Otherwise (e.g. an active entry that doesn't list this
+          master): nothing to do locally.  Other masters will own the
+          ring.
         """
         log.info(
-            "RaftService: ring policy committed — members=%s replicas=%d",
+            "RaftService: ring registry committed — ring=%s status=%s "
+            "founding_voters=%s",
+            ring_id,
+            status,
+            list(founding_voters or []),
+        )
+        if status == RING_STATUS_DESTROYED:
+            self._tear_down_ring(ring_id)
+            return
+        if self._node.node_id not in (founding_voters or []):
+            # Not a founder — this ring's data plane runs elsewhere.
+            return
+        self._bring_up_ring(ring_id, founding_voters)
+
+    def _bring_up_ring(self, ring_id, founding_voters):
+        """
+        Construct and register the per-ring Raft ``Node`` for this
+        master.  Idempotent: if the ring is already up locally the
+        call is a no-op.
+
+        The per-ring Node has its own :class:`SaltStorage` keyed by
+        ``ring_id``, its own ``MembershipStateMachine`` and
+        ``RingConfigStateMachine`` registered on its log, its own
+        :class:`SaltPeer` instances stamping ``raft_group_id`` into
+        outbound RPCs, and its own election + heartbeat path driven
+        by the shared scheduler.
+        """
+        if ring_id == "cluster":
+            log.warning(
+                "RaftService: refusing to bring up a ring named 'cluster' — "
+                "reserved for the main cluster Raft group"
+            )
+            return
+        if ring_id in self._nodes:
+            log.debug(
+                "RaftService: ring %s already up locally, skipping bring-up",
+                ring_id,
+            )
+            return
+
+        node_id = self._node.node_id
+        log.info(
+            "RaftService: bringing up ring %s with founders=%s",
+            ring_id,
+            sorted(founding_voters or []),
+        )
+        storage = SaltStorage(node_id, self.opts, ring_id=ring_id)
+        # Election windows reuse the same opts as the cluster Node —
+        # if the operator tuned them for their environment, the
+        # per-ring nodes inherit the tuning automatically.
+        election_min = self.opts.get("cluster_election_min", 750)
+        election_max = self.opts.get("cluster_election_max", 1500)
+        ring_node = Node(
+            node_id,
+            storage=storage,
+            voting=True,
+            _follower_min=election_min,
+            _follower_max=election_max,
+            max_log_size=self.opts.get("cluster_max_log_size"),
+            max_voters=self.opts.get("cluster_max_voters"),
+        )
+        ring_node.register_schedule_timeout(self._scheduler.schedule)
+        # Per-ring RingConfigStateMachine: each ring has its own
+        # members/replicas policy, persisted in its own snapshot
+        # envelope.
+        ring_config_sm = RingConfigStateMachine(
+            on_change=lambda m, r, _ring_id=ring_id: self._on_ring_config_change_for(
+                _ring_id, m, r
+            )
+        )
+        ring_node.log.register_state_machine("ring_sm", ring_config_sm)
+        # Wire the per-ring MembershipStateMachine's on_change so a
+        # committed CONFIG entry on the ring's log triggers a rebuild
+        # of the named HashRing.  Without this, ring policy =
+        # ``"voters"`` would see the ring's voter set change without
+        # the local HashRing reflecting it.
+        ring_node.membership_sm.on_change = lambda voters, learners, _ring_id=ring_id: self._on_ring_membership_change_for(
+            _ring_id, voters, learners
+        )
+        # ``Node.__init__`` ran the snapshot restore for
+        # ``membership_sm`` only.  Replay it now that ``ring_sm`` is
+        # registered so a master that previously hosted this ring
+        # picks up its committed policy from disk instead of starting
+        # at the SM default.
+        try:
+            snap = storage.load_snapshot()
+        except Exception:  # pylint: disable=broad-except
+            snap = None
+        if snap and "data" in snap:
+            ring_node.log.restore_state_machines_from_data(snap["data"])
+
+        # Build peers for this ring: every founder other than self.
+        peers = []
+        for addr in sorted(founding_voters or []):
+            if addr == node_id:
+                continue
+            peers.append(self._make_peer(addr, voting=True, raft_group_id=ring_id))
+        ring_node.peers = peers
+        # Peer factory for membership-change-driven additions.
+        ring_node.register_peer_factory(
+            lambda addr, voting=True, _ring_id=ring_id: self._make_peer(
+                addr, voting=voting, raft_group_id=_ring_id
+            )
+        )
+
+        # Replay any persisted state.  ``SaltStorage`` was loaded by
+        # ``Node.__init__`` already; reconcile fires on_change to
+        # rebuild peer flags.
+        ring_node.reconcile_membership()
+
+        self._nodes[ring_id] = ring_node
+        # Mirror the registration into the dispatcher's routing
+        # table so inbound RPCs tagged with this ``raft_group_id``
+        # land on the new Node.  The dispatcher keeps its own dict
+        # (constructed from a copy at start time) — pushing the
+        # update explicitly keeps the two in sync without coupling
+        # them.
+        self._dispatcher.register_node(ring_id, ring_node)
+
+        ring_node.become_follower()
+
+    def _tear_down_ring(self, ring_id):
+        """
+        Stop the per-ring ``Node`` and drop it from ``self._nodes``.
+        Idempotent.  On-disk state is left in place so an operator
+        who re-creates the ring with the same id and founders can
+        recover historical state.
+        """
+        if ring_id == "cluster":
+            log.warning("RaftService: refusing to tear down the cluster Raft group")
+            return
+        ring_node = self._nodes.pop(ring_id, None)
+        if ring_node is None:
+            return
+        self._dispatcher.unregister_node(ring_id)
+        # Drop the per-process ring snapshot so subsequent
+        # ``owns_for`` calls treat this master as a non-member of the
+        # destroyed ring.
+        import salt.cluster.ring_membership  # pylint: disable=import-outside-toplevel
+
+        salt.cluster.ring_membership.drop_ring(ring_id)
+        log.info("RaftService: tearing down ring %s", ring_id)
+        try:
+            ring_node.become_follower()
+            # Cancel any pending timers stored on the Node; the
+            # shared scheduler will simply not re-arm them since the
+            # Node is no longer in ``self._nodes`` and the heartbeat
+            # tick skips unregistered Nodes.
+            if getattr(ring_node, "_follower_timeout", None):
+                ring_node._follower_timeout.cancel()
+                ring_node._follower_timeout = None
+            if getattr(ring_node, "_leader_beacon_timeout", None):
+                ring_node._leader_beacon_timeout.cancel()
+                ring_node._leader_beacon_timeout = None
+        except Exception:  # pylint: disable=broad-except
+            log.exception("RaftService: error stopping ring %s", ring_id)
+
+    def _on_ring_membership_change_for(self, ring_id, voters, learners):
+        """
+        Called by a per-ring :class:`MembershipStateMachine` after each
+        committed CONFIG entry on the *ring's* log.  Mirrors the
+        cluster-side ``_on_membership_change`` but routes the rebuild
+        to the named ring.  Re-applies the current ring policy so the
+        ``HashRing`` reflects the new voter set.
+        """
+        ring_node = self._nodes.get(ring_id)
+        if ring_node is None:
+            return
+        ring_sm = ring_node.log._extra_state_machines.get("ring_sm")
+        if ring_sm is None:
+            return
+        self._on_ring_config_change_for(ring_id, ring_sm.members, ring_sm.replicas)
+
+    def _on_ring_config_change_for(self, ring_id, members, replicas):
+        """
+        Called by a per-ring :class:`RingConfigStateMachine` after a
+        ``RING_CONFIG`` commit on that ring's own log.
+
+        Rebuilds the named ring's :class:`HashRing` from the per-ring
+        Raft group's committed voter set.  ``"self"`` means the
+        local master is the only ring node (broadcast within the
+        ring); ``"voters"`` means the ring contains every committed
+        voter and the gate sites will hash by ring ownership.
+        """
+        import salt.cluster.ring_membership  # pylint: disable=import-outside-toplevel
+
+        ring_node = self._nodes.get(ring_id)
+        if ring_node is None:
+            log.debug(
+                "RaftService: ring=%s policy commit observed but local "
+                "Node is not up — skipping rebuild",
+                ring_id,
+            )
+            return
+        log.info(
+            "RaftService: ring=%s policy committed — members=%s replicas=%d",
+            ring_id,
             members,
             replicas,
         )
-        self._apply_ring_policy()
+        if members == RING_MEMBERS_VOTERS:
+            voters = ring_node.membership_sm.current_voters()
+            salt.cluster.ring_membership.rebuild(ring_id, voters, replicas=replicas)
+        else:  # RING_MEMBERS_SELF (default)
+            salt.cluster.ring_membership.rebuild(
+                ring_id, [ring_node.node_id], replicas=replicas
+            )
 
-    def _apply_ring_policy(self):
+    def _on_route_change(self, data_type, ring_id):
         """
-        Rebuild the per-process ring from current SM state.
-
-        Resolves ``ring_config_sm.members``:
-
-        * ``"self"`` — ring contains only this master; ``owns`` returns
-          True for every key.  Default; matches today's broadcast.
-        * ``"voters"`` — ring contains the current Raft voter set
-          (``membership_sm.current_voters()``); ``owns`` shards by
-          consistent hash.
-
-        Called from both the membership-change and ring-config-change
-        paths because either can shift the ring's contents under the
-        ``"voters"`` policy.
+        Called by :class:`RoutingStateMachine` after each committed
+        ``ROUTE`` entry.  Updates the process-local routing snapshot
+        consulted by the gate sites in :mod:`salt.master` so a route
+        flip takes effect on every master without IPC.
         """
-        # Lazy import keeps the consensus package independent of the
-        # ring module's load order.
         import salt.cluster.ring_membership  # pylint: disable=import-outside-toplevel
 
-        if self._ring_config_sm.members == RING_MEMBERS_VOTERS:
-            voters = self._node.membership_sm.current_voters()
-            salt.cluster.ring_membership.rebuild(voters)
-        else:  # RING_MEMBERS_SELF (default)
-            # Self-only ring: contains just this master so owns()
-            # answers True for everything.  Empty ring would also do —
-            # we use the explicit single-node form so logs are clear.
-            salt.cluster.ring_membership.rebuild([self._node.node_id])
+        salt.cluster.ring_membership.set_route(data_type, ring_id)
+        if ring_id is None:
+            log.info(
+                "RaftService: route cleared — data_type=%s now broadcasts",
+                data_type,
+            )
+        else:
+            log.info(
+                "RaftService: route committed — data_type=%s -> ring=%s",
+                data_type,
+                ring_id,
+            )
 
-    def propose_ring_config(self, members=None, replicas=None):
+    def propose_ring_create(self, ring_id, founding_voters, status=RING_STATUS_ACTIVE):
         """
-        Propose a RING_CONFIG entry through Raft.
+        Propose a ``RING_REGISTRY`` entry creating (or marking
+        destroyed) the named ring.
 
-        Only valid on the leader; followers will see a future commit
-        once the leader replicates the entry.  Either argument can be
-        omitted to keep the existing value (the SM merges partial
-        updates).
+        Only valid on the leader.  Slice 2 wires the cluster-log
+        replication path; the per-ring Raft group does not actually
+        come up until slice 3 attaches its lifecycle to
+        ``_on_ring_registry_change``.
 
-        :param members: ``"self"`` or ``"voters"`` (or ``None`` to
-                        keep current).
-        :param replicas: integer >= 1 (or ``None`` to keep current).
-        :raises ValueError: if *members* is set to an unknown value.
-        :raises RuntimeError: if this node is not currently the
-                              leader (the entry would not commit).
+        :param ring_id:         Operator-chosen name for the ring.
+        :param founding_voters: List of master node-ids that will be
+                                this ring's initial voter set.  Sorted
+                                deterministically before the entry is
+                                appended.
+        :param status:          ``"active"`` (default) or
+                                ``"destroyed"``.
+
+        :raises ValueError:   if ``ring_id`` is empty or ``status`` is
+                              unknown.
+        :raises RuntimeError: if this node is not currently the leader.
         """
-        if members is not None and members not in (
-            RING_MEMBERS_SELF,
-            RING_MEMBERS_VOTERS,
-        ):
+        if not ring_id:
+            raise ValueError("propose_ring_create requires a non-empty ring_id")
+        if status not in RING_STATUS_VALID:
             raise ValueError(
-                f"Unknown ring members policy {members!r}; "
-                f"expected 'self' or 'voters'"
+                f"Unknown ring status {status!r}; "
+                f"expected one of {RING_STATUS_VALID}"
             )
         if self._node.state != NodeState.LEADER:
             raise RuntimeError(
-                "propose_ring_config must run on the Raft leader; "
+                "propose_ring_create must run on the Raft leader; "
                 f"this node is in state {self._node.state}"
             )
-        cmd = {}
-        if members is not None:
-            cmd["members"] = members
-        if replicas is not None:
-            cmd["replicas"] = int(replicas)
-        if not cmd:
-            return  # no-op
-        self._node.log_add(cmd, entry_type=LogEntryType.RING_CONFIG)
+        founders = sorted(founding_voters or [])
+        cmd = {
+            "ring_id": ring_id,
+            "founding_voters": founders,
+            "status": status,
+        }
+        self._node.log_add(cmd, entry_type=LogEntryType.RING_REGISTRY)
+
+    def propose_ring_destroy(self, ring_id):
+        """
+        Propose a ``RING_REGISTRY`` entry marking *ring_id* as
+        destroyed.  Idempotent at the registry level; the on_change
+        callback decides whether to tear down a per-ring Node based
+        on its previous status.
+
+        The command omits ``founding_voters`` so the registry SM
+        preserves the original founder list as audit history — the
+        operator can still see who founded a ring after it's been
+        destroyed.
+        """
+        if not ring_id:
+            raise ValueError("propose_ring_destroy requires a non-empty ring_id")
+        if self._node.state != NodeState.LEADER:
+            raise RuntimeError(
+                "propose_ring_destroy must run on the Raft leader; "
+                f"this node is in state {self._node.state}"
+            )
+        cmd = {"ring_id": ring_id, "status": RING_STATUS_DESTROYED}
+        self._node.log_add(cmd, entry_type=LogEntryType.RING_REGISTRY)
+
+    def propose_route(self, data_type, ring_id):
+        """
+        Propose a ``ROUTE`` entry mapping *data_type* to *ring_id*.
+
+        Pass ``ring_id=None`` to clear the route, returning the data
+        type to broadcast.  Only valid on the leader.
+
+        :param data_type: Logical cache identifier (e.g. ``"jobs"``).
+        :param ring_id:   Ring name to route to, or ``None`` for
+                          broadcast.
+        :raises ValueError:   if ``data_type`` is empty.
+        :raises RuntimeError: if this node is not currently the leader.
+        """
+        if not data_type:
+            raise ValueError("propose_route requires a non-empty data_type")
+        if self._node.state != NodeState.LEADER:
+            raise RuntimeError(
+                "propose_route must run on the Raft leader; "
+                f"this node is in state {self._node.state}"
+            )
+        cmd = {"data_type": data_type, "ring_id": ring_id}
+        self._node.log_add(cmd, entry_type=LogEntryType.ROUTE)
 
     # ------------------------------------------------------------------
     # Peer factory (used by Node.on_config_change)
     # ------------------------------------------------------------------
 
-    def _make_peer(self, addr, voting=True):
+    def _make_peer(self, addr, voting=True, raft_group_id="cluster"):
         """
         Create a ``SaltPeer`` for *addr*.
 
@@ -284,6 +598,14 @@ class RaftService:
         it is reused; otherwise we create a new one using the cluster port.
         Called by :meth:`Node.on_config_change` when a CONFIG log entry is
         applied and a previously unknown address appears in the voter list.
+
+        :param raft_group_id: Which Raft group this peer belongs to.
+                              Defaults to ``"cluster"`` so the existing
+                              cluster-Node call site is unchanged; per-
+                              ring bring-up passes the ring's id so the
+                              peer stamps every outbound RPC with the
+                              ring's group id (and the dispatcher on the
+                              receiver routes to the right Node).
         """
         import salt.transport.tcp  # pylint: disable=import-outside-toplevel
 
@@ -298,7 +620,13 @@ class RaftService:
             self._peer_pushers[addr] = pusher
             # Keep the dispatcher's pusher table in sync.
             self._dispatcher._pushers[addr] = pusher
-        return SaltPeer(addr, pusher, self.opts["interface"], voting=voting)
+        return SaltPeer(
+            addr,
+            pusher,
+            self.opts["interface"],
+            voting=voting,
+            raft_group_id=raft_group_id,
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -351,24 +679,33 @@ class RaftService:
 
     def _check_voter_health(self):
         """
-        Periodic leader-side watchdog.
+        Periodic leader-side watchdog, run once per scheduled tick
+        across every Raft group hosted in this process (cluster +
+        per-ring).
 
-        For each voting peer, compares its last_contact timestamp against
-        ``cluster_voter_timeout``.  Unhealthy voters are surfaced via a
-        sentinel file (read by the ``cluster.members`` runner) and — if
-        ``cluster_auto_replace_voters`` is True — proposed for demotion.
+        For each group where this master is the current leader: walk
+        the voter set, flag voters whose ``last_contact`` is older
+        than ``cluster_voter_timeout``, and — if
+        ``cluster_auto_replace_voters`` is True — propose a single
+        demotion + replacement promotion per tick (Ongaro thesis §6.4
+        single-server change semantics).
 
-        After a successful demotion, picks the best healthy learner (one
-        whose ``match_index`` is at or past the leader's log index and
-        not in the cooldown window) and proposes promotion-to-replace.
+        Per-group state:
 
-        Safety: relies on ``Node.propose_voter_demotion`` to enforce the
-        ``cluster_min_voters`` floor.  This watchdog never bypasses that.
-        Idempotent on re-entry — if a demotion CONFIG is already in
-        flight, the SM hasn't applied it yet so the demoted peer still
-        looks like a voter; the precondition check inside
-        ``propose_voter_demotion`` (peer must be in current_voters) is
-        the deduplication point.
+        * ``self._recently_demoted`` is keyed by ``(group_id,
+          peer_id)`` so a cooldown on one ring doesn't bleed into
+          another.
+        * The on-disk sentinel ``cachedir/cluster-health.json`` is a
+          structured document with one entry per group — read by
+          ``cluster.members`` for the cluster group; per-ring
+          consumers can pull from the same file via ``rings.<id>``.
+
+        Safety: relies on each ``Node.propose_voter_demotion`` to
+        enforce the ``cluster_min_voters`` floor.  The watchdog
+        never bypasses that.  Idempotent on re-entry — a demotion
+        CONFIG already in flight leaves the demoted peer in
+        ``current_voters`` until commit, so the precondition check
+        inside ``propose_voter_demotion`` deduplicates.
         """
         try:
             self._voter_health_handle = None
@@ -378,73 +715,125 @@ class RaftService:
             auto = self.opts.get("cluster_auto_replace_voters", False)
             min_voters = self.opts.get("cluster_min_voters", 3)
 
-            unhealthy = []
-            if self._node.state == NodeState.LEADER:
-                voters = set(self._node.membership_sm.current_voters())
-                for peer in self._node.peers:
-                    if peer.node_id not in voters:
-                        continue
-                    last = self._node._peer_last_contact.get(peer.node_id)
-                    if last is None:
-                        continue
-                    if now - last > timeout:
-                        unhealthy.append(peer.node_id)
-
-            # Expire cooldown entries.
+            # Expire cooldown entries first so a fresh tick can
+            # promote a candidate that's just exited its cooldown.
             self._recently_demoted = {
-                pid: ts
-                for pid, ts in self._recently_demoted.items()
+                key: ts
+                for key, ts in self._recently_demoted.items()
                 if now - ts < cooldown
             }
 
-            self._write_health_sentinel(unhealthy)
+            per_group_unhealthy = {}
+            for group_id, node in list(self._nodes.items()):
+                if node is None:
+                    continue
+                unhealthy = []
+                if node.state == NodeState.LEADER:
+                    voters = set(node.membership_sm.current_voters())
+                    for peer in node.peers:
+                        if peer.node_id not in voters:
+                            continue
+                        last = node._peer_last_contact.get(peer.node_id)
+                        if last is None:
+                            continue
+                        if now - last > timeout:
+                            unhealthy.append(peer.node_id)
+                per_group_unhealthy[group_id] = unhealthy
 
-            if auto and unhealthy:
-                # One demotion + replacement per tick to honour Ongaro
-                # §6.4 single-server semantics.
+            self._write_health_sentinel(per_group_unhealthy)
+
+            if not auto:
+                return
+
+            for group_id, unhealthy in per_group_unhealthy.items():
+                if not unhealthy:
+                    continue
+                node = self._nodes.get(group_id)
+                if node is None or node.state != NodeState.LEADER:
+                    continue
+                # One demotion + replacement per group per tick.
                 target = unhealthy[0]
-                if self._node.propose_voter_demotion(target, min_voters=min_voters):
-                    self._recently_demoted[target] = now
-                    # Find the best healthy learner to promote in its
-                    # place: caught up, not in cooldown.
-                    learners = self._node.membership_sm.current_learners()
+                if node.propose_voter_demotion(target, min_voters=min_voters):
+                    self._recently_demoted[(group_id, target)] = now
+                    learners = node.membership_sm.current_learners()
                     for candidate in learners:
-                        if candidate in self._recently_demoted:
+                        if (group_id, candidate) in self._recently_demoted:
                             continue
-                        if (
-                            self._node.match_index.get(candidate, -1)
-                            < self._node.log.index
-                        ):
+                        if node.match_index.get(candidate, -1) < node.log.index:
                             continue
-                        self._node.propose_voter_promotion_to_replace(candidate)
+                        node.propose_voter_promotion_to_replace(candidate)
                         break
         except Exception:  # pylint: disable=broad-except
             log.exception("RaftService: voter health check failed")
         finally:
             self._schedule_voter_health_check()
 
-    def _write_health_sentinel(self, unhealthy):
+    def _write_health_sentinel(self, per_group_unhealthy):
         """
-        Persist a small JSON sentinel so the read-only ``cluster.members``
-        runner can surface health state without IPC into this daemon.
+        Persist a structured health sentinel covering every Raft
+        group hosted in this process.
+
+        Shape (a single JSON document at
+        ``cachedir/cluster-health.json``)::
+
+            {
+              "updated_at": <epoch>,
+              "unhealthy_voters": [<cluster_group_unhealthy>, …],
+              "recently_demoted": [<cluster_group_demoted>, …],
+              "rings": {
+                "<ring_id>": {
+                  "unhealthy_voters": […],
+                  "recently_demoted": […],
+                },
+                …
+              }
+            }
+
+        The top-level ``unhealthy_voters`` / ``recently_demoted``
+        fields preserve the pre-multi-ring shape so the
+        ``cluster.members`` runner reads them unchanged.  Per-ring
+        consumers reach into ``rings.<id>`` for the same view per
+        ring.
         """
         import json  # pylint: disable=import-outside-toplevel
         import os  # pylint: disable=import-outside-toplevel
         import time  # pylint: disable=import-outside-toplevel
 
-        import salt.utils.files  # pylint: disable=import-outside-toplevel
+        import salt.utils.atomicfile  # pylint: disable=import-outside-toplevel
 
         cachedir = self.opts.get("cachedir")
         if not cachedir:
             return
         path = os.path.join(cachedir, "cluster-health.json")
+
+        # Split the cooldown table by group for the per-ring view.
+        cooldown_by_group = {}
+        for (group_id, peer_id), _ts in self._recently_demoted.items():
+            cooldown_by_group.setdefault(group_id, []).append(peer_id)
+
+        cluster_unhealthy = per_group_unhealthy.get("cluster", [])
+        cluster_cooldown = cooldown_by_group.get("cluster", [])
+
+        rings = {}
+        for group_id, unhealthy in per_group_unhealthy.items():
+            if group_id == "cluster":
+                continue
+            rings[group_id] = {
+                "unhealthy_voters": sorted(unhealthy),
+                "recently_demoted": sorted(cooldown_by_group.get(group_id, [])),
+            }
+
         body = {
-            "unhealthy_voters": sorted(unhealthy),
-            "recently_demoted": sorted(self._recently_demoted.keys()),
             "updated_at": time.time(),
+            "unhealthy_voters": sorted(cluster_unhealthy),
+            "recently_demoted": sorted(cluster_cooldown),
+            "rings": rings,
         }
+        # Atomic write so the every-N-seconds watchdog rewrite
+        # never overlaps an operator's ``cluster.members`` read on
+        # a torn-mid-write file.
         try:
-            with salt.utils.files.fopen(path, "w") as fp:
+            with salt.utils.atomicfile.atomic_open(path, "w") as fp:
                 json.dump(body, fp)
         except OSError as exc:
             log.warning(
@@ -619,69 +1008,103 @@ class RaftService:
         """
         Called periodically by the event loop.
 
-        If this node is the leader, send an empty AppendEntries to every
-        peer to suppress their election timers.  On the *first* heartbeat
-        after winning an election with an empty log, also commit a founding
-        CONFIG entry so the voter set is durably recorded.
+        Iterates every Raft group hosted in this process — the
+        cluster group plus any per-ring groups — and heartbeats from
+        whichever ones consider themselves leader.  On the *first*
+        heartbeat after winning an election with an empty log,
+        commits a founding CONFIG so the group's voter set is durably
+        recorded.
+
+        A single tick services all groups: each group's heartbeat
+        load scales with peer count; even a master that hosts a dozen
+        rings still issues O(peers) sends per tick.
         """
         try:
-            if self._node.state == NodeState.LEADER:
-                self._maybe_commit_founding_config()
-                for peer in self._node.peers:
+            for ring_id, node in list(self._nodes.items()):
+                if node is None:
+                    continue
+                if node.state != NodeState.LEADER:
+                    continue
+                self._maybe_commit_founding_config(ring_id, node)
+                for peer in node.peers:
                     try:
-                        ni = self._node.next_index.get(
-                            peer.node_id, self._node.log.index + 1
-                        )
-                        # Send a heartbeat (empty) only when the peer is
-                        # caught up.  If it's behind, include the entries so
-                        # it can advance — important for lagging learners.
-                        entries = [] if ni > self._node.log.index else None
-                        self._node.send_append_entries(peer, entries=entries)
+                        ni = node.next_index.get(peer.node_id, node.log.index + 1)
+                        # Send a heartbeat (empty) only when the peer
+                        # is caught up.  If it's behind, include the
+                        # entries so it can advance — important for
+                        # lagging learners.
+                        entries = [] if ni > node.log.index else None
+                        node.send_append_entries(peer, entries=entries)
                     except Exception:  # pylint: disable=broad-except
                         log.exception(
-                            "RaftService: error sending heartbeat to %s",
+                            "RaftService: error sending heartbeat to %s (ring=%s)",
                             peer.node_id,
+                            ring_id,
                         )
         except Exception:  # pylint: disable=broad-except
             log.exception("RaftService: error in heartbeat tick")
         finally:
             self._schedule_heartbeat()
 
-    def _maybe_commit_founding_config(self):
+    def _maybe_commit_founding_config(self, ring_id="cluster", node=None):
         """
-        Propose the initial CONFIG entry when this leader has an empty log.
+        Propose the initial CONFIG entry for *node* when its log is
+        empty.
 
-        This records the founding voter set durably so that a node recovering
-        from storage can reconstruct the cluster membership without relying
-        solely on ``opts["cluster_peers"]``.
+        ``ring_id`` defaults to ``"cluster"`` (and ``node`` to
+        ``self._node``) so the existing ``self._maybe_commit_founding_config()``
+        call sites — heartbeat tick on the cluster Node, the
+        ``notify_peer_joined`` flow — keep working without changes.
+        Per-ring callers (multi-ring heartbeat tick) pass both.
 
-        No-ops if the log already has any entries (founding entry already
-        written, or leader inherited a non-empty log).
+        Records the founding voter set durably so that a node
+        recovering from storage can reconstruct membership without
+        relying solely on ``opts["cluster_peers"]`` (cluster group)
+        or the registry entry (per-ring groups).
+
+        For the cluster group the bootstrap pool comes from
+        ``cluster_peers`` (the static list the operator configured).
+        For a per-ring group it comes from that ring's registry
+        entry on the cluster log, which records the founding voter
+        set chosen by the operator when the ring was created.
+
+        No-ops if the log already has any entries (founding entry
+        already written, or this leader inherited a non-empty log).
         """
-        if self._node.log.index >= 0:
+        if node is None:
+            node = self._node
+        if node.log.index >= 0:
             return
         # Membership already populated (e.g. via state-sync or test
         # seeding) — no need to synthesize a founding CONFIG.
-        if self._node.membership_sm.current_voters():
+        if node.membership_sm.current_voters():
             return
         from salt.cluster.consensus.raft.log import (
             LogEntryType,  # pylint: disable=import-outside-toplevel
         )
 
-        # Deterministic bootstrap pool: sorted set of {this node} ∪ peer
-        # addresses.  Every prospective founder runs this code, but only
-        # the deterministic founder (lowest interface in the pool; see
-        # ``salt/master.py:920`` and ``salt/channel/server.py:2101``)
-        # actually writes the CONFIG.  Tying the founding-voter selection
-        # to the same sort means every node agrees on the partition
-        # regardless of startup order.
-        bootstrap_pool = sorted(
-            {self._node.node_id, *[p.node_id for p in self._node.peers]}
-        )
-        # ``cluster_max_voters`` (default ``None``) caps the founding voter
-        # set.  Excess peers go into the learner set in the same CONFIG
-        # entry so they're still durably registered (see also the
-        # ``notify_peer_joined`` learner-registration path).
+        if ring_id == "cluster":
+            # Deterministic bootstrap pool: sorted set of
+            # {this node} ∪ peer addresses.  Every prospective
+            # founder runs this code, but only the deterministic
+            # founder (lowest interface in the pool; see
+            # ``salt/master.py:920`` and
+            # ``salt/channel/server.py:2101``) actually writes the
+            # CONFIG.
+            bootstrap_pool = sorted({node.node_id, *[p.node_id for p in node.peers]})
+        else:
+            # Per-ring founders come from the registry entry on the
+            # cluster log — the operator-chosen founding voters.
+            registry_entry = self._ring_registry_sm.get(ring_id) or {}
+            bootstrap_pool = sorted(registry_entry.get("founding_voters", []))
+            if not bootstrap_pool:
+                # Registry entry already missing or destroyed — don't
+                # commit a spurious founding CONFIG.
+                return
+
+        # ``cluster_max_voters`` (default ``None``) caps the founding
+        # voter set.  Excess peers go into the learner set in the
+        # same CONFIG entry so they're still durably registered.
         max_voters = self.opts.get("cluster_max_voters")
         if max_voters is not None and len(bootstrap_pool) > max_voters:
             voters = bootstrap_pool[:max_voters]
@@ -690,12 +1113,14 @@ class RaftService:
             voters = bootstrap_pool
             learners = []
         log.info(
-            "RaftService: committing founding CONFIG entry voters=%s learners=%s",
+            "RaftService: committing founding CONFIG entry (ring=%s) "
+            "voters=%s learners=%s",
+            ring_id,
             voters,
             learners,
         )
         try:
-            self._node.log_add(
+            node.log_add(
                 {"voters": voters, "learners": learners},
                 entry_type=LogEntryType.CONFIG,
             )

--- a/salt/cluster/consensus/storage.py
+++ b/salt/cluster/consensus/storage.py
@@ -8,12 +8,18 @@ automatically.
 
 Bank layout::
 
-    cluster/consensus/<node_id>/        — state + snapshot
+    cluster/consensus/<node_id>/<ring_id>/        — state + snapshot
         state     — {"term": int, "voted_for": str|None}
         snapshot  — {"data": base64-str, "index": int, "term": int}
 
-    cluster/consensus/<node_id>/log/    — one cache key per log entry
+    cluster/consensus/<node_id>/<ring_id>/log/    — one cache key per log entry
         <index>   — LogEntry.info() tuple
+
+The ``<ring_id>`` segment exists so multiple Raft groups can coexist
+on the same master.  The default ``"cluster"`` value is the main
+cluster Raft group; named rings (e.g. ``"jobs"``) get their own
+sibling directory and run an independent Raft node out of one Salt
+master process.
 
 Per-entry log keys keep ``append_log`` O(1) on a backend whose store
 primitive is O(1) (mmap_cache).  ``save_log`` (used for truncation and
@@ -50,11 +56,17 @@ class SaltStorage(BaseStorage):
     :param node_id: Raft node identifier (the master's interface address).
     :param opts:    Salt master opts dict — passed straight to
                     :class:`salt.cache.Cache`.
+    :param ring_id: Identifier of the Raft group this storage belongs
+                    to.  ``"cluster"`` (default) is the main cluster
+                    Raft log; per-ring Raft groups pass their ring
+                    name to isolate state on disk.
     """
 
-    def __init__(self, node_id, opts):
-        self._meta_bank = f"cluster/consensus/{node_id}"
-        self._log_bank = f"cluster/consensus/{node_id}/log"
+    def __init__(self, node_id, opts, ring_id="cluster"):
+        self._node_id = node_id
+        self._ring_id = ring_id
+        self._meta_bank = f"cluster/consensus/{node_id}/{ring_id}"
+        self._log_bank = f"cluster/consensus/{node_id}/{ring_id}/log"
         self._cache = salt.cache.Cache(opts)
         # Retained so the localfs fsync helper can resolve the on-disk
         # path of each bank/key.  Cluster Raft consensus is correctness-

--- a/salt/cluster/migration.py
+++ b/salt/cluster/migration.py
@@ -1,0 +1,228 @@
+"""
+Multi-ring migration helpers shared between the runner subprocess
+and the publish daemon.
+
+Both surfaces need the same "drop unowned keys" logic:
+
+* ``salt.runners.cluster.shed_unowned`` runs it from the operator's
+  ``salt-run`` invocation.
+* ``salt.channel.server.MasterPubServerChannel`` runs it on the
+  daemon side when a peer's ``cluster/peer/shed-request`` event
+  arrives (the fan-out path triggered by
+  ``cluster.shed_unowned_all``).
+
+Centralising the implementation here avoids the runner and the
+daemon drifting apart on bank layout, cascade rules, or storage
+replay quirks.  Both call sites pass their own ``__opts__`` dict in
+explicitly so the helper has no loader dependency.
+"""
+
+import logging
+import os
+import time
+
+log = logging.getLogger(__name__)
+
+
+SHED_STATUS_FILENAME = "cluster-shed-status.json"
+
+
+def perform_shed(
+    opts,
+    ring,
+    banks=("jobs/loads", "jobs/minions", "jobs/endtimes", "jobs/nocache"),
+    subbank_template="jobs/returns/{key}",
+    driver=None,
+    dry_run=False,
+):
+    """
+    Drop the cache entries this master no longer owns under *ring*.
+
+    Mirrors the operator-runner contract of
+    ``salt.runners.cluster.shed_unowned`` but takes *opts* as an
+    explicit argument so the publish daemon can call it without the
+    loader's ``__opts__`` injection.
+
+    Returns the same structured dict :func:`shed_unowned` returns
+    (status / dropped / kept / subbanks_dropped / dry_run / ring).
+    A "skipped" status carries a ``reason`` field; an "ok" status
+    means the walk completed.
+    """
+    # Lazy imports — this module is loaded by the runner subprocess
+    # which doesn't always have consensus deps available.
+    import salt.cache  # pylint: disable=import-outside-toplevel
+    from salt.cluster.consensus.raft.log import (  # pylint: disable=import-outside-toplevel
+        RING_STATUS_ACTIVE,
+        Log,
+        LogEntryType,
+        MembershipStateMachine,
+        RingRegistryStateMachine,
+    )
+    from salt.cluster.consensus.storage import (  # pylint: disable=import-outside-toplevel
+        SaltStorage,
+    )
+    from salt.cluster.ring import HashRing  # pylint: disable=import-outside-toplevel
+
+    if not ring:
+        raise ValueError("perform_shed requires a non-empty 'ring'")
+    if not banks:
+        raise ValueError("perform_shed requires at least one bank")
+
+    node_id = opts.get("interface") or opts.get("id") or "unknown"
+
+    # Cluster registry replay — same shape the runner uses.
+    cluster_storage = SaltStorage(node_id, opts, ring_id="cluster")
+    registry_sm = RingRegistryStateMachine()
+    Log(
+        storage=cluster_storage,
+        state_machines={"ring_registry_sm": registry_sm},
+    )
+    for entry in cluster_storage.load_log():
+        if entry.type == LogEntryType.RING_REGISTRY:
+            registry_sm.apply(entry.cmd, index=entry.index)
+    registry_entry = registry_sm.get(ring)
+    if not registry_entry or registry_entry.get("status") != RING_STATUS_ACTIVE:
+        return {
+            "status": "skipped",
+            "reason": f"ring {ring!r} is not active in the registry",
+            "ring": ring,
+            "dropped": 0,
+            "kept": 0,
+            "subbanks_dropped": 0,
+            "dry_run": dry_run,
+        }
+    if node_id not in registry_entry.get("founding_voters", []):
+        return {
+            "status": "skipped",
+            "reason": (
+                f"this master ({node_id}) is not a founding voter of ring {ring!r}"
+            ),
+            "ring": ring,
+            "dropped": 0,
+            "kept": 0,
+            "subbanks_dropped": 0,
+            "dry_run": dry_run,
+        }
+
+    # Per-ring membership replay.
+    ring_storage = SaltStorage(node_id, opts, ring_id=ring)
+    ring_membership_sm = MembershipStateMachine()
+    Log(
+        storage=ring_storage,
+        state_machines={"membership_sm": ring_membership_sm},
+    )
+    for entry in ring_storage.load_log():
+        if entry.type == LogEntryType.CONFIG:
+            ring_membership_sm.apply(entry.cmd, index=entry.index)
+    voters = ring_membership_sm.current_voters() or registry_entry.get(
+        "founding_voters", []
+    )
+    if not voters:
+        return {
+            "status": "skipped",
+            "reason": f"ring {ring!r} has no committed voters yet",
+            "ring": ring,
+            "dropped": 0,
+            "kept": 0,
+            "subbanks_dropped": 0,
+            "dry_run": dry_run,
+        }
+
+    hash_ring = HashRing()
+    hash_ring.rebuild(voters)
+
+    if driver is None:
+        driver = opts.get("cache") or opts.get("keys.cache_driver")
+    cache = salt.cache.Cache(opts, driver=driver)
+
+    primary_bank = banks[0]
+    unowned_primary_keys = []
+    dropped, kept = 0, 0
+    for idx, bank in enumerate(banks):
+        try:
+            keys = list(cache.list(bank))
+        except Exception:  # pylint: disable=broad-except
+            continue
+        for key in keys:
+            if hash_ring.owns(key, node_id):
+                kept += 1
+                continue
+            if idx == 0:
+                unowned_primary_keys.append(key)
+            if not dry_run:
+                try:
+                    cache.flush(bank, key)
+                except Exception:  # pylint: disable=broad-except
+                    continue
+            dropped += 1
+
+    subbanks_dropped = 0
+    if subbank_template and unowned_primary_keys:
+        for key in unowned_primary_keys:
+            subbank = subbank_template.format(key=key)
+            if not dry_run:
+                try:
+                    cache.flush(subbank)
+                except Exception:  # pylint: disable=broad-except
+                    continue
+            subbanks_dropped += 1
+
+    log.info(
+        "perform_shed: ring=%s dropped=%d kept=%d subbanks_dropped=%d "
+        "dry_run=%s (primary_bank=%s)",
+        ring,
+        dropped,
+        kept,
+        subbanks_dropped,
+        dry_run,
+        primary_bank,
+    )
+    return {
+        "status": "ok",
+        "ring": ring,
+        "dropped": dropped,
+        "kept": kept,
+        "subbanks_dropped": subbanks_dropped,
+        "dry_run": dry_run,
+    }
+
+
+def write_shed_status(opts, result, source):
+    """
+    Persist a shed result for ``cluster.shed_status`` to surface.
+
+    *source* explains who triggered the shed:
+
+    * ``"runner"`` — this master ran ``cluster.shed_unowned``
+      directly.
+    * ``"runner_originator"`` — this master is the originator of a
+      ``cluster.shed_unowned_all`` fan-out and ran its local pass.
+    * ``"peer_request"`` — a peer's ``shed-request`` event reached
+      this master.
+
+    The sentinel is rewritten on every shed run.  Operators
+    inspecting it always see the most-recent result.
+
+    Writes are atomic — tmp file + rename — so a concurrent reader
+    or a second writer mid-write never sees a partial JSON document.
+    The bug this fixes: ``shed_unowned_all`` fan-out occasionally
+    arrives twice at the same peer (see the ``self.pushers``
+    duplication note in MULTI_RING_DESIGN.md), and the second write
+    used to overwrite mid-stream and produce invalid JSON.
+    """
+    import json  # pylint: disable=import-outside-toplevel
+
+    import salt.utils.atomicfile  # pylint: disable=import-outside-toplevel
+
+    cachedir = opts.get("cachedir")
+    if not cachedir:
+        return
+    path = os.path.join(cachedir, SHED_STATUS_FILENAME)
+    body = dict(result)
+    body["source"] = source
+    body["updated_at"] = time.time()
+    try:
+        with salt.utils.atomicfile.atomic_open(path, "w") as fp:
+            json.dump(body, fp)
+    except OSError as exc:
+        log.warning("shed-status: failed to write sentinel %s: %s", path, exc)

--- a/salt/cluster/ring_membership.py
+++ b/salt/cluster/ring_membership.py
@@ -1,41 +1,48 @@
 """
 High-level ownership query for cluster-distributed state.
 
-Wraps a per-process :class:`salt.cluster.ring.HashRing` instance with
-the convenience API the rest of the cluster code reaches for:
+Wraps per-process :class:`salt.cluster.ring.HashRing` instances with a
+named-registry API the rest of the cluster code reaches for:
 
-* :func:`owns` — does this master own *key* per the current ring?
-* :func:`rebuild` — replace the ring contents (called from
-  :meth:`salt.cluster.consensus.service.RaftService._on_membership_change`).
-* :func:`get_ring` — escape hatch for tests and diagnostics.
+* :func:`get_ring(name)` — fetch (or lazily create) the named ring.
+* :func:`rebuild(name, voters, replicas=1)` — replace a ring's
+  contents (called from
+  :meth:`salt.cluster.consensus.service.RaftService._on_ring_config_change_for`
+  for per-ring policy commits).
+* :func:`owns_for(opts, data_type, key)` — multi-ring gate: consult
+  the routing table, then ask that ring whether this master owns
+  *key*.
+* :func:`owns(opts, key)` — legacy single-ring gate that targets the
+  ``"cluster"`` named ring.  Pre-multi-ring callers keep working with
+  no changes; new gate sites use :func:`owns_for` instead.
 
-Stage 0 semantics
------------------
-For the initial rollout the ring is **per-process** (a module-level
-singleton) and only ``RaftService`` rebuilds its copy.  Every other
-process (notably ``EventMonitor``, which runs as its own
-``SignalHandlingProcess`` subprocess and does not see the parent's
-membership commits) keeps an *empty* ring.  Because
-:meth:`HashRing.owns` returns ``True`` for an empty ring, every master
-still acts as the owner of every key in those subprocesses.  That
-preserves today's broadcast-fan-out behaviour while putting the gate
-points in code so a future config flip — *not* a code change — can
-turn on real sharding.
+Multi-ring semantics
+--------------------
+For multi-ring deployments each Salt cache has its own
+:class:`HashRing` keyed by a ring name (e.g. ``"jobs"``,
+``"events"``).  ``_RINGS`` is the per-process registry — a subprocess
+inherits the parent's registry at fork time and keeps it for its
+lifetime.  Rings are only rebuilt in the publish daemon (where the
+per-ring Raft groups live); other subprocesses see whatever the
+parent had at fork.
 
-Stage 1 will switch to a process-shared ring driven by a
-``RingConfigStateMachine`` so every subprocess agrees on the
-authoritative ring.  At that point the call sites here do not need to
-change; only the underlying transport for ring state does.
+Routing
+-------
+``_ROUTING`` is a per-process snapshot of the cluster-log
+:class:`RoutingStateMachine` (data_type -> ring_id-or-None).
+Populated by ``RaftService`` on each committed ``ROUTE`` entry so
+gate sites can decide quickly without IPC.  A data type with no
+routing entry is broadcast — every master keeps acting as the owner.
 
 Why not pass a ring instance everywhere
 ---------------------------------------
-The receivers we gate (``EventMonitor.handle_event`` at master.py:1149-
-1197) live across a ``SignalHandlingProcess`` boundary from the place
-that owns Raft membership (``RaftService`` inside the publish daemon).
-A single instance can't be smuggled across a fork without a shared-
-memory backing store.  A module-level singleton per process is the
-smallest abstraction that survives both the current shape and the
-stage-1 swap.
+The receivers we gate (``EventMonitor.handle_event`` at master.py)
+live across a ``SignalHandlingProcess`` boundary from the place that
+owns Raft membership (``RaftService`` inside the publish daemon).  A
+single instance can't be smuggled across a fork without a shared-
+memory backing store.  A module-level registry per process is the
+smallest abstraction that survives both the current shape and any
+future move to a shared-memory ring.
 """
 
 import logging
@@ -46,71 +53,289 @@ from salt.cluster.ring import HashRing
 log = logging.getLogger(__name__)
 
 
-# Per-process singleton.  Module load creates an empty ring; only
-# RaftService.rebuild() populates it.  A subprocess inherits the empty
-# ring at fork time and keeps it empty for its lifetime in stage 0.
-_PROCESS_RING = HashRing()
+# Per-process registry of named rings.  Module load creates an empty
+# dict; ``RaftService`` populates entries as rings come up.  A
+# subprocess inherits this dict at fork time.
+_RINGS = {}
+
+# Per-process routing snapshot: data_type -> ring_id or None.  ``None``
+# (or a missing entry) means broadcast — every master is the owner
+# for that data type.
+_ROUTING = {}
+
 _LOCK = threading.RLock()
 
 
-def get_ring():
+# The canonical name for the legacy single-ring path so pre-multi-ring
+# callers of ``owns(opts, key)`` route to a stable place.
+DEFAULT_RING = "cluster"
+
+
+def get_ring(name=DEFAULT_RING):
     """
-    Return this process's :class:`HashRing` singleton.
+    Return this process's :class:`HashRing` for the named ring.
 
-    Use only from code that needs ring-internals (diagnostics, tests).
-    Production call sites should prefer :func:`owns` so the ownership
-    decision flows through one place.
+    Creates an empty ring on first reference so callers never have to
+    null-check.  Use only from code that needs ring-internals
+    (diagnostics, tests).  Production call sites should prefer
+    :func:`owns_for` so the ownership decision flows through one
+    place.
     """
-    return _PROCESS_RING
+    with _LOCK:
+        ring = _RINGS.get(name)
+        if ring is None:
+            ring = HashRing()
+            _RINGS[name] = ring
+        return ring
 
 
-def owns(opts, key):
+def owns(opts, key, ring=DEFAULT_RING):
     """
     Return ``True`` if this master should process *key* locally.
 
     *opts* must carry ``"interface"`` — the cluster-wide node identity
-    matching :func:`rebuild`'s input and ``cluster_peers``.
+    matching :func:`rebuild`'s input and ``cluster_peers``.  *ring* is
+    the name of the ring to consult (defaults to the legacy
+    ``"cluster"`` ring so pre-multi-ring call sites keep working).
 
-    Stage 0: the ring is empty in any process that did not call
-    :func:`rebuild` (which is currently only ``RaftService``).  An
-    empty ring's :meth:`HashRing.owns` returns ``True`` for every key,
-    so behaviour is unchanged from the pre-ring code path.
+    Empty rings answer ``True`` for every key, so a master that has
+    not had its ring populated (subprocess pre-fork, or one without a
+    routing entry) keeps the broadcast behaviour.
     """
     node_id = opts.get("interface")
     if node_id is None:
-        # Defensive: opts without an interface (some test fixtures) act
-        # as a standalone master — own everything.
+        # Defensive: opts without an interface (some test fixtures)
+        # act as a standalone master — own everything.
         return True
-    return _PROCESS_RING.owns(key, node_id)
+    return get_ring(ring).owns(key, node_id)
 
 
-def rebuild(voters):
+def owns_for(opts, data_type, key):
     """
-    Replace the process ring's contents with *voters*.
+    Multi-ring ownership gate.
 
-    Called from :meth:`RaftService._on_membership_change` after every
-    committed CONFIG entry.  Idempotent: rebuilding to the same voter
-    set is cheap and emits no spurious log noise beyond ``HashRing``'s
-    own info-level "rebuilt with N node(s)" message.
+    Consults the routing table for *data_type*:
+
+    * No entry, or entry mapping to ``None``: broadcast — every
+      master owns everything (returns ``True``).
+    * Entry maps to a ring this master *does not* host locally:
+      returns ``False``.  Per the design the operator must arrange
+      for traffic to reach a ring member; non-members no-op writes.
+    * Entry maps to a ring this master hosts: defers to that ring's
+      :meth:`HashRing.owns` answer.
+
+    Used by gate sites in :mod:`salt.master` to decide whether to
+    persist a job/event/etc. write locally.
+
+    When the answer is ``False`` because this master isn't a ring
+    member, the call increments a per-(data_type, ring) drop counter
+    surfaced via :func:`drop_stats` so operators can detect a
+    misconfigured load balancer — i.e. traffic for a routed data
+    type landing on masters that aren't in the ring.
+    """
+    ring_id = _ROUTING.get(data_type)
+    if ring_id is None:
+        return True  # broadcast
+    with _LOCK:
+        ring = _RINGS.get(ring_id)
+    if ring is None or not ring.nodes():
+        # This master is not in the ring (no local Node) or the ring
+        # is still empty.  Non-member masters no-op writes for routed
+        # data — the operator is expected to route traffic at the
+        # load balancer.  Count the drop so a misconfig is visible.
+        _record_drop(data_type, ring_id, "not_a_member")
+        return False
+    node_id = opts.get("interface")
+    if node_id is None:
+        return True
+    if ring.owns(key, node_id):
+        return True
+    # Owned by some other ring member.  This is the expected sharding
+    # path, not a misconfig — counted separately so operators can
+    # tell shedding from drops.
+    _record_drop(data_type, ring_id, "other_ring_member")
+    return False
+
+
+# Per-process drop counters — populated by ``owns_for`` when it
+# answers False, queried by the ``cluster.routes`` runner so
+# operators can spot misconfigured routing without tailing logs.
+# Keyed by ``(data_type, ring_id, reason)``; reason is
+# "not_a_member" (this master isn't in the named ring at all) or
+# "other_ring_member" (the key hashed to a sibling — expected
+# under sharded routing, included for completeness).
+_DROP_STATS = {}
+
+
+def _record_drop(data_type, ring_id, reason):
+    """
+    Bump the drop counter for the given (data_type, ring, reason) bucket
+    and emit a rate-limited log line so a misconfigured deployment is
+    visible in the master log without operator intervention.
+
+    Rate limit: one log line per (data_type, ring_id, reason) bucket
+    every ``_DROP_LOG_RATE_SECONDS`` (60s default).  Counters keep
+    advancing on every drop; the log line carries the cumulative
+    count so an operator scanning logs can see the magnitude even
+    between rate-limited windows.
+
+    Only the ``not_a_member`` reason logs at WARNING — that's the
+    misconfig signal.  ``other_ring_member`` is the expected
+    sharded-traffic path and would drown out the warning, so it's
+    counter-only.
+    """
+    import time  # pylint: disable=import-outside-toplevel
+
+    key = (data_type, ring_id, reason)
+    now = time.monotonic()
+    log_now = False
+    count = 0
+    with _LOCK:
+        _DROP_STATS[key] = _DROP_STATS.get(key, 0) + 1
+        count = _DROP_STATS[key]
+        if reason == "not_a_member":
+            last = _DROP_LAST_LOG.get(key, 0.0)
+            if now - last >= _DROP_LOG_RATE_SECONDS:
+                _DROP_LAST_LOG[key] = now
+                log_now = True
+    if log_now:
+        log.warning(
+            "ring_membership: dropping %s write — this master is not in "
+            "ring %r (count=%d).  Operator likely needs to route traffic "
+            "for data_type=%s to a ring member.",
+            data_type,
+            ring_id,
+            count,
+            data_type,
+        )
+
+
+# Rate-limit knob.  60 s is fast enough for an operator running a
+# checklist to spot the warning, slow enough that a busy master
+# under sustained misrouting doesn't spam the log.
+_DROP_LOG_RATE_SECONDS = 60.0
+
+# Last-log-time tracking, parallel to _DROP_STATS but consumed by
+# the rate limiter, not the operator surface.
+_DROP_LAST_LOG = {}
+
+
+def drop_stats():
+    """
+    Return a snapshot of the per-process drop counters.
+
+    Shape::
+
+        {
+            "<data_type>": {
+                "ring_id": "<ring_id>",
+                "not_a_member": int,
+                "other_ring_member": int,
+            },
+            ...
+        }
+
+    ``not_a_member`` is the field operators should care about — a
+    rising count means traffic for a routed data type is landing on
+    masters that aren't in the ring.  ``other_ring_member`` is
+    expected to rise steadily under sharded routing and isn't a
+    misconfig signal on its own.
+    """
+    with _LOCK:
+        snapshot = dict(_DROP_STATS)
+    result = {}
+    for (data_type, ring_id, reason), count in snapshot.items():
+        bucket = result.setdefault(
+            data_type,
+            {"ring_id": ring_id, "not_a_member": 0, "other_ring_member": 0},
+        )
+        bucket[reason] = count
+    return result
+
+
+def rebuild(name_or_voters, voters=None, replicas=1):
+    """
+    Replace the named ring's contents.
+
+    Two call shapes:
+
+    * ``rebuild(voters)`` (legacy single-ring) — targets the
+      ``"cluster"`` ring for backward compatibility.
+    * ``rebuild(name, voters, replicas=N)`` (multi-ring) — names the
+      ring explicitly.
+
+    Idempotent: rebuilding to the same voter set is cheap and emits
+    no spurious log noise.
 
     *voters* is the committed voter list — learners are excluded
     because they don't yet hold replica state to be the canonical
-    owner of anything.  When the ring policy later allows
-    learner-as-replica, this function will grow a ``learners`` arg.
+    owner of anything.
+    """
+    if voters is None:
+        # Legacy shape: rebuild(voters_list)
+        name = DEFAULT_RING
+        voters_list = name_or_voters
+    else:
+        name = name_or_voters
+        voters_list = voters
+    with _LOCK:
+        ring = _RINGS.get(name)
+        if ring is None:
+            ring = HashRing(replicas=replicas)
+            _RINGS[name] = ring
+        elif replicas != ring._replicas:
+            # Replica count changed — rebuild a new ring instead of
+            # silently keeping the old factor.
+            ring = HashRing(replicas=replicas)
+            _RINGS[name] = ring
+        ring.rebuild(voters_list)
+
+
+def set_route(data_type, ring_id):
+    """
+    Update the per-process routing snapshot.
+
+    Called by ``RaftService`` after each committed ``ROUTE`` entry so
+    gate sites in this process see the new mapping without IPC.  Set
+    *ring_id* to ``None`` to clear the route (broadcast).
     """
     with _LOCK:
-        _PROCESS_RING.rebuild(voters)
+        if ring_id is None:
+            _ROUTING.pop(data_type, None)
+        else:
+            _ROUTING[data_type] = ring_id
+
+
+def get_routes():
+    """
+    Return a copy of the per-process routing snapshot.  Diagnostic /
+    test helper.
+    """
+    with _LOCK:
+        return dict(_ROUTING)
+
+
+def drop_ring(name):
+    """
+    Remove the named ring from the registry.  Called when ``RaftService``
+    tears down a per-ring Raft group so subsequent ``owns_for`` calls
+    treat this master as a non-member of the destroyed ring.
+    """
+    with _LOCK:
+        _RINGS.pop(name, None)
 
 
 def reset():
     """
-    Replace the process ring with a fresh empty one.
+    Replace the registry with a fresh empty one.
 
     Test-only escape hatch — production code never calls this.  Pytest
     fixtures that build and tear down a cluster within the same
-    process need to reset the ring between tests so leftover voters
-    from one test don't bleed into the next.
+    process need to reset the registry between tests so leftover
+    voters from one test don't bleed into the next.
     """
-    global _PROCESS_RING  # pylint: disable=global-statement
     with _LOCK:
-        _PROCESS_RING = HashRing()
+        _RINGS.clear()
+        _ROUTING.clear()
+        _DROP_STATS.clear()
+        _DROP_LAST_LOG.clear()

--- a/salt/cluster/state_sync.py
+++ b/salt/cluster/state_sync.py
@@ -72,6 +72,27 @@ DENIED_CHANNEL = "denied_keys"
 FILE_ROOTS_CHANNEL = "file_roots"
 PILLAR_ROOTS_CHANNEL = "pillar_roots"
 
+# Channel prefix for arbitrary cache banks (multi-ring migration).  A
+# channel string ``"bank:jobs/loads"`` names the cache bank that
+# carries the payload; the receiver routes by prefix to
+# :func:`install_bank_chunk`.  Used by
+# ``cluster.collect_from_peers`` for caches other than the four
+# join-time channels above.
+BANK_CHANNEL_PREFIX = "bank:"
+
+
+def bank_channel(bank):
+    """Return the wire channel name for *bank*."""
+    return f"{BANK_CHANNEL_PREFIX}{bank}"
+
+
+def bank_from_channel(channel):
+    """Return the bank name a ``bank:`` channel was made from, or None."""
+    if not channel or not channel.startswith(BANK_CHANNEL_PREFIX):
+        return None
+    return channel[len(BANK_CHANNEL_PREFIX) :]
+
+
 ALL_CHANNELS = (
     KEYS_CHANNEL,
     DENIED_CHANNEL,
@@ -116,15 +137,22 @@ def _by_count(items, n):
         yield chunk
 
 
-def iter_keys_chunks(opts, channel, count=DEFAULT_KEY_CHUNK_COUNT):
+def iter_keys_chunks(opts, channel, count=DEFAULT_KEY_CHUNK_COUNT, key_filter=None):
     """
     Yield ``items`` lists for the ``keys`` or ``denied_keys`` channel.
 
     Each item is ``{"id": minion_id, "value": cache_value}`` — a
     self-contained record the receiver hands straight to ``cache.store``.
 
-    A bank with no entries still yields one empty list so the caller can
-    emit a single eof chunk.
+    A bank with no entries (or whose entries are all filtered out) still
+    yields one empty list so the caller can emit a single eof chunk.
+
+    :param key_filter: Optional ``callable(minion_id) -> bool``.  When
+                       present, only entries whose id passes the
+                       filter are emitted.  Used by the multi-ring
+                       ``cluster.collect_from_peers`` runner so a peer
+                       only sends back the keys the requester asked
+                       for, rather than its entire bank.
     """
     if channel not in (KEYS_CHANNEL, DENIED_CHANNEL):
         raise ValueError(f"iter_keys_chunks: unsupported channel {channel!r}")
@@ -133,7 +161,10 @@ def iter_keys_chunks(opts, channel, count=DEFAULT_KEY_CHUNK_COUNT):
         dump = cache.list_all(channel, include_data=True)
     except (AttributeError, salt.exceptions.SaltCacheError):
         dump = {}
-    items = [{"id": mid, "value": value} for mid, value in (dump or {}).items()]
+    pairs = list((dump or {}).items())
+    if key_filter is not None:
+        pairs = [(mid, value) for mid, value in pairs if key_filter(mid)]
+    items = [{"id": mid, "value": value} for mid, value in pairs]
     if not items:
         yield []
         return
@@ -188,6 +219,48 @@ def iter_root_chunks(roots_map, byte_budget=DEFAULT_ROOTS_CHUNK_BYTES):
         yield chunk
 
 
+def iter_bank_chunks(opts, bank, count=DEFAULT_KEY_CHUNK_COUNT, key_filter=None):
+    """
+    Yield ``items`` lists for an arbitrary :class:`salt.cache.Cache`
+    bank.
+
+    Each item is ``{"key": str, "value": any}`` — the bank name is
+    carried separately in the wire channel
+    (``BANK_CHANNEL_PREFIX + bank``) so a single channel maps to a
+    single bank on the receiver.
+
+    Used by :func:`salt.runners.cluster.collect_from_peers` to pull
+    arbitrary operator-routed caches (e.g. the salt_cache returner's
+    ``jobs/loads``) from peers.  Mirrors :func:`iter_keys_chunks`'s
+    contract: an empty bank still yields a single empty list so the
+    eof flag fires uniformly.
+    """
+    cache_driver = opts.get("cache") or opts.get("keys.cache_driver")
+    cache = salt.cache.Cache(opts, driver=cache_driver)
+    pairs = []
+    try:
+        # Prefer the bulk list_all interface — drivers that implement
+        # it avoid the N+1 fetch.
+        dump = cache.list_all(bank, include_data=True)
+        pairs = list((dump or {}).items())
+    except (AttributeError, salt.exceptions.SaltCacheError):
+        # Fallback for drivers that don't expose list_all (e.g.
+        # custom plugin caches).
+        try:
+            for key in cache.list(bank):
+                value = cache.fetch(bank, key)
+                pairs.append((key, value))
+        except salt.exceptions.SaltCacheError:
+            pairs = []
+    if key_filter is not None:
+        pairs = [(k, v) for k, v in pairs if key_filter(k)]
+    items = [{"key": k, "value": v} for k, v in pairs]
+    if not items:
+        yield []
+        return
+    yield from _by_count(items, count)
+
+
 # ---------------------------------------------------------------------------
 # Receiver-side: install one chunk
 # ---------------------------------------------------------------------------
@@ -215,6 +288,38 @@ def install_keys_chunk(opts, channel, items):
             written += 1
         except Exception:  # pylint: disable=broad-except
             log.exception("state-sync: failed to install %s entry for %s", channel, mid)
+    return written
+
+
+def install_bank_chunk(opts, bank, items):
+    """
+    Apply a single chunk of generic bank entries.
+
+    Each item is ``{"key": str, "value": any}``; the receiver writes
+    via ``cache.store(bank, key, value)``.  Idempotent — receiving
+    the same chunk twice overwrites but doesn't break.  Returns the
+    number of entries successfully written.
+    """
+    if not bank:
+        raise ValueError("install_bank_chunk: bank is required")
+    cache_driver = opts.get("cache") or opts.get("keys.cache_driver")
+    cache = salt.cache.Cache(opts, driver=cache_driver)
+    written = 0
+    for entry in items or []:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get("key")
+        if key is None:
+            continue
+        try:
+            cache.store(bank, key, entry.get("value"))
+            written += 1
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "state-sync: failed to install %s/%s",
+                bank,
+                key,
+            )
     return written
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1251,32 +1251,46 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
             # local job cache so any CLI on this master can later look
             # up the jid without sharing ``cachedir``.
             #
-            # Stage 0 ring gating: ``ring_membership.owns(opts, jid)`` is
-            # the durable hook a future ring config flip will use to
-            # shard job state.  In stage 0 the per-process ring stays
-            # empty in this subprocess, so ``owns`` returns ``True`` and
-            # we mirror everything (today's behaviour).
+            # Multi-ring gating: ``owns_for(opts, "jobs", jid)``
+            # consults the cluster-log routing snapshot.  No routing
+            # entry == broadcast (today's behaviour, every master
+            # mirrors).  A route to a ring this master hosts defers
+            # to that ring's consistent hash; routed-to-a-ring-this-
+            # master-is-not-in returns False so non-members no-op
+            # the write.  Delegate-on-miss: when the drop happens
+            # AND we know the ring owner's address, forward the
+            # write to that owner so a misconfigured topology
+            # doesn't silently lose data.
             peer_id = data.pop("__peer_id", None)
             if peer_id and self.opts.get("cluster_id"):
                 jid = data.get("jid")
                 minions = data.get("minions") or []
-                if jid and salt.cluster.ring_membership.owns(self.opts, jid):
+                if jid and salt.cluster.ring_membership.owns_for(
+                    self.opts, "jobs", jid
+                ):
                     try:
                         salt.utils.job.store_minions(self.opts, jid, minions)
                     except Exception:  # pylint: disable=broad-except
                         log.exception("Failed to mirror peer job submission %s", jid)
+                elif jid:
+                    self._delegate_on_miss(
+                        "jobs", jid, "store_minions", {"jid": jid, "minions": minions}
+                    )
         elif tag.startswith("salt/job") and "/ret/" in tag:
             # Cluster replication of job returns: minion responded to a
             # peer master; persist the return into our local cache so a
             # CLI on this master can deliver it to the user.
             #
-            # Same ring-gating as the /new branch above.  Once stage 1
-            # ships, the ring will only let the jid's owner write the
-            # return; today every master writes every return.
+            # Same multi-ring gating as the /new branch above.  Once
+            # the operator routes ``"jobs"`` to a ring, only ring
+            # owners persist the return locally; today (no routing
+            # entry) every master writes every return.  Delegate-on-
+            # miss forwards the write to the owner when this master
+            # isn't a ring member.
             peer_id = data.pop("__peer_id", None)
             if peer_id and self.opts.get("cluster_id"):
                 jid = data.get("jid")
-                if salt.cluster.ring_membership.owns(self.opts, jid):
+                if salt.cluster.ring_membership.owns_for(self.opts, "jobs", jid):
                     try:
                         salt.utils.job.store_job(self.opts, data)
                     except Exception:  # pylint: disable=broad-except
@@ -1284,6 +1298,8 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
                             "Failed to mirror peer job return for jid %s",
                             jid,
                         )
+                elif jid:
+                    self._delegate_on_miss("jobs", jid, "store_job", dict(data))
         elif tag.startswith("salt/key"):
             # Replicate accepted/rejected/denied/deleted minion key state
             # across the cluster.  When a minion's key state changes on one
@@ -1328,6 +1344,74 @@ class EventMonitor(salt.utils.process.SignalHandlingProcess):
         "reject": "rejected",
         "pend": "pending",
     }
+
+    def _delegate_on_miss(self, data_type, key, write_kind, payload):
+        """
+        Delegate a routed write this master doesn't own to the ring
+        owner.
+
+        When :func:`salt.cluster.ring_membership.owns_for` answers
+        ``False`` because this master isn't a ring member (or the
+        key hashes to a sibling), the cluster bus has already
+        replicated the same event to every cluster peer including
+        the owner.  Under symmetric cluster topology the owner
+        already wrote — this delegate is a safety net for asymmetric
+        topologies where the bus event might not reach the owner.
+
+        Fires a local salt event ``cluster/runner/delegate_write``
+        that the publish daemon picks up and forwards as a cluster-
+        AES-encrypted ``cluster/peer/delegate-write`` event targeted
+        at the named ring's current owner.
+
+        :param data_type:  Logical cache identifier
+                           (e.g. ``"jobs"``).
+        :param key:        The key whose ownership determines the
+                           owner (typically the JID).
+        :param write_kind: ``"store_minions"`` or ``"store_job"`` —
+                           the receiver dispatches based on this.
+        :param payload:    Opaque dict the receiver applies via the
+                           appropriate returner function.
+        """
+        import salt.utils.event  # pylint: disable=import-outside-toplevel
+
+        ring_id = salt.cluster.ring_membership.get_routes().get(data_type)
+        if not ring_id:
+            # No routing for this data_type — owns_for would have
+            # returned True (broadcast) and we wouldn't have ended
+            # up here.  Defensive skip.
+            return
+        ring = salt.cluster.ring_membership.get_ring(ring_id)
+        owner = None
+        if ring and ring.nodes():
+            try:
+                owner = ring.get_owner(key)
+            except Exception:  # pylint: disable=broad-except
+                owner = None
+        if not owner or owner == self.opts.get("interface"):
+            # No reachable owner, or we ARE the owner (shouldn't
+            # happen — owns_for would have returned True).  Drop
+            # silently; ``drop_stats`` already counted this.
+            return
+        try:
+            with salt.utils.event.get_event(
+                "master", sock_dir=self.opts["sock_dir"], opts=self.opts, listen=False
+            ) as event:
+                event.fire_event(
+                    {
+                        "data_type": data_type,
+                        "ring_id": ring_id,
+                        "owner": owner,
+                        "write_kind": write_kind,
+                        "payload": payload,
+                    },
+                    "cluster/runner/delegate_write",
+                )
+        except Exception:  # pylint: disable=broad-except
+            log.exception(
+                "delegate-on-miss: failed to fire delegate event for %s/%s",
+                data_type,
+                key,
+            )
 
     def _apply_peer_key_change(self, act, minion_id, pub):
         """

--- a/salt/returners/salt_cache.py
+++ b/salt/returners/salt_cache.py
@@ -1,0 +1,394 @@
+"""
+Job-cache returner backed by ``salt.cache.Cache``.
+
+A drop-in replacement for the default ``local_cache`` returner that
+routes every read and write through the :class:`salt.cache.Cache`
+abstraction.  This unlocks two operational capabilities the default
+returner does not provide:
+
+* **Pluggable storage.**  Whichever ``cache:`` driver the operator
+  configures (``localfs``, ``mmap_cache``, ``redis``, …) is what
+  backs the job cache.  ``master_job_cache: salt_cache`` plus
+  ``cache: mmap_cache`` gives an mmap-backed job cache.
+
+* **Multi-ring sharding.**  Because every entry flows through one
+  ``salt.cache.Cache`` instance, the cluster's
+  :func:`salt.cluster.ring_membership.owns_for` gate can shard job
+  state across ring members, and the
+  :func:`salt.runners.cluster.shed_unowned` /
+  :func:`salt.runners.cluster.collect_from_peers` runners can
+  enumerate and move data.
+
+Bank layout
+-----------
+
+Each JID's state is spread across a small set of banks so per-JID
+operations are atomic and ring ownership maps cleanly to a single
+key per JID at the routing layer:
+
+* ``jobs/loads`` -- key=jid -> pub load dict
+* ``jobs/minions`` -- key=jid -> sorted list of minion ids
+* ``jobs/returns/<jid>`` -- key=minion_id -> ``{return, retcode, success, out}``
+* ``jobs/endtimes`` -- key=jid -> epoch seconds (only when
+  ``job_cache_store_endtime`` is set)
+* ``jobs/nocache`` -- key=jid -> True (job-was-fired-with-nocache marker)
+
+The ``jobs/<jid>`` granularity is what the ring sites consult: the
+gate at ``salt/master.py`` calls
+``ring_membership.owns_for(opts, "jobs", jid)`` and only persists
+when this master owns the JID.
+
+Compatibility
+-------------
+
+API-compatible with ``local_cache`` for every function ``Salt`` calls
+through the returner interface (``prep_jid``, ``returner``,
+``save_load``, ``save_minions``, ``get_load``, ``get_jid``,
+``get_jids``, ``get_jids_filter``, ``clean_old_jobs``,
+``update_endtime``, ``get_endtime``).  The on-disk layout differs
+from ``local_cache`` — operators migrating need to either drain
+existing jobs or run the migration runners on the old data.
+
+Configuration
+-------------
+
+.. code-block:: yaml
+
+    master_job_cache: salt_cache
+    cache: mmap_cache         # or localfs, redis_cache, ...
+
+When ``mmap_cache`` is used, ``mmap_cache_max_segment_bytes`` /
+``mmap_cache_dirs`` apply as usual.
+"""
+
+import logging
+import time
+
+import salt.cache
+import salt.exceptions
+import salt.utils.jid
+import salt.utils.job
+import salt.utils.minions
+
+log = logging.getLogger(__name__)
+
+
+# Bank names — single source of truth so a future refactor can move
+# them without grepping the whole file.
+_BANK_LOADS = "jobs/loads"
+_BANK_MINIONS = "jobs/minions"
+_BANK_RETURNS_FMT = "jobs/returns/{jid}"
+_BANK_ENDTIMES = "jobs/endtimes"
+_BANK_NOCACHE = "jobs/nocache"
+
+
+def _cache():
+    """
+    Build a :class:`salt.cache.Cache` from ``__opts__``.
+
+    The driver is whatever the operator set in ``cache:`` (default
+    ``localfs``).  Returners get a fresh ``__opts__`` per call from
+    the loader, so a per-call construction is the simplest correct
+    shape — caching the instance would risk a stale driver if opts
+    were reloaded mid-process.
+    """
+    return salt.cache.Cache(__opts__)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks called by the master
+# ---------------------------------------------------------------------------
+
+
+def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
+    """
+    Return a job id and record any pre-flight state for it.
+
+    Mirrors ``local_cache.prep_jid``:
+
+    * If *passed_jid* is supplied (e.g. by ``salt-call --jid …`` or a
+      syndic), use it.  Otherwise generate one via
+      :func:`salt.utils.jid.gen_jid`.
+    * On collision (an existing ``jobs/loads`` key with the same id)
+      generate a new one, up to 5 retries.  Operators who hit the
+      retry cap have a deeper clock-skew problem the returner
+      shouldn't paper over.
+    * When *nocache* is set, write a marker so :func:`returner`
+      knows to short-circuit subsequent minion returns.
+    """
+    if recurse_count >= 5:
+        raise salt.exceptions.SaltCacheError(
+            f"prep_jid could not store a jid after {recurse_count} tries."
+        )
+    jid = passed_jid if passed_jid else salt.utils.jid.gen_jid(__opts__)
+    cache = _cache()
+    if not passed_jid and cache.contains(_BANK_LOADS, jid):
+        # Collision — retry with a fresh jid.
+        return prep_jid(
+            nocache=nocache, passed_jid=None, recurse_count=recurse_count + 1
+        )
+    if nocache:
+        cache.store(_BANK_NOCACHE, jid, True)
+    return jid
+
+
+def returner(load):
+    """
+    Persist one minion return for a JID.
+
+    Idempotency: a second return from the same minion for the same
+    jid is treated as a replay attempt and dropped (mirrors
+    ``local_cache``'s ``EEXIST`` branch).  Returning ``False`` lets
+    the master's reactor flag the event.
+    """
+    if load["jid"] == "req":
+        load["jid"] = prep_jid(nocache=load.get("nocache", False))
+
+    cache = _cache()
+    jid = load["jid"]
+
+    if cache.contains(_BANK_NOCACHE, jid):
+        # Job was fired with nocache=True — drop the return silently.
+        return
+
+    returns_bank = _BANK_RETURNS_FMT.format(jid=jid)
+    if cache.contains(returns_bank, load["id"]):
+        log.error(
+            "An extra return was detected from minion %s, please verify "
+            "the minion, this could be a replay attack",
+            load["id"],
+        )
+        return False
+
+    record = {key: load[key] for key in ("return", "retcode", "success") if key in load}
+    if "out" in load:
+        record["out"] = load["out"]
+    cache.store(returns_bank, load["id"], record)
+    return None
+
+
+def save_load(jid, clear_load, minions=None, recurse_count=0):
+    """
+    Persist the pub load (``tgt``, ``fun``, ``arg``, …) for a JID.
+
+    If the load carries a ``tgt`` we compute the matched minion set
+    here (unless the caller supplied one) and pass it to
+    :func:`save_minions`.  The minion set is what
+    ``get_load()`` later exposes as ``Minions`` to the UI.
+    """
+    if recurse_count >= 5:
+        raise salt.exceptions.SaltCacheError(
+            f"save_load could not write job load after {recurse_count} retries."
+        )
+    cache = _cache()
+    try:
+        cache.store(_BANK_LOADS, jid, clear_load)
+    except salt.exceptions.SaltCacheError as exc:
+        # localfs occasionally races on the dir-create step; mirror
+        # local_cache's tiny retry rather than failing the publish.
+        log.warning("Could not write job invocation cache entry: %s", exc)
+        time.sleep(0.1)
+        return save_load(
+            jid=jid, clear_load=clear_load, recurse_count=recurse_count + 1
+        )
+
+    if "tgt" in clear_load and clear_load["tgt"]:
+        if minions is None:
+            ckminions = salt.utils.minions.CkMinions(__opts__)
+            _res = ckminions.check_minions(
+                clear_load["tgt"], clear_load.get("tgt_type", "glob")
+            )
+            minions = _res["minions"]
+        save_minions(jid, minions)
+
+
+def save_minions(jid, minions, syndic_id=None):
+    """
+    Store the list of matched minions for a JID.
+
+    Merge with any previously-saved list so syndic-master appends
+    don't clobber the main-master record (mirrors
+    ``local_cache.save_minions``).  ``syndic_id`` is accepted for
+    API compatibility but folded into the same merged list; the
+    distinction is preserved on-disk in ``local_cache`` only because
+    its file naming scheme uses it for routing.
+    """
+    minions = list(minions or [])
+    cache = _cache()
+    existing = cache.fetch(_BANK_MINIONS, jid) or []
+    merged = sorted(set(existing) | set(minions))
+    cache.store(_BANK_MINIONS, jid, merged)
+
+
+# ---------------------------------------------------------------------------
+# Read API
+# ---------------------------------------------------------------------------
+
+
+def get_load(jid):
+    """
+    Return the pub load for *jid*, plus a sorted ``Minions`` list if
+    the matched set was recorded by :func:`save_minions`.
+    """
+    cache = _cache()
+    load = cache.fetch(_BANK_LOADS, jid)
+    if not load:
+        return {}
+    minions = cache.fetch(_BANK_MINIONS, jid)
+    if minions:
+        load["Minions"] = sorted(minions)
+    return load
+
+
+def get_jid(jid):
+    """
+    Return ``{minion_id: return_dict}`` for every return recorded
+    against *jid*.
+
+    Each return is a dict with at least ``return``; ``retcode``,
+    ``success``, and ``out`` are populated when the minion reported
+    them (same shape as ``local_cache``).
+    """
+    cache = _cache()
+    returns_bank = _BANK_RETURNS_FMT.format(jid=jid)
+    try:
+        raw = cache.list_all(returns_bank, include_data=True)
+    except (AttributeError, salt.exceptions.SaltCacheError):
+        # Fallback for drivers that don't implement list_all (or for
+        # a JID that has no returns yet).
+        raw = {}
+        for minion_id in cache.list(returns_bank):
+            record = cache.fetch(returns_bank, minion_id)
+            if record is not None:
+                raw[minion_id] = record
+    ret = {}
+    for minion_id, record in (raw or {}).items():
+        if not isinstance(record, dict) or "return" not in record:
+            # Backwards-compat: ``local_cache`` v1 stored just the
+            # return value at this key.  Wrap into the new shape so
+            # consumers get a consistent dict.
+            record = {"return": record}
+        ret[minion_id] = record
+    return ret
+
+
+def get_jids():
+    """
+    Return ``{jid: jid_info}`` for every load on disk.
+
+    ``jid_info`` is what :func:`salt.utils.jid.format_jid_instance`
+    produces — used by the runner / API surfaces (``salt-run
+    jobs.list_jobs`` etc.).  When ``job_cache_store_endtime`` is on,
+    the matching ``EndTime`` is folded in.
+    """
+    cache = _cache()
+    ret = {}
+    for jid in cache.list(_BANK_LOADS):
+        load = cache.fetch(_BANK_LOADS, jid)
+        if not load:
+            continue
+        info = salt.utils.jid.format_jid_instance(jid, load)
+        if __opts__.get("job_cache_store_endtime"):
+            endtime = get_endtime(jid)
+            if endtime:
+                info["EndTime"] = endtime
+        ret[jid] = info
+    return ret
+
+
+def get_jids_filter(count, filter_find_job=True):
+    """
+    Return the *count* most-recent JIDs as ``jid_info_ext`` dicts,
+    optionally filtering out ``saltutil.find_job`` traffic.
+
+    JIDs sort lexicographically by their timestamp prefix so the
+    most-recent is the last in sorted order.  We accumulate into a
+    bounded list to stay O(N log count) rather than O(N log N).
+    """
+    cache = _cache()
+    keys = []
+    ret = []
+    import bisect  # pylint: disable=import-outside-toplevel
+
+    for jid in cache.list(_BANK_LOADS):
+        load = cache.fetch(_BANK_LOADS, jid)
+        if not load:
+            continue
+        job = salt.utils.jid.format_jid_instance_ext(jid, load)
+        if filter_find_job and job.get("Function") == "saltutil.find_job":
+            continue
+        i = bisect.bisect(keys, jid)
+        if len(keys) == count and i == 0:
+            continue
+        keys.insert(i, jid)
+        ret.insert(i, job)
+        if len(keys) > count:
+            del keys[0]
+            del ret[0]
+    return ret
+
+
+# ---------------------------------------------------------------------------
+# Endtime helpers — populated only when ``job_cache_store_endtime`` is set
+# ---------------------------------------------------------------------------
+
+
+def update_endtime(jid, the_time):
+    """Record (or overwrite) the end-time for *jid*."""
+    _cache().store(_BANK_ENDTIMES, jid, the_time)
+
+
+def get_endtime(jid):
+    """Return the recorded end-time for *jid*, or ``None``."""
+    return _cache().fetch(_BANK_ENDTIMES, jid) or None
+
+
+# ---------------------------------------------------------------------------
+# Maintenance
+# ---------------------------------------------------------------------------
+
+
+def clean_old_jobs():
+    """
+    Drop loads (and all their associated banks) older than
+    ``keep_jobs_seconds`` opt.
+
+    Uses :meth:`salt.cache.Cache.updated` to age each load; falls
+    back to "keep" when the driver can't report a timestamp (some
+    drivers don't implement ``updated``).  Mirrors
+    ``local_cache.clean_old_jobs`` semantically; the loop is far
+    simpler because we don't have to walk a two-level directory
+    hierarchy.
+    """
+    keep_jobs_seconds = salt.utils.job.get_keep_jobs_seconds(__opts__)
+    if keep_jobs_seconds == 0:
+        return
+    cache = _cache()
+    now = time.time()
+    for jid in cache.list(_BANK_LOADS):
+        try:
+            updated = cache.updated(_BANK_LOADS, jid)
+        except (AttributeError, salt.exceptions.SaltCacheError):
+            # Driver can't tell us when this was written — leave the
+            # entry alone rather than risk dropping a fresh job.
+            continue
+        if updated is None:
+            continue
+        if now - updated <= keep_jobs_seconds:
+            continue
+        _drop_jid(cache, jid)
+
+
+def _drop_jid(cache, jid):
+    """Remove every per-JID entry across all banks.  Best-effort."""
+    cache.flush(_BANK_LOADS, jid)
+    cache.flush(_BANK_MINIONS, jid)
+    cache.flush(_BANK_ENDTIMES, jid)
+    cache.flush(_BANK_NOCACHE, jid)
+    # The per-jid returns bank is a whole-bank flush so every minion
+    # return for the jid goes in one call.
+    try:
+        cache.flush(_BANK_RETURNS_FMT.format(jid=jid))
+    except salt.exceptions.SaltCacheError:
+        # No bank for a jid that never received a return is fine.
+        pass

--- a/salt/runners/cluster.py
+++ b/salt/runners/cluster.py
@@ -150,6 +150,79 @@ def _read_health_sentinel():
         return {}
 
 
+def sync_roots(roots="both"):
+    """
+    Push this master's ``file_roots`` and/or ``pillar_roots`` to every
+    other cluster master.
+
+    Runs the operator-driven counterpart of the bulk state-sync that
+    fires automatically during a cluster join.  Use it when the
+    canonical content on this master has changed and you want every
+    peer to pick up the new files without restarting them or waiting
+    for the next join handshake.
+
+    The runner fires a local event; the master daemon picks it up and
+    fans out chunks to every peer over the encrypted cluster pub bus
+    (same transport as the join-time state-sync).  Returns immediately
+    after the event is fired — the actual sync runs asynchronously in
+    the master process.  Check each peer's master log for the
+    ``state-sync ... installed N items`` lines to confirm delivery.
+
+    :param roots: ``"file"``, ``"pillar"``, or ``"both"`` (default
+                  ``"both"``).  Selects which content trees to sync.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Push both file_roots and pillar_roots to all peers
+        salt-run cluster.sync_roots
+
+        # Push only file_roots
+        salt-run cluster.sync_roots roots=file
+
+    .. versionadded:: 3009.0
+    """
+    if roots not in ("file", "pillar", "both"):
+        raise ValueError(f"roots must be 'file', 'pillar', or 'both', got {roots!r}")
+    # Lazy imports — keep the runner module light.
+    import salt.utils.event  # pylint: disable=import-outside-toplevel
+
+    cluster_id = __opts__.get("cluster_id")
+    if not cluster_id:
+        return {
+            "status": "skipped",
+            "reason": "no cluster_id configured; this master is not a cluster member",
+        }
+
+    channels = []
+    if roots in ("file", "both"):
+        channels.append("file_roots")
+    if roots in ("pillar", "both"):
+        channels.append("pillar_roots")
+
+    with salt.utils.event.get_event(
+        "master",
+        sock_dir=__opts__["sock_dir"],
+        opts=__opts__,
+        listen=False,
+    ) as event:
+        event.fire_event(
+            {"channels": channels},
+            "cluster/runner/sync_roots",
+        )
+    return {
+        "status": "fan-out initiated",
+        "channels": channels,
+        "cluster_id": cluster_id,
+        "note": (
+            "The sync runs asynchronously inside the master daemon.  Tail "
+            "each peer's master log for the 'state-sync ... installed N items' "
+            "lines to confirm delivery."
+        ),
+    }
+
+
 def ring_info():
     """
     Return a snapshot of this master's ring state.

--- a/salt/runners/cluster.py
+++ b/salt/runners/cluster.py
@@ -123,6 +123,148 @@ def members():
     }
 
 
+def rings():
+    """
+    Return the cluster-log multi-ring registry as this master sees it.
+
+    Reads the persisted cluster Raft log on this master and replays
+    every committed ``RING_REGISTRY`` entry through a fresh
+    :class:`~salt.cluster.consensus.raft.log.RingRegistryStateMachine`.
+    The result is the registry view *this* master has applied
+    locally — in a healthy cluster every master converges to the
+    same answer, but during a membership change a follower may lag
+    by a heartbeat.
+
+    Output:
+
+    .. code-block:: python
+
+        {
+            "node_id": str,                # this master's interface
+            "rings": {
+                "<ring_id>": {
+                    "founding_voters": [str, ...],
+                    "status":          "active" | "destroyed",
+                },
+                ...
+            },
+            "active_rings":       [str, ...],   # sorted, status=="active" only
+            "registry_version":   int,          # log index of last commit, -1 if none
+        }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.rings
+
+    .. versionadded:: 3009.0
+    """
+    from salt.cluster.consensus.raft.log import (  # pylint: disable=import-outside-toplevel
+        Log,
+        LogEntryType,
+        RingRegistryStateMachine,
+    )
+    from salt.cluster.consensus.storage import (  # pylint: disable=import-outside-toplevel
+        SaltStorage,
+    )
+
+    node_id = __opts__.get("id") or __opts__.get("interface") or "unknown"
+    registry_sm = RingRegistryStateMachine()
+    storage = SaltStorage(node_id, __opts__)
+    log_ = Log(
+        storage=storage,
+        state_machines={"ring_registry_sm": registry_sm},
+    )
+    for entry in log_.entries:
+        if entry.type == LogEntryType.RING_REGISTRY:
+            registry_sm.apply(entry.cmd, index=entry.index)
+
+    return {
+        "node_id": node_id,
+        "rings": registry_sm.rings(),
+        "active_rings": registry_sm.active_rings(),
+        "registry_version": registry_sm.registry_version,
+    }
+
+
+def routes():
+    """
+    Return the cluster-log data-type -> ring routing table as this
+    master sees it.
+
+    Reads the persisted cluster Raft log and replays every committed
+    ``ROUTE`` entry through a fresh
+    :class:`~salt.cluster.consensus.raft.log.RoutingStateMachine`.
+    Same caveats as :func:`rings`: a follower's view may briefly
+    lag the leader during a routing change.
+
+    Output:
+
+    .. code-block:: python
+
+        {
+            "node_id":         str,
+            "routes":          {"<data_type>": "<ring_id>" | None, ...},
+            "routing_version": int,           # log index of last commit, -1
+            "drop_stats":      {              # see ring_membership.drop_stats
+                "<data_type>": {
+                    "ring_id":           str,
+                    "not_a_member":      int,
+                    "other_ring_member": int,
+                },
+                ...
+            },
+        }
+
+    The ``drop_stats`` field is local-process only — it reflects what
+    *this* master has gated since startup.  ``not_a_member`` is the
+    misconfig signal: a non-zero count means traffic for the named
+    data type landed on a master that isn't in the routed ring (the
+    load balancer probably needs adjusting).
+
+    Note: the runner subprocess and the publish daemon are separate
+    processes with their own counter state, so this surface reflects
+    the runner's view, not the daemon's.  For an operational signal
+    use ``grep "ring_membership: dropping"`` in the master log.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.routes
+
+    .. versionadded:: 3009.0
+    """
+    from salt.cluster import ring_membership  # pylint: disable=import-outside-toplevel
+    from salt.cluster.consensus.raft.log import (  # pylint: disable=import-outside-toplevel
+        Log,
+        LogEntryType,
+        RoutingStateMachine,
+    )
+    from salt.cluster.consensus.storage import (  # pylint: disable=import-outside-toplevel
+        SaltStorage,
+    )
+
+    node_id = __opts__.get("id") or __opts__.get("interface") or "unknown"
+    routing_sm = RoutingStateMachine()
+    storage = SaltStorage(node_id, __opts__)
+    log_ = Log(
+        storage=storage,
+        state_machines={"routing_sm": routing_sm},
+    )
+    for entry in log_.entries:
+        if entry.type == LogEntryType.ROUTE:
+            routing_sm.apply(entry.cmd, index=entry.index)
+
+    return {
+        "node_id": node_id,
+        "routes": routing_sm.routes(),
+        "routing_version": routing_sm.routing_version,
+        "drop_stats": ring_membership.drop_stats(),
+    }
+
+
 def _read_health_sentinel():
     """
     Read the per-master health sentinel written by
@@ -266,38 +408,753 @@ def ring_info():
     }
 
 
-def ring_set(members=None, replicas=None):  # pylint: disable=unused-argument
+def _fire_cluster_event(tag, data):
     """
-    Propose a new ring policy through Raft.
+    Shared helper: fire *tag* with *data* on the master's local event
+    bus.  The publish daemon's ``publish_payload`` intercepts the
+    event and dispatches to ``RaftService``.
 
-    Stage 1 placeholder — actual Raft propose path requires IPC from
-    this runner subprocess to the publish daemon's
-    :class:`RaftService`, which is not yet wired.  Today the function
-    raises :class:`NotImplementedError` so an operator who tries it
-    sees the gap loudly rather than thinking their commit landed.
+    Returns the fire-and-forget result; the runner subprocess is
+    done as soon as the event is on the bus.  Operators check
+    ``cluster.members`` or other read-only runners to confirm the
+    proposed entry committed.
+    """
+    import salt.utils.event  # pylint: disable=import-outside-toplevel
 
-    Once the IPC path lands, expected semantics:
+    cluster_id = __opts__.get("cluster_id")
+    if not cluster_id:
+        return {
+            "status": "skipped",
+            "reason": "no cluster_id configured; this master is not a cluster member",
+        }
+    with salt.utils.event.get_event(
+        "master",
+        sock_dir=__opts__["sock_dir"],
+        opts=__opts__,
+        listen=False,
+    ) as event:
+        event.fire_event(data, tag)
+    return {"status": "fan-out initiated", "tag": tag, "data": data}
 
-    * *members*: ``"self"`` (default ring contents — every master a
-      single-node ring, broadcast everywhere) or ``"voters"`` (ring
-      tracks the Raft voter set so writes shard).
-    * *replicas*: integer >= 1.  ``1`` (default) means each key has
-      exactly one owner; higher values request additional replica
-      owners for fault tolerance.
 
-    Until the propose path lands, operators wanting to flip the
-    policy can call ``RaftService.propose_ring_config`` directly from
-    a python hook running inside the master process — see the
-    functional tests under
-    ``tests/pytests/functional/cluster/consensus/test_raft_service.py``.
+def ring_create(name, voters):
+    """
+    Create a named ring with the given founding voters.
 
-    CLI Example (will raise until stage 2):
+    Fires a ``cluster/runner/ring_create`` event on the master's
+    local bus; the publish daemon intercepts it and proposes a
+    ``RING_REGISTRY`` entry through the cluster Raft group.  Each
+    master that is in *voters* will then bring up the per-ring
+    Raft group locally when the registry entry commits.
+
+    :param name:   Operator-chosen ring identifier (e.g. ``"jobs"``).
+    :param voters: List of master node-ids (interface addresses) to
+                   serve as the founding voter set of the ring.
+
+    Asymmetric with ``cluster.ring_destroy``: this runner only
+    requests creation — bring-up of the per-ring Node is driven by
+    the registry's commit callback inside the daemon.
+
+    CLI Example:
 
     .. code-block:: bash
 
-        salt-run cluster.ring_set members=voters replicas=2
+        salt-run cluster.ring_create name=jobs voters='["m1","m2","m3"]'
     """
-    raise NotImplementedError(
-        "cluster.ring_set: cross-process Raft propose path is not yet wired. "
-        "Track GAPS.md for the follow-up that adds runner -> RaftService IPC."
+    if not name:
+        raise ValueError("cluster.ring_create requires a non-empty 'name'")
+    if not voters:
+        raise ValueError("cluster.ring_create requires a non-empty 'voters' list")
+    return _fire_cluster_event(
+        "cluster/runner/ring_create",
+        {"ring_id": name, "founding_voters": list(voters)},
     )
+
+
+def ring_destroy(name):
+    """
+    Mark the named ring as destroyed.
+
+    Fires a ``cluster/runner/ring_destroy`` event; the publish daemon
+    proposes a ``RING_REGISTRY`` entry with ``status="destroyed"``.
+    Once committed, every master that hosted the ring's Raft group
+    tears it down locally.  The on-disk state is left in place so an
+    operator who re-creates the same ring picks up the persisted
+    state.
+
+    :param name: Ring identifier (must match the ``name`` used at
+                 :func:`ring_create` time).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.ring_destroy name=jobs
+    """
+    if not name:
+        raise ValueError("cluster.ring_destroy requires a non-empty 'name'")
+    return _fire_cluster_event(
+        "cluster/runner/ring_destroy",
+        {"ring_id": name},
+    )
+
+
+def route_set(data_type, ring):
+    """
+    Route a data type to a named ring.
+
+    Fires a ``cluster/runner/route_set`` event; the publish daemon
+    proposes a ``ROUTE`` entry through the cluster Raft group.  Once
+    committed, gate sites in :mod:`salt.master` consult the routing
+    table when they receive a write for *data_type* and defer to
+    that ring's :meth:`HashRing.owns` answer.
+
+    :param data_type: Logical cache identifier (e.g. ``"jobs"``).
+    :param ring:      Ring name to route to (must have been created
+                      via :func:`ring_create`).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.route_set data_type=jobs ring=jobs
+    """
+    if not data_type:
+        raise ValueError("cluster.route_set requires a non-empty 'data_type'")
+    if not ring:
+        raise ValueError("cluster.route_set requires a non-empty 'ring'")
+    return _fire_cluster_event(
+        "cluster/runner/route_set",
+        {"data_type": data_type, "ring_id": ring},
+    )
+
+
+def route_clear(data_type):
+    """
+    Clear the route for a data type, returning it to broadcast.
+
+    Fires a ``cluster/runner/route_clear`` event; the publish daemon
+    proposes a ``ROUTE`` entry mapping *data_type* to ``None``.
+    Once committed, every master mirrors the data type's writes
+    again (the pre-multi-ring default).
+
+    :param data_type: Logical cache identifier (e.g. ``"jobs"``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.route_clear data_type=jobs
+    """
+    if not data_type:
+        raise ValueError("cluster.route_clear requires a non-empty 'data_type'")
+    return _fire_cluster_event(
+        "cluster/runner/route_clear",
+        {"data_type": data_type},
+    )
+
+
+_DEFAULT_SHED_BANKS = (
+    "jobs/loads",
+    "jobs/minions",
+    "jobs/endtimes",
+    "jobs/nocache",
+)
+_DEFAULT_SUBBANK_TEMPLATE = "jobs/returns/{key}"
+
+
+def shed_unowned(
+    ring,
+    banks=_DEFAULT_SHED_BANKS,
+    subbank_template=_DEFAULT_SUBBANK_TEMPLATE,
+    driver=None,
+    dry_run=False,
+):
+    """
+    Drop cache entries this master does not own for the named ring.
+
+    The migration "going in" runner.  After
+    ``cluster.ring_create``/``route_set`` have wired *ring* into the
+    routing table and the per-ring Raft group has elected a leader,
+    every master still has the *full* keyspace in its caches (a
+    legacy of the pre-multi-ring broadcast era).  This runner walks
+    the configured cache banks on this master and deletes the entries
+    that hash to other ring members.
+
+    :param ring:             Ring identifier whose voter set defines
+                             ownership.
+    :param banks:            Cache banks to scan.  Defaults match the
+                             :mod:`salt.returners.salt_cache` job
+                             layout (``jobs/loads`` is the primary
+                             JID index; the others are sibling banks
+                             keyed by JID).  Operators routing other
+                             caches override.
+    :param subbank_template: Optional ``str.format``-able template.
+                             When set, for each unowned key found in
+                             the first ``banks`` entry the runner
+                             also flushes the templated bank in its
+                             entirety — used for the salt_cache
+                             returner's per-JID returns bank
+                             (``"jobs/returns/{key}"``).  Pass
+                             ``None`` for caches without sub-banks.
+    :param driver:           Optional override for the
+                             ``salt.cache.Cache`` driver.  Defaults
+                             to the ``cache:`` opt — the same driver
+                             the returner writes through.
+    :param dry_run:          If ``True``, compute the counts but
+                             don't flush anything.  Use to preview
+                             the partition before committing.
+
+    Returns a structured result::
+
+        {
+            "status":           "ok" | "skipped",
+            "ring":             str,
+            "dropped":          int,   # primary-bank entries flushed
+            "kept":             int,   # primary-bank entries this master owns
+            "subbanks_dropped": int,   # cascade banks flushed wholesale
+            "dry_run":          bool,
+        }
+
+    Reads membership from local persisted Raft state (same path
+    ``cluster.members`` already uses) so the runner subprocess can
+    answer "what does the ring look like?" without IPC into the
+    publish daemon.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Preview which JIDs would be dropped on this master.
+        salt-run cluster.shed_unowned ring=jobs dry_run=True
+
+        # Commit the deletions on the default jobs/* banks.
+        salt-run cluster.shed_unowned ring=jobs
+
+        # Shard a different cache type (the keys/denied-keys banks
+        # are intentionally broadcast and should NOT be sharded; this
+        # example assumes the operator has built a routed
+        # ``inventory`` cache).
+        salt-run cluster.shed_unowned ring=inventory \\
+            banks='["inventory/items"]' subbank_template=None
+    """
+    if not ring:
+        raise ValueError("cluster.shed_unowned requires a non-empty 'ring'")
+    if not banks:
+        raise ValueError("cluster.shed_unowned requires at least one bank")
+    # The shed implementation is shared with the daemon-side
+    # ``cluster/peer/shed-request`` intercept; both paths call into
+    # ``salt.cluster.migration.perform_shed`` so the bank layout +
+    # cascade rules stay consistent.
+    from salt.cluster import migration  # pylint: disable=import-outside-toplevel
+
+    result = migration.perform_shed(
+        __opts__,
+        ring,
+        banks=banks,
+        subbank_template=subbank_template,
+        driver=driver,
+        dry_run=dry_run,
+    )
+    migration.write_shed_status(__opts__, result, source="runner")
+    return result
+
+
+_DEFAULT_COLLECT_BANKS = (
+    "jobs/loads",
+    "jobs/minions",
+    "jobs/endtimes",
+    "jobs/nocache",
+)
+
+
+def shed_unowned_all(
+    ring,
+    banks=_DEFAULT_SHED_BANKS,
+    subbank_template=_DEFAULT_SUBBANK_TEMPLATE,
+    driver=None,
+    dry_run=False,
+):
+    """
+    Fan-out :func:`shed_unowned` across every master in the cluster.
+
+    The single-master :func:`shed_unowned` runner drops the local
+    master's unowned cache entries.  For a complete migration the
+    operator has to run that on every ring member — error-prone
+    and verbose for clusters with more than three or four masters.
+    This runner solves the operator UX:
+
+    1. Fires a ``cluster/runner/shed_unowned_all`` event from the
+       runner subprocess on this master.
+    2. The publish daemon intercepts the event, broadcasts a
+       ``cluster/peer/shed-request`` event (cluster_aes-encrypted)
+       to every peer carrying the runner's parameters.
+    3. Each peer's daemon intercepts the request and runs the same
+       shed-unowned logic locally, writing a per-master sentinel
+       at ``cachedir/cluster-shed-status.json`` so the operator can
+       poll for results without tailing logs.
+    4. The originator also runs its own local shed inline so the
+       runner returns with a useful result even before peer
+       sentinels appear.
+
+    :param ring:             Ring identifier whose voter set defines
+                             ownership.  Same shape as
+                             :func:`shed_unowned`.
+    :param banks:            Cache banks to scan; defaults to the
+                             salt_cache jobs layout.
+    :param subbank_template: Cascade bank template; defaults to
+                             ``"jobs/returns/{key}"``.  Pass
+                             ``None`` to disable the cascade.
+    :param driver:           Optional ``salt.cache.Cache`` driver
+                             override.  Defaults to the ``cache:``
+                             opt.
+    :param dry_run:          When True, runs the partition preview
+                             on every master without committing.
+
+    Returns the same shape as :func:`shed_unowned` for *this*
+    master's local pass, plus a ``fan_out`` field naming the
+    cluster/peer/shed-request event that fanned to peers.
+    Per-peer results land in their own sentinel files; operators
+    can collect them with ``cluster.shed_status``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Preview shed across every master in the cluster.
+        salt-run cluster.shed_unowned_all ring=jobs dry_run=True
+
+        # Commit shed across every master.
+        salt-run cluster.shed_unowned_all ring=jobs
+    """
+    if not ring:
+        raise ValueError("cluster.shed_unowned_all requires a non-empty 'ring'")
+    payload = {
+        "ring_id": ring,
+        "banks": list(banks),
+        "subbank_template": subbank_template,
+        "driver": driver,
+        "dry_run": bool(dry_run),
+    }
+    # Fire the event so the publish daemon fans it out to peers.
+    fan_out = _fire_cluster_event("cluster/runner/shed_unowned_all", payload)
+    # Also run locally — operator gets back a meaningful per-master
+    # result from this side of the fan-out without polling.
+    local = shed_unowned(
+        ring,
+        banks=banks,
+        subbank_template=subbank_template,
+        driver=driver,
+        dry_run=dry_run,
+    )
+    return {
+        "fan_out": fan_out,
+        "local": local,
+    }
+
+
+def shed_status():
+    """
+    Read this master's local ``cluster-shed-status.json`` sentinel,
+    if any.
+
+    The sentinel is written by the master daemon whenever it runs a
+    local shed (either operator-triggered ``cluster.shed_unowned``,
+    or a peer-triggered fan-out via
+    ``cluster.shed_unowned_all``).  Operators check this file
+    cluster-wide to confirm shed completed on every master.
+
+    Returns ``{"status": "missing"}`` when no sentinel has been
+    written yet — typical on a master that has never run shed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.shed_status
+    """
+    import json  # pylint: disable=import-outside-toplevel
+    import os  # pylint: disable=import-outside-toplevel
+
+    import salt.utils.files  # pylint: disable=import-outside-toplevel
+
+    cachedir = __opts__.get("cachedir")
+    if not cachedir:
+        return {"status": "missing", "reason": "no cachedir opt"}
+    path = os.path.join(cachedir, "cluster-shed-status.json")
+    try:
+        with salt.utils.files.fopen(path) as fp:
+            return json.load(fp)
+    except (OSError, ValueError):
+        return {"status": "missing", "path": path}
+
+
+def collect_from_peers(channels=(), banks=_DEFAULT_COLLECT_BANKS):
+    """
+    Pull cache contents from every peer to this master.
+
+    The migration "going out" runner — reverses
+    :func:`cluster.sync_roots` direction.  This master fires a
+    ``cluster/runner/collect_from_peers`` event; the publish daemon
+    broadcasts a collect-request to every peer.  Each peer streams
+    its cache contents for the requested channels back over the
+    existing state-sync chunk transport, and this master's receiver
+    applies them locally.
+
+    Use to gather full coverage before flipping
+    :func:`cluster.route_clear` a data type back to broadcast: after
+    every master has run this runner successfully, every master
+    holds the full keyspace again and a route flip won't strand
+    reads.
+
+    Two channel families are supported:
+
+    * ``channels`` — fixed state-sync channels ``keys`` and
+      ``denied_keys`` (the join-time minion-key transport).
+    * ``banks`` — arbitrary :class:`salt.cache.Cache` banks (e.g.
+      the salt_cache returner's ``jobs/*`` banks).  Each bank name
+      is wrapped as a ``bank:<bank>`` channel on the wire and the
+      peer streams it via
+      :func:`salt.cluster.state_sync.iter_bank_chunks`.
+
+    :param channels: Iterable of fixed state-sync channel names
+                     (subset of ``{"keys", "denied_keys"}``).
+                     Defaults to empty; only set when migrating PKI
+                     banks (the default keys/denied_keys layout is
+                     intentionally broadcast in this branch — see
+                     ``MULTI_RING_DESIGN.md``).
+    :param banks:    Iterable of :class:`salt.cache.Cache` bank
+                     names.  Defaults to the four ``jobs/*`` banks
+                     written by :mod:`salt.returners.salt_cache`,
+                     which is the production case for multi-ring
+                     migrations.
+
+    Fire-and-forget: the runner returns immediately after the event
+    is on the bus.  Poll local cache contents (or tail the master
+    log for ``state-sync ... installed N items``) to confirm
+    delivery from each peer.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Default: collect the jobs/* banks from every peer.
+        salt-run cluster.collect_from_peers
+
+        # Collect a specific bank only.
+        salt-run cluster.collect_from_peers banks='["jobs/loads"]'
+
+        # Operator migrating a routed PKI-keys bank (rare).
+        salt-run cluster.collect_from_peers channels='["keys"]' banks='[]'
+    """
+    from salt.cluster.state_sync import (  # pylint: disable=import-outside-toplevel
+        BANK_CHANNEL_PREFIX,
+    )
+
+    fixed = list(channels) if channels else []
+    bank_list = list(banks) if banks else []
+    invalid = [ch for ch in fixed if ch not in ("keys", "denied_keys")]
+    if invalid:
+        raise ValueError(
+            f"cluster.collect_from_peers: unsupported fixed channels {invalid!r} "
+            "(only 'keys' and 'denied_keys' are recognised; arbitrary cache "
+            "banks go through the 'banks' parameter)"
+        )
+    if not fixed and not bank_list:
+        raise ValueError(
+            "cluster.collect_from_peers requires at least one channel or bank"
+        )
+    requested = fixed + [f"{BANK_CHANNEL_PREFIX}{b}" for b in bank_list]
+    return _fire_cluster_event(
+        "cluster/runner/collect_from_peers",
+        {"channels": requested},
+    )
+
+
+def ring_set(name=None, members=None, replicas=None):
+    """
+    Propose a new policy for the named ring.
+
+    Fires a ``cluster/runner/ring_set`` event; the publish daemon
+    proposes a ``RING_CONFIG`` entry on the *ring's own* Raft log
+    (not the cluster log).  Partial updates are honoured — omit a
+    knob to keep its existing value.
+
+    :param name:     Ring identifier (required).
+    :param members:  ``"self"`` (ring is self-only — gate writes
+                     broadcast) or ``"voters"`` (ring tracks the
+                     ring's committed voter set — gate writes shard).
+                     ``None`` keeps the existing value.
+    :param replicas: Integer >= 1.  ``None`` keeps the existing value.
+
+    Must be invoked on a master that is a leader of the named ring's
+    Raft group.  Operators typically discover this by checking
+    ``cluster.members`` first to find the ring's current leader.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cluster.ring_set name=jobs members=voters replicas=2
+    """
+    if not name:
+        raise ValueError("cluster.ring_set requires a non-empty 'name'")
+    payload = {"ring_id": name}
+    if members is not None:
+        payload["members"] = members
+    if replicas is not None:
+        payload["replicas"] = int(replicas)
+    return _fire_cluster_event("cluster/runner/ring_set", payload)
+
+
+# Filename constants matching ``salt.returners.local_cache``.  Kept
+# verbatim so the migration is bit-exact against existing on-disk
+# state — DO NOT rename without verifying old caches still parse.
+_LC_LOAD_P = ".load.p"
+_LC_MINIONS_P = ".minions.p"
+_LC_SYNDIC_MINIONS_PREFIX = ".minions."  # ".minions.<syndic_id>.p"
+_LC_RETURN_P = "return.p"
+_LC_OUT_P = "out.p"
+_LC_ENDTIME = "endtime"
+_LC_NOCACHE = "nocache"
+
+
+def migrate_jobs_to_cache(dry_run=False):
+    """
+    Migrate job-cache state from the ``local_cache`` returner layout
+    into the bank layout :mod:`salt.returners.salt_cache` uses.
+
+    The default ``master_job_cache: local_cache`` returner writes
+    each JID to
+    ``<cachedir>/jobs/<2-hex>/<28-hex>/{.load.p, .minions.p,
+    <minion_id>/return.p, …}``.  Operators flipping to
+    ``master_job_cache: salt_cache`` (the multi-ring-capable
+    returner) start with an empty bank set — every job submitted
+    before the flip becomes invisible to the new returner.
+
+    This one-shot runner walks the old filesystem layout and
+    populates the salt_cache banks::
+
+        <cachedir>/jobs/<2>/<28>/.load.p        -> bank "jobs/loads",     key=jid
+        <cachedir>/jobs/<2>/<28>/.minions.p     -> bank "jobs/minions",   key=jid
+        <cachedir>/jobs/<2>/<28>/endtime        -> bank "jobs/endtimes",  key=jid
+        <cachedir>/jobs/<2>/<28>/nocache        -> bank "jobs/nocache",   key=jid
+        <cachedir>/jobs/<2>/<28>/<m>/return.p   -> bank "jobs/returns/<jid>", key=<m>
+        <cachedir>/jobs/<2>/<28>/<m>/out.p      -> folded into the same record
+
+    The original files are left in place — operators who want to
+    reclaim the disk can ``rm -rf`` ``<cachedir>/jobs`` after
+    confirming the new banks are correct (running ``cluster.members``
+    /  ``salt-run jobs.list_jobs`` against the new returner is the
+    smoke check).
+
+    :param dry_run: If ``True``, walk and count without writing any
+                    cache entries.  Use to verify the runner sees
+                    every JID before committing.
+
+    Returns a structured result::
+
+        {
+            "status":           "ok" | "skipped",
+            "scanned":          int,   # JIDs walked
+            "migrated":         int,   # JIDs successfully written
+            "skipped":          int,   # malformed entries the runner ignored
+            "returns_migrated": int,   # minion return records written
+            "dry_run":          bool,
+            "jobs_root":        str,   # path that was walked
+        }
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Preview without writing anything.
+        salt-run cluster.migrate_jobs_to_cache dry_run=True
+
+        # Actually copy the state across.
+        salt-run cluster.migrate_jobs_to_cache
+
+    Operationally: stop the master before flipping
+    ``master_job_cache`` so new writes don't race the migration,
+    run this runner, restart the master with the new opt set.
+    """
+    import os  # pylint: disable=import-outside-toplevel
+
+    import salt.cache  # pylint: disable=import-outside-toplevel
+    import salt.payload  # pylint: disable=import-outside-toplevel
+    import salt.utils.files  # pylint: disable=import-outside-toplevel
+
+    cachedir = __opts__.get("cachedir")
+    if not cachedir:
+        return {
+            "status": "skipped",
+            "reason": "cachedir opt not set; cannot locate jobs root",
+            "scanned": 0,
+            "migrated": 0,
+            "skipped": 0,
+            "returns_migrated": 0,
+            "dry_run": dry_run,
+            "jobs_root": None,
+        }
+    jobs_root = os.path.join(cachedir, "jobs")
+    if not os.path.isdir(jobs_root):
+        return {
+            "status": "skipped",
+            "reason": f"no local_cache jobs root at {jobs_root!r}; nothing to do",
+            "scanned": 0,
+            "migrated": 0,
+            "skipped": 0,
+            "returns_migrated": 0,
+            "dry_run": dry_run,
+            "jobs_root": jobs_root,
+        }
+
+    cache = (
+        None
+        if dry_run
+        else salt.cache.Cache(
+            __opts__,
+            driver=__opts__.get("cache") or __opts__.get("keys.cache_driver"),
+        )
+    )
+
+    scanned = migrated = skipped = returns_migrated = 0
+
+    for top in sorted(os.listdir(jobs_root)):
+        t_path = os.path.join(jobs_root, top)
+        if not os.path.isdir(t_path):
+            continue
+        for jid_hash in sorted(os.listdir(t_path)):
+            jid_dir = os.path.join(t_path, jid_hash)
+            if not os.path.isdir(jid_dir):
+                continue
+            scanned += 1
+            try:
+                ok, ret_count = _migrate_one_jid(
+                    jid_dir, cache, dry_run, salt.utils.files, salt.payload
+                )
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    "cluster.migrate_jobs_to_cache: failed to migrate %s",
+                    jid_dir,
+                )
+                skipped += 1
+                continue
+            if ok:
+                migrated += 1
+                returns_migrated += ret_count
+            else:
+                skipped += 1
+
+    log.info(
+        "cluster.migrate_jobs_to_cache: scanned=%d migrated=%d skipped=%d "
+        "returns_migrated=%d dry_run=%s (root=%s)",
+        scanned,
+        migrated,
+        skipped,
+        returns_migrated,
+        dry_run,
+        jobs_root,
+    )
+    return {
+        "status": "ok",
+        "scanned": scanned,
+        "migrated": migrated,
+        "skipped": skipped,
+        "returns_migrated": returns_migrated,
+        "dry_run": dry_run,
+        "jobs_root": jobs_root,
+    }
+
+
+def _migrate_one_jid(jid_dir, cache, dry_run, files_mod, payload_mod):
+    """
+    Migrate a single ``local_cache`` JID directory.
+
+    Returns ``(success, return_count)``.  *success* is False when the
+    JID directory has no usable ``.load.p`` (i.e. a stub left behind
+    by an in-flight crash); the caller bumps the ``skipped`` counter
+    and moves on.
+    """
+    import os  # pylint: disable=import-outside-toplevel
+
+    load_path = os.path.join(jid_dir, _LC_LOAD_P)
+    if not os.path.isfile(load_path):
+        return False, 0
+    with files_mod.fopen(load_path, "rb") as fp:
+        load = payload_mod.load(fp)
+    if not isinstance(load, dict):
+        return False, 0
+    jid = load.get("jid") or os.path.basename(jid_dir)
+
+    # ``jobs/minions`` — merge the main file with any syndic-supplied
+    # variants so the new bank reflects the union (which is also what
+    # ``local_cache.get_load`` returns under ``Minions``).
+    minions = set()
+    for fname in os.listdir(jid_dir):
+        if fname == _LC_MINIONS_P or (
+            fname.startswith(_LC_SYNDIC_MINIONS_PREFIX) and fname.endswith(".p")
+        ):
+            try:
+                with files_mod.fopen(os.path.join(jid_dir, fname), "rb") as fp:
+                    blob = payload_mod.load(fp)
+            except Exception:  # pylint: disable=broad-except
+                continue
+            if isinstance(blob, (list, tuple, set)):
+                minions.update(blob)
+    minions_list = sorted(minions)
+
+    # ``endtime`` is plain text, not msgpack.
+    endtime = None
+    endtime_path = os.path.join(jid_dir, _LC_ENDTIME)
+    if os.path.isfile(endtime_path):
+        try:
+            with files_mod.fopen(endtime_path) as fp:
+                endtime = float(fp.read().strip())
+        except (OSError, ValueError):
+            endtime = None
+
+    nocache = os.path.isfile(os.path.join(jid_dir, _LC_NOCACHE))
+
+    # Per-minion returns: each subdir is a minion id.
+    returns = {}
+    for fname in os.listdir(jid_dir):
+        sub = os.path.join(jid_dir, fname)
+        if not os.path.isdir(sub):
+            continue
+        ret_path = os.path.join(sub, _LC_RETURN_P)
+        if not os.path.isfile(ret_path):
+            continue
+        try:
+            with files_mod.fopen(ret_path, "rb") as fp:
+                record = payload_mod.load(fp)
+        except Exception:  # pylint: disable=broad-except
+            continue
+        if not isinstance(record, dict) or "return" not in record:
+            # Legacy v1: bare return value at the key.  Wrap into
+            # the modern dict shape so the salt_cache get_jid path
+            # treats it consistently.
+            record = {"return": record}
+        out_path = os.path.join(sub, _LC_OUT_P)
+        if os.path.isfile(out_path):
+            try:
+                with files_mod.fopen(out_path, "rb") as fp:
+                    record["out"] = payload_mod.load(fp)
+            except Exception:  # pylint: disable=broad-except
+                pass
+        returns[fname] = record
+
+    if dry_run:
+        return True, len(returns)
+
+    cache.store("jobs/loads", jid, load)
+    if minions_list:
+        cache.store("jobs/minions", jid, minions_list)
+    if endtime is not None:
+        cache.store("jobs/endtimes", jid, endtime)
+    if nocache:
+        cache.store("jobs/nocache", jid, True)
+    for minion_id, record in returns.items():
+        cache.store(f"jobs/returns/{jid}", minion_id, record)
+
+    return True, len(returns)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,9 @@ def _patch_psutil_pidfd_open_einval() -> None:
         from psutil import _psposix
     except ImportError:
         return
+    # psutil <5.10 doesn't expose wait_pid_pidfd_open; nothing to patch.
+    if not hasattr(_psposix, "wait_pid_pidfd_open"):
+        return
     if getattr(_psposix.wait_pid_pidfd_open, "_salt_einval_wrap", False):
         return
     original = _psposix.wait_pid_pidfd_open

--- a/tests/pytests/functional/channel/test_worker_pool_starvation.py
+++ b/tests/pytests/functional/channel/test_worker_pool_starvation.py
@@ -246,6 +246,7 @@ def test_auth_starved_without_routing(master_without_routing):
         )
 
 
+@pytest.mark.timeout(180, func_only=True)
 def test_auth_not_starved_with_routing(master_with_routing):
     """
     WITH pool routing, auth succeeds even while the default pool is saturated.
@@ -253,6 +254,16 @@ def test_auth_not_starved_with_routing(master_with_routing):
     The ``_auth`` command is mapped to a dedicated 'auth' pool so it is
     processed immediately, independently of the slow pillar work happening
     in the 'default' pool.
+
+    Spawns 7 daemons (1 master + 5 saturating minions + 1 auth minion)
+    plus an ``AUTH_TIMEOUT=15`` deadline for the auth minion to
+    successfully start.  Under coverage tracing on a loaded GHA
+    runner the cumulative process start + saturation work has been
+    observed at 60-90 s — right at the edge of the global 90 s
+    pytest-timeout.  The explicit ``@pytest.mark.timeout(180)``
+    raises the wall-clock ceiling so the test's own ``AUTH_TIMEOUT``
+    assertion remains the failure signal (rather than pytest killing
+    the test mid-fixture-teardown).
     """
     with master_with_routing.started():
         # Saturate the 'default' pool workers with slow pillar refreshes.

--- a/tests/pytests/functional/cluster/consensus/conftest.py
+++ b/tests/pytests/functional/cluster/consensus/conftest.py
@@ -99,8 +99,10 @@ async def _deliver_all(members, rounds=8):
                 while pusher.sent:
                     raw = pusher.sent.popleft()
                     try:
-                        tag, s, rid, payload = rpc.unpack(raw)
-                        await members[dst_id].dispatcher.dispatch(tag, s, rid, payload)
+                        tag, s, rid, group, payload = rpc.unpack(raw)
+                        await members[dst_id].dispatcher.dispatch(
+                            tag, s, rid, payload, raft_group_id=group
+                        )
                         delivered = True
                     except Exception:  # pylint: disable=broad-except
                         pass

--- a/tests/pytests/functional/cluster/consensus/test_raft_scenarios.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_scenarios.py
@@ -203,9 +203,11 @@ class ServiceCluster:
                     while pusher.sent:
                         raw = pusher.sent.popleft()
                         try:
-                            tag, s, rid, payload = rpc.unpack(raw)
+                            tag, s, rid, group, payload = rpc.unpack(raw)
                             dst_svc = self.services[dst_id]
-                            await dst_svc._dispatcher.dispatch(tag, s, rid, payload)
+                            await dst_svc._dispatcher.dispatch(
+                                tag, s, rid, payload, raft_group_id=group
+                            )
                             delivered = True
                         except Exception:  # pylint: disable=broad-except
                             pass

--- a/tests/pytests/functional/cluster/consensus/test_raft_service.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_service.py
@@ -603,20 +603,24 @@ class TestOnReady:
 
 
 # ---------------------------------------------------------------------------
-# Ring rebuild hook (Stage 0 of the ring rollout)
+# Cluster-ring rebuild on membership change
 # ---------------------------------------------------------------------------
 
 
-class TestRingRebuildHook:
+class TestClusterRingRebuildHook:
     """
-    ``RaftService._on_membership_change`` must rebuild the per-process
-    ``HashRing`` so any code consulting ``ring_membership.owns`` sees the
-    committed voter set.
+    ``RaftService._on_membership_change`` keeps the default
+    ``"cluster"`` :class:`HashRing` in lock-step with the committed
+    voter set so pre-multi-ring callers
+    (``ring_membership.owns(opts, key)`` with no ring name) see a
+    meaningful answer.
 
-    Stage 0 invariant: in the master/EventMonitor processes the ring
-    stays empty (broadcast everything); only the publish daemon's
-    process — where ``RaftService`` lives — actually rebuilds.  This
-    proves the rebuild side of that invariant.
+    Multi-ring deployments don't actually shard via the default
+    ring — they route data types through named rings created with
+    ``cluster.ring_create``.  But the rebuild on commit is what
+    keeps the default ring's contents from drifting away from the
+    cluster's voter set, which a misconfigured deployment may still
+    rely on.
     """
 
     def _make_svc(self, node_id="m1", peers=("m2",), on_ready=None):
@@ -626,158 +630,53 @@ class TestRingRebuildHook:
         svc = RaftService(opts, loop, pushers, on_ready=on_ready)
         return svc, loop
 
-    def test_membership_change_under_voters_policy_rebuilds_with_voter_set(self):
+    def test_commit_drives_rebuild_with_voter_set(self):
         """
-        A CONFIG commit drives ``ring_membership.rebuild`` with the
-        committed voter set *only when ring policy is voters*.
-
-        ``_apply_ring_policy`` reads the voter list from
-        ``membership_sm.current_voters()`` (not from on_change args)
-        so we apply through the SM directly to make the test meaningful.
+        A CONFIG commit drives ``ring_membership.rebuild`` for the
+        default ring with the committed voter set.  Learners are
+        excluded — they don't own data.
         """
         from salt.cluster import ring_membership
 
         ring_membership.reset()
         svc, loop = self._make_svc()
         try:
-            svc._ring_config_sm.apply({"members": "voters"}, index=1)
             svc._node.membership_sm.apply(
-                {"voters": ["m1", "m2", "m3"], "learners": []}, index=2
+                {"voters": ["m1", "m2", "m3"], "learners": ["m4"]}, index=1
             )
             assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2", "m3"]
         finally:
             ring_membership.reset()
             loop.close()
 
-    def test_membership_change_under_voters_policy_excludes_learners(self):
+    def test_repeated_commits_atomically_swap_ring(self):
         """
-        Learners do not own data — only voters appear in the ring under
-        ``members=voters``.  Stage-1 contract; learner-as-replica
-        support is later work.
-        """
-        from salt.cluster import ring_membership
-
-        ring_membership.reset()
-        svc, loop = self._make_svc()
-        try:
-            svc._ring_config_sm.apply({"members": "voters"}, index=1)
-            # Drive on_change directly via the SM so the membership SM
-            # records ["m1", "m2"] as voters and ["m3"] as a learner.
-            svc._node.membership_sm.apply(
-                {"voters": ["m1", "m2"], "learners": ["m3"]}, index=2
-            )
-            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2"]
-        finally:
-            ring_membership.reset()
-            loop.close()
-
-    def test_repeated_membership_change_atomically_swaps_ring(self):
-        """
-        Two CONFIG commits (e.g. add-then-remove) leave the ring in the
-        latest committed shape, not a union.  Ensures rebuild replaces
-        the ring rather than additively merging.  Under default ``self``
-        policy the ring stays single-node throughout — this test runs
-        under ``voters`` policy to actually exercise replacement.
+        Two CONFIG commits leave the ring in the latest committed
+        shape, not a union.  Pins that rebuild replaces.
         """
         from salt.cluster import ring_membership
 
         ring_membership.reset()
         svc, loop = self._make_svc()
         try:
-            svc._ring_config_sm.apply({"members": "voters"}, index=1)
             svc._node.membership_sm.apply(
-                {"voters": ["m1", "m2", "m3"], "learners": []}, index=2
+                {"voters": ["m1", "m2", "m3"], "learners": []}, index=1
             )
             svc._node.membership_sm.apply(
-                {"voters": ["m1", "m4"], "learners": []}, index=3
+                {"voters": ["m1", "m4"], "learners": []}, index=2
             )
             assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m4"]
         finally:
             ring_membership.reset()
             loop.close()
 
-    def test_membership_change_under_self_policy_keeps_ring_single_node(self):
+    def test_empty_voters_leaves_ring_alone(self):
         """
-        Default ``members=self`` policy: a CONFIG commit with three
-        voters does not shard the ring.  Stage 0 default behaviour;
-        previously verified in test_self_policy_keeps_single_node_ring
-        but worth pinning at the on_change boundary too.
-        """
-        from salt.cluster import ring_membership
-
-        ring_membership.reset()
-        svc, loop = self._make_svc()
-        try:
-            # Default policy is "self" — do NOT flip the SM.
-            svc._on_membership_change(["m1", "m2", "m3"], [])
-            assert sorted(ring_membership.get_ring().nodes()) == ["m1"]
-        finally:
-            ring_membership.reset()
-            loop.close()
-
-
-# ---------------------------------------------------------------------------
-# RingConfigStateMachine integration (Stage 1 of the ring rollout)
-# ---------------------------------------------------------------------------
-
-
-class TestRingPolicyPlumbing:
-    """
-    Verify that RaftService honours the committed ring policy when
-    rebuilding the per-process ring on membership / ring-config commits.
-    """
-
-    def _make_svc(self, node_id="m1", peers=("m2",)):
-        opts = _make_opts(node_id, list(peers))
-        loop = asyncio.new_event_loop()
-        pushers = _make_pushers(peers)
-        svc = RaftService(opts, loop, pushers)
-        return svc, loop
-
-    def test_self_policy_keeps_single_node_ring(self):
-        """
-        Default policy is ``members=self``.  A CONFIG commit with three
-        voters must NOT shard the ring across them — it stays single-
-        node so ``owns`` returns ``True`` everywhere (today's broadcast
-        behaviour).
-        """
-        from salt.cluster import ring_membership
-
-        ring_membership.reset()
-        svc, loop = self._make_svc()
-        try:
-            svc._on_membership_change(["m1", "m2", "m3"], [])
-            assert sorted(ring_membership.get_ring().nodes()) == ["m1"]
-        finally:
-            ring_membership.reset()
-            loop.close()
-
-    def test_voters_policy_shards_ring_across_voters(self):
-        """
-        After a RING_CONFIG entry flips members to ``voters``, the ring
-        rebuild includes every committed voter.  The next call to
-        ``ring_membership.owns`` will route by consistent hash.
-        """
-        from salt.cluster import ring_membership
-
-        ring_membership.reset()
-        svc, loop = self._make_svc()
-        try:
-            # Commit voters first.
-            svc._node.membership_sm.apply(
-                {"voters": ["m1", "m2", "m3"], "learners": []}, index=1
-            )
-            # Then flip ring policy.
-            svc._ring_config_sm.apply({"members": "voters", "replicas": 2}, index=2)
-            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2", "m3"]
-        finally:
-            ring_membership.reset()
-            loop.close()
-
-    def test_ring_policy_change_triggers_rebuild_with_current_voters(self):
-        """
-        Ring SM commits without arg-bundled voters: the rebuild must
-        consult ``membership_sm.current_voters()`` for the contents.
+        An empty-voter commit (shouldn't happen in steady state) is
+        tolerated: rebuild is skipped so the ring keeps whatever
+        contents it had.  Defensive — guards against a buggy
+        upstream commit that would otherwise erase the ring on the
+        gate side.
         """
         from salt.cluster import ring_membership
 
@@ -785,51 +684,70 @@ class TestRingPolicyPlumbing:
         svc, loop = self._make_svc()
         try:
             svc._node.membership_sm.apply(
-                {"voters": ["m1", "m4", "m5"], "learners": []}, index=1
+                {"voters": ["m1", "m2"], "learners": []}, index=1
             )
-            svc._ring_config_sm.apply({"members": "voters"}, index=2)
-            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m4", "m5"]
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2"]
+            # Pathological empty commit — ring stays at the last
+            # non-empty state rather than going empty.
+            svc._on_membership_change([], [])
+            assert sorted(ring_membership.get_ring().nodes()) == ["m1", "m2"]
         finally:
             ring_membership.reset()
             loop.close()
 
-    def test_propose_ring_config_rejects_unknown_members(self):
-        """The propose API validates input before reaching Raft."""
+
+# ---------------------------------------------------------------------------
+# Multi-ring registry + routing propose helpers (slice 2)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRingProposeHelpers:
+    """
+    The cluster-log multi-ring entrypoints: ``propose_ring_create``,
+    ``propose_ring_destroy``, and ``propose_route``.
+
+    Slice 2 wires the cluster-log persistence path; per-ring Raft
+    groups themselves come up in slice 3 once
+    ``_on_ring_registry_change`` is taught the lifecycle.
+    """
+
+    def test_propose_ring_create_validates_inputs(self):
         import pytest
 
-        svc, loop = self._make_svc()
-        try:
-            with pytest.raises(ValueError):
-                svc.propose_ring_config(members="moon")
-        finally:
-            loop.close()
+        async def _body():
+            opts = _make_opts("solo", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
 
-    def test_propose_ring_config_requires_leader_state(self):
-        """
-        ``propose_ring_config`` fails fast if this node is not the
-        leader — followers cannot append entries that will commit.
-        """
+            with pytest.raises(ValueError, match="non-empty ring_id"):
+                svc.propose_ring_create("", ["solo"])
+
+            with pytest.raises(ValueError, match="Unknown ring status"):
+                svc.propose_ring_create("jobs", ["solo"], status="zombie")
+
+            svc.stop()
+
+        _run(_body())
+
+    def test_propose_ring_create_requires_leader(self):
         import pytest
 
-        svc, loop = self._make_svc()
-        try:
-            # Default state is FOLLOWER (or START); not LEADER.
-            with pytest.raises(RuntimeError):
-                svc.propose_ring_config(members="voters", replicas=2)
-        finally:
-            loop.close()
+        async def _body():
+            opts = _make_opts("follower", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            # No start(); node stays a follower.
+            with pytest.raises(RuntimeError, match="must run on the Raft leader"):
+                svc.propose_ring_create("jobs", ["follower"])
 
-    def test_propose_ring_config_appends_log_entry_on_leader(self):
-        """
-        On a leader, ``propose_ring_config`` lands a RING_CONFIG log
-        entry (correct entry_type and cmd shape) that the apply path
-        will drive through ``ring_sm.apply`` once a quorum acks.
+        _run(_body())
 
-        For a solo leader there is no peer to ack, so the in-memory log
-        is the durable proof of "the propose path appended the right
-        entry".  A separate test (with a multi-node cluster harness)
-        covers the full propose -> ack -> apply path.
-        """
+    def test_propose_ring_create_appends_registry_entry(self):
         from salt.cluster.consensus.raft.log import LogEntryType
 
         async def _body():
@@ -843,33 +761,50 @@ class TestRingPolicyPlumbing:
                     break
             assert svc.node.state == NodeState.LEADER
 
-            initial_index = svc.node.log.index
-            svc.propose_ring_config(members="voters", replicas=3)
-            # Verify a new entry of type RING_CONFIG with the proposed cmd.
-            assert svc.node.log.index == initial_index + 1
+            initial = svc.node.log.index
+            svc.propose_ring_create("jobs", ["m2", "m1"])
+            assert svc.node.log.index == initial + 1
             entry = svc.node.log.get(svc.node.log.index)
-            assert entry is not None
-            assert entry.type == LogEntryType.RING_CONFIG
-            assert entry.cmd == {"members": "voters", "replicas": 3}
+            assert entry.type == LogEntryType.RING_REGISTRY
+            # Founders sorted canonically so every replica sees the same form.
+            assert entry.cmd == {
+                "ring_id": "jobs",
+                "founding_voters": ["m1", "m2"],
+                "status": "active",
+            }
 
-            # Drive the solo-leader commit path: with no peers, the
-            # heartbeat does not advance commit_index for us, so the
-            # apply happens once the test calls advance_commit_index
-            # (or a multi-node cluster's append_entries_reply triggers
-            # it naturally).
             svc.node.advance_commit_index()
-            assert svc._ring_config_sm.members == "voters"
-            assert svc._ring_config_sm.replicas == 3
+            assert svc._ring_registry_sm.active_rings() == ["jobs"]
             svc.stop()
 
         _run(_body())
 
-    def test_propose_ring_config_no_args_is_noop(self):
-        """
-        Calling ``propose_ring_config()`` with no kwargs commits no
-        entry — the SM stays at its default.  Pins the partial-update
-        contract: an empty dict would be pointless.
-        """
+    def test_propose_ring_destroy_marks_status_destroyed(self):
+        async def _body():
+            opts = _make_opts("solo", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            svc.propose_ring_create("jobs", ["solo"])
+            svc.node.advance_commit_index()
+            assert svc._ring_registry_sm.active_rings() == ["jobs"]
+
+            svc.propose_ring_destroy("jobs")
+            svc.node.advance_commit_index()
+            assert svc._ring_registry_sm.active_rings() == []
+            # The destroy record itself remains for audit.
+            assert svc._ring_registry_sm.get("jobs")["status"] == "destroyed"
+            svc.stop()
+
+        _run(_body())
+
+    def test_propose_route_appends_route_entry(self):
+        from salt.cluster.consensus.raft.log import LogEntryType
 
         async def _body():
             opts = _make_opts("solo", [])
@@ -880,24 +815,27 @@ class TestRingPolicyPlumbing:
                 await asyncio.sleep(0.01)
                 if svc.node.state == NodeState.LEADER:
                     break
-            assert svc.node.state == NodeState.LEADER
 
-            initial_index = svc.node.log.index
-            svc.propose_ring_config()  # no kwargs
-            await asyncio.sleep(0.05)
-            assert (
-                svc.node.log.index == initial_index
-            ), "propose_ring_config with no args must not append a log entry"
+            initial = svc.node.log.index
+            svc.propose_route("jobs", "jobs_ring")
+            entry = svc.node.log.get(svc.node.log.index)
+            assert svc.node.log.index == initial + 1
+            assert entry.type == LogEntryType.ROUTE
+            assert entry.cmd == {"data_type": "jobs", "ring_id": "jobs_ring"}
+
+            svc.node.advance_commit_index()
+            assert svc._routing_sm.get("jobs") == "jobs_ring"
+
+            # Clearing the route routes data back to broadcast.
+            svc.propose_route("jobs", None)
+            svc.node.advance_commit_index()
+            assert svc._routing_sm.get("jobs") is None
             svc.stop()
 
         _run(_body())
 
-    def test_propose_ring_config_partial_update(self):
-        """
-        Setting only ``replicas`` keeps the existing ``members`` value
-        — this is the atomic-flip-of-one-knob contract that lets a
-        runbook tweak replication without re-asserting members.
-        """
+    def test_propose_route_validates_data_type(self):
+        import pytest
 
         async def _body():
             opts = _make_opts("solo", [])
@@ -908,17 +846,500 @@ class TestRingPolicyPlumbing:
                 await asyncio.sleep(0.01)
                 if svc.node.state == NodeState.LEADER:
                     break
+
+            with pytest.raises(ValueError, match="non-empty data_type"):
+                svc.propose_route("", "jobs_ring")
+            svc.stop()
+
+        _run(_body())
+
+    def test_propose_route_requires_leader(self):
+        import pytest
+
+        async def _body():
+            opts = _make_opts("follower", [])
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            with pytest.raises(RuntimeError, match="must run on the Raft leader"):
+                svc.propose_route("jobs", "jobs_ring")
+
+        _run(_body())
+
+
+# ---------------------------------------------------------------------------
+# Per-ring Raft group lifecycle (slice 3)
+# ---------------------------------------------------------------------------
+
+
+def _make_ring_opts(node_id, peers, tmp_path):
+    """
+    Variant of ``_make_opts`` that pins ``cachedir`` per-test so each
+    case gets a clean on-disk slate.  Multi-ring lifecycle tests need
+    isolation because a ring's storage persists across calls — sharing
+    the module-level ``_TMPDIR`` lets prior tests leak state.
+    """
+    return {
+        "id": f"{node_id}-hostname",
+        "interface": node_id,
+        "cluster_id": "test-cluster",
+        "cluster_peers": peers,
+        "cachedir": str(tmp_path),
+        "cluster_election_min": 150,
+        "cluster_election_max": 300,
+    }
+
+
+class TestPerRingLifecycle:
+    """
+    The ``RING_REGISTRY`` -> per-ring ``Node`` lifecycle: creating a
+    ring spins up an in-process Raft group; destroying it tears the
+    group down without touching the cluster group.
+    """
+
+    def test_create_ring_brings_up_node_when_self_is_founder(self, tmp_path):
+        from salt.cluster.consensus.raft.node import NodeState
+
+        async def _body():
+            opts = _make_ring_opts("solo", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
             assert svc.node.state == NodeState.LEADER
 
-            svc.propose_ring_config(members="voters", replicas=2)
-            svc.node.advance_commit_index()  # solo leader self-commit
-            assert svc._ring_config_sm.members == "voters"
-            assert svc._ring_config_sm.replicas == 2
-
-            svc.propose_ring_config(replicas=4)
+            svc.propose_ring_create("jobs", ["solo"])
             svc.node.advance_commit_index()
-            assert svc._ring_config_sm.members == "voters"
-            assert svc._ring_config_sm.replicas == 4
+
+            # Per-ring Node now registered in self._nodes; dispatcher
+            # routes inbound RPCs for that ring to it.
+            assert "jobs" in svc._nodes
+            assert svc._nodes["jobs"] is not svc._node
+            assert svc._nodes["jobs"].node_id == "solo"
+            assert svc.dispatcher._nodes["jobs"] is svc._nodes["jobs"]
+
+            # The heartbeat tick drives the per-ring Node through
+            # election + founding-CONFIG.  Give it a few cycles to
+            # converge (single-node so it elects itself), then push
+            # commit_index ourselves the way the cluster-Node solo
+            # tests do (no peers means no acks ever land).
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                ring_node = svc._nodes["jobs"]
+                if ring_node.state == NodeState.LEADER and ring_node.log.index >= 0:
+                    break
+            ring_node = svc._nodes["jobs"]
+            assert ring_node.state == NodeState.LEADER
+            ring_node.advance_commit_index()
+            # Founding CONFIG committed to the *ring's* own log,
+            # naming ``["solo"]`` as the founding voter.
+            assert ring_node.membership_sm.current_voters() == ["solo"]
             svc.stop()
+
+        _run(_body())
+
+    def test_non_founder_does_not_bring_up_ring(self, tmp_path):
+        """
+        A registry entry that does not list this master is observed
+        but does not cause local bring-up — the ring's data plane
+        runs on the founders, not this master.
+        """
+
+        async def _body():
+            opts = _make_ring_opts("bystander", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            svc.propose_ring_create("jobs", ["other-1", "other-2"])
+            svc.node.advance_commit_index()
+
+            assert "jobs" not in svc._nodes
+            # Registry SM still records the entry — every master
+            # agrees on the registry; only the data plane is local.
+            assert svc._ring_registry_sm.active_rings() == ["jobs"]
+            svc.stop()
+
+        _run(_body())
+
+    def test_destroy_ring_tears_down_node(self, tmp_path):
+        async def _body():
+            opts = _make_ring_opts("solo", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            svc.propose_ring_create("jobs", ["solo"])
+            svc.node.advance_commit_index()
+            assert "jobs" in svc._nodes
+
+            svc.propose_ring_destroy("jobs")
+            svc.node.advance_commit_index()
+            assert "jobs" not in svc._nodes
+            assert "jobs" not in svc.dispatcher._nodes
+            # The cluster group is untouched.
+            assert "cluster" in svc._nodes
+            svc.stop()
+
+        _run(_body())
+
+    def test_ring_storage_isolated_from_cluster(self, tmp_path):
+        """
+        The per-ring ``Node`` writes to a ring-keyed on-disk path,
+        not the cluster's path.  Pin the invariant that a committed
+        log entry in the ring does not appear in the cluster's log
+        bank — otherwise multi-ring would corrupt cluster Raft state.
+        """
+        from salt.cluster.consensus.storage import SaltStorage
+
+        async def _body():
+            opts = _make_ring_opts("solo", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            svc.propose_ring_create("jobs", ["solo"])
+            svc.node.advance_commit_index()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                ring_node = svc._nodes["jobs"]
+                if ring_node.log.index >= 0:
+                    break
+            svc._nodes["jobs"].advance_commit_index()
+
+            ring_storage = SaltStorage("solo", opts, ring_id="jobs")
+            cluster_storage = SaltStorage("solo", opts, ring_id="cluster")
+            assert ring_storage._meta_bank != cluster_storage._meta_bank
+            # The ring's log on disk has at least the founding CONFIG.
+            ring_entries = ring_storage.load_log()
+            assert ring_entries, "ring log should have committed entries"
+            svc.stop()
+
+        _run(_body())
+
+    def test_refuse_to_create_ring_named_cluster(self, tmp_path):
+        """
+        ``"cluster"`` is the reserved group id for the main cluster
+        Raft group.  Bringing up a ring named ``"cluster"`` would
+        shadow it; ``_bring_up_ring`` refuses and logs a warning.
+        """
+
+        async def _body():
+            opts = _make_ring_opts("solo", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            # Bypass propose_ring_create and call the lifecycle
+            # callback directly so we exercise the guard.
+            svc._on_ring_registry_change("cluster", ["solo"], "active")
+            # No second cluster Node created.
+            assert len(svc._nodes) == 1
+            assert svc._nodes["cluster"] is svc._node
+            svc.stop()
+
+        _run(_body())
+
+    def test_create_destroy_roundtrip_reuses_ring_storage(self, tmp_path):
+        """
+        Re-creating a destroyed ring with the same id picks up the
+        persisted on-disk state — Raft state survives a destroy/create
+        cycle, which is the documented recovery story for an operator
+        who tore a ring down too eagerly.
+        """
+
+        async def _body():
+            opts = _make_ring_opts("solo", [], tmp_path)
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+            svc.start()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if svc.node.state == NodeState.LEADER:
+                    break
+
+            svc.propose_ring_create("jobs", ["solo"])
+            svc.node.advance_commit_index()
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                ring_node = svc._nodes["jobs"]
+                if ring_node.log.index >= 0:
+                    break
+            svc._nodes["jobs"].advance_commit_index()
+            committed_index = svc._nodes["jobs"].log.index
+
+            svc.propose_ring_destroy("jobs")
+            svc.node.advance_commit_index()
+            assert "jobs" not in svc._nodes
+
+            # Re-create.  The bring-up reads the ring's storage,
+            # which still has the founding CONFIG from before.
+            svc.propose_ring_create("jobs", ["solo"])
+            svc.node.advance_commit_index()
+            assert "jobs" in svc._nodes
+            # Same log index as before the destroy — proves we picked
+            # up persisted state instead of starting fresh.
+            assert svc._nodes["jobs"].log.index == committed_index
+            svc.stop()
+
+        _run(_body())
+
+
+# ---------------------------------------------------------------------------
+# Per-ring voter-health watchdog
+# ---------------------------------------------------------------------------
+
+
+class TestPerRingVoterHealth:
+    """
+    The voter-health watchdog iterates every Raft group hosted in
+    this process so a ring losing quorum gets the same auto-replace
+    treatment the cluster Raft group does.
+
+    These tests stand up a solo master, manually inject per-ring
+    Nodes whose membership has a stale-contact peer, run one tick of
+    the watchdog, and assert the structured sentinel records the
+    unhealthy voter under the right group.
+    """
+
+    def _make_ring_node(self, svc, ring_id, voters, learners=()):
+        """
+        Build a per-ring ``Node`` with the given voter/learner set,
+        elect it leader, and register it on the service so the
+        watchdog walks it.
+        """
+        from salt.cluster.consensus.raft import Node
+        from salt.cluster.consensus.storage import SaltStorage
+
+        node_id = svc.opts["interface"]
+        storage = SaltStorage(node_id, svc.opts, ring_id=ring_id)
+        ring_node = Node(node_id, storage=storage, voting=True)
+        ring_node.register_schedule_timeout(svc._scheduler.schedule)
+        # Seed the membership SM directly — we don't need to drive a
+        # full election for the watchdog test.
+        ring_node.membership_sm.apply(
+            {"voters": list(voters), "learners": list(learners)}, index=0
+        )
+        ring_node._applied_config_index = 0
+        # Force leader state so the watchdog inspects this node's
+        # last_contact map.  The same hot-path the production
+        # ``_check_voter_health`` walks.  Follower → candidate →
+        # leader is the legal NodeState transition order; jumping
+        # straight from start to leader raises by design.
+        ring_node.become_follower()
+        ring_node.become_candidate()
+        ring_node.state.become_leader()
+        svc._nodes[ring_id] = ring_node
+        return ring_node
+
+    def test_watchdog_records_unhealthy_voter_per_ring(self, tmp_path):
+        """
+        A stale ``last_contact`` on a ring voter shows up under
+        ``rings.<ring>.unhealthy_voters`` in the health sentinel.
+        Pin the structured-sentinel contract — ``cluster.members``
+        consumes the top-level fields, and per-ring consumers reach
+        into the rings dict.
+        """
+        import json
+
+        async def _body():
+            opts = _make_ring_opts("self", [], tmp_path)
+            opts["cluster_voter_timeout"] = 0.001  # everything is "stale"
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+
+            ring_node = self._make_ring_node(
+                svc,
+                ring_id="jobs",
+                voters=["self", "peer-A"],
+            )
+            # Inject a peer with a stale last_contact.  In production
+            # this is updated by AppendEntries replies; absence means
+            # "never heard from" which the watchdog conservatively
+            # ignores, so we set an explicit timestamp.
+            ring_node.peers = []
+            # Use a peer-like stub: just needs node_id + the peer
+            # appearing in current_voters.
+            from salt.cluster.consensus.raft.node import Peer
+
+            class _StubPeer(Peer):
+                def __init__(self, node_id):
+                    super().__init__(None, node_id=node_id, voting=True)
+
+            ring_node.peers = [_StubPeer("peer-A")]
+            ring_node._peer_last_contact["peer-A"] = ring_node.get_now() - 10.0
+
+            # Run a single watchdog tick by calling the method
+            # directly (the periodic schedule would do the same).
+            svc._check_voter_health()
+
+            sentinel_path = tmp_path / "cluster-health.json"
+            with sentinel_path.open() as fp:
+                body = json.load(fp)
+            assert "rings" in body
+            assert body["rings"]["jobs"]["unhealthy_voters"] == ["peer-A"]
+            # The cluster group's lists stay at the top level so
+            # pre-multi-ring readers (``cluster.members``) keep
+            # working unchanged.
+            assert body["unhealthy_voters"] == []
+
+        _run(_body())
+
+    def test_watchdog_replaces_dead_voter_with_caught_up_learner(self, tmp_path):
+        """
+        Ring outage / recovery scenario.  Two scenarios in one test:
+
+        1. A 3-voter ring with one healthy learner.  Mark one voter
+           stale.  The watchdog (auto_replace=True) demotes the
+           stale voter and promotes the learner — the ring keeps
+           three voters and stays writable.
+        2. After replacement, the ring's voter set is
+           ``{healthy_voters} ∪ {promoted_learner}`` — sorted, the
+           previously-stale voter is gone.
+
+        This is the per-ring counterpart of the cluster-Raft
+        single-server change in Ongaro §6.4.  Without it, a dead
+        ring voter would silently stall the ring until an operator
+        intervened.
+        """
+        from salt.cluster.consensus.raft import ManualPeer, Node
+
+        async def _body():
+            opts = _make_ring_opts("self", [], tmp_path)
+            opts["cluster_voter_timeout"] = 0.001
+            opts["cluster_auto_replace_voters"] = True
+            opts["cluster_min_voters"] = 2  # 3-voter ring; floor at 2
+            opts["cluster_demote_cooldown"] = 0.0  # no cooldown for tests
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+
+            # 3 voters + 1 learner.  ``self`` is the leader; voter-A
+            # will go stale, voter-B stays healthy.
+            ring_node = self._make_ring_node(
+                svc,
+                ring_id="jobs",
+                voters=["self", "voter-A", "voter-B"],
+                learners=["candidate-L"],
+            )
+
+            # Stub peers so heartbeats don't blow up.
+            def _stub(node_id):
+                stub_node = Node(node_id)
+                stub_node.register_schedule_timeout(svc._scheduler.schedule)
+                stub_node.become_follower()
+                return ManualPeer(stub_node, node_id=node_id)
+
+            ring_node.peers = [
+                _stub("voter-A"),
+                _stub("voter-B"),
+                _stub("candidate-L"),
+            ]
+            now = ring_node.get_now()
+            ring_node._peer_last_contact["voter-A"] = now - 10.0
+            ring_node._peer_last_contact["voter-B"] = now  # healthy
+            ring_node._peer_last_contact["candidate-L"] = now
+            # Mark the learner as caught up so it's a promotion
+            # candidate.  Without this the watchdog skips it.  Use a
+            # generous lookahead because the demotion proposal
+            # advances ``log.index`` by 1 before the candidate-check
+            # runs; setting match_index well past the current index
+            # means the learner stays caught-up through that bump.
+            ring_node.match_index["candidate-L"] = ring_node.log.index + 100
+
+            demoted = []
+            promoted = []
+            original_demote = ring_node.propose_voter_demotion
+            original_promote = ring_node.propose_voter_promotion_to_replace
+
+            def _spy_demote(peer_id, min_voters=3):
+                demoted.append(peer_id)
+                return original_demote(peer_id, min_voters=min_voters)
+
+            def _spy_promote(peer_id):
+                promoted.append(peer_id)
+                return original_promote(peer_id)
+
+            ring_node.propose_voter_demotion = _spy_demote
+            ring_node.propose_voter_promotion_to_replace = _spy_promote
+
+            svc._check_voter_health()
+
+            assert demoted == ["voter-A"], (
+                f"expected voter-A to be demoted, watchdog called "
+                f"propose_voter_demotion with {demoted!r}"
+            )
+            assert promoted == ["candidate-L"], (
+                f"expected candidate-L to be promoted, watchdog called "
+                f"propose_voter_promotion_to_replace with {promoted!r}"
+            )
+            assert ("jobs", "voter-A") in svc._recently_demoted
+
+        _run(_body())
+
+    def test_watchdog_demotes_per_ring_voter_with_auto_replace(self, tmp_path):
+        """
+        With ``cluster_auto_replace_voters=True``, an unhealthy
+        per-ring voter is proposed for demotion.  The cooldown is
+        keyed by (group, peer) so a demote on one ring doesn't lock
+        out the same peer-id on another ring.
+        """
+
+        async def _body():
+            opts = _make_ring_opts("self", [], tmp_path)
+            opts["cluster_voter_timeout"] = 0.001
+            opts["cluster_auto_replace_voters"] = True
+            opts["cluster_min_voters"] = 1  # allow demotion in this tiny ring
+            loop = asyncio.get_running_loop()
+            svc = RaftService(opts, loop, {})
+
+            ring_node = self._make_ring_node(
+                svc, ring_id="jobs", voters=["self", "peer-A"]
+            )
+            # ManualPeer wraps a real Node, so the leader's heartbeat
+            # path (driven inside propose_voter_demotion) doesn't
+            # crash on a None backing Node.  The wrapped peer is a
+            # cheap stand-in — it doesn't need a real Raft loop for
+            # this test.
+            from salt.cluster.consensus.raft import ManualPeer, Node
+
+            peer_a = Node("peer-A")
+            peer_a.register_schedule_timeout(svc._scheduler.schedule)
+            peer_a.become_follower()
+            ring_node.peers = [ManualPeer(peer_a, node_id="peer-A")]
+            ring_node._peer_last_contact["peer-A"] = ring_node.get_now() - 10.0
+            ring_node.match_index["peer-A"] = ring_node.log.index
+
+            # Capture the propose_voter_demotion call.
+            demoted = []
+            original = ring_node.propose_voter_demotion
+
+            def _spy(peer_id, min_voters=3):
+                demoted.append(peer_id)
+                return original(peer_id, min_voters=min_voters)
+
+            ring_node.propose_voter_demotion = _spy
+
+            svc._check_voter_health()
+
+            assert demoted == ["peer-A"]
+            assert ("jobs", "peer-A") in svc._recently_demoted
 
         _run(_body())

--- a/tests/pytests/functional/cluster/consensus/test_raft_transport.py
+++ b/tests/pytests/functional/cluster/consensus/test_raft_transport.py
@@ -75,7 +75,7 @@ class TestRpcEnvelope:
     def test_roundtrip(self, tag):
         payload = {"term": 7, "index": 42, "data": [1, 2, 3]}
         raw = rpc.pack(tag, "node-a", "corr-99", payload)
-        out_tag, src, rid, out = rpc.unpack(raw)
+        out_tag, src, rid, _, out = rpc.unpack(raw)
         assert out_tag == tag
         assert src == "node-a"
         assert rid == "corr-99"
@@ -118,14 +118,14 @@ class TestSingleHopRpc:
 
             # Deliver to b's dispatcher
             raw = a.pushers_out["b"].sent.popleft()
-            tag, src, rid, payload = rpc.unpack(raw)
+            tag, src, rid, _, payload = rpc.unpack(raw)
             assert tag == rpc.REQUEST_VOTE
             await b.dispatcher.dispatch(tag, src, rid, payload)
 
             # b's dispatcher replied into b.pushers_out["a"]
             assert b.pushers_out["a"].sent
             r_raw = b.pushers_out["a"].sent.popleft()
-            r_tag, _, _, r_payload = rpc.unpack(r_raw)
+            r_tag, _, _, _, r_payload = rpc.unpack(r_raw)
             assert r_tag == rpc.REQUEST_VOTE_REPLY
             assert isinstance(r_payload["granted"], bool)
 
@@ -139,11 +139,11 @@ class TestSingleHopRpc:
             a.node.peers[0].pre_request_vote(None, "a", 1, 0, -1)
             await asyncio.sleep(0)
             raw = a.pushers_out["b"].sent.popleft()
-            tag, src, rid, payload = rpc.unpack(raw)
+            tag, src, rid, _, payload = rpc.unpack(raw)
             assert tag == rpc.PRE_REQUEST_VOTE
             await b.dispatcher.dispatch(tag, src, rid, payload)
             r_raw = b.pushers_out["a"].sent.popleft()
-            r_tag, _, _, _ = rpc.unpack(r_raw)
+            r_tag, _, _, _, _ = rpc.unpack(r_raw)
             assert r_tag == rpc.PRE_REQUEST_VOTE_REPLY
 
         _run(_body())
@@ -158,11 +158,11 @@ class TestSingleHopRpc:
             a.node.peers[0].append_entries(None, "a", 1, 0, -1, -1)
             await asyncio.sleep(0)
             raw = a.pushers_out["b"].sent.popleft()
-            tag, src, rid, payload = rpc.unpack(raw)
+            tag, src, rid, _, payload = rpc.unpack(raw)
             assert tag == rpc.APPEND_ENTRIES
             await b.dispatcher.dispatch(tag, src, rid, payload)
             r_raw = b.pushers_out["a"].sent.popleft()
-            r_tag, _, _, r_payload = rpc.unpack(r_raw)
+            r_tag, _, _, _, r_payload = rpc.unpack(r_raw)
             assert r_tag == rpc.APPEND_ENTRIES_REPLY
             assert r_payload["success"] is True
 
@@ -182,12 +182,12 @@ class TestSingleHopRpc:
             a.node.peers[0].install_snapshot(None, "a", 1, 9, 1, bytes(snap))
             await asyncio.sleep(0)
             raw = a.pushers_out["b"].sent.popleft()
-            tag, src, rid, payload = rpc.unpack(raw)
+            tag, src, rid, _, payload = rpc.unpack(raw)
             assert tag == rpc.INSTALL_SNAPSHOT
             assert payload["data"] == snap
             await b.dispatcher.dispatch(tag, src, rid, payload)
             r_raw = b.pushers_out["a"].sent.popleft()
-            r_tag, _, _, r_payload = rpc.unpack(r_raw)
+            r_tag, _, _, _, r_payload = rpc.unpack(r_raw)
             assert r_tag == rpc.INSTALL_SNAPSHOT_REPLY
             assert r_payload["peer_id"] == "b"
 
@@ -405,7 +405,7 @@ class TestFaultTolerance:
             # Reply should be failure
             reply_raw = follower_cn.pushers_out.get(leader_cn.node_id)
             if reply_raw and reply_raw.sent:
-                r_tag, _, _, r_payload = rpc.unpack(reply_raw.sent.popleft())
+                r_tag, _, _, _, r_payload = rpc.unpack(reply_raw.sent.popleft())
                 assert r_tag == rpc.APPEND_ENTRIES_REPLY
                 assert r_payload["success"] is False
 
@@ -433,7 +433,7 @@ class TestFaultTolerance:
                 rpc.REQUEST_VOTE, "interloper", "rid", stale_payload
             )
             assert interloper_pusher.sent
-            r_tag, _, _, r_payload = rpc.unpack(interloper_pusher.sent.popleft())
+            r_tag, _, _, _, r_payload = rpc.unpack(interloper_pusher.sent.popleft())
             assert r_tag == rpc.REQUEST_VOTE_REPLY
             assert r_payload["granted"] is False
 

--- a/tests/pytests/functional/returners/test_salt_cache_integration.py
+++ b/tests/pytests/functional/returners/test_salt_cache_integration.py
@@ -1,0 +1,168 @@
+"""
+Functional integration for the ``salt_cache`` returner.
+
+The unit tests in ``tests/pytests/unit/returners/test_salt_cache.py``
+exercise every returner function directly with ``__opts__`` injected
+via the loader fixture.  This test goes one layer up: it loads the
+returner the way Salt's master loader does it and calls into the
+public ``salt.utils.job`` surface (``store_load``, ``store_job``,
+``store_minions``), proving that flipping ``master_job_cache:
+salt_cache`` actually routes every job-cache code path through the
+:class:`salt.cache.Cache` abstraction.
+
+Why this matters
+----------------
+The multi-ring gate sites in ``salt/master.py`` only intercept
+``salt/job/*`` events when ``master_job_cache`` writes through
+``salt.cache.Cache`` — otherwise ``cluster.shed_unowned`` /
+``cluster.collect_from_peers`` can't see the data.  This test pins
+that the wiring works end-to-end without needing a full cluster.
+"""
+
+import pytest
+
+import salt.cache
+import salt.loader
+import salt.utils.job
+
+
+@pytest.fixture
+def master_opts(tmp_path):
+    """
+    Minimal master opts with the salt_cache returner selected.
+
+    ``master_job_cache: salt_cache`` is the operator-facing knob; the
+    rest are bookkeeping the loader needs (``extension_modules``,
+    ``cachedir``, ``hash_type``).  Using the real ``localfs`` cache
+    driver means writes hit disk in ``tmp_path`` — the test cleans
+    up via pytest's tmp_path teardown.
+    """
+    import salt.config
+
+    opts = salt.config.master_config("/dev/null")
+    opts["cachedir"] = str(tmp_path)
+    opts["extension_modules"] = str(tmp_path / "extmods")
+    opts["master_job_cache"] = "salt_cache"
+    opts["cache"] = "localfs"
+    opts["keep_jobs_seconds"] = 86400
+    return opts
+
+
+@pytest.fixture
+def mminion(master_opts):
+    """
+    A ``MasterMinion`` with the returners loaded.  ``salt.utils.job``
+    builds one of these per call if not supplied; we pre-build it
+    here so the test exercises a single returner load (faster + the
+    same path the master daemon uses internally).
+    """
+    return salt.minion.MasterMinion(master_opts, states=False, rend=False)
+
+
+def test_loader_resolves_salt_cache(master_opts, mminion):
+    """
+    The master loader resolves ``salt_cache`` and exposes every
+    returner function the master and the cluster runners depend on.
+    Pins the contract that ``master_job_cache: salt_cache`` is a
+    valid drop-in for ``local_cache``.
+    """
+    for fname in (
+        "salt_cache.prep_jid",
+        "salt_cache.save_load",
+        "salt_cache.save_minions",
+        "salt_cache.returner",
+        "salt_cache.get_load",
+        "salt_cache.get_jid",
+        "salt_cache.get_jids",
+        "salt_cache.clean_old_jobs",
+    ):
+        assert fname in mminion.returners, f"missing returner function {fname}"
+
+
+def test_save_load_routes_through_salt_cache(master_opts, mminion):
+    """
+    Calling ``salt_cache.save_load`` through the returner dispatch
+    lands the pub load in ``jobs/loads`` — the bank
+    ``cluster.shed_unowned`` reads to find shardable JIDs.  Pins
+    the end-to-end wiring: the master daemon's publish path goes
+    through this same dispatch (see
+    :func:`salt.utils.job.store_job`'s ``saveload_fstr`` lookup at
+    ``salt/utils/job.py``).
+    """
+    mminion.returners["salt_cache.save_load"](
+        "20260516-A",
+        {"jid": "20260516-A", "fun": "test.ping"},
+    )
+    cache = salt.cache.Cache(master_opts, driver="localfs")
+    stored = cache.fetch("jobs/loads", "20260516-A")
+    assert stored["fun"] == "test.ping"
+
+
+def test_store_job_routes_through_salt_cache(master_opts, mminion):
+    """
+    A minion return lands in the per-JID returns bank.
+    ``salt.utils.job.store_job`` is the master daemon's entry
+    point; with ``master_job_cache: salt_cache`` it dispatches to
+    ``salt_cache.returner``.
+    ``cluster.shed_unowned``'s cascade flush
+    (``jobs/returns/<jid>`` whole-bank drop) operates on exactly
+    these entries.
+    """
+    # Master would normally save the load first via
+    # ``salt_cache.save_load``; do the same here so the returner has
+    # the JID registered.
+    mminion.returners["salt_cache.save_load"](
+        "20260516-B",
+        {"jid": "20260516-B", "fun": "test.ping"},
+    )
+    salt.utils.job.store_job(
+        master_opts,
+        {
+            "jid": "20260516-B",
+            "id": "minion-a",
+            "return": "pong",
+            "retcode": 0,
+            "success": True,
+        },
+        mminion=mminion,
+    )
+    cache = salt.cache.Cache(master_opts, driver="localfs")
+    record = cache.fetch("jobs/returns/20260516-B", "minion-a")
+    assert record["return"] == "pong"
+    assert record["retcode"] == 0
+
+
+def test_store_minions_routes_through_salt_cache(master_opts, mminion):
+    """
+    ``salt.utils.job.store_minions`` is what the cluster gate site
+    in ``salt/master.py`` calls on a forwarded ``salt/job/<jid>/new``
+    event.  Pin that the minion list lands in ``jobs/minions`` —
+    the bank ``cluster.shed_unowned`` reads to know what's
+    shardable.
+    """
+    salt.utils.job.store_minions(
+        master_opts, "20260516-C", ["m1", "m2"], mminion=mminion
+    )
+    cache = salt.cache.Cache(master_opts, driver="localfs")
+    assert cache.fetch("jobs/minions", "20260516-C") == ["m1", "m2"]
+
+
+def test_get_load_round_trips_through_returner_dispatch(master_opts, mminion):
+    """
+    Read-back through the returner dispatch returns what was saved.
+    Round-trips through the public ``salt.utils.job`` →
+    ``salt_cache.get_load`` path so a UI/CLI consumer would see the
+    same answer.
+    """
+    mminion.returners["salt_cache.save_load"](
+        "20260516-D",
+        {"jid": "20260516-D", "fun": "test.ping"},
+    )
+    out = mminion.returners["salt_cache.get_load"]("20260516-D")
+    assert out["fun"] == "test.ping"
+
+
+# Lazy import: ``salt.minion`` pulls in a lot; only imported when a
+# test actually requests the ``mminion`` fixture.  Avoids the cost
+# on test collection for sibling functional tests that don't need it.
+import salt.minion  # noqa: E402  pylint: disable=wrong-import-position

--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -598,7 +598,15 @@ def test_win_user_present_new_password(states, account_with_password):
     """
     Running user.present with a different password should change it and
     report the change as passwd: XXX-REDACTED-XXX.
+
+    Newer ``shadow.info`` on Windows additionally surfaces
+    ``password_changed`` and ``lstchg`` keys (the wrapped Unix shadow
+    fields) whenever the password changes, so the changes dict now
+    has more than just ``passwd``.  The contract this test pins is
+    that the redacted ``passwd`` change is *present*; the auxiliary
+    timestamp keys are implementation detail and aren't worth
+    re-asserting on every shadow refactor.
     """
     ret = states.user.present(name=account_with_password, password="N3wP@ssW0rd!")
     assert ret.result is True
-    assert ret.changes == {"passwd": "XXX-REDACTED-XXX"}
+    assert ret.changes.get("passwd") == "XXX-REDACTED-XXX", ret.changes

--- a/tests/pytests/integration/cluster/test_isolated_cluster.py
+++ b/tests/pytests/integration/cluster/test_isolated_cluster.py
@@ -467,3 +467,173 @@ def test_isolated_late_joiner_targets_all_existing_minions(
             f"Minion {mid!r} did not return True via late-joining master_4 "
             f"(got {data[mid]!r})"
         )
+
+
+# ---------------------------------------------------------------------------
+# cluster.sync_roots runner — operator-driven content fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_isolated_sync_roots_runner_propagates_content(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    Content added to master_1's ``file_roots`` and ``pillar_roots`` *after*
+    the cluster is up must propagate to every peer when the operator runs
+    ``salt-run cluster.sync_roots``.
+
+    Pins the runner-to-peer fan-out contract:
+
+    * The runner returns immediately with ``status: "fan-out initiated"``.
+    * The actual sync happens asynchronously inside the master daemon.
+    * Each peer's content tree gets the new files via the same encrypted
+      state-sync transport used at join time — no special path, no IPC.
+
+    Distinct from ``test_isolated_late_joiner_receives_file_and_pillar_roots``:
+    that one tests *join-time* bulk sync (content present before a master
+    joins).  This one tests *post-join* operator-driven sync (content added
+    after the cluster is steady-state).
+    """
+    src_file_root = pathlib.Path(
+        cluster_master_1_isolated.config["file_roots"]["base"][0]
+    )
+    src_pillar_root = pathlib.Path(
+        cluster_master_1_isolated.config["pillar_roots"]["base"][0]
+    )
+
+    # Unique marker so we can't be fooled by leftover state from a
+    # neighbouring test or a previous run.
+    marker = f"sync-roots-marker-{int(time.time())}"
+    sls_body = f"post-join-id:\n  test.succeed_without_changes:\n    - name: {marker}\n"
+    pillar_body = f"sync_roots_marker: {marker}\n"
+
+    sls_path = src_file_root / "post_join_synced.sls"
+    pillar_path = src_pillar_root / "post_join_synced.sls"
+    sls_path.write_text(sls_body)
+    pillar_path.write_text(pillar_body)
+
+    # Fire the runner from master_1.  Returns immediately; the daemon
+    # owns the fan-out.
+    salt_run = cluster_master_1_isolated.salt_run_cli(timeout=60)
+    ret = salt_run.run("cluster.sync_roots")
+    assert ret.returncode == 0, (
+        f"cluster.sync_roots exited non-zero (stdout={ret.stdout!r}, "
+        f"stderr={ret.stderr!r})"
+    )
+    # JSON deserialisation may give us a dict or the raw string depending
+    # on output format; just check the success substring loosely.
+    assert "fan-out initiated" in (ret.stdout or "") or (
+        isinstance(ret.data, dict) and ret.data.get("status") == "fan-out initiated"
+    ), f"runner output missing fan-out marker: {ret.stdout!r} / {ret.data!r}"
+
+    # Poll for content arrival on master_2 and master_3.  Same transport
+    # as the join-time bulk sync, so 30 s is comfortably above the
+    # observed live-cluster window (~5-8 s on a healthy LAN).
+    peers = (cluster_master_2_isolated, cluster_master_3_isolated)
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        all_landed = True
+        for master in peers:
+            dst_sls = (
+                pathlib.Path(master.config["file_roots"]["base"][0])
+                / "post_join_synced.sls"
+            )
+            dst_pillar = (
+                pathlib.Path(master.config["pillar_roots"]["base"][0])
+                / "post_join_synced.sls"
+            )
+            if not dst_sls.is_file() or not dst_pillar.is_file():
+                all_landed = False
+                break
+        if all_landed:
+            break
+        time.sleep(0.5)
+
+    # Per-peer assertions so a failure points at the right master.
+    for master in peers:
+        addr = master.config["interface"]
+        dst_sls = (
+            pathlib.Path(master.config["file_roots"]["base"][0])
+            / "post_join_synced.sls"
+        )
+        dst_pillar = (
+            pathlib.Path(master.config["pillar_roots"]["base"][0])
+            / "post_join_synced.sls"
+        )
+        assert dst_sls.is_file(), (
+            f"master {addr} never received post_join_synced.sls "
+            f"(looked under {dst_sls.parent})"
+        )
+        assert dst_pillar.is_file(), (
+            f"master {addr} never received post_join_synced.sls pillar "
+            f"(looked under {dst_pillar.parent})"
+        )
+        assert (
+            marker in dst_sls.read_text()
+        ), f"master {addr} received the file but marker is wrong"
+        assert (
+            marker in dst_pillar.read_text()
+        ), f"master {addr} received the pillar but marker is wrong"
+
+
+def test_isolated_sync_roots_runner_file_only(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    ``cluster.sync_roots roots=file`` syncs only ``file_roots``; pillars
+    on the peers are unchanged.  Pins the channel-filter contract so an
+    operator who only wanted SLS updates doesn't accidentally fan out
+    secret pillar data.
+    """
+    src_file_root = pathlib.Path(
+        cluster_master_1_isolated.config["file_roots"]["base"][0]
+    )
+    src_pillar_root = pathlib.Path(
+        cluster_master_1_isolated.config["pillar_roots"]["base"][0]
+    )
+
+    marker = f"file-only-{int(time.time())}"
+    file_path = src_file_root / "file_only.sls"
+    pillar_path = src_pillar_root / "file_only_pillar.sls"
+    file_path.write_text(f"id:\n  test.nop:\n    - name: {marker}\n")
+    pillar_path.write_text(f"never_fanned_out: {marker}\n")
+
+    salt_run = cluster_master_1_isolated.salt_run_cli(timeout=60)
+    ret = salt_run.run("cluster.sync_roots", "roots=file")
+    assert ret.returncode == 0
+
+    peers = (cluster_master_2_isolated, cluster_master_3_isolated)
+
+    # Wait for the file_roots side to land; we deliberately do not wait
+    # for the pillar (because it shouldn't land at all).
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if all(
+            (
+                pathlib.Path(m.config["file_roots"]["base"][0]) / "file_only.sls"
+            ).is_file()
+            for m in peers
+        ):
+            break
+        time.sleep(0.5)
+
+    for master in peers:
+        addr = master.config["interface"]
+        dst_file = (
+            pathlib.Path(master.config["file_roots"]["base"][0]) / "file_only.sls"
+        )
+        dst_pillar = (
+            pathlib.Path(master.config["pillar_roots"]["base"][0])
+            / "file_only_pillar.sls"
+        )
+        assert (
+            dst_file.is_file()
+        ), f"master {addr} did not receive file_only.sls via roots=file"
+        assert not dst_pillar.is_file(), (
+            f"master {addr} received file_only_pillar.sls despite roots=file "
+            "(pillar should be excluded)"
+        )

--- a/tests/pytests/integration/cluster/test_jobs_migration.py
+++ b/tests/pytests/integration/cluster/test_jobs_migration.py
@@ -243,25 +243,13 @@ def test_jobs_migration_round_trip(
     )
     assert collect.get("status") == "fan-out initiated"
 
-    def _master_1_has_everything():
-        cache = _master_cache(cluster_master_1_isolated)
-        return set(cache.list("jobs/loads")) == set(seeded)
-
-    assert _wait_until(_master_1_has_everything, timeout=30), (
-        f"master 1 did not collect full set: missing "
-        f"{sorted(set(seeded) - set(_master_cache(cluster_master_1_isolated).list('jobs/loads')))}"
-    )
-
-    # Master 1 now holds the full jobs/loads set; the other banks
-    # (jobs/minions, jobs/endtimes, jobs/nocache) flow through the
-    # same default-banks collection.
-    cache_1 = _master_cache(cluster_master_1_isolated)
-    assert set(cache_1.list("jobs/minions")) == set(seeded)
-
-    # Sentinel: the collect status file shipped, parses, and shows
-    # complete=True once every peer eof'd every channel.  Operators
-    # rely on this to confirm the runner's fan-out reached every
-    # peer without tailing master logs.
+    # The peer-side ``_handle_collect_request`` streams the requested
+    # channels sequentially (``jobs/loads`` first, then ``jobs/minions``,
+    # then ``jobs/endtimes``, then ``jobs/nocache``).  Waiting on a
+    # single bank's contents would return as soon as that bank
+    # completed and race the in-flight chunks for the rest; wait on the
+    # operator-facing sentinel instead, which only flips to
+    # ``complete=True`` once every peer has eof'd every channel.
     import pathlib
 
     sentinel_path = (
@@ -280,8 +268,20 @@ def test_jobs_migration_round_trip(
         return doc.get("complete") is True
 
     assert _wait_until(
-        _sentinel_complete, timeout=30
+        _sentinel_complete, timeout=60
     ), "collect status sentinel did not reach complete=True"
+
+    # Now that every peer has eof'd every channel, master 1 holds the
+    # full keyspace across every default bank.
+    cache_1 = _master_cache(cluster_master_1_isolated)
+    assert set(cache_1.list("jobs/loads")) == set(seeded), (
+        f"master 1 missing jobs/loads entries: "
+        f"{sorted(set(seeded) - set(cache_1.list('jobs/loads')))}"
+    )
+    assert set(cache_1.list("jobs/minions")) == set(seeded), (
+        f"master 1 missing jobs/minions entries: "
+        f"{sorted(set(seeded) - set(cache_1.list('jobs/minions')))}"
+    )
 
     # Phase 5: clear route + destroy ring.
     _run_runner(cluster_master_1_isolated, "cluster.route_clear", "data_type=jobs")

--- a/tests/pytests/integration/cluster/test_jobs_migration.py
+++ b/tests/pytests/integration/cluster/test_jobs_migration.py
@@ -1,0 +1,390 @@
+"""
+End-to-end jobs migration scenario on the isolated 3-master cluster.
+
+Exercises the full multi-ring round-trip for the data plane:
+
+1. **Seed** synthetic ``jobs/loads`` entries on every master so each
+   one holds the same baseline keyspace (mimics the broadcast era).
+2. **Create** ring=jobs with all three masters as founders and
+   route ``data_type=jobs`` to it.
+3. **Shed** unowned JIDs on each master, asserting that each one
+   keeps only its ring-owned slice and that the union across masters
+   equals the original set.
+4. **Collect** from peers on master 1, asserting it ends up with
+   the full keyspace again.
+5. **Clear** the route and **destroy** the ring; verify the cluster
+   is back to broadcast.
+
+The salt_cache returner integration is covered separately by
+``tests/pytests/unit/returners/test_salt_cache.py`` — this test
+proves the multi-ring runners can move arbitrary
+:class:`salt.cache.Cache` bank contents end-to-end on a real
+cluster, which is the production case once
+``master_job_cache: salt_cache`` lands in operator configs.
+"""
+
+import json
+import time
+
+import pytest
+
+import salt.cache
+import salt.utils.files
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_runner(master, fun, *args, timeout=60):
+    """Run a runner via ``salt-run --output=json`` and decode."""
+    cli = master.salt_run_cli(timeout=timeout)
+    ret = cli.run("--output=json", fun, *args)
+    assert (
+        ret.returncode == 0
+    ), f"{fun} exited non-zero (stdout={ret.stdout!r}, stderr={ret.stderr!r})"
+    if not ret.stdout.strip():
+        return None
+    try:
+        return json.loads(ret.stdout)
+    except json.JSONDecodeError:
+        return ret.stdout
+
+
+def _wait_until(predicate, timeout=30, interval=0.5):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    return last
+
+
+def _master_cache(master):
+    """
+    Build a :class:`salt.cache.Cache` rooted at *master*'s configured
+    cachedir.  Used to seed and inspect bank state from the test
+    process.  Reads the same on-disk paths the master daemon (and
+    the runner subprocesses it spawns) read.
+    """
+    opts = dict(master.config)
+    # The Cache abstraction uses ``cachedir`` plus the configured
+    # driver.  Both are present in the fixture's opts.
+    return salt.cache.Cache(opts, driver=opts.get("cache", "localfs"))
+
+
+def _expected_partition(jids, voters):
+    """Compute which JID each voter owns under the canonical hash ring."""
+    from salt.cluster.ring import HashRing
+
+    ring = HashRing()
+    ring.rebuild(list(voters))
+    per_voter = {v: [] for v in voters}
+    for jid in jids:
+        per_voter[ring.get_owner(jid)].append(jid)
+    return per_voter
+
+
+# ---------------------------------------------------------------------------
+# The scenario
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_migration_round_trip(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    Full data-plane round-trip for the jobs cache:
+
+    * Each master holds the same 40-jid baseline.
+    * ``ring_create`` + ``route_set`` brings up a 3-voter ring.
+    * ``shed_unowned`` partitions the keyspace across the masters.
+    * ``collect_from_peers`` reconstitutes the full set on master 1.
+    * ``route_clear`` + ``ring_destroy`` returns the cluster to
+      broadcast.
+
+    Asserts at every step that:
+
+    * the cluster-log entries propagate to all masters,
+    * the data plane on disk matches expected ownership,
+    * the cluster itself stays steady (voter set / leader stable).
+    """
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+    addrs = [m.config["interface"] for m in masters]
+
+    # Baseline: cluster has the right voter set on every master.
+    def _baseline_ready():
+        for m in masters:
+            view = _run_runner(m, "cluster.members")
+            if not isinstance(view, dict):
+                return False
+            if sorted(view.get("voters") or []) != sorted(addrs):
+                return False
+        return True
+
+    assert _wait_until(_baseline_ready, timeout=60), "cluster baseline never ready"
+
+    # Phase 1: seed the same 40 JIDs into every master's cache.
+    seeded = [f"jid-{i:04d}" for i in range(40)]
+    for master in masters:
+        cache = _master_cache(master)
+        for jid in seeded:
+            cache.store("jobs/loads", jid, {"fun": "test.ping", "tgt": "*"})
+            cache.store("jobs/minions", jid, ["minion-a"])
+            # One return entry per JID so the cascade flush actually
+            # has something to drop.
+            cache.store(f"jobs/returns/{jid}", "minion-a", {"return": True})
+
+    # Sanity: every master sees all 40 JIDs initially.
+    for master in masters:
+        cache = _master_cache(master)
+        assert set(cache.list("jobs/loads")) == set(seeded)
+
+    # Phase 2: create ring + route from master 1.
+    create = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_create",
+        "name=jobs",
+        f"voters={json.dumps(addrs)}",
+    )
+    assert create.get("status") == "fan-out initiated"
+
+    route = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.route_set",
+        "data_type=jobs",
+        "ring=jobs",
+    )
+    assert route.get("status") == "fan-out initiated"
+
+    # Wait for both registry + routing entries to commit on every
+    # master by tailing the master logs.
+    def _ring_and_route_ready():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            if "ring=jobs status=active" not in text:
+                return False
+            if "route committed — data_type=jobs -> ring=jobs" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _ring_and_route_ready, timeout=45
+    ), "ring + route commits not visible on every master"
+
+    # Phase 3: shed unowned JIDs on each master.
+    shed_results = {}
+    for master in masters:
+        result = _run_runner(
+            master,
+            "cluster.shed_unowned",
+            "ring=jobs",
+        )
+        assert isinstance(result, dict), f"shed result not dict: {result!r}"
+        assert result["status"] == "ok"
+        shed_results[master.config["interface"]] = result
+
+    # Verify the partition: each master kept its ring-owned JIDs,
+    # the union across masters equals the original set, and no
+    # master has any unowned JID.
+    expected = _expected_partition(seeded, addrs)
+    for master in masters:
+        addr = master.config["interface"]
+        cache = _master_cache(master)
+        survivors = set(cache.list("jobs/loads"))
+        owned = set(expected[addr])
+        unowned = set(seeded) - owned
+
+        assert survivors == owned, (
+            f"master {addr}: survivors {sorted(survivors)} != "
+            f"expected {sorted(owned)}"
+        )
+        # Cascade: the returns sub-banks for unowned JIDs are gone.
+        for jid in unowned:
+            assert (
+                list(cache.list(f"jobs/returns/{jid}")) == []
+            ), f"master {addr}: returns bank for unowned JID {jid} survived shed"
+        # And the returns sub-banks for owned JIDs are intact.
+        for jid in owned:
+            assert list(cache.list(f"jobs/returns/{jid}")) == ["minion-a"]
+
+    # Union of survivors equals the original set — no JID was lost.
+    union = set()
+    for master in masters:
+        union |= set(_master_cache(master).list("jobs/loads"))
+    assert union == set(seeded), (
+        f"jids lost in shed: missing={sorted(set(seeded) - union)}, "
+        f"extra={sorted(union - set(seeded))}"
+    )
+
+    # Phase 4: collect from peers on master 1 — recover full set.
+    collect = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.collect_from_peers",
+        "channels=[]",  # only banks, no fixed channels
+    )
+    assert collect.get("status") == "fan-out initiated"
+
+    def _master_1_has_everything():
+        cache = _master_cache(cluster_master_1_isolated)
+        return set(cache.list("jobs/loads")) == set(seeded)
+
+    assert _wait_until(_master_1_has_everything, timeout=30), (
+        f"master 1 did not collect full set: missing "
+        f"{sorted(set(seeded) - set(_master_cache(cluster_master_1_isolated).list('jobs/loads')))}"
+    )
+
+    # Master 1 now holds the full jobs/loads set; the other banks
+    # (jobs/minions, jobs/endtimes, jobs/nocache) flow through the
+    # same default-banks collection.
+    cache_1 = _master_cache(cluster_master_1_isolated)
+    assert set(cache_1.list("jobs/minions")) == set(seeded)
+
+    # Sentinel: the collect status file shipped, parses, and shows
+    # complete=True once every peer eof'd every channel.  Operators
+    # rely on this to confirm the runner's fan-out reached every
+    # peer without tailing master logs.
+    import pathlib
+
+    sentinel_path = (
+        pathlib.Path(cluster_master_1_isolated.config["cachedir"])
+        / "cluster-collect-status.json"
+    )
+
+    def _sentinel_complete():
+        if not sentinel_path.exists():
+            return False
+        try:
+            with salt.utils.files.fopen(sentinel_path) as fp:
+                doc = json.load(fp)
+        except (OSError, json.JSONDecodeError):
+            return False
+        return doc.get("complete") is True
+
+    assert _wait_until(
+        _sentinel_complete, timeout=30
+    ), "collect status sentinel did not reach complete=True"
+
+    # Phase 5: clear route + destroy ring.
+    _run_runner(cluster_master_1_isolated, "cluster.route_clear", "data_type=jobs")
+    _run_runner(cluster_master_1_isolated, "cluster.ring_destroy", "name=jobs")
+
+    def _cleanup_visible():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            if "route cleared — data_type=jobs now broadcasts" not in text:
+                return False
+            if "status=destroyed" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _cleanup_visible, timeout=30
+    ), "route_clear / ring_destroy not visible on every master"
+
+    # Cluster stayed healthy through the whole churn — voter set
+    # unchanged, leader still present.
+    final = _run_runner(cluster_master_1_isolated, "cluster.members")
+    assert isinstance(final, dict)
+    assert sorted(final.get("voters") or []) == sorted(addrs)
+    assert final.get("leader_id") in addrs
+
+
+def test_shed_unowned_dry_run_preserves_state(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    ``cluster.shed_unowned dry_run=True`` reports the partition but
+    leaves the on-disk state untouched.  Operators must be able to
+    preview before committing.
+    """
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+    addrs = [m.config["interface"] for m in masters]
+
+    # Baseline.
+    def _baseline():
+        view = _run_runner(cluster_master_1_isolated, "cluster.members")
+        return isinstance(view, dict) and sorted(view.get("voters") or []) == sorted(
+            addrs
+        )
+
+    assert _wait_until(_baseline, timeout=60)
+
+    # Seed master 1 with a small set.
+    cache = _master_cache(cluster_master_1_isolated)
+    jids = [f"dryrun-{i:04d}" for i in range(20)]
+    for jid in jids:
+        cache.store("jobs/loads", jid, {"fun": "x"})
+
+    # Create + route.
+    _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_create",
+        "name=jobs_dry",
+        f"voters={json.dumps(addrs)}",
+    )
+    _run_runner(
+        cluster_master_1_isolated,
+        "cluster.route_set",
+        "data_type=jobs",
+        "ring=jobs_dry",
+    )
+
+    def _ring_ready():
+        log_path = cluster_master_1_isolated.config.get("log_file")
+        try:
+            with salt.utils.files.fopen(log_path) as fp:
+                return "ring=jobs_dry status=active" in fp.read()
+        except OSError:
+            return False
+
+    assert _wait_until(_ring_ready, timeout=45)
+
+    # Dry-run shed.
+    result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.shed_unowned",
+        "ring=jobs_dry",
+        "dry_run=True",
+    )
+    assert result["status"] == "ok"
+    assert result["dry_run"] is True
+    assert result["dropped"] > 0
+
+    # Cache is untouched: every seeded JID is still present.
+    assert set(cache.list("jobs/loads")) >= set(
+        jids
+    ), "dry_run shed_unowned dropped state it shouldn't have"
+
+    # Cleanup.
+    _run_runner(cluster_master_1_isolated, "cluster.route_clear", "data_type=jobs")
+    _run_runner(cluster_master_1_isolated, "cluster.ring_destroy", "name=jobs_dry")

--- a/tests/pytests/integration/cluster/test_ring_lifecycle.py
+++ b/tests/pytests/integration/cluster/test_ring_lifecycle.py
@@ -1,0 +1,368 @@
+"""
+Integration tests for the multi-ring control plane on the isolated
+3-master cluster.
+
+These tests drive ``salt-run cluster.*`` commands against a live
+cluster and assert the cluster-log state machines converge on every
+master.  They don't depend on a particular cache layout — the
+``cluster.ring_create`` / ``route_set`` / ``ring_destroy`` /
+``ring_info`` / ``members`` runners are pure cluster-log surface and
+work regardless of how the data plane is configured.
+
+The companion ``test_jobs_migration.py`` covers the end-to-end jobs
+migration (broadcast → ring → broadcast) using a master_job_cache=
+salt_cache configuration.  Splitting the lifecycle from the data-plane
+migration keeps the lifecycle assertions fast and decoupled from job
+returner setup.
+"""
+
+import json
+import time
+
+import pytest
+
+import salt.utils.files
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_runner(master, fun, *args, timeout=60):
+    """
+    Invoke ``salt-run`` on *master* with ``--output=json`` so the
+    result parses straight from stdout.  Returns the JSON-decoded
+    output (a dict or list, depending on the runner).
+    """
+    cli = master.salt_run_cli(timeout=timeout)
+    ret = cli.run("--output=json", fun, *args)
+    assert ret.returncode == 0, (
+        f"{fun} exited non-zero " f"(stdout={ret.stdout!r}, stderr={ret.stderr!r})"
+    )
+    # ``salt-run --output=json`` writes the structured result to stdout.
+    # Empty stdout (some skip-paths) → return None.
+    if not ret.stdout.strip():
+        return None
+    try:
+        return json.loads(ret.stdout)
+    except json.JSONDecodeError:
+        # Some runners (notably fire-and-forget event-only ones) emit
+        # a "skipped" status as plain text.  Hand back the raw stdout
+        # so the caller can assert on substring.
+        return ret.stdout
+
+
+def _wait_until(predicate, timeout=30, interval=0.5):
+    """
+    Block until *predicate* returns truthy or *timeout* elapses.
+    Returns the last predicate value (truthy on success, falsy on
+    timeout) so the caller can assert directly on it.
+    """
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    return last
+
+
+def _members_view(master):
+    """Read ``cluster.members`` on *master* and return the view dict."""
+    return _run_runner(master, "cluster.members")
+
+
+# ---------------------------------------------------------------------------
+# Ring lifecycle: create -> route -> destroy
+# ---------------------------------------------------------------------------
+
+
+def test_ring_create_route_destroy_round_trip(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    Full multi-ring control-plane round trip on a live 3-master
+    cluster:
+
+    1. Confirm baseline: every master sees the same 3-voter cluster.
+    2. ``cluster.ring_create name=jobs voters='[m1,m2,m3]'`` from
+       master 1.  Within a heartbeat-or-two every master should have
+       a ``"jobs"`` ring in its registry.
+    3. ``cluster.route_set data_type=jobs ring=jobs`` from master 1.
+       Routing snapshot updates everywhere.
+    4. ``cluster.route_clear data_type=jobs`` reverts to broadcast.
+    5. ``cluster.ring_destroy name=jobs`` marks the ring destroyed.
+       The registry entry stays (audit trail) but the local Raft
+       group on each founder is torn down.
+
+    Each runner is fire-and-forget; the daemon publishes the
+    cluster-log entry asynchronously.  We poll each master's
+    ``cluster.members`` (which replays the persisted log) until the
+    expected state is visible everywhere.
+    """
+    masters = [
+        cluster_master_1_isolated,
+        cluster_master_2_isolated,
+        cluster_master_3_isolated,
+    ]
+    addrs = [m.config["interface"] for m in masters]
+
+    # 1. Baseline — every master agrees on the voter set.
+    def _all_agree_on_voters():
+        views = [_members_view(m) for m in masters]
+        return all(
+            isinstance(v, dict) and sorted(v.get("voters") or []) == sorted(addrs)
+            for v in views
+        )
+
+    assert _wait_until(
+        _all_agree_on_voters, timeout=60
+    ), "Baseline cluster never converged on the 3-voter set"
+
+    # 2. Create the ring on master 1.
+    create_result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_create",
+        "name=jobs",
+        f"voters={json.dumps(addrs)}",
+    )
+    assert isinstance(create_result, dict)
+    assert create_result.get("status") == "fan-out initiated"
+
+    # The runner fires a local event; the publish daemon proposes a
+    # RING_REGISTRY entry.  We don't have a runner that reads the
+    # registry directly, but we can verify the per-ring Raft group
+    # was committed by reading the ring's persisted membership via
+    # cluster.members — it surfaces the cluster-log view, and the
+    # registry entry is on that same log.  The simplest end-to-end
+    # check: spawn cluster.ring_info (which reads the per-process
+    # ring) on each master and assert no errors.
+    #
+    # For a tight assertion we tail the master logs for the
+    # "ring registry committed" message that
+    # ``RaftService._on_ring_registry_change`` writes — present on
+    # any founder that brought the ring up locally.
+    def _registry_committed_everywhere():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            if not log_path:
+                return False
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            if "ring registry committed" not in text:
+                return False
+            if "ring=jobs status=active" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _registry_committed_everywhere, timeout=30
+    ), "ring registry RING_REGISTRY commit not observed on every master"
+
+    # 3. Set the route from master 1.
+    route_result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.route_set",
+        "data_type=jobs",
+        "ring=jobs",
+    )
+    assert isinstance(route_result, dict)
+    assert route_result.get("status") == "fan-out initiated"
+
+    def _route_committed_everywhere():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            if "route committed — data_type=jobs -> ring=jobs" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _route_committed_everywhere, timeout=30
+    ), "ROUTE commit not observed on every master"
+
+    # 4. Clear the route — back to broadcast.
+    clear_result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.route_clear",
+        "data_type=jobs",
+    )
+    assert isinstance(clear_result, dict)
+    assert clear_result.get("status") == "fan-out initiated"
+
+    def _route_cleared_everywhere():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            if "route cleared — data_type=jobs now broadcasts" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _route_cleared_everywhere, timeout=30
+    ), "ROUTE clear not observed on every master"
+
+    # 5. Destroy the ring.
+    destroy_result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_destroy",
+        "name=jobs",
+    )
+    assert isinstance(destroy_result, dict)
+    assert destroy_result.get("status") == "fan-out initiated"
+
+    def _ring_destroyed_everywhere():
+        for master in masters:
+            log_path = master.config.get("log_file")
+            try:
+                with salt.utils.files.fopen(log_path) as fp:
+                    text = fp.read()
+            except OSError:
+                return False
+            # Either the destroy commit message or the explicit
+            # tear-down message confirms the lifecycle for that
+            # master.  Non-founder masters only see the registry
+            # commit (no Node to tear down locally).
+            if "status=destroyed" not in text:
+                return False
+        return True
+
+    assert _wait_until(
+        _ring_destroyed_everywhere, timeout=30
+    ), "ring destroy commit not observed on every master"
+
+    # After tear-down: cluster.members still works (cluster Raft is
+    # unaffected by per-ring lifecycle) — pin that the cluster log
+    # didn't lose state across the ring churn.
+    final_view = _members_view(cluster_master_1_isolated)
+    assert isinstance(final_view, dict)
+    assert sorted(final_view.get("voters") or []) == sorted(
+        addrs
+    ), "Cluster voter set drifted during ring lifecycle"
+
+
+def test_ring_create_idempotent_across_repeated_invocations(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    Re-creating an active ring with the same id should leave the
+    cluster log with a single active registry entry (every commit
+    overwrites the previous one in-place).  Pins the operator
+    contract that running ``ring_create`` twice by mistake doesn't
+    corrupt the registry.
+    """
+    addrs = [
+        cluster_master_1_isolated.config["interface"],
+        cluster_master_2_isolated.config["interface"],
+        cluster_master_3_isolated.config["interface"],
+    ]
+
+    # First create.
+    _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_create",
+        "name=audit_ring",
+        f"voters={json.dumps(addrs)}",
+    )
+    # Second create with the same voters — should be a no-op-equivalent
+    # at the registry level.
+    _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_create",
+        "name=audit_ring",
+        f"voters={json.dumps(addrs)}",
+    )
+
+    # Both commits should appear in the leader's log, but the
+    # registry SM ends in a single deterministic state.  We don't
+    # have a runner that surfaces the registry directly; the
+    # robustness assertion is that the cluster itself remains
+    # healthy after the double-create — voters unchanged, term
+    # didn't churn.
+    def _cluster_still_steady():
+        view = _members_view(cluster_master_1_isolated)
+        return (
+            isinstance(view, dict)
+            and sorted(view.get("voters") or []) == sorted(addrs)
+            and view.get("leader_id") in addrs
+        )
+
+    assert _wait_until(_cluster_still_steady, timeout=30)
+
+    # Cleanup so the next test starts clean (these isolated fixtures
+    # don't tear down between tests in the same module).
+    _run_runner(
+        cluster_master_1_isolated,
+        "cluster.ring_destroy",
+        "name=audit_ring",
+    )
+
+
+def test_route_clear_for_unrouted_data_type_is_safe(
+    cluster_master_1_isolated,
+    cluster_master_2_isolated,
+    cluster_master_3_isolated,
+):
+    """
+    ``cluster.route_clear`` for a data type that was never routed
+    must be a successful no-op — operators running cleanup playbooks
+    shouldn't have to know which routes already exist.  The clear
+    commits an entry mapping the data type to ``None`` (broadcast),
+    which is also the absent-entry default; the cluster ends in the
+    same effective state either way.
+    """
+    addrs = [
+        cluster_master_1_isolated.config["interface"],
+        cluster_master_2_isolated.config["interface"],
+        cluster_master_3_isolated.config["interface"],
+    ]
+
+    # Wait for baseline cluster.
+    def _baseline_ready():
+        view = _members_view(cluster_master_1_isolated)
+        return isinstance(view, dict) and sorted(view.get("voters") or []) == sorted(
+            addrs
+        )
+
+    assert _wait_until(_baseline_ready, timeout=60)
+
+    # Clear a route that doesn't exist.
+    result = _run_runner(
+        cluster_master_1_isolated,
+        "cluster.route_clear",
+        "data_type=never_routed",
+    )
+    assert isinstance(result, dict)
+    assert result.get("status") == "fan-out initiated"
+
+    # Cluster stays healthy — no spurious term churn or voter drop.
+    def _cluster_still_steady():
+        view = _members_view(cluster_master_1_isolated)
+        return (
+            isinstance(view, dict)
+            and sorted(view.get("voters") or []) == sorted(addrs)
+            and view.get("leader_id") in addrs
+        )
+
+    assert _wait_until(_cluster_still_steady, timeout=30)

--- a/tests/pytests/integration/cluster/test_ring_lifecycle_shared_fs.py
+++ b/tests/pytests/integration/cluster/test_ring_lifecycle_shared_fs.py
@@ -1,0 +1,154 @@
+"""
+Shared-filesystem variant of the multi-ring lifecycle integration
+test.
+
+The companion ``test_ring_lifecycle.py`` runs against the
+``*_isolated`` fixtures with ``cluster_isolated_filesystem: True``
+— each master has its own pki + cache dirs, exercising the
+no-shared-FS path.  This test runs against the default
+``cluster_master_{1,2,3}`` fixtures which share ``cluster_pki_dir``
+and ``cache_dir`` across all three masters on the test box.
+
+Why both
+--------
+The :class:`SaltStorage` path scheme is keyed by ``(node_id,
+ring_id)``, so per-master Raft state should never collide on a
+shared FS.  This test pins that the multi-ring runners and the
+per-ring Raft groups all work the same way under shared-FS, since
+that's the deployment most operators with shared NFS or single-host
+test clusters actually run.
+"""
+
+import json
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def _run_runner(master, fun, *args, timeout=60):
+    cli = master.salt_run_cli(timeout=timeout)
+    ret = cli.run("--output=json", fun, *args)
+    assert (
+        ret.returncode == 0
+    ), f"{fun} exited non-zero (stdout={ret.stdout!r}, stderr={ret.stderr!r})"
+    if not ret.stdout.strip():
+        return None
+    try:
+        return json.loads(ret.stdout)
+    except json.JSONDecodeError:
+        return ret.stdout
+
+
+def _wait_until(predicate, timeout=30, interval=0.5):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    return last
+
+
+def test_ring_lifecycle_on_shared_filesystem(
+    cluster_master_1,
+    cluster_master_2,
+    cluster_master_3,
+):
+    """
+    The ``cluster.ring_create`` / ``route_set`` / ``ring_destroy``
+    surface works the same way under shared-FS as under the
+    isolated-FS path.  Pin the storage-path-keying contract: per-node
+    Raft state never bleeds across masters even when their cachedirs
+    share a parent.
+
+    Three masters, all rooted at the same cachedir on disk.  Create
+    a ring, route a data type to it, confirm the registry + routing
+    commits propagate (via master log tail), then destroy the ring
+    and confirm the cluster is unaffected.
+    """
+    masters = [cluster_master_1, cluster_master_2, cluster_master_3]
+    addrs = [m.config["interface"] for m in masters]
+
+    # Baseline — every master sees the same voter set.
+    def _baseline_ready():
+        for m in masters:
+            view = _run_runner(m, "cluster.members")
+            if not isinstance(view, dict):
+                return False
+            if sorted(view.get("voters") or []) != sorted(addrs):
+                return False
+        return True
+
+    assert _wait_until(_baseline_ready, timeout=60), "cluster baseline never ready"
+
+    # Note on "shared FS" scope: this fixture shares
+    # ``cluster_pki_dir`` and ``cache_dir`` across all three masters
+    # — that's the meaningful operator-facing knob.  Each master's
+    # own ``cachedir`` (the opt :class:`SaltStorage` uses for the
+    # Raft log path) is per-master regardless, because
+    # ``salt-factories`` injects a per-daemon ``cachedir``.  So
+    # multi-ring on-disk state is always isolated by node-id and
+    # this test exercises the bootstrap + lifecycle path that runs
+    # when operators share ``cluster_pki_dir`` (the common NFS-backed
+    # production layout).
+
+    # Create + route — same shape as the isolated test.
+    _run_runner(
+        cluster_master_1,
+        "cluster.ring_create",
+        "name=jobs_shared",
+        f"voters={json.dumps(addrs)}",
+    )
+    _run_runner(
+        cluster_master_1,
+        "cluster.route_set",
+        "data_type=jobs",
+        "ring=jobs_shared",
+    )
+
+    def _registry_and_route_on_every_master():
+        # Use the new cluster.rings / cluster.routes runners instead
+        # of tailing logs — more robust against unrelated log lines
+        # from other tests sharing the cachedir.
+        for m in masters:
+            rings = _run_runner(m, "cluster.rings")
+            if not isinstance(rings, dict):
+                return False
+            if "jobs_shared" not in rings.get("active_rings", []):
+                return False
+            routes = _run_runner(m, "cluster.routes")
+            if not isinstance(routes, dict):
+                return False
+            if routes.get("routes", {}).get("jobs") != "jobs_shared":
+                return False
+        return True
+
+    assert _wait_until(_registry_and_route_on_every_master, timeout=45), (
+        "ring + route not visible on every master via cluster.rings / " "cluster.routes"
+    )
+
+    # Destroy.
+    _run_runner(cluster_master_1, "cluster.ring_destroy", "name=jobs_shared")
+    _run_runner(cluster_master_1, "cluster.route_clear", "data_type=jobs")
+
+    def _ring_destroyed_everywhere():
+        for m in masters:
+            rings = _run_runner(m, "cluster.rings")
+            if not isinstance(rings, dict):
+                return False
+            entry = rings.get("rings", {}).get("jobs_shared")
+            if entry is None or entry.get("status") != "destroyed":
+                return False
+        return True
+
+    assert _wait_until(_ring_destroyed_everywhere, timeout=30)
+
+    # Cluster stays healthy.
+    view = _run_runner(cluster_master_1, "cluster.members")
+    assert sorted(view.get("voters") or []) == sorted(addrs)
+    assert view.get("leader_id") in addrs

--- a/tests/pytests/integration/cluster/test_ring_lifecycle_shared_fs.py
+++ b/tests/pytests/integration/cluster/test_ring_lifecycle_shared_fs.py
@@ -26,6 +26,15 @@ import pytest
 
 pytestmark = [
     pytest.mark.slow_test,
+    # The lifecycle test polls three predicates serially against the
+    # 3-master cluster (baseline ready, registry+route propagated,
+    # ring destroyed), each ``_wait_until`` running ``cluster.members``
+    # as a fresh ``salt-run`` subprocess.  Under coverage tracing on a
+    # 2-vCPU GHA runner the cumulative wall-clock for those subprocess
+    # invocations has been observed at 95-130 s — past the global 90 s
+    # pytest-timeout default.  Bump the wall-clock ceiling so the
+    # test's own predicate timeouts remain the failure signal.
+    pytest.mark.timeout(360, func_only=True),
 ]
 
 

--- a/tests/pytests/integration/runners/state/orchestrate/test_events.py
+++ b/tests/pytests/integration/runners/state/orchestrate/test_events.py
@@ -301,6 +301,14 @@ def test_orchestration_with_pillar_dot_items(salt_run_cli, salt_master):
     one of those state files includes pillar related functions that will not
     be pulling from the pillar cache that all the state files are available and
     the file_roots has been preserved.  See issues #48277 and #46986.
+
+    The default ``salt_run_cli`` fixture sets a 30 s subprocess timeout
+    (``tests/pytests/integration/conftest.py``).  This test recursively
+    invokes ``saltutil.runner('pillar.show_pillar')`` from inside the
+    SLS render — under coverage tracing on GHA the inner runner load
+    plus a 4-SLS orchestration can take 40-50 s.  We override the
+    per-call timeout (``_timeout=120``) so the test isn't killed
+    before its assertions can run.
     """
     main_sls_contents = """
     include:
@@ -332,7 +340,9 @@ def test_orchestration_with_pillar_dot_items(salt_run_cli, salt_master):
     ):
         jid = salt.utils.jid.gen_jid(salt_master.config)
 
-        ret = salt_run_cli.run("--jid", jid, "state.orchestrate", "test-orch")
+        ret = salt_run_cli.run(
+            "--jid", jid, "state.orchestrate", "test-orch", _timeout=120
+        )
         assert ret.returncode == 0
         for state_data in ret.data["data"][salt_master.id].values():
             # Each state should be successful

--- a/tests/pytests/smoke-tests.txt
+++ b/tests/pytests/smoke-tests.txt
@@ -191,6 +191,76 @@ tests/pytests/functional/runners/test_cache_migrate.py
 #     once for correctness without timing) ---
 tests/pytests/perf/test_cache_benchmarks.py
 
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Multi-ring rollout + salt_cache returner + delegate-on-miss
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── UNIT: per-ring SaltStorage path keying (slice 1) ────────────────────────
+tests/pytests/unit/cluster/consensus/test_storage.py
+
+# ── UNIT: RPC envelope carries raft_group_id, dispatcher routes by group ────
+tests/pytests/unit/cluster/consensus/test_rpc.py::test_pack_unpack_carries_raft_group_id
+tests/pytests/unit/cluster/consensus/test_rpc.py::test_unpack_pre_multi_ring_envelope_defaults_to_cluster
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_default_raft_group_id_is_cluster
+tests/pytests/unit/cluster/consensus/test_peer.py::TestSaltPeer::test_raft_group_id_is_packed_into_outgoing_rpcs
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_routes_by_raft_group_id
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatch_drops_rpc_for_unknown_group
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_register_and_unregister_node_dynamically
+tests/pytests/unit/cluster/consensus/test_peer.py::TestRaftDispatcher::test_dispatcher_setting_node_to_none_clears_cluster_group
+
+# ── UNIT: cluster-log SMs — registry + routing + entry dispatch ─────────────
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestRingRegistryStateMachine
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestRoutingStateMachine
+tests/pytests/unit/cluster/consensus/test_raft_log.py::TestMultiRingEntryDispatch
+
+# ── UNIT: ring_membership becomes a named-ring registry + drop accounting ───
+tests/pytests/unit/cluster/test_ring_membership.py::TestMultiRingRegistry
+tests/pytests/unit/cluster/test_ring_membership.py::TestOwnsFor
+tests/pytests/unit/cluster/test_ring_membership.py::TestDropStats
+
+# ── UNIT: state-sync bank: channel + selective key_filter ───────────────────
+tests/pytests/unit/cluster/test_state_sync.py::test_bank_channel_round_trip
+tests/pytests/unit/cluster/test_state_sync.py::test_bank_from_channel_rejects_non_bank
+tests/pytests/unit/cluster/test_state_sync.py::test_iter_bank_chunks_empty_yields_one_chunk
+tests/pytests/unit/cluster/test_state_sync.py::test_iter_bank_chunks_emits_key_value_records
+tests/pytests/unit/cluster/test_state_sync.py::test_iter_bank_chunks_honours_key_filter
+tests/pytests/unit/cluster/test_state_sync.py::test_install_bank_chunk_writes_through_cache
+tests/pytests/unit/cluster/test_state_sync.py::test_install_bank_chunk_skips_malformed_entries
+tests/pytests/unit/cluster/test_state_sync.py::test_install_bank_chunk_rejects_empty_bank
+tests/pytests/unit/cluster/test_state_sync.py::test_iter_keys_chunks_key_filter_emits_only_matching
+tests/pytests/unit/cluster/test_state_sync.py::test_iter_keys_chunks_key_filter_excluding_everything_yields_eof
+
+# ── UNIT: salt_cache returner — every public function + bank layout ─────────
+tests/pytests/unit/returners/test_salt_cache.py
+
+# ── UNIT: cluster runner surface — every new operator-facing runner ─────────
+tests/pytests/unit/runners/test_cluster_runner.py
+
+# ── UNIT: master.py gate sites + delegate-on-miss on routed drops ───────────
+tests/pytests/unit/test_event_monitor_ring_gating.py
+
+# ── FUNCTIONAL: per-ring Raft — propose helpers, lifecycle, watchdog ────────
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestMultiRingProposeHelpers
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestPerRingLifecycle
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestPerRingVoterHealth
+tests/pytests/functional/cluster/consensus/test_raft_service.py::TestClusterRingRebuildHook
+
+# ── FUNCTIONAL: salt_cache returner-in-the-loop (loader + dispatch) ─────────
+tests/pytests/functional/returners/test_salt_cache_integration.py
+
+# ── INTEGRATION: multi-ring lifecycle on isolated-FS cluster ────────────────
+tests/pytests/integration/cluster/test_ring_lifecycle.py
+
+# ── INTEGRATION: multi-ring lifecycle on shared-FS cluster ──────────────────
+tests/pytests/integration/cluster/test_ring_lifecycle_shared_fs.py
+
+# ── INTEGRATION: full jobs migration round-trip (shed + collect) ────────────
+tests/pytests/integration/cluster/test_jobs_migration.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. mmap_cache CI regressions (renumbered from 3)
+# ─────────────────────────────────────────────────────────────────────────────
+
 # --- Explicit CI regression (Ubuntu 22.04 Arm64 unit / Python 3.12 mmap write path) ---
 # Placed after whole-module entries so pytest does not narrow collection (module+node adjacency quirk).
 tests/pytests/unit/cache/test_cache_backends.py::test_updated_changes_after_overwrite[mmap_cache]

--- a/tests/pytests/smoke-tests.txt
+++ b/tests/pytests/smoke-tests.txt
@@ -218,6 +218,9 @@ tests/pytests/unit/cluster/test_ring_membership.py::TestMultiRingRegistry
 tests/pytests/unit/cluster/test_ring_membership.py::TestOwnsFor
 tests/pytests/unit/cluster/test_ring_membership.py::TestDropStats
 
+# ── UNIT: multi-ring runner fan-out wire shape (cluster_aes envelope) ───────
+tests/pytests/unit/cluster/consensus/test_multi_ring_fanout.py
+
 # ── UNIT: state-sync bank: channel + selective key_filter ───────────────────
 tests/pytests/unit/cluster/test_state_sync.py::test_bank_channel_round_trip
 tests/pytests/unit/cluster/test_state_sync.py::test_bank_from_channel_rejects_non_bank

--- a/tests/pytests/unit/cli/test_caller_resources.py
+++ b/tests/pytests/unit/cli/test_caller_resources.py
@@ -187,6 +187,7 @@ def test_r_grains_items_per_resource_for_each_target(call_opts):
         assert payload[rid].get("resource_id") == rid, (rid, payload[rid])
 
 
+@pytest.mark.timeout(180, func_only=True)
 def test_r_state_apply_logical_resource_no_state_module(call_opts):
     """
     state.apply against a logical resource type (no per-resource state
@@ -202,6 +203,14 @@ def test_r_state_apply_logical_resource_no_state_module(call_opts):
     succeeds (no caller-level rejection), the state machinery runs,
     and the operator sees per-resource provenance for whatever the
     state run produced.
+
+    Runs ``state.apply`` three times (once per dummy resource), each of
+    which spins up a HighState and loads state modules.  Local
+    wall-clock is ~3-5 s; under coverage tracing on a loaded GHA
+    runner the cumulative cost has been observed at 30-60 s.  The
+    explicit ``@pytest.mark.timeout(180)`` override raises the global
+    90 s pytest-timeout default so a slow runner doesn't trip the
+    wall-clock before the test's logical assertions run.
     """
     call_opts["resources_dispatch"] = True
     call_opts["fun"] = "state.apply"

--- a/tests/pytests/unit/cluster/consensus/test_multi_ring_fanout.py
+++ b/tests/pytests/unit/cluster/consensus/test_multi_ring_fanout.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for the multi-ring runner fan-out path in
+:class:`salt.channel.server.MasterPubServerChannel`.
+
+The fan-out wraps a ``cluster/runner/ring_*`` / ``route_*`` /
+``ring_set`` event payload in a cluster_aes-encrypted
+``cluster/peer/multi-ring-request`` envelope and pushes it to every
+peer pusher.  Each peer that receives the envelope re-dispatches via
+``_handle_multi_ring_runner_event``; only the master that is the
+Raft leader of the relevant group actually appends an entry.
+
+These tests pin the wire shape — encryption, tagify, payload
+round-trip — so a future refactor doesn't drift the fan-out away
+from what the peer-side handler expects to decrypt.
+"""
+
+import asyncio
+import collections
+
+import pytest
+
+import salt.crypt
+import salt.master
+import salt.utils.event
+from salt.channel.server import MasterPubServerChannel
+
+
+class _FakePusher:
+    """Captures the bytes published to a peer."""
+
+    def __init__(self, pull_host):
+        self.pull_host = pull_host
+        self.pull_port = 4506
+        self.sent = collections.deque()
+
+    async def publish(self, raw):
+        self.sent.append(raw)
+
+
+@pytest.fixture
+def _seeded_cluster_aes():
+    """
+    Install a ``cluster_aes`` secret on ``SMaster.secrets`` so the
+    fan-out can build a Crypticle, and restore the prior state after.
+    """
+    orig = salt.master.SMaster.secrets.copy()
+    secret = salt.crypt.Crypticle.generate_key_string()
+
+    class _Sec:
+        def __init__(self, val):
+            self.value = val
+
+    salt.master.SMaster.secrets["cluster_aes"] = {"secret": _Sec(secret)}
+    yield secret
+    salt.master.SMaster.secrets.clear()
+    salt.master.SMaster.secrets.update(orig)
+
+
+def _make_channel(opts=None):
+    ch = MasterPubServerChannel.__new__(MasterPubServerChannel)
+    ch.opts = opts or {"id": "test-master"}
+    ch.pushers = []
+    return ch
+
+
+def test_fanout_publishes_to_every_pusher(_seeded_cluster_aes):
+    """One publish per pusher, each carrying the encrypted envelope."""
+    ch = _make_channel()
+    ch.pushers = [_FakePusher("127.0.0.2"), _FakePusher("127.0.0.3")]
+
+    asyncio.run(
+        ch._fanout_multi_ring_request(
+            "cluster/runner/ring_create",
+            {"ring_id": "jobs", "founding_voters": ["m1", "m2", "m3"]},
+        )
+    )
+
+    for pusher in ch.pushers:
+        assert len(pusher.sent) == 1, f"{pusher.pull_host} got {len(pusher.sent)} pubs"
+
+
+def test_fanout_payload_round_trips_through_cluster_aes(_seeded_cluster_aes):
+    """
+    The peer-side handler decrypts with ``cluster_aes`` and reads
+    ``runner_tag`` + ``data`` back out — pin that contract here.
+    """
+    ch = _make_channel()
+    ch.pushers = [_FakePusher("127.0.0.2")]
+    data = {"ring_id": "jobs", "founding_voters": ["m1", "m2", "m3"]}
+
+    asyncio.run(ch._fanout_multi_ring_request("cluster/runner/ring_create", data))
+
+    raw = ch.pushers[0].sent.pop()
+    tag, encrypted = salt.utils.event.SaltEvent.unpack(raw)
+    assert tag.endswith("cluster/peer/multi-ring-request")
+
+    crypticle = salt.crypt.Crypticle(ch.opts, _seeded_cluster_aes)
+    decoded = crypticle.loads(encrypted)
+    assert decoded == {
+        "runner_tag": "cluster/runner/ring_create",
+        "data": data,
+    }
+
+
+def test_fanout_with_no_pushers_is_noop(_seeded_cluster_aes):
+    """A solo master (no peers) fan-out is a clean no-op, not an error."""
+    ch = _make_channel()
+    ch.pushers = []
+
+    # Should not raise.
+    asyncio.run(ch._fanout_multi_ring_request("cluster/runner/route_set", {}))
+
+
+def test_fanout_skips_silently_when_cluster_aes_missing():
+    """
+    Before the join handshake completes there's no cluster_aes secret;
+    the fan-out logs and returns rather than crashing the publish loop.
+    """
+    orig = salt.master.SMaster.secrets.copy()
+    salt.master.SMaster.secrets.pop("cluster_aes", None)
+    try:
+        ch = _make_channel()
+        ch.pushers = [_FakePusher("127.0.0.2")]
+        asyncio.run(
+            ch._fanout_multi_ring_request(
+                "cluster/runner/ring_create", {"ring_id": "jobs"}
+            )
+        )
+        assert len(ch.pushers[0].sent) == 0
+    finally:
+        salt.master.SMaster.secrets.clear()
+        salt.master.SMaster.secrets.update(orig)
+
+
+def test_fanout_swallows_per_pusher_publish_errors(_seeded_cluster_aes):
+    """
+    A broken pusher (transport dropped) must not abort delivery to the
+    other peers — they're independent links.
+    """
+    good = _FakePusher("127.0.0.3")
+
+    class _BrokenPusher(_FakePusher):
+        async def publish(self, raw):
+            raise OSError("transport closed")
+
+    broken = _BrokenPusher("127.0.0.2")
+    ch = _make_channel()
+    ch.pushers = [broken, good]
+
+    asyncio.run(
+        ch._fanout_multi_ring_request(
+            "cluster/runner/route_clear", {"data_type": "jobs"}
+        )
+    )
+
+    assert len(good.sent) == 1
+    assert len(broken.sent) == 0

--- a/tests/pytests/unit/cluster/consensus/test_peer.py
+++ b/tests/pytests/unit/cluster/consensus/test_peer.py
@@ -48,6 +48,29 @@ class TestSaltPeer:
         peer = SaltPeer("b", _make_pusher(), "a", voting=False)
         assert peer.voting is False
 
+    def test_default_raft_group_id_is_cluster(self):
+        """
+        SaltPeer defaults to the main cluster Raft group so existing
+        (pre-multi-ring) call sites keep their behaviour without
+        opting in.
+        """
+        peer = SaltPeer("b", _make_pusher(), "a")
+        assert peer._raft_group_id == "cluster"
+
+    def test_raft_group_id_is_packed_into_outgoing_rpcs(self):
+        """
+        A SaltPeer constructed for a per-ring Raft group stamps that
+        ring's id into every RPC it sends, so the receiver's
+        dispatcher can route the message to the correct local Node.
+        """
+        peer = SaltPeer("remote", _make_pusher(), "local", raft_group_id="jobs")
+        sent = self._collect_published(
+            peer,
+            lambda p: p.request_vote(None, "local", 1, 0, -1),
+        )
+        _, _, _, group, _ = rpc.unpack(sent[0])
+        assert group == "jobs"
+
     def _collect_published(self, peer, call_fn):
         """Run an event loop, call call_fn(peer), return the raw bytes published."""
         published = []
@@ -68,7 +91,7 @@ class TestSaltPeer:
             lambda p: p.request_vote(None, "local", 3, 2, 10),
         )
         assert len(sent) == 1
-        tag, src, _, payload = rpc.unpack(sent[0])
+        tag, src, _, _, payload = rpc.unpack(sent[0])
         assert tag == rpc.REQUEST_VOTE
         assert src == "local"
         assert payload["term"] == 3
@@ -81,7 +104,7 @@ class TestSaltPeer:
             peer,
             lambda p: p.pre_request_vote(None, "local", 4, 1, 5),
         )
-        tag, _, _, payload = rpc.unpack(sent[0])
+        tag, _, _, _, payload = rpc.unpack(sent[0])
         assert tag == rpc.PRE_REQUEST_VOTE
         assert payload["term"] == 4
 
@@ -91,7 +114,7 @@ class TestSaltPeer:
             peer,
             lambda p: p.append_entries(None, "local", 2, 1, 0, -1),
         )
-        tag, _, _, payload = rpc.unpack(sent[0])
+        tag, _, _, _, payload = rpc.unpack(sent[0])
         assert tag == rpc.APPEND_ENTRIES
         assert payload["term"] == 2
         assert payload["entries"] == []
@@ -105,7 +128,7 @@ class TestSaltPeer:
             peer,
             lambda p: p.append_entries(None, "local", 1, 0, -1, 0, entry),
         )
-        tag, _, _, payload = rpc.unpack(sent[0])
+        tag, _, _, _, payload = rpc.unpack(sent[0])
         assert tag == rpc.APPEND_ENTRIES
         assert len(payload["entries"]) == 1
 
@@ -115,7 +138,7 @@ class TestSaltPeer:
             peer,
             lambda p: p.install_snapshot(None, "local", 1, 5, 1, b"\x01\x02\x03"),
         )
-        tag, _, _, payload = rpc.unpack(sent[0])
+        tag, _, _, _, payload = rpc.unpack(sent[0])
         assert tag == rpc.INSTALL_SNAPSHOT
         assert payload["data"] == [1, 2, 3]
 
@@ -173,13 +196,13 @@ class TestRaftDispatcher:
                 "last_log_index": -1,
             },
         )
-        tag, src, rid, payload = rpc.unpack(raw)
+        tag, src, rid, group, payload = rpc.unpack(raw)
 
-        _run(dispatcher.dispatch(tag, src, rid, payload))
+        _run(dispatcher.dispatch(tag, src, rid, payload, raft_group_id=group))
 
         pusher.publish.assert_awaited_once()
         reply_raw = pusher.publish.call_args[0][0]
-        r_tag, _, _, r_payload = rpc.unpack(reply_raw)
+        r_tag, _, _, _, r_payload = rpc.unpack(reply_raw)
         assert r_tag == rpc.REQUEST_VOTE_REPLY
         assert isinstance(r_payload["granted"], bool)
 
@@ -199,7 +222,7 @@ class TestRaftDispatcher:
         _run(dispatcher.dispatch(rpc.PRE_REQUEST_VOTE, "2", "r", payload))
 
         pusher.publish.assert_awaited_once()
-        r_tag, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
+        r_tag, _, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
         assert r_tag == rpc.PRE_REQUEST_VOTE_REPLY
 
     def test_dispatch_vote_reply_calls_node(self):
@@ -234,7 +257,7 @@ class TestRaftDispatcher:
         _run(dispatcher.dispatch(rpc.APPEND_ENTRIES, "1", "r", payload))
 
         pusher.publish.assert_awaited_once()
-        r_tag, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
+        r_tag, _, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
         assert r_tag == rpc.APPEND_ENTRIES_REPLY
         assert r_payload["success"] is True
 
@@ -283,7 +306,7 @@ class TestRaftDispatcher:
         _run(dispatcher.dispatch(rpc.INSTALL_SNAPSHOT, "1", "r", payload))
 
         pusher.publish.assert_awaited_once()
-        r_tag, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
+        r_tag, _, _, _, r_payload = rpc.unpack(pusher.publish.call_args[0][0])
         assert r_tag == rpc.INSTALL_SNAPSHOT_REPLY
         assert r_payload["peer_id"] == follower.node_id
 
@@ -338,6 +361,127 @@ class TestRaftDispatcher:
         }
         _run(dispatcher.dispatch(rpc.REQUEST_VOTE, "2", "r", payload))
         # exception caught, no re-raise
+
+    def test_dispatch_routes_by_raft_group_id(self):
+        """
+        With multiple nodes registered, RPCs land on the Node whose
+        group id matches the envelope's ``raft_group_id``.  Each Node
+        is independent: the wrong node must not observe the RPC.
+        """
+        cluster_node = MagicMock()
+        cluster_node.request_vote = MagicMock(return_value=(True, 1, None))
+        jobs_node = MagicMock()
+        jobs_node.request_vote = MagicMock(return_value=(True, 1, None))
+        dispatcher = RaftDispatcher(
+            {"cluster": cluster_node, "jobs": jobs_node}, "1", {}
+        )
+
+        payload = {
+            "callback_node": "2",
+            "candidate_id": "2",
+            "term": 1,
+            "last_log_term": 0,
+            "last_log_index": -1,
+        }
+        _run(
+            dispatcher.dispatch(
+                rpc.REQUEST_VOTE, "2", "r", payload, raft_group_id="jobs"
+            )
+        )
+
+        jobs_node.request_vote.assert_called_once()
+        cluster_node.request_vote.assert_not_called()
+
+    def test_dispatch_drops_rpc_for_unknown_group(self):
+        """
+        An RPC tagged for a group the dispatcher has not registered
+        (e.g. a stale ring this master tore down) is dropped without
+        raising, the way an RPC for a missing node always has been.
+        """
+        cluster_node = MagicMock()
+        cluster_node.request_vote = MagicMock()
+        dispatcher = RaftDispatcher({"cluster": cluster_node}, "1", {})
+
+        _run(
+            dispatcher.dispatch(
+                rpc.REQUEST_VOTE,
+                "2",
+                "r",
+                {"callback_node": "2", "candidate_id": "2", "term": 1},
+                raft_group_id="bogus",
+            )
+        )
+
+        cluster_node.request_vote.assert_not_called()
+
+    def test_register_and_unregister_node_dynamically(self):
+        """
+        ``register_node`` adds a Node for a new group; the dispatcher
+        immediately routes RPCs to it.  ``unregister_node`` drops the
+        entry and subsequent RPCs for that group are silently
+        discarded.  Used by RaftService when a per-ring Raft group is
+        spun up or torn down at runtime.
+        """
+        cluster_node = MagicMock()
+        dispatcher = RaftDispatcher({"cluster": cluster_node}, "1", {})
+
+        # New ring brought up.
+        ring_node = MagicMock()
+        ring_node.request_vote = MagicMock(return_value=(True, 1, None))
+        dispatcher.register_node("events", ring_node)
+
+        _run(
+            dispatcher.dispatch(
+                rpc.REQUEST_VOTE,
+                "2",
+                "r",
+                {"callback_node": "2", "candidate_id": "2", "term": 1},
+                raft_group_id="events",
+            )
+        )
+        ring_node.request_vote.assert_called_once()
+
+        # Ring torn down — subsequent RPCs are dropped.
+        dispatcher.unregister_node("events")
+        ring_node.request_vote.reset_mock()
+        _run(
+            dispatcher.dispatch(
+                rpc.REQUEST_VOTE,
+                "2",
+                "r",
+                {"callback_node": "2", "candidate_id": "2", "term": 1},
+                raft_group_id="events",
+            )
+        )
+        ring_node.request_vote.assert_not_called()
+
+    def test_dispatcher_setting_node_to_none_clears_cluster_group(self):
+        """
+        Some tests simulate a leader losing its Node by writing
+        ``dispatcher._node = None``.  The setter routes that to the
+        cluster group; subsequent cluster RPCs drop, while other
+        groups stay registered.
+        """
+        cluster_node = MagicMock()
+        ring_node = MagicMock()
+        ring_node.request_vote = MagicMock(return_value=(True, 1, None))
+        dispatcher = RaftDispatcher(
+            {"cluster": cluster_node, "jobs": ring_node}, "1", {}
+        )
+
+        dispatcher._node = None
+        assert dispatcher._node is None
+        # ring group still alive
+        _run(
+            dispatcher.dispatch(
+                rpc.REQUEST_VOTE,
+                "2",
+                "r",
+                {"callback_node": "2", "candidate_id": "2", "term": 1},
+                raft_group_id="jobs",
+            )
+        )
+        ring_node.request_vote.assert_called_once()
 
 
 def test_dispatcher_publish_exception_is_caught():

--- a/tests/pytests/unit/cluster/consensus/test_raft_log.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_log.py
@@ -1659,9 +1659,11 @@ class TestNodeAppliesRingConfigEntry:
 
     def test_ring_config_apply_fires_registered_on_change(self):
         """
-        Apply path runs the SM's ``on_change`` observer.  RaftService
-        wires this to ``_apply_ring_policy`` so the per-process ring
-        re-syncs after every committed RING_CONFIG entry.
+        Apply path runs the SM's ``on_change`` observer.  Each
+        per-ring :class:`RaftService` wires this to
+        ``_on_ring_config_change_for`` so the named ring's
+        :class:`HashRing` re-syncs after every committed RING_CONFIG
+        entry on the ring's own log.
         """
         from salt.cluster.consensus.raft.log import LogEntryType, RingConfigStateMachine
         from salt.cluster.consensus.raft.node import Node
@@ -1849,6 +1851,296 @@ class TestSnapshotEnvelopeMultiSM:
         assert node.membership_sm.current_voters() == ["a", "b"]
         assert ring_sm.members == "self"
         assert ring_sm.replicas == 1
+
+
+# ---------------------------------------------------------------------------
+# RingRegistryStateMachine — cluster-log registry of named rings (multi-ring)
+# ---------------------------------------------------------------------------
+
+
+class TestRingRegistryStateMachine:
+    """
+    Pin the contract of :class:`RingRegistryStateMachine`: applies
+    ``RING_REGISTRY`` entries, fires ``on_change``, snapshots and
+    restores round-trip, and the apply loop is tolerant of malformed
+    entries (which it must be, since rogue cmd payloads must not
+    crash committed-entry replay).
+    """
+
+    def _sm(self, **kwargs):
+        from salt.cluster.consensus.raft.log import RingRegistryStateMachine
+
+        return RingRegistryStateMachine(**kwargs)
+
+    def test_default_state_is_empty(self):
+        sm = self._sm()
+        assert sm.rings() == {}
+        assert sm.active_rings() == []
+        assert sm.registry_version == -1
+        assert sm.get("jobs") is None
+
+    def test_apply_records_ring_and_status(self):
+        sm = self._sm()
+        sm.apply(
+            {"ring_id": "jobs", "founding_voters": ["m2", "m1"], "status": "active"},
+            index=4,
+        )
+        # Founding voters are stored sorted so every replica sees the
+        # same canonical form regardless of how the operator listed them.
+        assert sm.get("jobs") == {
+            "founding_voters": ["m1", "m2"],
+            "status": "active",
+        }
+        assert sm.active_rings() == ["jobs"]
+        assert sm.registry_version == 4
+
+    def test_status_defaults_to_active(self):
+        """
+        The common case is a two-field create; status defaults to
+        active so the operator only spells out the voter list.
+        """
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "founding_voters": ["m1"]}, index=1)
+        assert sm.get("jobs")["status"] == "active"
+
+    def test_destroy_marks_ring_destroyed_and_drops_from_active(self):
+        """
+        Destroying a ring keeps it in the registry (so the lifecycle
+        is auditable) but removes it from ``active_rings`` — daemons
+        watching for active rings know to tear down their per-ring
+        Raft group.
+        """
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "founding_voters": ["m1"]}, index=1)
+        sm.apply({"ring_id": "jobs", "status": "destroyed"}, index=2)
+        entry = sm.get("jobs")
+        assert entry["status"] == "destroyed"
+        assert sm.active_rings() == []
+        assert sm.registry_version == 2
+
+    def test_unknown_status_is_ignored(self):
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "status": "bogus"}, index=1)
+        assert sm.get("jobs") is None
+        # Version unchanged — invalid entry never applied.
+        assert sm.registry_version == -1
+
+    def test_missing_ring_id_is_ignored(self):
+        sm = self._sm()
+        sm.apply({"founding_voters": ["m1"]}, index=1)
+        assert sm.rings() == {}
+
+    def test_non_dict_cmd_is_ignored(self):
+        sm = self._sm()
+        sm.apply("not a dict", index=1)
+        assert sm.rings() == {}
+
+    def test_on_change_callback_fires_with_canonical_args(self):
+        seen = []
+        sm = self._sm(on_change=lambda r, v, s: seen.append((r, list(v), s)))
+        sm.apply(
+            {"ring_id": "jobs", "founding_voters": ["m3", "m1"], "status": "active"},
+            index=1,
+        )
+        assert seen == [("jobs", ["m1", "m3"], "active")]
+
+    def test_multiple_rings_coexist(self):
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "founding_voters": ["m1", "m2"]}, index=1)
+        sm.apply({"ring_id": "events", "founding_voters": ["m3"]}, index=2)
+        assert sm.active_rings() == ["events", "jobs"]
+        assert sm.get("jobs")["founding_voters"] == ["m1", "m2"]
+        assert sm.get("events")["founding_voters"] == ["m3"]
+
+    def test_snapshot_restore_roundtrip(self):
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "founding_voters": ["m1", "m2"]}, index=3)
+        sm.apply({"ring_id": "events", "founding_voters": ["m3"]}, index=4)
+        data = sm.get_snapshot()
+        restored = self._sm()
+        restored.restore_snapshot(data)
+        assert restored.rings() == sm.rings()
+        assert restored.registry_version == 4
+
+    def test_restore_from_json_bytes(self):
+        """
+        ``restore_snapshot`` accepts JSON-encoded bytes (as the
+        envelope hands back when reading the snapshot off disk).
+        """
+        import json
+
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs", "founding_voters": ["m1"]}, index=1)
+        raw = json.dumps(sm.get_snapshot()).encode("utf-8")
+
+        restored = self._sm()
+        restored.restore_snapshot(raw)
+        assert restored.active_rings() == ["jobs"]
+        assert restored.registry_version == 1
+
+
+# ---------------------------------------------------------------------------
+# RoutingStateMachine — cluster-log data-type -> ring routing (multi-ring)
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingStateMachine:
+    """
+    Pin the contract of :class:`RoutingStateMachine`: applies
+    ``ROUTE`` entries, fires ``on_change``, snapshots and restores,
+    and tolerates malformed entries the same way the registry does.
+    """
+
+    def _sm(self, **kwargs):
+        from salt.cluster.consensus.raft.log import RoutingStateMachine
+
+        return RoutingStateMachine(**kwargs)
+
+    def test_default_state_is_empty(self):
+        sm = self._sm()
+        assert sm.routes() == {}
+        assert sm.get("jobs") is None
+        assert sm.routing_version == -1
+
+    def test_apply_records_data_type_to_ring(self):
+        sm = self._sm()
+        sm.apply({"data_type": "jobs", "ring_id": "jobs_ring"}, index=2)
+        assert sm.get("jobs") == "jobs_ring"
+        assert sm.routing_version == 2
+
+    def test_clear_route_returns_to_broadcast(self):
+        """
+        Routing a data type to ``None`` is the operator-facing way to
+        flip it back to broadcast.  ``get`` returns ``None`` for an
+        explicitly-cleared route (same as for one that was never
+        routed), and ``routes()`` retains the entry so the lifecycle
+        is auditable.
+        """
+        sm = self._sm()
+        sm.apply({"data_type": "jobs", "ring_id": "jobs_ring"}, index=1)
+        sm.apply({"data_type": "jobs", "ring_id": None}, index=2)
+        assert sm.get("jobs") is None
+        assert sm.routes() == {"jobs": None}
+        assert sm.routing_version == 2
+
+    def test_missing_data_type_is_ignored(self):
+        sm = self._sm()
+        sm.apply({"ring_id": "jobs_ring"}, index=1)
+        assert sm.routes() == {}
+        assert sm.routing_version == -1
+
+    def test_non_dict_cmd_is_ignored(self):
+        sm = self._sm()
+        sm.apply(["not", "a", "dict"], index=1)
+        assert sm.routes() == {}
+
+    def test_on_change_fires_with_data_type_and_ring(self):
+        seen = []
+        sm = self._sm(on_change=lambda d, r: seen.append((d, r)))
+        sm.apply({"data_type": "jobs", "ring_id": "jobs_ring"}, index=1)
+        sm.apply({"data_type": "events", "ring_id": None}, index=2)
+        assert seen == [("jobs", "jobs_ring"), ("events", None)]
+
+    def test_snapshot_restore_roundtrip(self):
+        sm = self._sm()
+        sm.apply({"data_type": "jobs", "ring_id": "jobs_ring"}, index=1)
+        sm.apply({"data_type": "events", "ring_id": None}, index=2)
+        data = sm.get_snapshot()
+        restored = self._sm()
+        restored.restore_snapshot(data)
+        assert restored.routes() == sm.routes()
+        assert restored.routing_version == 2
+
+    def test_restore_from_json_bytes(self):
+        import json
+
+        sm = self._sm()
+        sm.apply({"data_type": "jobs", "ring_id": "jobs_ring"}, index=1)
+        raw = json.dumps(sm.get_snapshot()).encode("utf-8")
+
+        restored = self._sm()
+        restored.restore_snapshot(raw)
+        assert restored.get("jobs") == "jobs_ring"
+
+
+# ---------------------------------------------------------------------------
+# Node.apply_entries dispatches RING_REGISTRY / ROUTE entries (multi-ring)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRingEntryDispatch:
+    """
+    Pin the behaviour that committed RING_REGISTRY and ROUTE entries
+    are dispatched to their registered state machines on the cluster
+    log — the wire path between Raft commit and ``on_change``.
+    """
+
+    def test_ring_registry_entry_dispatches_to_registered_sm(self):
+        from salt.cluster.consensus.raft.log import (
+            LogEntryType,
+            RingRegistryStateMachine,
+        )
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("self")
+        node.register_schedule_timeout(lambda t, c: None)
+        registry_sm = RingRegistryStateMachine()
+        node.log.register_state_machine("ring_registry_sm", registry_sm)
+
+        node.log.add(
+            1,
+            {"ring_id": "jobs", "founding_voters": ["self"], "status": "active"},
+            entry_type=LogEntryType.RING_REGISTRY,
+        )
+        node.commit_index = node.log.index
+
+        assert registry_sm.active_rings() == ["jobs"]
+        assert registry_sm.get("jobs")["founding_voters"] == ["self"]
+
+    def test_route_entry_dispatches_to_registered_sm(self):
+        from salt.cluster.consensus.raft.log import LogEntryType, RoutingStateMachine
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("self")
+        node.register_schedule_timeout(lambda t, c: None)
+        routing_sm = RoutingStateMachine()
+        node.log.register_state_machine("routing_sm", routing_sm)
+
+        node.log.add(
+            1,
+            {"data_type": "jobs", "ring_id": "jobs_ring"},
+            entry_type=LogEntryType.ROUTE,
+        )
+        node.commit_index = node.log.index
+
+        assert routing_sm.get("jobs") == "jobs_ring"
+
+    def test_unregistered_sm_is_safe(self):
+        """
+        A RING_REGISTRY / ROUTE entry committed on a node that has not
+        registered the corresponding SM must not crash apply_entries
+        — the entries are simply dropped on the floor.  Important on
+        rolling upgrades where some masters know the new entry types
+        and others may not yet.
+        """
+        from salt.cluster.consensus.raft.log import LogEntryType
+        from salt.cluster.consensus.raft.node import Node
+
+        node = Node("self")
+        node.register_schedule_timeout(lambda t, c: None)
+
+        node.log.add(
+            1,
+            {"ring_id": "jobs", "founding_voters": ["self"]},
+            entry_type=LogEntryType.RING_REGISTRY,
+        )
+        node.log.add(
+            1,
+            {"data_type": "jobs", "ring_id": "jobs_ring"},
+            entry_type=LogEntryType.ROUTE,
+        )
+        node.commit_index = node.log.index  # must not raise
+        assert node.log.last_applied == node.log.index
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pytests/unit/cluster/consensus/test_rpc.py
+++ b/tests/pytests/unit/cluster/consensus/test_rpc.py
@@ -27,21 +27,54 @@ def test_pack_unpack_roundtrip():
     raw = rpc.pack(rpc.REQUEST_VOTE_REPLY, "node-a", "corr-123", payload)
     assert isinstance(raw, bytes)
 
-    tag, src, rpc_id, out = rpc.unpack(raw)
+    tag, src, rpc_id, raft_group_id, out = rpc.unpack(raw)
     assert tag == rpc.REQUEST_VOTE_REPLY
     assert src == "node-a"
     assert rpc_id == "corr-123"
+    # Default group is the main cluster Raft log.
+    assert raft_group_id == "cluster"
     assert out == payload
 
 
 def test_pack_unpack_all_kinds():
     for tag in rpc.ALL_TAGS:
         raw = rpc.pack(tag, "src-node", "rid-1", {"x": 1})
-        out_tag, out_src, out_rid, out_payload = rpc.unpack(raw)
+        out_tag, out_src, out_rid, out_group, out_payload = rpc.unpack(raw)
         assert out_tag == tag
         assert out_src == "src-node"
         assert out_rid == "rid-1"
+        assert out_group == "cluster"
         assert out_payload == {"x": 1}
+
+
+def test_pack_unpack_carries_raft_group_id():
+    """
+    A non-default ``raft_group_id`` round-trips through the envelope.
+    Multi-ring support depends on the field reaching the receiver
+    intact so the dispatcher can pick the correct local ``Node``.
+    """
+    raw = rpc.pack(rpc.APPEND_ENTRIES, "src", "rid", {"x": 1}, raft_group_id="jobs")
+    _, _, _, group, _ = rpc.unpack(raw)
+    assert group == "jobs"
+
+
+def test_unpack_pre_multi_ring_envelope_defaults_to_cluster():
+    """
+    Envelopes packed before multi-ring support omit
+    ``raft_group_id``; ``unpack`` must default the field to
+    ``"cluster"`` so old senders are still routed to the main cluster
+    Raft group.
+    """
+    raw = salt.utils.event.SaltEvent.pack(
+        rpc.REQUEST_VOTE,
+        {"src": "n1", "rpc_id": "r1", "payload": {"term": 0}},
+    )
+    tag, src, rpc_id, group, payload = rpc.unpack(raw)
+    assert tag == rpc.REQUEST_VOTE
+    assert src == "n1"
+    assert rpc_id == "r1"
+    assert group == "cluster"
+    assert payload == {"term": 0}
 
 
 def test_unpack_malformed_envelope():

--- a/tests/pytests/unit/cluster/consensus/test_storage.py
+++ b/tests/pytests/unit/cluster/consensus/test_storage.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for :class:`salt.cluster.consensus.storage.SaltStorage`.
+
+Most of SaltStorage's behaviour is exercised transitively through
+``test_raft_log.py``; this file covers the multi-ring constructor
+parameter and the on-disk path layout that makes per-ring Raft groups
+coexist on a single master.
+"""
+
+import pytest
+
+import salt.config
+from salt.cluster.consensus.raft.log import LogEntry, LogEntryType
+from salt.cluster.consensus.storage import SaltStorage
+
+
+@pytest.fixture
+def opts(tmp_path):
+    """Master opts with a per-test cachedir so storage writes are isolated."""
+    opts = salt.config.master_config("/dev/null")
+    opts["cachedir"] = str(tmp_path)
+    return opts
+
+
+def test_default_ring_id_is_cluster(opts):
+    """
+    Pre-multi-ring callers that omit ``ring_id`` are routed to the
+    main cluster Raft log.  This is the source of backward compat
+    for every existing site that builds a ``SaltStorage``.
+    """
+    storage = SaltStorage("node-a", opts)
+    assert storage._ring_id == "cluster"
+    assert storage._meta_bank == "cluster/consensus/node-a/cluster"
+    assert storage._log_bank == "cluster/consensus/node-a/cluster/log"
+
+
+def test_explicit_ring_id_isolates_paths(opts):
+    """
+    Two storages on the same node but different rings persist into
+    disjoint cache banks.  This is the invariant that lets one
+    master process host the cluster Raft group plus N per-ring
+    Raft groups without their logs colliding on disk.
+    """
+    cluster_storage = SaltStorage("node-a", opts, ring_id="cluster")
+    jobs_storage = SaltStorage("node-a", opts, ring_id="jobs")
+
+    assert cluster_storage._meta_bank != jobs_storage._meta_bank
+    assert cluster_storage._log_bank != jobs_storage._log_bank
+    assert "/jobs" in jobs_storage._meta_bank
+    assert "/cluster" in cluster_storage._meta_bank
+
+
+def test_per_ring_state_does_not_collide(opts):
+    """
+    Writing state through one ring's storage must not appear in
+    another ring's storage.  Concrete check that the path keying
+    actually keeps committed Raft state separated, not just that
+    the strings differ.
+    """
+    cluster_storage = SaltStorage("node-a", opts, ring_id="cluster")
+    jobs_storage = SaltStorage("node-a", opts, ring_id="jobs")
+
+    cluster_storage.save_state(term=7, voted_for="node-a", leader_id="node-a")
+    jobs_storage.save_state(term=2, voted_for="node-b", leader_id="node-b")
+
+    # Each ring sees its own state, unaffected by the other.
+    cluster = cluster_storage.load_state()
+    jobs = jobs_storage.load_state()
+    assert cluster["term"] == 7
+    assert jobs["term"] == 2
+    assert cluster["leader_id"] == "node-a"
+    assert jobs["leader_id"] == "node-b"
+
+
+def test_per_ring_log_does_not_collide(opts):
+    """
+    A log entry committed in one ring's storage is invisible from
+    another ring.  The ring_id segment is the only thing keeping
+    these apart; without it both Raft groups would corrupt each
+    other's commit stream.
+    """
+    cluster_storage = SaltStorage("node-a", opts, ring_id="cluster")
+    jobs_storage = SaltStorage("node-a", opts, ring_id="jobs")
+
+    cluster_storage.append_log(
+        LogEntry(term=1, index=0, cmd={"x": 1}, type=LogEntryType.COMMAND)
+    )
+    jobs_storage.append_log(
+        LogEntry(term=1, index=0, cmd={"y": 2}, type=LogEntryType.COMMAND)
+    )
+
+    cluster_entries = cluster_storage.load_log()
+    jobs_entries = jobs_storage.load_log()
+    assert len(cluster_entries) == 1
+    assert len(jobs_entries) == 1
+    assert cluster_entries[0].cmd == {"x": 1}
+    assert jobs_entries[0].cmd == {"y": 2}

--- a/tests/pytests/unit/cluster/test_ring_membership.py
+++ b/tests/pytests/unit/cluster/test_ring_membership.py
@@ -141,6 +141,200 @@ def test_reset_swaps_singleton_identity():
 
 
 # ---------------------------------------------------------------------------
+# Multi-ring registry: named rings stay isolated from each other
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRingRegistry:
+    """
+    Pin the multi-ring contract: rings are keyed by name, isolated
+    from each other; the routing snapshot decides which ring (if any)
+    a given data type is bound to.
+    """
+
+    def test_get_ring_creates_named_rings_lazily(self):
+        jobs = ring_membership.get_ring("jobs")
+        events = ring_membership.get_ring("events")
+        # Distinct rings, both initially empty.
+        assert jobs is not events
+        assert jobs.node_count() == 0
+        assert events.node_count() == 0
+
+    def test_rebuild_named_ring_does_not_perturb_others(self):
+        """
+        Rebuilding ring "jobs" must not touch ring "events".  Each
+        ring is its own consensus group; sharing state would be a
+        correctness bug.
+        """
+        ring_membership.rebuild("jobs", ["m1", "m2", "m3"])
+        ring_membership.rebuild("events", ["m4", "m5"])
+        assert sorted(ring_membership.get_ring("jobs").nodes()) == [
+            "m1",
+            "m2",
+            "m3",
+        ]
+        assert sorted(ring_membership.get_ring("events").nodes()) == ["m4", "m5"]
+
+    def test_default_ring_name_is_cluster(self):
+        """
+        ``get_ring()`` without a name returns the "cluster" ring so
+        pre-multi-ring callers keep working.  Equivalently,
+        ``rebuild(voters)`` (legacy single-arg) keeps populating that
+        same ring.
+        """
+        ring_membership.rebuild(["m1", "m2"])
+        assert ring_membership.get_ring() is ring_membership.get_ring("cluster")
+        assert sorted(ring_membership.get_ring("cluster").nodes()) == ["m1", "m2"]
+
+    def test_owns_takes_ring_name(self):
+        ring_membership.rebuild("jobs", ["m1", "m2", "m3"])
+        owners = [
+            m
+            for m in ("m1", "m2", "m3")
+            if ring_membership.owns(_opts(m), "jid-X", ring="jobs")
+        ]
+        assert len(owners) == 1
+
+    def test_drop_ring_makes_subsequent_lookups_empty(self):
+        """
+        After ``drop_ring``, the registry creates a fresh empty ring
+        on the next ``get_ring`` call so this master is treated as a
+        non-member of the destroyed ring.
+        """
+        ring_membership.rebuild("jobs", ["m1", "m2"])
+        ring_membership.drop_ring("jobs")
+        # A subsequent get_ring call lazily creates a new empty
+        # HashRing under "jobs" again.
+        assert ring_membership.get_ring("jobs").node_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Routing + owns_for: the multi-ring gate
+# ---------------------------------------------------------------------------
+
+
+class TestOwnsFor:
+    """
+    Pin the contract of :func:`ring_membership.owns_for`: it consults
+    the routing snapshot, then defers to the named ring (or broadcasts
+    if no route exists).  This is what the gate sites in
+    :mod:`salt.master` will call.
+    """
+
+    def test_unrouted_data_type_broadcasts(self):
+        """
+        With no routing entry, every master owns every key for that
+        data type — the broadcast behaviour that pre-multi-ring code
+        relied on.
+        """
+        assert ring_membership.owns_for(_opts("m1"), "jobs", "jid-1") is True
+
+    def test_route_cleared_to_none_broadcasts(self):
+        """
+        An explicit ``set_route(data_type, None)`` is equivalent to
+        clearing the route — the data type returns to broadcast.
+        """
+        ring_membership.set_route("jobs", "jobs_ring")
+        ring_membership.set_route("jobs", None)
+        assert ring_membership.owns_for(_opts("m1"), "jobs", "jid-1") is True
+
+    def test_routed_to_unknown_ring_returns_false(self):
+        """
+        A data type routed to a ring this master does not host
+        locally (no Node, ring not in the registry, or empty ring)
+        is a non-owner — the master no-ops writes for routed data
+        it doesn't own.
+        """
+        ring_membership.set_route("jobs", "jobs_ring")
+        # No master ever rebuilt "jobs_ring" — empty / unknown.
+        assert ring_membership.owns_for(_opts("m1"), "jobs", "jid-1") is False
+
+    def test_routed_to_known_ring_defers_to_ring_owns(self):
+        """
+        With a routed ring populated, ``owns_for`` answers whatever
+        the ring's consistent-hash thinks.  Exactly one member of
+        the ring's voter set wins for any given key.
+        """
+        ring_membership.rebuild("jobs_ring", ["m1", "m2", "m3"])
+        ring_membership.set_route("jobs", "jobs_ring")
+        owners = [
+            m
+            for m in ("m1", "m2", "m3")
+            if ring_membership.owns_for(_opts(m), "jobs", "jid-1")
+        ]
+        assert len(owners) == 1
+
+    def test_routes_are_returned_as_a_copy(self):
+        ring_membership.set_route("jobs", "jobs_ring")
+        snap = ring_membership.get_routes()
+        # Mutating the returned copy must not bleed into the
+        # registry's snapshot.
+        snap["jobs"] = "different"
+        assert ring_membership.get_routes() == {"jobs": "jobs_ring"}
+
+
+# ---------------------------------------------------------------------------
+# Drop accounting — surfaces silent non-member drops to operators
+# ---------------------------------------------------------------------------
+
+
+class TestDropStats:
+    """
+    Pin the contract that :func:`ring_membership.owns_for` records
+    why it answered ``False`` so an operator can spot a misconfigured
+    load balancer (traffic for a routed data type landing on
+    masters that aren't in the ring).
+    """
+
+    def test_no_drops_when_no_route(self):
+        # Broadcast (no route) writes never drop.
+        assert ring_membership.owns_for(_opts("m1"), "jobs", "k1") is True
+        assert ring_membership.drop_stats() == {}
+
+    def test_not_a_member_bucket_counts_drops(self):
+        """
+        Route exists, ring unknown to this master → ``not_a_member``
+        bucket counts every drop.  This is the misconfig signal.
+        """
+        ring_membership.set_route("jobs", "jobs_ring")
+        for _ in range(3):
+            assert ring_membership.owns_for(_opts("m1"), "jobs", "k") is False
+        stats = ring_membership.drop_stats()
+        assert stats["jobs"]["ring_id"] == "jobs_ring"
+        assert stats["jobs"]["not_a_member"] == 3
+        assert stats["jobs"]["other_ring_member"] == 0
+
+    def test_other_ring_member_bucket_counts_sharded_misses(self):
+        """
+        With a populated ring, keys owned by sibling voters get
+        counted under ``other_ring_member`` — that's the expected
+        sharded-traffic shape, not a misconfig.  Pin it so an
+        operator inspecting drop_stats knows which bucket is signal.
+        """
+        ring_membership.rebuild("jobs_ring", ["m1", "m2", "m3"])
+        ring_membership.set_route("jobs", "jobs_ring")
+        # Burn through 30 keys; some will hash to m1 (returns True),
+        # the rest to siblings (False with reason "other_ring_member").
+        seen_owned = seen_other = 0
+        for i in range(30):
+            if ring_membership.owns_for(_opts("m1"), "jobs", f"k-{i}"):
+                seen_owned += 1
+            else:
+                seen_other += 1
+        assert seen_owned and seen_other  # sanity: hash distributes
+        stats = ring_membership.drop_stats()
+        assert stats["jobs"]["other_ring_member"] == seen_other
+        assert stats["jobs"]["not_a_member"] == 0
+
+    def test_reset_clears_drop_stats(self):
+        ring_membership.set_route("jobs", "jobs_ring")
+        ring_membership.owns_for(_opts("m1"), "jobs", "k")
+        assert ring_membership.drop_stats()
+        ring_membership.reset()
+        assert ring_membership.drop_stats() == {}
+
+
+# ---------------------------------------------------------------------------
 # Optional xxhash: master must still start when the package is missing
 # ---------------------------------------------------------------------------
 

--- a/tests/pytests/unit/cluster/test_state_sync.py
+++ b/tests/pytests/unit/cluster/test_state_sync.py
@@ -103,6 +103,174 @@ def test_iter_keys_chunks_unknown_channel_raises(monkeypatch):
         list(iter_keys_chunks(opts, "wat"))
 
 
+def test_iter_keys_chunks_key_filter_emits_only_matching(monkeypatch):
+    """
+    With a ``key_filter`` callable the sender only emits entries
+    whose minion-id passes the filter.  Used by the multi-ring
+    ``cluster.collect_from_peers`` flow: the requester names the
+    subset of keys it lacks and the peer responds with only those.
+    """
+    bank = {f"m{i:03d}": {"state": "accepted", "pub": "p"} for i in range(10)}
+    opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: bank})
+    wanted = {"m001", "m005", "m009"}
+    chunks = list(
+        iter_keys_chunks(opts, KEYS_CHANNEL, key_filter=lambda mid: mid in wanted)
+    )
+    items = [item for chunk in chunks for item in chunk]
+    assert {item["id"] for item in items} == wanted
+
+
+# ---------------------------------------------------------------------------
+# bank: channel — arbitrary salt.cache.Cache banks (multi-ring collect)
+# ---------------------------------------------------------------------------
+
+
+def test_bank_channel_round_trip():
+    from salt.cluster.state_sync import bank_channel, bank_from_channel
+
+    assert bank_channel("jobs/loads") == "bank:jobs/loads"
+    assert bank_from_channel("bank:jobs/loads") == "jobs/loads"
+
+
+def test_bank_from_channel_rejects_non_bank():
+    from salt.cluster.state_sync import bank_from_channel
+
+    assert bank_from_channel("keys") is None
+    assert bank_from_channel("") is None
+    assert bank_from_channel(None) is None
+
+
+def _bank_opts(monkeypatch, fake_dump):
+    """Mock ``salt.cache.Cache.list_all`` for arbitrary bank reads."""
+    import salt.cache
+
+    class _FakeCache:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def list_all(self, bank, include_data=False):  # noqa: ARG002
+            return dict(fake_dump.get(bank, {}))
+
+        def list(self, bank):
+            return list(fake_dump.get(bank, {}).keys())
+
+        def fetch(self, bank, key):
+            return fake_dump.get(bank, {}).get(key)
+
+        def store(self, bank, key, value):
+            fake_dump.setdefault(bank, {})[key] = value
+
+    monkeypatch.setattr(salt.cache, "Cache", _FakeCache)
+    return {"cache": "localfs"}
+
+
+def test_iter_bank_chunks_empty_yields_one_chunk(monkeypatch):
+    from salt.cluster.state_sync import iter_bank_chunks
+
+    opts = _bank_opts(monkeypatch, {"jobs/loads": {}})
+    assert list(iter_bank_chunks(opts, "jobs/loads")) == [[]]
+
+
+def test_iter_bank_chunks_emits_key_value_records(monkeypatch):
+    from salt.cluster.state_sync import iter_bank_chunks
+
+    opts = _bank_opts(
+        monkeypatch, {"jobs/loads": {"jid-1": {"fun": "a"}, "jid-2": {"fun": "b"}}}
+    )
+    chunks = list(iter_bank_chunks(opts, "jobs/loads"))
+    items = [item for chunk in chunks for item in chunk]
+    assert {item["key"] for item in items} == {"jid-1", "jid-2"}
+    by_key = {item["key"]: item["value"] for item in items}
+    assert by_key == {"jid-1": {"fun": "a"}, "jid-2": {"fun": "b"}}
+
+
+def test_iter_bank_chunks_honours_key_filter(monkeypatch):
+    """
+    A ``key_filter`` selects only matching keys.  Used by collect so
+    the requester can name the keys it lacks rather than re-receiving
+    its full set.
+    """
+    from salt.cluster.state_sync import iter_bank_chunks
+
+    opts = _bank_opts(
+        monkeypatch,
+        {"jobs/loads": {f"jid-{i}": {} for i in range(10)}},
+    )
+    wanted = {"jid-1", "jid-7"}
+    chunks = list(
+        iter_bank_chunks(opts, "jobs/loads", key_filter=lambda k: k in wanted)
+    )
+    items = [item for chunk in chunks for item in chunk]
+    assert {item["key"] for item in items} == wanted
+
+
+def test_install_bank_chunk_writes_through_cache(monkeypatch):
+    """
+    ``install_bank_chunk`` issues one ``cache.store`` per item and
+    returns the count.  Round-trip ``iter_bank_chunks`` ->
+    ``install_bank_chunk`` against the same mock to prove the wire
+    shape is symmetric.
+    """
+    from salt.cluster.state_sync import install_bank_chunk, iter_bank_chunks
+
+    dump = {"jobs/loads": {"jid-1": {"fun": "a"}, "jid-2": {"fun": "b"}}}
+    opts = _bank_opts(monkeypatch, dump)
+    chunks = list(iter_bank_chunks(opts, "jobs/loads"))
+    items = [item for chunk in chunks for item in chunk]
+
+    # Clear the destination side and install.
+    dump["jobs/loads"] = {}
+    written = install_bank_chunk(opts, "jobs/loads", items)
+    assert written == 2
+    assert dump["jobs/loads"] == {"jid-1": {"fun": "a"}, "jid-2": {"fun": "b"}}
+
+
+def test_install_bank_chunk_skips_malformed_entries(monkeypatch):
+    """
+    Items that aren't dicts or that lack a ``key`` are dropped
+    silently; the install count reflects only successful writes.
+    Pins the wire-tolerance invariant — a corrupted chunk does not
+    raise mid-install.
+    """
+    from salt.cluster.state_sync import install_bank_chunk
+
+    dump = {"jobs/loads": {}}
+    opts = _bank_opts(monkeypatch, dump)
+    items = [
+        "not-a-dict",
+        {"value": "no-key"},
+        {"key": "jid-A", "value": {"fun": "ok"}},
+    ]
+    written = install_bank_chunk(opts, "jobs/loads", items)
+    assert written == 1
+    assert dump["jobs/loads"] == {"jid-A": {"fun": "ok"}}
+
+
+def test_install_bank_chunk_rejects_empty_bank(monkeypatch):
+    from salt.cluster.state_sync import install_bank_chunk
+
+    _bank_opts(monkeypatch, {})
+    with pytest.raises(ValueError, match="bank is required"):
+        install_bank_chunk({"cache": "localfs"}, "", [])
+
+
+# ---------------------------------------------------------------------------
+# Original tests resume below
+# ---------------------------------------------------------------------------
+
+
+def test_iter_keys_chunks_key_filter_excluding_everything_yields_eof(monkeypatch):
+    """
+    A filter that rejects every entry still yields a single empty
+    chunk so the caller can emit the eof marker — same contract as
+    a literally-empty bank.
+    """
+    bank = {f"m{i:03d}": {"state": "accepted", "pub": "p"} for i in range(5)}
+    opts = _keys_opts(monkeypatch, {KEYS_CHANNEL: bank})
+    chunks = list(iter_keys_chunks(opts, KEYS_CHANNEL, key_filter=lambda mid: False))
+    assert chunks == [[]]
+
+
 # ---------------------------------------------------------------------------
 # iter_root_chunks (sender, byte-budget-based)
 # ---------------------------------------------------------------------------

--- a/tests/pytests/unit/returners/test_salt_cache.py
+++ b/tests/pytests/unit/returners/test_salt_cache.py
@@ -1,0 +1,386 @@
+"""
+Unit tests for ``salt.returners.salt_cache`` — the job-cache returner
+that routes through ``salt.cache.Cache``.
+
+These tests pin the returner API contract (``prep_jid`` / ``returner``
+/ ``save_load`` / ``save_minions`` / ``get_load`` / ``get_jid`` /
+``get_jids`` / ``get_jids_filter`` / ``clean_old_jobs`` /
+``update_endtime`` / ``get_endtime``) using the real ``localfs`` cache
+driver so the on-disk behaviour is exercised end-to-end.
+
+Multi-ring integration (``ring_membership.owns_for`` calls in
+``salt.master``) is covered separately under
+``tests/pytests/unit/test_event_monitor_ring_gating.py``; here we just
+prove that this returner does what ``local_cache`` does, only via the
+:class:`salt.cache.Cache` abstraction so the multi-ring runners can
+operate on the data.
+"""
+
+import time
+
+import pytest
+
+import salt.cache
+import salt.returners.salt_cache as salt_cache
+from tests.support.mock import patch
+
+
+@pytest.fixture
+def opts(tmp_path):
+    """
+    Master opts pointing at a per-test cachedir with the default
+    ``localfs`` cache driver.  Using a real driver (rather than a
+    mock) catches wire-shape bugs that a tighter mock would mask.
+    """
+    return {
+        "cachedir": str(tmp_path),
+        "cache": "localfs",
+        "extension_modules": str(tmp_path / "extmods"),
+        "hash_type": "sha256",
+        "keep_jobs_seconds": 86400,
+        "job_cache_store_endtime": False,
+    }
+
+
+@pytest.fixture
+def configure_loader_modules(opts):
+    """Inject opts into the returner module the way Salt's loader would."""
+    return {salt_cache: {"__opts__": opts}}
+
+
+def _cache(opts):
+    """Helper: independent Cache instance for inspecting writes."""
+    return salt.cache.Cache(opts)
+
+
+# ---------------------------------------------------------------------------
+# prep_jid
+# ---------------------------------------------------------------------------
+
+
+def test_prep_jid_generates_jid_when_none_passed(opts):
+    jid = salt_cache.prep_jid()
+    assert isinstance(jid, str)
+    assert len(jid) >= 8  # gen_jid always returns a non-trivial id
+
+
+def test_prep_jid_honours_passed_jid(opts):
+    jid = salt_cache.prep_jid(passed_jid="20260516-special")
+    assert jid == "20260516-special"
+
+
+def test_prep_jid_retries_on_collision(opts):
+    """
+    A generated jid that collides with an existing load triggers a
+    fresh generate.  Pin via a controlled ``gen_jid`` that returns
+    the same id twice then a new one — first round collides, second
+    round wins.
+    """
+    cache = _cache(opts)
+    cache.store("jobs/loads", "collide-1", {"fun": "test.ping"})
+
+    sequence = iter(["collide-1", "collide-1", "fresh-2"])
+    with patch("salt.utils.jid.gen_jid", lambda _opts: next(sequence)):
+        jid = salt_cache.prep_jid()
+
+    assert jid == "fresh-2"
+
+
+def test_prep_jid_records_nocache_marker(opts):
+    """
+    ``nocache=True`` writes a marker so subsequent minion returns are
+    dropped by :func:`returner`.
+    """
+    jid = salt_cache.prep_jid(nocache=True, passed_jid="20260516-nc")
+    cache = _cache(opts)
+    assert cache.contains("jobs/nocache", "20260516-nc")
+    assert cache.fetch("jobs/nocache", jid) is True
+
+
+# ---------------------------------------------------------------------------
+# returner — minion returns
+# ---------------------------------------------------------------------------
+
+
+def test_returner_persists_minion_return(opts):
+    salt_cache.returner(
+        {
+            "jid": "20260516-A",
+            "id": "minion-a",
+            "return": {"ok": True},
+            "retcode": 0,
+            "success": True,
+        }
+    )
+    cache = _cache(opts)
+    record = cache.fetch("jobs/returns/20260516-A", "minion-a")
+    assert record == {"return": {"ok": True}, "retcode": 0, "success": True}
+
+
+def test_returner_includes_out_when_present(opts):
+    salt_cache.returner(
+        {
+            "jid": "20260516-B",
+            "id": "minion-a",
+            "return": "x",
+            "out": "highstate",
+        }
+    )
+    record = _cache(opts).fetch("jobs/returns/20260516-B", "minion-a")
+    assert record["out"] == "highstate"
+
+
+def test_returner_drops_duplicate_minion_returns(opts):
+    """
+    Replay protection: a second return from the same (jid, minion)
+    is rejected without overwriting the first record.  Pins the
+    invariant that returns are append-once.
+    """
+    load = {
+        "jid": "20260516-C",
+        "id": "minion-a",
+        "return": "first",
+        "retcode": 0,
+        "success": True,
+    }
+    salt_cache.returner(load)
+
+    second = dict(load, **{"return": "second"})
+    assert salt_cache.returner(second) is False
+
+    record = _cache(opts).fetch("jobs/returns/20260516-C", "minion-a")
+    assert record["return"] == "first"
+
+
+def test_returner_skips_when_nocache_marker_set(opts):
+    salt_cache.prep_jid(nocache=True, passed_jid="20260516-nc-2")
+    salt_cache.returner(
+        {
+            "jid": "20260516-nc-2",
+            "id": "minion-a",
+            "return": "x",
+        }
+    )
+    # No return persisted for the nocache jid.
+    assert _cache(opts).list("jobs/returns/20260516-nc-2") == []
+
+
+# ---------------------------------------------------------------------------
+# save_load + save_minions + get_load
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_round_trips(opts):
+    payload = {
+        "fun": "test.ping",
+        "arg": [],
+        "tgt": "*",
+        "tgt_type": "glob",
+        "user": "ops",
+    }
+    # Pass an explicit minion list so save_load doesn't construct
+    # CkMinions (which needs PKI-cache opts we don't carry in this
+    # test harness).  The "compute matched set when tgt is set"
+    # branch is exercised separately below by stubbing CkMinions.
+    salt_cache.save_load("20260516-D", dict(payload), minions=["m1"])
+    out = salt_cache.get_load("20260516-D")
+    assert out["fun"] == "test.ping"
+    assert out["tgt"] == "*"
+    assert out["Minions"] == ["m1"]
+
+
+def test_save_load_computes_matched_minions_when_not_supplied(opts):
+    """
+    With ``minions=None`` and a ``tgt`` in the load, ``save_load``
+    invokes ``CkMinions`` to populate the matched set.  We stub it
+    out so the test doesn't need a real PKI tree.
+    """
+
+    class _FakeCkMinions:
+        def __init__(self, _opts):
+            pass
+
+        def check_minions(self, _tgt, _tgt_type="glob"):
+            return {"minions": ["m1", "m2"]}
+
+    with patch("salt.utils.minions.CkMinions", _FakeCkMinions):
+        salt_cache.save_load(
+            "20260516-D2",
+            {"fun": "test.ping", "tgt": "*", "tgt_type": "glob"},
+        )
+
+    out = salt_cache.get_load("20260516-D2")
+    assert out["Minions"] == ["m1", "m2"]
+
+
+def test_save_load_skips_minion_computation_when_no_tgt(opts):
+    """
+    Loads without a ``tgt`` (e.g. runner jobs) must not invoke
+    CkMinions — the matched set doesn't apply to them.
+    """
+    with patch.object(salt_cache, "save_minions") as save_minions_mock:
+        salt_cache.save_load("20260516-E", {"fun": "test.ping"})
+    save_minions_mock.assert_not_called()
+
+
+def test_save_minions_merges_with_existing(opts):
+    salt_cache.save_minions("20260516-F", ["minion-a", "minion-b"])
+    # Second call merges; the master and the syndic each contribute
+    # a slice of the same job's matched set.
+    salt_cache.save_minions("20260516-F", ["minion-b", "minion-c"])
+    assert _cache(opts).fetch("jobs/minions", "20260516-F") == [
+        "minion-a",
+        "minion-b",
+        "minion-c",
+    ]
+
+
+def test_get_load_includes_sorted_minions(opts):
+    salt_cache.save_load(
+        "20260516-G",
+        {"fun": "test.ping"},  # no tgt → no auto-save_minions
+    )
+    salt_cache.save_minions("20260516-G", ["m2", "m1", "m3"])
+
+    load = salt_cache.get_load("20260516-G")
+    assert load["Minions"] == ["m1", "m2", "m3"]
+
+
+def test_get_load_returns_empty_dict_for_unknown_jid(opts):
+    assert salt_cache.get_load("never-existed") == {}
+
+
+# ---------------------------------------------------------------------------
+# get_jid — all returns for one jid
+# ---------------------------------------------------------------------------
+
+
+def test_get_jid_returns_every_minion_record(opts):
+    for minion in ("m1", "m2", "m3"):
+        salt_cache.returner(
+            {
+                "jid": "20260516-H",
+                "id": minion,
+                "return": f"hello from {minion}",
+                "retcode": 0,
+                "success": True,
+            }
+        )
+    got = salt_cache.get_jid("20260516-H")
+    assert set(got) == {"m1", "m2", "m3"}
+    assert got["m1"]["return"] == "hello from m1"
+
+
+def test_get_jid_wraps_legacy_v1_payloads(opts):
+    """
+    Older returners stored the bare return value at the minion key
+    instead of the ``{"return": …}`` dict.  ``get_jid`` must coerce
+    those into the modern shape so callers see a consistent contract.
+    """
+    cache = _cache(opts)
+    cache.store("jobs/returns/20260516-legacy", "m1", "bare-return-value")
+    got = salt_cache.get_jid("20260516-legacy")
+    assert got == {"m1": {"return": "bare-return-value"}}
+
+
+# ---------------------------------------------------------------------------
+# get_jids / get_jids_filter
+# ---------------------------------------------------------------------------
+
+
+def test_get_jids_returns_every_known_load(opts):
+    for jid in ("20260516-J", "20260516-K"):
+        salt_cache.save_load(jid, {"fun": "test.ping"})
+    got = salt_cache.get_jids()
+    assert set(got) == {"20260516-J", "20260516-K"}
+
+
+def test_get_jids_filter_keeps_most_recent(opts):
+    jids = ["20260516-0001", "20260516-0002", "20260516-0003"]
+    for jid in jids:
+        salt_cache.save_load(jid, {"fun": "test.ping"})
+
+    out = salt_cache.get_jids_filter(count=2)
+    assert len(out) == 2
+
+
+def test_get_jids_filter_drops_find_job(opts):
+    """``saltutil.find_job`` traffic is excluded by default."""
+    salt_cache.save_load("20260516-Q", {"fun": "test.ping"})
+    salt_cache.save_load("20260516-R", {"fun": "saltutil.find_job"})
+
+    out = salt_cache.get_jids_filter(count=10)
+    funs = [j.get("Function") for j in out]
+    assert "saltutil.find_job" not in funs
+    assert "test.ping" in funs
+
+
+# ---------------------------------------------------------------------------
+# Endtime
+# ---------------------------------------------------------------------------
+
+
+def test_endtime_round_trips(opts):
+    salt_cache.update_endtime("20260516-T", 1234567890.0)
+    assert salt_cache.get_endtime("20260516-T") == 1234567890.0
+
+
+def test_get_endtime_returns_none_for_unknown_jid(opts):
+    assert salt_cache.get_endtime("never-existed") is None
+
+
+# ---------------------------------------------------------------------------
+# clean_old_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_clean_old_jobs_is_noop_when_retention_is_zero(opts):
+    opts["keep_jobs_seconds"] = 0
+    salt_cache.save_load("20260516-U", {"fun": "test.ping"})
+    salt_cache.clean_old_jobs()
+    # The load is still there.
+    assert _cache(opts).contains("jobs/loads", "20260516-U")
+
+
+def test_clean_old_jobs_drops_aged_entries(opts):
+    """
+    A load older than ``keep_jobs_seconds`` is removed along with
+    every per-jid bank (returns, minions, endtimes, nocache).  We
+    set retention to a tiny window and sleep just long enough to
+    cross it.
+    """
+    opts["keep_jobs_seconds"] = 0.01
+
+    # Seed: load, minions, an end-time, and one minion return.
+    salt_cache.save_load("20260516-V", {"fun": "test.ping"})
+    salt_cache.save_minions("20260516-V", ["m1"])
+    salt_cache.update_endtime("20260516-V", 1.0)
+    salt_cache.returner({"jid": "20260516-V", "id": "m1", "return": "ok"})
+
+    cache = _cache(opts)
+    assert cache.contains("jobs/loads", "20260516-V")
+
+    # Cross the retention window.  localfs uses mtime which is
+    # filesystem-bound; sleep a bit to ensure we're definitely past
+    # the threshold.
+    time.sleep(0.05)
+
+    salt_cache.clean_old_jobs()
+
+    assert not cache.contains("jobs/loads", "20260516-V")
+    assert not cache.contains("jobs/minions", "20260516-V")
+    assert not cache.contains("jobs/endtimes", "20260516-V")
+    assert cache.list("jobs/returns/20260516-V") == []
+
+
+def test_clean_old_jobs_keeps_fresh_entries(opts):
+    """
+    Loads younger than ``keep_jobs_seconds`` must survive the sweep
+    — pins the invariant that ``clean_old_jobs`` is conservative.
+    """
+    opts["keep_jobs_seconds"] = 3600
+    salt_cache.save_load("20260516-W", {"fun": "test.ping"})
+
+    salt_cache.clean_old_jobs()
+
+    assert _cache(opts).contains("jobs/loads", "20260516-W")

--- a/tests/pytests/unit/runners/test_cluster_runner.py
+++ b/tests/pytests/unit/runners/test_cluster_runner.py
@@ -231,3 +231,99 @@ def test_members_skips_non_config_entries(_runner_opts):
     # version stamp is from the CONFIG entry, not the trailing
     # non-membership entries.
     assert result["membership_version"] == 0
+
+
+# ---------------------------------------------------------------------------
+# cluster.sync_roots — operator-driven content fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_sync_roots_rejects_invalid_roots(_runner_opts):
+    """
+    ``roots`` is constrained to ``{"file", "pillar", "both"}``.  Anything
+    else is rejected up-front so the operator doesn't silently fire a
+    no-op event.
+    """
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="roots must be"):
+        cluster_runner.sync_roots(roots="everything")
+
+
+def test_sync_roots_no_cluster_id_is_skip(_runner_opts):
+    """
+    A non-cluster master returns a structured skip rather than
+    firing a meaningless event.  Lets ops automation call this runner
+    unconditionally without breaking standalone masters.
+    """
+    _runner_opts["cluster_id"] = None
+    result = cluster_runner.sync_roots()
+    assert result["status"] == "skipped"
+    assert "no cluster_id" in result["reason"]
+
+
+def test_sync_roots_fires_local_event(_runner_opts, monkeypatch):
+    """
+    The happy path: the runner fires a ``cluster/runner/sync_roots``
+    event with the resolved channel list.  The master daemon (not the
+    runner subprocess) is responsible for the actual fan-out — the
+    runner's job is just to make the request loudly enough that the
+    daemon picks it up.
+    """
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = []
+
+    class _FakeEvent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def fire_event(self, data, tag):
+            fired.append((tag, data))
+
+    import salt.utils.event
+
+    monkeypatch.setattr(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent())
+
+    result = cluster_runner.sync_roots(roots="both")
+    assert result["status"] == "fan-out initiated"
+    assert result["channels"] == ["file_roots", "pillar_roots"]
+    assert len(fired) == 1
+    tag, data = fired[0]
+    assert tag == "cluster/runner/sync_roots"
+    assert data == {"channels": ["file_roots", "pillar_roots"]}
+
+
+def test_sync_roots_file_only_filters_channels(_runner_opts, monkeypatch):
+    """
+    ``roots="file"`` requests only the file_roots channel; pillar_roots
+    is excluded from the runner's event payload so the daemon doesn't
+    push pillars when the operator only wanted SLS.
+    """
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = []
+
+    class _FakeEvent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def fire_event(self, data, tag):
+            fired.append((tag, data))
+
+    import salt.utils.event
+
+    monkeypatch.setattr(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent())
+
+    result = cluster_runner.sync_roots(roots="file")
+    assert result["channels"] == ["file_roots"]
+    assert fired[0][1] == {"channels": ["file_roots"]}

--- a/tests/pytests/unit/runners/test_cluster_runner.py
+++ b/tests/pytests/unit/runners/test_cluster_runner.py
@@ -55,21 +55,16 @@ def test_ring_info_after_rebuild():
     assert info["vnodes"] >= 1
 
 
-def test_ring_set_raises_until_propose_path_lands():
+def test_ring_set_validates_required_name():
     """
-    Operators who try to commit a new policy through the runner today
-    must see a loud failure rather than a silent no-op.  ``ring_set``
-    raises :class:`NotImplementedError` until the runner-to-master
-    IPC arrives.
+    ``cluster.ring_set`` requires a ring name — every per-ring
+    propose is scoped to a named ring, never to "the ring".  Pre-
+    multi-ring callers that pass no name see a clear error.
     """
-    with pytest.raises(NotImplementedError):
-        cluster_runner.ring_set(members="voters", replicas=2)
-
-
-def test_ring_set_raises_with_no_args_too():
-    """``ring_set`` raises before validating arguments."""
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="non-empty 'name'"):
         cluster_runner.ring_set()
+    with pytest.raises(ValueError, match="non-empty 'name'"):
+        cluster_runner.ring_set(members="voters", replicas=2)
 
 
 # ---------------------------------------------------------------------------
@@ -327,3 +322,871 @@ def test_sync_roots_file_only_filters_channels(_runner_opts, monkeypatch):
     result = cluster_runner.sync_roots(roots="file")
     assert result["channels"] == ["file_roots"]
     assert fired[0][1] == {"channels": ["file_roots"]}
+
+
+# ---------------------------------------------------------------------------
+# Multi-ring operator runners (slice 6)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    """Minimal context-manager fake used by the runner tests."""
+
+    fired = None
+
+    def __init__(self, *a, **kw):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def fire_event(self, data, tag):
+        _FakeEvent.fired.append((tag, data))
+
+
+def _intercept_event_bus(monkeypatch):
+    """
+    Replace ``salt.utils.event.get_event`` with a fake that records
+    every fired event, returning a list the test can assert on.
+    """
+    import salt.utils.event
+
+    _FakeEvent.fired = []
+    monkeypatch.setattr(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent())
+    return _FakeEvent.fired
+
+
+def test_ring_create_fires_event(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    result = cluster_runner.ring_create(name="jobs", voters=["m1", "m2", "m3"])
+    assert result["status"] == "fan-out initiated"
+    assert fired == [
+        (
+            "cluster/runner/ring_create",
+            {"ring_id": "jobs", "founding_voters": ["m1", "m2", "m3"]},
+        )
+    ]
+
+
+def test_ring_create_validates_inputs(_runner_opts):
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="non-empty 'name'"):
+        cluster_runner.ring_create(name="", voters=["m1"])
+    with pytest.raises(ValueError, match="non-empty 'voters'"):
+        cluster_runner.ring_create(name="jobs", voters=[])
+
+
+def test_ring_create_skips_outside_cluster(_runner_opts):
+    """A non-cluster master returns a structured skip rather than firing."""
+    _runner_opts["cluster_id"] = None
+    result = cluster_runner.ring_create(name="jobs", voters=["m1"])
+    assert result["status"] == "skipped"
+
+
+def test_ring_destroy_fires_event(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.ring_destroy(name="jobs")
+    assert fired == [("cluster/runner/ring_destroy", {"ring_id": "jobs"})]
+
+
+def test_route_set_fires_event(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.route_set(data_type="jobs", ring="jobs_ring")
+    assert fired == [
+        (
+            "cluster/runner/route_set",
+            {"data_type": "jobs", "ring_id": "jobs_ring"},
+        )
+    ]
+
+
+def test_route_clear_fires_event(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.route_clear(data_type="jobs")
+    assert fired == [("cluster/runner/route_clear", {"data_type": "jobs"})]
+
+
+def test_route_set_validates_inputs(_runner_opts):
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="non-empty 'data_type'"):
+        cluster_runner.route_set(data_type="", ring="r")
+    with pytest.raises(ValueError, match="non-empty 'ring'"):
+        cluster_runner.route_set(data_type="jobs", ring="")
+
+
+def test_ring_set_fires_event_with_partial_update(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.ring_set(name="jobs", members="voters")
+    assert fired == [
+        (
+            "cluster/runner/ring_set",
+            {"ring_id": "jobs", "members": "voters"},
+        )
+    ]
+
+
+def test_ring_set_fires_event_with_replicas(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.ring_set(name="jobs", replicas=2)
+    assert fired == [("cluster/runner/ring_set", {"ring_id": "jobs", "replicas": 2})]
+
+
+# ---------------------------------------------------------------------------
+# cluster.shed_unowned — migration "going in" runner (slice 7)
+# ---------------------------------------------------------------------------
+
+
+def _seed_registry_and_ring_membership(opts, ring, voters):
+    """
+    Helper: write a RING_REGISTRY entry into the cluster log and a
+    matching CONFIG entry into the ring's own log so the runner has
+    something to replay.
+    """
+    from salt.cluster.consensus.raft.log import LogEntry, LogEntryType
+    from salt.cluster.consensus.storage import SaltStorage
+
+    node_id = opts["interface"]
+    cluster_storage = SaltStorage(node_id, opts, ring_id="cluster")
+    cluster_storage.append_log(
+        LogEntry(
+            term=1,
+            index=0,
+            cmd={
+                "ring_id": ring,
+                "founding_voters": voters,
+                "status": "active",
+            },
+            type=LogEntryType.RING_REGISTRY,
+        )
+    )
+    ring_storage = SaltStorage(node_id, opts, ring_id=ring)
+    ring_storage.append_log(
+        LogEntry(
+            term=1,
+            index=0,
+            cmd={"voters": voters, "learners": []},
+            type=LogEntryType.CONFIG,
+        )
+    )
+
+
+def test_shed_unowned_validates_inputs(_runner_opts):
+    with pytest.raises(ValueError, match="non-empty 'ring'"):
+        cluster_runner.shed_unowned(ring="")
+    with pytest.raises(ValueError, match="at least one bank"):
+        cluster_runner.shed_unowned(ring="jobs", banks=[])
+
+
+def test_shed_unowned_skips_when_ring_not_registered(_runner_opts):
+    """
+    Without a RING_REGISTRY entry for the ring, the runner refuses
+    to drop anything — protects against typos like running with the
+    wrong ring name and quietly nuking data.
+    """
+    result = cluster_runner.shed_unowned(ring="never-created")
+    assert result["status"] == "skipped"
+    assert "not active" in result["reason"]
+
+
+def test_shed_unowned_skips_when_not_a_founder(_runner_opts):
+    """
+    Master is not in the ring's founding voter set: nothing to shed
+    because nothing on this master is governed by the ring.  The
+    runner skips rather than producing a confusing "kept=0,
+    dropped=0" result with no explanation.
+    """
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=["other-1", "other-2"]
+    )
+    result = cluster_runner.shed_unowned(ring="jobs")
+    assert result["status"] == "skipped"
+    assert "not a founding voter" in result["reason"]
+
+
+def test_shed_unowned_drops_only_unowned_entries(_runner_opts):
+    """
+    With this master as a founder and a populated generic cache
+    bank, the runner keeps the entries this master owns and flushes
+    the rest.  Uses the standard ``salt.cache.Cache`` (localfs
+    driver) so the test exercises the real flush path on opaque
+    payloads — the same shape any future per-ring cache routes will
+    take.
+    """
+    import salt.cache
+
+    node_id = _runner_opts["interface"]
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[node_id, "m2", "m3"]
+    )
+
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    # Seed enough entries that the hash distributes some on this
+    # master and some elsewhere.  Verify by checking owns() ourselves.
+    from salt.cluster.ring import HashRing
+
+    hash_ring = HashRing()
+    hash_ring.rebuild([node_id, "m2", "m3"])
+    seeded = [f"jid-{i:04d}" for i in range(50)]
+    for jid in seeded:
+        cache.store("jobs/jid", jid, {"minions": ["m"]})
+
+    owned_before = [k for k in seeded if hash_ring.owns(k, node_id)]
+    unowned_before = [k for k in seeded if not hash_ring.owns(k, node_id)]
+    # Sanity: hash distributes at least one to each side; otherwise
+    # the test would be vacuous.
+    assert owned_before and unowned_before
+
+    result = cluster_runner.shed_unowned(
+        ring="jobs",
+        banks=["jobs/jid"],
+        driver="localfs",
+        subbank_template=None,
+    )
+    assert result["status"] == "ok"
+    assert result["dropped"] == len(unowned_before)
+    assert result["kept"] == len(owned_before)
+    assert result["subbanks_dropped"] == 0
+
+    # The cache reflects the partition: every owned key is still
+    # there, every unowned key is gone.
+    after = set(cache.list("jobs/jid"))
+    assert set(owned_before).issubset(after)
+    assert not set(unowned_before) & after
+
+
+def test_shed_unowned_cascades_subbanks_for_unowned_keys(_runner_opts):
+    """
+    The salt_cache returner stores per-JID returns in their own
+    bank ``jobs/returns/<jid>``.  When the parent JID is shed, the
+    runner must also flush that per-JID sub-bank wholesale —
+    otherwise the returns leak forever.  Pins the cascade-flush
+    contract that makes the salt_cache returner usable end-to-end.
+    """
+    import salt.cache
+
+    node_id = _runner_opts["interface"]
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[node_id, "m2", "m3"]
+    )
+
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    from salt.cluster.ring import HashRing
+
+    hash_ring = HashRing()
+    hash_ring.rebuild([node_id, "m2", "m3"])
+    seeded = [f"jid-{i:04d}" for i in range(30)]
+    for jid in seeded:
+        cache.store("jobs/loads", jid, {"fun": "test.ping"})
+        cache.store(f"jobs/returns/{jid}", "minion-x", {"return": True})
+        cache.store(f"jobs/returns/{jid}", "minion-y", {"return": False})
+
+    owned = [k for k in seeded if hash_ring.owns(k, node_id)]
+    unowned = [k for k in seeded if not hash_ring.owns(k, node_id)]
+    assert owned and unowned
+
+    result = cluster_runner.shed_unowned(
+        ring="jobs",
+        banks=["jobs/loads"],
+        driver="localfs",
+        subbank_template="jobs/returns/{key}",
+    )
+    assert result["status"] == "ok"
+    assert result["dropped"] == len(unowned)
+    assert result["kept"] == len(owned)
+    assert result["subbanks_dropped"] == len(unowned)
+
+    # Primary bank partitioned correctly.
+    after = set(cache.list("jobs/loads"))
+    assert set(owned).issubset(after)
+    assert not set(unowned) & after
+
+    # Returns sub-banks: gone for unowned JIDs, intact for owned ones.
+    for jid in unowned:
+        assert list(cache.list(f"jobs/returns/{jid}")) == []
+    for jid in owned:
+        assert set(cache.list(f"jobs/returns/{jid}")) == {"minion-x", "minion-y"}
+
+
+def test_shed_unowned_default_banks_match_salt_cache_layout(_runner_opts):
+    """
+    Calling ``shed_unowned ring=jobs`` with no other arguments must
+    target the four ``jobs/*`` banks that
+    :mod:`salt.returners.salt_cache` writes through.  Operators
+    using the recommended ``master_job_cache: salt_cache`` shouldn't
+    need to spell the layout out by hand.
+    """
+    import salt.cache
+
+    node_id = _runner_opts["interface"]
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[node_id, "m2", "m3"]
+    )
+
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    # Seed each default bank with the same JID so we can prove every
+    # bank gets visited.
+    seeded = [f"jid-{i:04d}" for i in range(40)]
+    for jid in seeded:
+        cache.store("jobs/loads", jid, {"fun": "test.ping"})
+        cache.store("jobs/minions", jid, ["m"])
+        cache.store("jobs/endtimes", jid, 0.0)
+        cache.store("jobs/nocache", jid, True)
+        cache.store(f"jobs/returns/{jid}", "minion-x", {"return": True})
+
+    result = cluster_runner.shed_unowned(ring="jobs", driver="localfs")
+    assert result["status"] == "ok"
+    # Each of the four banks contributes the same unowned-JID set;
+    # dropped counts them all.  Cascade counts the unowned set once
+    # (from the primary bank, ``jobs/loads``).
+    assert result["dropped"] % 4 == 0
+    assert result["subbanks_dropped"] * 4 == result["dropped"]
+
+    from salt.cluster.ring import HashRing
+
+    hash_ring = HashRing()
+    hash_ring.rebuild([node_id, "m2", "m3"])
+    unowned = [k for k in seeded if not hash_ring.owns(k, node_id)]
+    owned = [k for k in seeded if hash_ring.owns(k, node_id)]
+
+    for bank in ("jobs/loads", "jobs/minions", "jobs/endtimes", "jobs/nocache"):
+        remaining = set(cache.list(bank))
+        assert set(owned).issubset(remaining)
+        assert not set(unowned) & remaining
+
+
+def test_collect_from_peers_default_targets_jobs_banks(_runner_opts, monkeypatch):
+    """
+    ``cluster.collect_from_peers`` with no arguments collects the
+    four ``jobs/*`` banks the salt_cache returner writes through.
+    Pins the operator default that lines up with the going-out
+    migration flow documented in ``MULTI_RING_DESIGN.md``.
+    """
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    result = cluster_runner.collect_from_peers()
+    assert result["status"] == "fan-out initiated"
+    assert fired == [
+        (
+            "cluster/runner/collect_from_peers",
+            {
+                "channels": [
+                    "bank:jobs/loads",
+                    "bank:jobs/minions",
+                    "bank:jobs/endtimes",
+                    "bank:jobs/nocache",
+                ]
+            },
+        )
+    ]
+
+
+def test_collect_from_peers_mixes_channels_and_banks(_runner_opts, monkeypatch):
+    _runner_opts["cluster_id"] = "test_cluster"
+    fired = _intercept_event_bus(monkeypatch)
+    cluster_runner.collect_from_peers(
+        channels=["keys"], banks=["jobs/loads", "jobs/minions"]
+    )
+    assert fired == [
+        (
+            "cluster/runner/collect_from_peers",
+            {"channels": ["keys", "bank:jobs/loads", "bank:jobs/minions"]},
+        )
+    ]
+
+
+def test_collect_from_peers_rejects_unknown_fixed_channels(_runner_opts):
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="unsupported fixed channels"):
+        cluster_runner.collect_from_peers(channels=["bogus"])
+
+
+def test_collect_from_peers_rejects_no_request(_runner_opts):
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="at least one channel or bank"):
+        cluster_runner.collect_from_peers(channels=[], banks=[])
+
+
+# ---------------------------------------------------------------------------
+# cluster.rings — read-only registry replay
+# ---------------------------------------------------------------------------
+
+
+def test_rings_empty_storage(_runner_opts):
+    """
+    Fresh cluster with no committed RING_REGISTRY entries returns
+    empty registry + active_rings == [] and version -1.  Stable
+    shape so the operator runbook doesn't have to special-case
+    "no rings yet."
+    """
+    result = cluster_runner.rings()
+    assert result == {
+        "node_id": _runner_opts["id"],
+        "rings": {},
+        "active_rings": [],
+        "registry_version": -1,
+    }
+
+
+def test_rings_surfaces_active_and_destroyed_entries(_runner_opts):
+    """
+    The runner replays every committed RING_REGISTRY entry; the
+    response carries the latest state per ring + a convenience
+    ``active_rings`` list excluding destroyed entries.
+    """
+    storage = SaltStorage(_runner_opts["id"], _runner_opts)
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=0,
+            cmd={
+                "ring_id": "jobs",
+                "founding_voters": ["m1", "m2", "m3"],
+                "status": "active",
+            },
+            type=LogEntryType.RING_REGISTRY,
+        )
+    )
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=1,
+            cmd={
+                "ring_id": "events",
+                "founding_voters": ["m1", "m2"],
+                "status": "active",
+            },
+            type=LogEntryType.RING_REGISTRY,
+        )
+    )
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=2,
+            cmd={"ring_id": "events", "status": "destroyed"},
+            type=LogEntryType.RING_REGISTRY,
+        )
+    )
+
+    result = cluster_runner.rings()
+    assert result["rings"] == {
+        "jobs": {"founding_voters": ["m1", "m2", "m3"], "status": "active"},
+        "events": {"founding_voters": ["m1", "m2"], "status": "destroyed"},
+    }
+    assert result["active_rings"] == ["jobs"]
+    assert result["registry_version"] == 2
+
+
+# ---------------------------------------------------------------------------
+# cluster.routes — read-only routing table replay
+# ---------------------------------------------------------------------------
+
+
+def test_routes_empty_storage(_runner_opts):
+    result = cluster_runner.routes()
+    assert result["node_id"] == _runner_opts["id"]
+    assert result["routes"] == {}
+    assert result["routing_version"] == -1
+    assert result["drop_stats"] == {}
+
+
+def test_routes_surfaces_route_entries_and_clears(_runner_opts):
+    """
+    A route to a ring followed by a clear (route to ``None``) ends
+    up in the table as ``None`` — the registry preserves the
+    lifecycle and the runner surfaces it directly.
+    """
+    storage = SaltStorage(_runner_opts["id"], _runner_opts)
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=0,
+            cmd={"data_type": "jobs", "ring_id": "jobs_ring"},
+            type=LogEntryType.ROUTE,
+        )
+    )
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=1,
+            cmd={"data_type": "events", "ring_id": "events_ring"},
+            type=LogEntryType.ROUTE,
+        )
+    )
+    storage.append_log(
+        LogEntry(
+            term=1,
+            index=2,
+            cmd={"data_type": "events", "ring_id": None},
+            type=LogEntryType.ROUTE,
+        )
+    )
+
+    result = cluster_runner.routes()
+    assert result["routes"] == {"jobs": "jobs_ring", "events": None}
+    assert result["routing_version"] == 2
+
+
+def test_routes_surfaces_drop_stats(_runner_opts):
+    """
+    The runner folds the per-process drop_stats snapshot into its
+    response so an operator can run a single command and see both
+    the routing table and any drop signal.
+    """
+    ring_membership.set_route("jobs", "jobs_ring")
+    # Trigger one not_a_member drop on this process.
+    ring_membership.owns_for({"interface": _runner_opts["id"]}, "jobs", "k")
+
+    result = cluster_runner.routes()
+    assert result["drop_stats"]["jobs"]["ring_id"] == "jobs_ring"
+    assert result["drop_stats"]["jobs"]["not_a_member"] == 1
+
+
+# ---------------------------------------------------------------------------
+# cluster.shed_unowned_all — fan-out runner
+# ---------------------------------------------------------------------------
+
+
+def test_shed_unowned_all_validates_inputs(_runner_opts):
+    _runner_opts["cluster_id"] = "test_cluster"
+    with pytest.raises(ValueError, match="non-empty 'ring'"):
+        cluster_runner.shed_unowned_all(ring="")
+
+
+def test_shed_unowned_all_fires_event_and_runs_local(_runner_opts, monkeypatch):
+    """
+    The runner fires ``cluster/runner/shed_unowned_all`` carrying
+    the operator's parameters, then runs the local shed inline so
+    the caller gets back an immediately useful result.  The fan-out
+    half is what the daemon's intercept consumes; the local half
+    pins the same exit shape the single-master runner returns.
+    """
+    import salt.cache
+
+    _runner_opts["cluster_id"] = "test_cluster"
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[_runner_opts["interface"], "m2", "m3"]
+    )
+    # Seed something to shed so the local result is non-trivial.
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    seeded = [f"jid-{i:04d}" for i in range(30)]
+    for jid in seeded:
+        cache.store("jobs/loads", jid, {"fun": "test.ping"})
+
+    fired = _intercept_event_bus(monkeypatch)
+    result = cluster_runner.shed_unowned_all(
+        ring="jobs",
+        banks=("jobs/loads",),
+        subbank_template=None,
+        driver="localfs",
+    )
+
+    # Event fanned out with the operator's parameters intact.
+    assert len(fired) == 1
+    tag, payload = fired[0]
+    assert tag == "cluster/runner/shed_unowned_all"
+    assert payload["ring_id"] == "jobs"
+    assert payload["banks"] == ["jobs/loads"]
+    assert payload["subbank_template"] is None
+    assert payload["driver"] == "localfs"
+    assert payload["dry_run"] is False
+
+    # Local pass committed and surfaces the standard shed shape.
+    assert result["local"]["status"] == "ok"
+    assert result["local"]["dropped"] + result["local"]["kept"] == 30
+
+
+# ---------------------------------------------------------------------------
+# cluster.shed_status — read-back of the per-master sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_shed_status_missing_returns_structured_skip(_runner_opts):
+    """
+    No sentinel on disk → operator sees a ``"missing"`` status with
+    the inspected path so they can correlate cluster-wide.
+    """
+    result = cluster_runner.shed_status()
+    assert result["status"] == "missing"
+
+
+def test_shed_status_round_trips_through_sentinel(_runner_opts):
+    """
+    ``cluster.shed_unowned`` writes ``cluster-shed-status.json`` via
+    :func:`salt.cluster.migration.write_shed_status`; the read-only
+    runner surfaces the latest record so an operator polling every
+    master can confirm shed completed.
+    """
+    import json
+    import pathlib
+
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[_runner_opts["interface"], "m2", "m3"]
+    )
+    cluster_runner.shed_unowned(
+        ring="jobs", banks=("jobs/loads",), subbank_template=None, driver="localfs"
+    )
+
+    sentinel = pathlib.Path(_runner_opts["cachedir"]) / "cluster-shed-status.json"
+    assert sentinel.exists()
+    on_disk = json.loads(sentinel.read_text())
+
+    result = cluster_runner.shed_status()
+    assert result == on_disk
+    assert result["ring"] == "jobs"
+    assert result["source"] == "runner"
+
+
+# ---------------------------------------------------------------------------
+# cluster.migrate_jobs_to_cache — local_cache → salt_cache one-shot
+# ---------------------------------------------------------------------------
+
+
+def _seed_local_cache_jid(
+    jobs_root,
+    jid,
+    load,
+    minions,
+    returns,
+    *,
+    endtime=None,
+    nocache=False,
+    syndic_minions=None,
+):
+    """
+    Write one JID's worth of state into the on-disk ``local_cache``
+    layout so the migration runner has something to walk.
+
+    ``jobs_root/<2>/<28>/`` is the canonical shape ``local_cache``
+    uses; we reuse :func:`salt.utils.jid.jid_dir` to keep the
+    hashing identical to production.
+    """
+    import os
+
+    import salt.payload
+    import salt.utils.files
+    import salt.utils.jid
+
+    jid_dir = salt.utils.jid.jid_dir(jid, str(jobs_root), "sha256")
+    os.makedirs(jid_dir, exist_ok=True)
+    with salt.utils.files.fopen(os.path.join(jid_dir, ".load.p"), "w+b") as fp:
+        salt.payload.dump(load, fp)
+    if minions is not None:
+        with salt.utils.files.fopen(os.path.join(jid_dir, ".minions.p"), "w+b") as fp:
+            salt.payload.dump(list(minions), fp)
+    for syndic_id, syndic_minion_list in (syndic_minions or {}).items():
+        with salt.utils.files.fopen(
+            os.path.join(jid_dir, f".minions.{syndic_id}.p"), "w+b"
+        ) as fp:
+            salt.payload.dump(list(syndic_minion_list), fp)
+    if endtime is not None:
+        with salt.utils.files.fopen(os.path.join(jid_dir, "endtime"), "w") as fp:
+            fp.write(str(endtime))
+    if nocache:
+        with salt.utils.files.fopen(os.path.join(jid_dir, "nocache"), "w") as fp:
+            fp.write("1")
+    for minion_id, record in (returns or {}).items():
+        minion_dir = os.path.join(jid_dir, minion_id)
+        os.makedirs(minion_dir, exist_ok=True)
+        with salt.utils.files.fopen(os.path.join(minion_dir, "return.p"), "w+b") as fp:
+            salt.payload.dump(record, fp)
+
+
+def test_migrate_jobs_to_cache_skip_when_no_cachedir(monkeypatch):
+    """
+    Without a ``cachedir`` opt the runner has nothing to walk.
+    Returns a structured skip rather than raising — operators
+    running cleanup playbooks shouldn't be surprised.
+    """
+    monkeypatch.setattr(cluster_runner, "__opts__", {}, raising=False)
+    result = cluster_runner.migrate_jobs_to_cache()
+    assert result["status"] == "skipped"
+    assert "cachedir" in result["reason"]
+
+
+def test_migrate_jobs_to_cache_skip_when_no_jobs_dir(_runner_opts):
+    """No existing jobs root → skip with a clear message."""
+    result = cluster_runner.migrate_jobs_to_cache()
+    assert result["status"] == "skipped"
+    assert "no local_cache jobs root" in result["reason"]
+
+
+def test_migrate_jobs_to_cache_round_trip(_runner_opts):
+    """
+    Seed the on-disk local_cache layout for two JIDs and confirm the
+    runner copies every field into the salt_cache bank layout.
+    Includes a JID with returns + endtime + nocache marker so each
+    code path is exercised.
+    """
+    import pathlib
+
+    import salt.cache
+
+    jobs_root = pathlib.Path(_runner_opts["cachedir"]) / "jobs"
+
+    _seed_local_cache_jid(
+        jobs_root,
+        "20260516-A",
+        load={"jid": "20260516-A", "fun": "test.ping", "tgt": "*"},
+        minions=["m1", "m2"],
+        returns={
+            "m1": {"return": True, "retcode": 0, "success": True},
+            "m2": {"return": False, "retcode": 1, "success": False},
+        },
+        endtime=1234567890.0,
+    )
+    _seed_local_cache_jid(
+        jobs_root,
+        "20260516-B",
+        load={"jid": "20260516-B", "fun": "state.apply"},
+        minions=["m1"],
+        returns={},
+        nocache=True,
+    )
+
+    result = cluster_runner.migrate_jobs_to_cache()
+    assert result["status"] == "ok"
+    assert result["scanned"] == 2
+    assert result["migrated"] == 2
+    assert result["skipped"] == 0
+    assert result["returns_migrated"] == 2  # 2 returns from JID A, 0 from B
+
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    # Loads landed under jobs/loads keyed by JID.
+    assert cache.fetch("jobs/loads", "20260516-A")["fun"] == "test.ping"
+    assert cache.fetch("jobs/loads", "20260516-B")["fun"] == "state.apply"
+    # Minions list merged + sorted.
+    assert cache.fetch("jobs/minions", "20260516-A") == ["m1", "m2"]
+    # Endtime preserved.
+    assert cache.fetch("jobs/endtimes", "20260516-A") == 1234567890.0
+    # Nocache marker preserved on the right JID only.  localfs
+    # returns ``{}`` for a missing key (not ``None``) — we just want
+    # to assert the marker isn't a truthy ``True``.
+    assert cache.fetch("jobs/nocache", "20260516-B") is True
+    assert not cache.fetch("jobs/nocache", "20260516-A")
+    # Returns landed in per-JID sub-banks.
+    assert set(cache.list("jobs/returns/20260516-A")) == {"m1", "m2"}
+    assert cache.fetch("jobs/returns/20260516-A", "m1")["return"] is True
+    assert cache.fetch("jobs/returns/20260516-A", "m1")["retcode"] == 0
+
+
+def test_migrate_jobs_to_cache_merges_syndic_minions(_runner_opts):
+    """
+    A JID that has both a main ``.minions.p`` and a syndic-supplied
+    ``.minions.<syndic>.p`` ends up with the union as a single sorted
+    list in ``jobs/minions``.  Matches what
+    :func:`salt.returners.local_cache.get_load` would compute.
+    """
+    import pathlib
+
+    import salt.cache
+
+    jobs_root = pathlib.Path(_runner_opts["cachedir"]) / "jobs"
+    _seed_local_cache_jid(
+        jobs_root,
+        "20260516-S",
+        load={"jid": "20260516-S", "fun": "test.ping"},
+        minions=["main-1"],
+        returns={},
+        syndic_minions={"syndic-a": ["syndic-m1", "main-1"]},
+    )
+
+    cluster_runner.migrate_jobs_to_cache()
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    assert cache.fetch("jobs/minions", "20260516-S") == [
+        "main-1",
+        "syndic-m1",
+    ]
+
+
+def test_migrate_jobs_to_cache_dry_run_writes_nothing(_runner_opts):
+    """
+    Dry-run counts JIDs but does not call ``cache.store`` for any of
+    them.  Pin the operator preview contract — ``salt-run
+    cluster.migrate_jobs_to_cache dry_run=True`` must be a pure read.
+    """
+    import pathlib
+
+    import salt.cache
+
+    jobs_root = pathlib.Path(_runner_opts["cachedir"]) / "jobs"
+    _seed_local_cache_jid(
+        jobs_root,
+        "20260516-D",
+        load={"jid": "20260516-D", "fun": "test.ping"},
+        minions=["m1"],
+        returns={"m1": {"return": "x"}},
+    )
+
+    result = cluster_runner.migrate_jobs_to_cache(dry_run=True)
+    assert result["status"] == "ok"
+    assert result["scanned"] == 1
+    assert result["migrated"] == 1
+    assert result["returns_migrated"] == 1
+    assert result["dry_run"] is True
+
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    # No bank populated despite the runner claiming success.
+    assert not cache.fetch("jobs/loads", "20260516-D")
+    assert cache.list("jobs/returns/20260516-D") == []
+
+
+def test_migrate_jobs_to_cache_skips_stub_jid_dirs(_runner_opts):
+    """
+    A JID directory with no ``.load.p`` (typically left over from a
+    crash mid-prep_jid) is counted as skipped rather than failing
+    the whole migration.
+    """
+    import os
+    import pathlib
+
+    import salt.utils.jid
+
+    jobs_root = pathlib.Path(_runner_opts["cachedir"]) / "jobs"
+    # Build the dir directly without dropping a .load.p.
+    jid_dir = salt.utils.jid.jid_dir("20260516-stub", str(jobs_root), "sha256")
+    os.makedirs(jid_dir, exist_ok=True)
+
+    result = cluster_runner.migrate_jobs_to_cache()
+    assert result["status"] == "ok"
+    assert result["scanned"] == 1
+    assert result["migrated"] == 0
+    assert result["skipped"] == 1
+
+
+def test_shed_unowned_dry_run_flushes_nothing(_runner_opts):
+    """
+    ``dry_run=True`` returns the same counts but leaves the cache
+    untouched — operator can preview the partition before committing.
+    """
+    import salt.cache
+
+    node_id = _runner_opts["interface"]
+    _seed_registry_and_ring_membership(
+        _runner_opts, "jobs", voters=[node_id, "m2", "m3"]
+    )
+    cache = salt.cache.Cache(_runner_opts, driver="localfs")
+    seeded = [f"jid-{i:04d}" for i in range(50)]
+    for jid in seeded:
+        cache.store("jobs/jid", jid, {"minions": ["m"]})
+
+    result = cluster_runner.shed_unowned(
+        ring="jobs",
+        banks=["jobs/jid"],
+        driver="localfs",
+        subbank_template=None,
+        dry_run=True,
+    )
+    assert result["status"] == "ok"
+    assert result["dry_run"] is True
+    assert result["dropped"] > 0
+    # All keys are still there.
+    assert set(cache.list("jobs/jid")) == set(seeded)

--- a/tests/pytests/unit/test_event_monitor_ring_gating.py
+++ b/tests/pytests/unit/test_event_monitor_ring_gating.py
@@ -43,6 +43,7 @@ def _opts(interface="m1"):
         "interface": interface,
         "id": f"{interface}-host",
         "cluster_id": "test-cluster",
+        "sock_dir": "/tmp",
     }
 
 
@@ -108,16 +109,18 @@ def test_job_ret_event_writes_when_ring_empty():
 # ---------------------------------------------------------------------------
 
 
-def _pick_owned_and_other_jid(members):
+def _pick_owned_and_other_jid(members, ring_name="jobs_ring"):
     """
     Return ``(owned_jid, other_jid)`` where ``owned_jid`` hashes to
     ``members[0]`` and ``other_jid`` hashes to a different member.
 
-    Owners are determined by ``HashRing.get_owner`` on the rebuilt
-    ring.  Iterating jid candidates is fast.
+    Multi-ring shape: the rebuild targets a named ring (``jobs_ring``
+    by default), and the caller is expected to install a routing
+    entry ``"jobs" -> ring_name`` so the gate site's
+    ``owns_for(opts, "jobs", jid)`` defers to this ring.
     """
-    ring_membership.rebuild(members)
-    ring = ring_membership.get_ring()
+    ring_membership.rebuild(ring_name, members)
+    ring = ring_membership.get_ring(ring_name)
     owner_target = members[0]
     owned = None
     other = None
@@ -139,12 +142,15 @@ def _pick_owned_and_other_jid(members):
 
 def test_job_new_event_drops_when_key_not_owned():
     """
-    With ring populated and the jid hashed to a different member,
-    the /new branch must NOT call ``store_minions``.  Direct evidence
-    that the gate sites in master.py drop writes once policy flips.
+    With the "jobs" data type routed to a ring and the jid hashed to
+    a different member, the /new branch must NOT call
+    ``store_minions``.  Direct evidence that the gate sites in
+    master.py drop writes once a route + ring policy are in place.
     """
     members = ["m1", "m2", "m3"]
     owned_jid, other_jid = _pick_owned_and_other_jid(members)
+    # Route "jobs" to the populated ring so ``owns_for`` defers to it.
+    ring_membership.set_route("jobs", "jobs_ring")
     monitor = _make_monitor(_opts(interface="m1"))
 
     with patch("salt.utils.job.store_minions") as mock_store:
@@ -171,6 +177,7 @@ def test_job_ret_event_drops_when_key_not_owned():
     """Mirror of the /new test for the /ret branch."""
     members = ["m1", "m2", "m3"]
     owned_jid, other_jid = _pick_owned_and_other_jid(members)
+    ring_membership.set_route("jobs", "jobs_ring")
     monitor = _make_monitor(_opts(interface="m1"))
 
     with patch("salt.utils.job.store_job") as mock_store:
@@ -235,3 +242,206 @@ def test_event_without_cluster_id_is_ignored():
             {"__peer_id": "m2", "jid": "x", "minions": ["a"]},
         )
     mock_store.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Multi-ring routing semantics at the gate site
+# ---------------------------------------------------------------------------
+
+
+def test_job_new_drops_when_routed_to_unknown_ring():
+    """
+    The "jobs" data type routed to a ring this master does NOT host
+    locally (no Node, no ring contents) is a non-member situation:
+    the gate site no-ops the write to avoid mirroring data that the
+    actual ring members will reject.
+    """
+    # Route exists, but no rebuild has populated "jobs_ring" — the
+    # ring is empty / unknown to this master.
+    ring_membership.set_route("jobs", "jobs_ring")
+    monitor = _make_monitor(_opts(interface="m1"))
+    with patch("salt.utils.job.store_minions") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/20260508/new",
+            {"__peer_id": "m2", "jid": "anything", "minions": ["x"]},
+        )
+    mock_store.assert_not_called()
+
+
+def test_job_new_drop_fires_delegate_when_owner_known():
+    """
+    When the gate drops a routed job event AND the ring has a known
+    owner, the EventMonitor fires a ``cluster/runner/delegate_write``
+    event so the publish daemon can forward the write to the owner.
+    Pin the delegate-on-miss safety net: a routed deployment with an
+    asymmetric topology doesn't silently lose data.
+    """
+    ring_membership.rebuild("jobs_ring", ["other-master", "another-one"])
+    ring_membership.set_route("jobs", "jobs_ring")
+    monitor = _make_monitor(_opts(interface="m1"))
+
+    fired = []
+
+    class _FakeEvent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def fire_event(self, data, tag):
+            fired.append((tag, data))
+
+    import salt.utils.event
+
+    with (
+        patch("salt.utils.job.store_minions") as mock_store,
+        patch.object(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent()),
+    ):
+        _fire(
+            monitor,
+            "salt/job/20260517/new",
+            {"__peer_id": "m2", "jid": "test-jid", "minions": ["m"]},
+        )
+
+    mock_store.assert_not_called()
+    delegates = [e for e in fired if e[0] == "cluster/runner/delegate_write"]
+    assert len(delegates) == 1
+    _, data = delegates[0]
+    assert data["data_type"] == "jobs"
+    assert data["ring_id"] == "jobs_ring"
+    assert data["write_kind"] == "store_minions"
+    assert data["payload"] == {"jid": "test-jid", "minions": ["m"]}
+    # Owner is one of the two ring members (consistent-hash answers
+    # one or the other depending on the jid's hash).
+    assert data["owner"] in {"other-master", "another-one"}
+
+
+def test_job_ret_drop_fires_delegate_for_returns():
+    """
+    Same delegate-on-miss path for the ``/ret/`` branch — pins that
+    minion-return writes also get forwarded to the ring owner when
+    this master isn't a member.
+    """
+    ring_membership.rebuild("jobs_ring", ["owner-a", "owner-b"])
+    ring_membership.set_route("jobs", "jobs_ring")
+    monitor = _make_monitor(_opts(interface="m1"))
+
+    fired = []
+
+    class _FakeEvent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def fire_event(self, data, tag):
+            fired.append((tag, data))
+
+    import salt.utils.event
+
+    with (
+        patch("salt.utils.job.store_job") as mock_store,
+        patch.object(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent()),
+    ):
+        _fire(
+            monitor,
+            "salt/job/20260517/ret/minion-x",
+            {
+                "__peer_id": "m2",
+                "jid": "test-jid",
+                "id": "minion-x",
+                "return": "ok",
+            },
+        )
+
+    mock_store.assert_not_called()
+    delegates = [e for e in fired if e[0] == "cluster/runner/delegate_write"]
+    assert len(delegates) == 1
+    _, data = delegates[0]
+    assert data["write_kind"] == "store_job"
+    assert data["payload"]["jid"] == "test-jid"
+    assert data["payload"]["id"] == "minion-x"
+
+
+def test_delegate_skip_when_this_master_is_the_owner():
+    """
+    Defensive: if ``ring_membership.get_owner`` somehow returns this
+    master's address (it shouldn't, since owns_for would have
+    returned True), the delegate path skips silently rather than
+    looping the event back to itself.
+    """
+    ring_membership.rebuild("jobs_ring", ["m1", "m2", "m3"])
+    ring_membership.set_route("jobs", "jobs_ring")
+    monitor = _make_monitor(_opts(interface="m1"))
+
+    fired = []
+
+    class _FakeEvent:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def fire_event(self, data, tag):
+            fired.append((tag, data))
+
+    import salt.utils.event
+    from salt.cluster.ring import HashRing
+
+    real_ring = HashRing()
+    real_ring.rebuild(["m1", "m2", "m3"])
+    # Pick a JID that DOES hash to m1 so owns_for returns True and
+    # the delegate path is never reached.
+    owned_jid = None
+    for i in range(2000):
+        jid = f"jid-{i:04d}"
+        if real_ring.get_owner(jid) == "m1":
+            owned_jid = jid
+            break
+    assert owned_jid is not None
+
+    with (
+        patch("salt.utils.job.store_minions") as mock_store,
+        patch.object(salt.utils.event, "get_event", lambda *a, **kw: _FakeEvent()),
+    ):
+        _fire(
+            monitor,
+            "salt/job/20260517/new",
+            {"__peer_id": "m2", "jid": owned_jid, "minions": ["m"]},
+        )
+
+    # We DID own it; store_minions ran and no delegate fired.
+    mock_store.assert_called_once()
+    assert not fired
+
+
+def test_job_new_writes_when_route_cleared():
+    """
+    Clearing the route returns "jobs" to broadcast — every master
+    writes regardless of the ring's contents.  Pins the reversibility
+    contract that operator runners depend on.
+    """
+    ring_membership.rebuild("jobs_ring", ["m1", "m2", "m3"])
+    ring_membership.set_route("jobs", "jobs_ring")
+    ring_membership.set_route("jobs", None)  # back to broadcast
+    monitor = _make_monitor(_opts(interface="m1"))
+    with patch("salt.utils.job.store_minions") as mock_store:
+        _fire(
+            monitor,
+            "salt/job/20260508/new",
+            {"__peer_id": "m2", "jid": "anything", "minions": ["x"]},
+        )
+    mock_store.assert_called_once()

--- a/tests/pytests/unit/utils/test_minions_resources.py
+++ b/tests/pytests/unit/utils/test_minions_resources.py
@@ -961,11 +961,20 @@ def test_check_minions_grain_target_1000_minions_100_resources_each(opts):
 
 
 @pytest.mark.slow_test
+@pytest.mark.timeout(240, func_only=True)
 def test_check_minions_grain_target_10000_minions_100_resources_each(opts):
     """
     End-to-end :meth:`CkMinions.check_minions` timing for grain targeting:
     10,000 minions × 100 resources (1,000,000 entries) — million-resource
     stress test for the in-process scan path.
     A ``-G env:prod`` query matches 5,000 minions + 500,000 resource IDs.
+
+    Carries an explicit ``@pytest.mark.timeout(240)`` override.  The
+    global default applied by ``tests/conftest.py`` is 90 s, but the
+    in-test ``budget=180.0`` allows the call itself to run that long
+    under coverage tracing on a loaded GHA runner.  Without this
+    override the global 90 s wall-clock fires before the test's own
+    budget assertion has a chance to evaluate, masking real
+    slowdowns as "timeout" failures.
     """
     _run_check_minions_grain_perf(opts, 10000, 100, budget=180.0)

--- a/tests/unit/netapi/rest_tornado/test_saltnado.py
+++ b/tests/unit/netapi/rest_tornado/test_saltnado.py
@@ -621,15 +621,22 @@ class TestDisbatchLocal(tornado.testing.AsyncTestCase):
         )
         self.handler = saltnado.SaltAPIHandler(self.mock, self.mock)
 
-    @tornado.testing.gen_test
+    @tornado.testing.gen_test(timeout=15)
     def test_when_is_timed_out_is_set_before_other_events_are_completed_then_result_should_be_empty_dictionary(
         self,
     ):
         completed_event = tornado.gen.Future()
         never_completed = tornado.gen.Future()
-        # TODO: We may need to tweak these values to get them close enough but not so far away -W. Werner, 2020-11-17
-        gather_timeout = 0.1
-        event_timeout = gather_timeout + 0.05
+        # Original margins (gather=0.1, event=0.15) were too tight for
+        # slow CI runners — the 50ms window between gather-timeout
+        # firing and the completer running is regularly inverted by
+        # GHA scheduler jitter, so the "fnord" event lands in chunk_ret
+        # before is_timed_out is set and the assertion below blows up.
+        # 1s gather + 2s event keeps the ordering invariant intact
+        # under realistic CI load.  The sister test below uses the
+        # same 2:1 ratio for the symmetric is_finished case.
+        gather_timeout = 1
+        event_timeout = gather_timeout + 1
 
         def fancy_get_event(*args, **kwargs):
             if kwargs.get("tag").endswith("/ret"):


### PR DESCRIPTION
 Add multi-ring Raft consensus and reversible mmap-cache migration on top
  of the existing cluster runner work:

  - **Multi-ring Raft groups.** Each cluster data type (jobs, events, …)
    can run on its own Raft group with an independent leader/voter set
    instead of every master holding the full keyspace. New cluster-log
    state machines (`RingRegistryStateMachine`, `RoutingStateMachine`)
    track which rings exist and which data types route to them.

  - **Migration runners.** `cluster.shed_unowned` drops keys this master
    no longer owns under a ring; `cluster.collect_from_peers` pulls them
    back. Both are operator-paced with a dry-run mode so the broadcast →
    ring-sharded → broadcast round-trip is fully reversible.

  - **Operator surface.** `cluster.ring_create`, `cluster.ring_destroy`,
    `cluster.route_set`, `cluster.route_clear`, `cluster.ring_set` —
    routed through the publish-channel fan-out so the runner works on
    any cluster master, not just the current leader.

  - **CI fixes.** Two integration test race conditions on slow runners,
    and disabling coverage's `dynamic_context = test_function` while Salt
    is on Python 3.14 (it forces the slow PyTracer path; see commit message
    on `f8aef153a6c` for the analysis).
