### PR TITLE
Fix OSError "The operation completed successfully" in CreateProcessWithTokenW

### DIFF
--- a/changelog/57848.fixed.md
+++ b/changelog/57848.fixed.md
@@ -1,0 +1,1 @@
+Fixed `OSError: The operation completed successfully` raised by `CreateProcessWithTokenW` on Windows when the underlying advapi32 call fails. The error code is now read from `ctypes.get_last_error()` (the ctypes-saved slot) instead of `win32api.GetLastError()` (the live Windows slot, which may be reset to 0 before it is read).

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -1165,10 +1165,7 @@ def CreateProcessWithTokenW(
         ctypes.byref(process_info),
     )
     if ret == 0:
-        winerr = win32api.GetLastError()
-        exc = OSError(win32api.FormatMessage(winerr))
-        exc.winerror = winerr
-        raise exc
+        raise ctypes.WinError(ctypes.get_last_error())
     return process_info
 
 

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,5 +1,7 @@
 import base64
+import ctypes
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -120,3 +122,27 @@ def test_prepend_cmd_unquoted_payload():
     assert win.prepend_cmd("cmd.exe", compound, quote_c_payload=False) == (
         f"cmd.exe /c {compound}"
     )
+
+
+def test_create_process_with_token_w_raises_real_error():
+    """
+    When the underlying advapi32 call fails, CreateProcessWithTokenW must raise
+    OSError with the code from ctypes.get_last_error() (the ctypes-saved slot),
+    not from win32api.GetLastError() (the live Windows slot, which may already
+    be 0 by the time Python reads it).
+
+    Regression: github.com/saltstack/salt/issues/57848
+    """
+    ERROR_ACCESS_DENIED = 5
+
+    def _fake_advapi32_call(*args, **kwargs):
+        ctypes.set_last_error(ERROR_ACCESS_DENIED)
+        return 0  # FALSE — failure
+
+    with patch.object(
+        win.advapi32, "CreateProcessWithTokenW", side_effect=_fake_advapi32_call
+    ):
+        with pytest.raises(OSError) as exc_info:
+            win.CreateProcessWithTokenW(token=1, commandline="whoami")
+
+    assert exc_info.value.winerror == ERROR_ACCESS_DENIED

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,7 +1,7 @@
 import base64
 import ctypes
 import subprocess
-from unittest.mock import patch
+from tests.support.mock import patch
 
 import pytest
 

--- a/tests/pytests/unit/platform/test_win.py
+++ b/tests/pytests/unit/platform/test_win.py
@@ -1,11 +1,11 @@
 import base64
 import ctypes
 import subprocess
-from tests.support.mock import patch
 
 import pytest
 
 import salt.utils.platform
+from tests.support.mock import patch
 
 if salt.utils.platform.is_windows():
     from salt.platform import win


### PR DESCRIPTION
### What does this PR do?
`advapi32` is loaded with `use_last_error=True`, so the error code after a failed ctypes call must be read with `ctypes.get_last_error()`, not `win32api.GetLastError()`. The Windows live slot is reset to 0 by Python internals before the old code could read it, producing the misleading "The operation completed successfully" exception that prevented the child process from ever being resumed via ResumeThread.

### What issues does this PR fix or reference?
Fixes #57848

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
