### PR TITLE
Fix LGPO duplicate policy error when ADMX files share an identical path

### DIFF
--- a/changelog/62732.fixed.md
+++ b/changelog/62732.fixed.md
@@ -1,0 +1,1 @@
+Fixed LGPO ``get_policy_info`` incorrectly returning a "multiple policies" error when duplicate ADMX policy definitions (e.g. ``TerminalServer.admx`` and ``TerminalServer-Server.admx``) resolve to the same full path.

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -8563,6 +8563,7 @@ def _lookup_admin_template(policy_name, policy_class, adml_language="en-US"):
                             )
                             return False, None, [], msg
                     else:
+                        all_paths = []
                         for possible_policy in admx_search_results:
                             this_parent_list = _build_parent_list(
                                 policy_definition=possible_policy,
@@ -8571,12 +8572,41 @@ def _lookup_admin_template(policy_name, policy_class, adml_language="en-US"):
                             )
                             this_parent_list.reverse()
                             this_parent_list.append(policy_name)
-                            if suggested_policies:
-                                suggested_policies = ", ".join(
-                                    [suggested_policies, "\\".join(this_parent_list)]
+                            all_paths.append("\\".join(this_parent_list))
+                        unique_paths = list(dict.fromkeys(all_paths))
+                        if len(unique_paths) == 1:
+                            # All matches resolve to the same full path (e.g.
+                            # duplicate policy definitions across ADMX files
+                            # like TerminalServer.admx and
+                            # TerminalServer-Server.admx). Treat as a single
+                            # unambiguous policy.
+                            search_result = admx_search_results[0]
+                            if "name" in search_result.attrib:
+                                policy_display_name = _getFullPolicyName(
+                                    policy_item=search_result,
+                                    policy_name=search_result.attrib["name"],
+                                    return_full_policy_names=True,
+                                    adml_language=adml_language,
                                 )
-                            else:
-                                suggested_policies = "\\".join(this_parent_list)
+                                policy_aliases.append(policy_display_name)
+                                policy_aliases.append(search_result.attrib["name"])
+                                full_path_list = _build_parent_list(
+                                    policy_definition=search_result,
+                                    return_full_policy_names=True,
+                                    adml_language=adml_language,
+                                )
+                                full_path_list.reverse()
+                                full_path_list.append(policy_display_name)
+                                policy_aliases.append("\\".join(full_path_list))
+                                return True, search_result, policy_aliases, None
+                        else:
+                            for full_path in all_paths:
+                                if suggested_policies:
+                                    suggested_policies = ", ".join(
+                                        [suggested_policies, full_path]
+                                    )
+                                else:
+                                    suggested_policies = full_path
             if suggested_policies:
                 msg = (
                     'ADML policy name "{}" is used as the display name for '

--- a/tests/pytests/functional/modules/win_lgpo/test_get_policy_info.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_get_policy_info.py
@@ -2,6 +2,7 @@
 Unit tests for the LGPO module
 """
 
+import os
 import platform
 
 import pytest
@@ -55,3 +56,26 @@ def test_61859(lgpo):
         policy_class="machine",
     )
     assert result["message"] == expected
+
+
+_TS_SERVER_ADMX = r"C:\Windows\PolicyDefinitions\TerminalServer-Server.admx"
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_TS_SERVER_ADMX),
+    reason="TerminalServer-Server.admx only present on Windows Server editions",
+)
+def test_62732_duplicate_policy_identical_paths(lgpo):
+    """
+    On Windows Server, TerminalServer.admx and TerminalServer-Server.admx
+    both define "Do not allow Clipboard redirection" with the same full path.
+    get_policy_info should resolve it as a single unambiguous policy rather
+    than returning a "multiple policies" error.
+    """
+    result = lgpo.get_policy_info(
+        policy_name="Do not allow Clipboard redirection",
+        policy_class="Machine",
+    )
+    assert result["policy_found"] is True
+    assert not result["message"]
+    assert result["policy_name"] == "Do not allow Clipboard redirection"

--- a/tests/pytests/unit/modules/test_win_lgpo.py
+++ b/tests/pytests/unit/modules/test_win_lgpo.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for salt.modules.win_lgpo
+"""
+
+import pytest
+
+import salt.modules.win_lgpo as win_lgpo
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+_ADML_TAG = "{http://www.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions}string"
+
+
+def _make_adml(policy_id):
+    fake = MagicMock()
+    fake.tag = _ADML_TAG
+    fake.attrib = {"id": policy_id}
+    return fake
+
+
+def _make_admx(name):
+    fake = MagicMock()
+    fake.attrib = {"name": name, "class": "Machine"}
+    return fake
+
+
+def test_duplicate_policies_identical_paths_returns_success():
+    """
+    When multiple ADMX entries share the same display name but all resolve
+    to the same full path (e.g. TerminalServer.admx and
+    TerminalServer-Server.admx for "Do not allow Clipboard redirection"),
+    _lookup_admin_template should return True with policy info rather than
+    a "multiple policies" error.
+    """
+    policy_name = "Do not allow Clipboard redirection"
+    policy_class = "Machine"
+
+    fake_adml = _make_adml("TS_CLIENT_CLIPBOARD")
+    fake_policy_1 = _make_admx("TS_CLIENT_CLIPBOARD")
+    fake_policy_2 = _make_admx("TS_CLIENT_CLIPBOARD")
+
+    # _build_parent_list returns innermost-first; the code reverses it
+    # in-place, so return a fresh list on every call.
+    shared_parent = [
+        "Device and Resource Redirection",
+        "Remote Desktop Session Host",
+        "Remote Desktop Services",
+        "Windows Components",
+    ]
+
+    with (
+        patch.object(win_lgpo, "_get_policy_definitions", return_value=MagicMock()),
+        patch.object(win_lgpo, "_get_policy_resources", return_value=MagicMock()),
+        patch.object(win_lgpo, "ADMX_SEARCH_XPATH", MagicMock(return_value=[])),
+        patch.object(
+            win_lgpo,
+            "ADML_SEARCH_XPATH",
+            MagicMock(return_value=[fake_adml]),
+        ),
+        patch.object(
+            win_lgpo,
+            "ADMX_DISPLAYNAME_SEARCH_XPATH",
+            MagicMock(return_value=[fake_policy_1, fake_policy_2]),
+        ),
+        patch.object(
+            win_lgpo,
+            "_build_parent_list",
+            side_effect=lambda **_: list(shared_parent),
+        ),
+        patch.object(win_lgpo, "_getFullPolicyName", return_value=policy_name),
+    ):
+        found, policy_xml, aliases, msg = win_lgpo._lookup_admin_template(
+            policy_name, policy_class
+        )
+
+    assert found is True
+    assert msg is None
+    assert policy_xml is fake_policy_1
+    assert policy_name in aliases
+
+
+def test_duplicate_policies_distinct_paths_returns_error():
+    """
+    When multiple ADMX entries share the same display name but resolve to
+    genuinely different full paths (e.g. "Access data sources across
+    domains" in multiple Internet Explorer sub-trees), _lookup_admin_template
+    should still return False with the existing "multiple policies" error.
+    """
+    policy_name = "Access data sources across domains"
+    policy_class = "Machine"
+
+    fake_adml = _make_adml("SomePolicyId")
+    fake_policy_1 = _make_admx("PolicyA")
+    fake_policy_2 = _make_admx("PolicyB")
+
+    parent_path_1 = ["Security Features", "Internet Explorer", "Windows Components"]
+    parent_path_2 = [
+        "Internet Control Panel",
+        "Internet Explorer",
+        "Windows Components",
+    ]
+
+    with (
+        patch.object(win_lgpo, "_get_policy_definitions", return_value=MagicMock()),
+        patch.object(win_lgpo, "_get_policy_resources", return_value=MagicMock()),
+        patch.object(win_lgpo, "ADMX_SEARCH_XPATH", MagicMock(return_value=[])),
+        patch.object(
+            win_lgpo,
+            "ADML_SEARCH_XPATH",
+            MagicMock(return_value=[fake_adml]),
+        ),
+        patch.object(
+            win_lgpo,
+            "ADMX_DISPLAYNAME_SEARCH_XPATH",
+            MagicMock(return_value=[fake_policy_1, fake_policy_2]),
+        ),
+        patch.object(
+            win_lgpo,
+            "_build_parent_list",
+            side_effect=[list(parent_path_1), list(parent_path_2)],
+        ),
+        patch.object(win_lgpo, "_getFullPolicyName", return_value=policy_name),
+    ):
+        found, policy_xml, aliases, msg = win_lgpo._lookup_admin_template(
+            policy_name, policy_class
+        )
+
+    assert found is False
+    assert policy_xml is None
+    assert aliases == []
+    assert "multiple policies" in msg
+    assert policy_name in msg


### PR DESCRIPTION
### What does this PR do?
When multiple ADMX files (e.g. TerminalServer.admx and TerminalServer-Server.admx on Windows Server) define the same policy display name resolving to an identical full path, _lookup_admin_template now deduplicates the matches and returns success rather than a spurious "multiple policies" error.

### What issues does this PR fix or reference?
Fixes #62732

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
