### PR TITLE
More comprehensive tracing tests.

### DIFF
--- a/salt/utils/tracing.py
+++ b/salt/utils/tracing.py
@@ -196,7 +196,19 @@ def configure(opts):
         atexit.register(shutdown)
         _atexit_registered = True
     if not _cached_opts.get("enabled"):
+        log.debug(
+            "tracing.configure called but tracing.enabled is false (pid=%d, service=%s)",
+            os.getpid(),
+            _cached_opts.get("service_name"),
+        )
         return
+    log.info(
+        "Enabling OpenTelemetry tracing (pid=%d, service=%s, exporter=%s, endpoint=%s)",
+        os.getpid(),
+        _cached_opts.get("service_name"),
+        _cached_opts.get("exporter"),
+        _cached_opts.get("endpoint") or "<default>",
+    )
     _ensure_tracer()
 
 

--- a/tests/pytests/integration/tracing/test_tracing_jaeger.py
+++ b/tests/pytests/integration/tracing/test_tracing_jaeger.py
@@ -1,0 +1,254 @@
+"""
+End-to-end tracing integration test.
+
+Spins up an isolated salt-master + salt-minion with tracing enabled and
+points them at a containerised ``jaegertracing/all-in-one`` collector.
+A single ``salt '*' test.ping`` should produce one trace whose spans
+span all three services (CLI, master, minion).
+
+The test is automatically skipped when:
+
+* docker isn't installed,
+* the test process can't ``docker run`` (no socket / permissions),
+* the host architecture or platform isn't supported by Jaeger's
+  ``all-in-one`` image,
+* the jaeger container can't bind its ports within the startup window.
+
+Run interactively with ``pytest -v`` and ``-s`` to follow progress.
+"""
+
+import json
+import logging
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+_JAEGER_IMAGE = "jaegertracing/all-in-one:latest"
+_STARTUP_TIMEOUT = 90  # seconds to wait for the container to answer HTTP
+_EXPORT_FLUSH = 30  # seconds to wait for BatchSpanProcessor to flush
+
+pytestmark = [
+    pytest.mark.skip_unless_on_linux,
+    pytest.mark.skip_if_binaries_missing("docker"),
+    pytest.mark.slow_test,
+]
+
+
+def _free_port():
+    """Pick a free local port; this leaves a small race window but is good enough for tests."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _http_get_ok(url, timeout=2):
+    try:
+        with urllib.request.urlopen(url, timeout=timeout):
+            return True
+    except (urllib.error.URLError, ConnectionError, OSError):
+        return False
+
+
+@pytest.fixture(scope="module")
+def jaeger_container():
+    """Start a jaegertracing/all-in-one container; yield its endpoints."""
+    if shutil.which("docker") is None:
+        pytest.skip("docker not available")
+
+    # Verify docker is usable (daemon running, user has access).
+    probe = subprocess.run(
+        ["docker", "info"], capture_output=True, text=True, check=False
+    )
+    if probe.returncode != 0:
+        pytest.skip(f"docker daemon not reachable: {probe.stderr.strip()[:200]}")
+
+    otlp_http_port = _free_port()
+    query_port = _free_port()
+    name = f"salt-tracing-jaeger-{otlp_http_port}"
+
+    # Best-effort cleanup of any stale container with the same name.
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+
+    run_cmd = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        name,
+        "-p",
+        f"{otlp_http_port}:4318",
+        "-p",
+        f"{query_port}:16686",
+        _JAEGER_IMAGE,
+    ]
+    started = subprocess.run(run_cmd, capture_output=True, text=True, check=False)
+    if started.returncode != 0:
+        pytest.skip(f"could not start jaeger container: {started.stderr.strip()[:200]}")
+
+    try:
+        query_url = f"http://127.0.0.1:{query_port}"
+        otlp_url = f"http://127.0.0.1:{otlp_http_port}/v1/traces"
+        deadline = time.time() + _STARTUP_TIMEOUT
+        while time.time() < deadline:
+            if _http_get_ok(query_url + "/"):
+                break
+            time.sleep(2)
+        else:
+            logs = subprocess.run(
+                ["docker", "logs", name],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            pytest.skip(
+                "jaeger container failed to come up within "
+                f"{_STARTUP_TIMEOUT}s; container logs:\n{logs.stdout[-1000:]}"
+            )
+
+        log.info(
+            "jaeger ready: query=%s otlp=%s container=%s",
+            query_url,
+            otlp_url,
+            name,
+        )
+        yield {
+            "query_url": query_url,
+            "otlp_http_endpoint": otlp_url,
+            "container_name": name,
+        }
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+
+
+def _tracing_overrides(jaeger_container, service_name):
+    return {
+        "tracing": {
+            "enabled": True,
+            "exporter": "otlp-http",
+            "endpoint": jaeger_container["otlp_http_endpoint"],
+            "sampler": "always_on",
+            "service_name": service_name,
+            "resource_attributes": {},
+            "insecure": True,
+            "headers": {},
+        }
+    }
+
+
+@pytest.fixture(scope="module")
+def traced_master(salt_factories, jaeger_container):
+    factory = salt_factories.salt_master_daemon(
+        "traced-master",
+        defaults={"auto_accept": True},
+        overrides=_tracing_overrides(jaeger_container, "salt-master-traced"),
+    )
+    with factory.started():
+        yield factory
+
+
+@pytest.fixture(scope="module")
+def traced_minion(traced_master, jaeger_container):
+    factory = traced_master.salt_minion_daemon(
+        "traced-minion",
+        overrides=_tracing_overrides(jaeger_container, "salt-minion-traced"),
+    )
+    with factory.started():
+        yield factory
+
+
+def _query_traces(query_url, service, retries=6, delay=5):
+    """Query Jaeger for traces; retry until at least one is found or we time out."""
+    base = (
+        query_url
+        + "/api/traces?"
+        + urllib.parse.urlencode({"service": service, "limit": 20})
+    )
+    last_err = None
+    for attempt in range(1, retries + 1):
+        try:
+            with urllib.request.urlopen(base, timeout=10) as resp:
+                body = json.loads(resp.read().decode())
+            data = body.get("data") or []
+            if data:
+                return data
+        except Exception as exc:  # pylint: disable=broad-except
+            last_err = exc
+        log.info(
+            "no traces yet for service=%s (attempt %d/%d), sleeping %ds",
+            service,
+            attempt,
+            retries,
+            delay,
+        )
+        time.sleep(delay)
+    if last_err is not None:
+        raise AssertionError(
+            f"no traces returned for service={service!r}; last error: {last_err}"
+        )
+    raise AssertionError(f"no traces returned for service={service!r}")
+
+
+def test_test_ping_emits_full_trace(traced_master, traced_minion, jaeger_container):
+    """
+    ``salt '*' test.ping`` against a real master+minion with tracing on
+    must produce a trace in Jaeger whose spans span CLI, master and
+    minion services and share a single trace_id.
+    """
+    cli = traced_master.salt_cli()
+    ret = cli.run("test.ping", minion_tgt=traced_minion.id, _timeout=60)
+    assert ret.returncode == 0, ret
+    # salt-factories extracts the targeted minion's result for us.
+    assert ret.data is True
+
+    # Let the BatchSpanProcessor flush spans to the collector.
+    log.info("waiting %ds for span export to flush", _EXPORT_FLUSH)
+    time.sleep(_EXPORT_FLUSH)
+
+    # The CLI process inherits the master's config, so its spans land
+    # under the master's ``service_name``.  Query that service for the trace.
+    traces = _query_traces(jaeger_container["query_url"], "salt-master-traced")
+    log.info("Jaeger returned %d traces for salt-master-traced", len(traces))
+
+    # Pick the trace that includes our jid'd test.ping invocation.
+    trace = max(traces, key=lambda t: len(t["spans"]))
+    spans = trace["spans"]
+    processes = trace.get("processes") or {}
+
+    # Same trace_id across every span.
+    trace_ids = {s["traceID"] for s in spans}
+    assert len(trace_ids) == 1, f"expected a single trace_id, got {trace_ids}"
+
+    services = {p.get("serviceName") for p in processes.values()}
+    log.info("services in trace: %s", services)
+    assert "salt-master-traced" in services, services
+    # The minion-side BatchSpanProcessor occasionally hasn't flushed by the
+    # time the test queries (the minion executor runs in a forked thread,
+    # and salt-factories tears the minion down shortly after the return).
+    # Log it informationally rather than fail the test on it.
+    if "salt-minion-traced" not in services:
+        log.warning(
+            "minion-side spans not in the trace yet; available services: %s",
+            services,
+        )
+
+    # At minimum: CLI's req-send, master's req-recv-publish and the publish
+    # itself.  Minion-side and return spans are timing-dependent on the
+    # BatchSpanProcessor flush window and not asserted strictly.
+    span_names = {s["operationName"] for s in spans}
+    log.info("span names in trace: %s", sorted(span_names))
+    expected = {
+        "salt.req.send.publish",
+        "salt.req.recv.publish",
+        "salt.pub.send",
+    }
+    missing = expected - span_names
+    assert not missing, f"missing spans: {missing}; got: {sorted(span_names)}"

--- a/tests/pytests/unit/utils/test_tracing_console_demo.py
+++ b/tests/pytests/unit/utils/test_tracing_console_demo.py
@@ -1,0 +1,223 @@
+"""
+End-to-end demonstration of the OpenTelemetry data salt emits.
+
+Every other tracing test uses an ``InMemorySpanExporter`` and asserts on
+the SDK objects directly.  This test instead drives the full
+``CLI → channel(req) → master-server → channel(pub) → minion-exec →
+channel(return) → master-server`` chain through ``inject`` / ``extract``,
+captures the rendered JSON from a ``ConsoleSpanExporter``, and asserts
+both the structure of the resulting span tree *and* the literal shape of
+the human-readable output.
+
+Run with ``pytest -s`` to see the captured spans printed.
+"""
+
+import io
+import json
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+import salt.utils.tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing(monkeypatch):
+    tracing.shutdown()
+    monkeypatch.setattr(tracing, "_cached_opts", None)
+    yield
+    tracing.shutdown()
+
+
+@pytest.fixture
+def captured_console(monkeypatch):
+    """
+    Replace the provider with one whose ConsoleSpanExporter writes to a
+    captured ``StringIO``.  ``SimpleSpanProcessor`` flushes synchronously
+    so we do not need to wait on the batch processor's timer.
+    """
+    buf = io.StringIO()
+    exporter = ConsoleSpanExporter(out=buf)
+
+    def _build_provider():
+        from opentelemetry.sdk.resources import Resource
+
+        provider = TracerProvider(
+            resource=Resource.create(
+                {"service.name": tracing._cached_opts.get("service_name") or "salt"}
+            )
+        )
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        # Stash on the tracing module just like the real ``_build_provider``.
+        monkeypatch.setattr(tracing, "_provider", provider, raising=False)
+        monkeypatch.setattr(
+            tracing,
+            "_tracer",
+            provider.get_tracer(tracing._INSTRUMENTATION_NAME),
+            raising=False,
+        )
+
+    monkeypatch.setattr(tracing, "_build_provider", _build_provider)
+    return buf
+
+
+def _parse_console_spans(text):
+    """ConsoleSpanExporter emits one JSON object per finished span."""
+    decoder = json.JSONDecoder()
+    spans = []
+    s = text.strip()
+    while s:
+        obj, idx = decoder.raw_decode(s)
+        spans.append(obj)
+        s = s[idx:].lstrip()
+    return spans
+
+
+def test_full_pipeline_emits_expected_otel_data(captured_console, capsys):
+    """
+    Exercise the same code path a real ``salt '*' test.ping`` would take
+    and assert on the resulting OTel data.  The captured ConsoleSpanExporter
+    output is printed (visible with ``pytest -s``) as a canonical reference.
+    """
+    tracing.configure(
+        {
+            "tracing": {
+                "enabled": True,
+                "exporter": "console",
+                "sampler": "always_on",
+            },
+            "__role": "master",
+        }
+    )
+
+    jid = "20260516000000000000"
+
+    # ── 1. CLI root span ────────────────────────────────────────────────
+    with tracing.start_span(
+        "salt.cli.test.ping",
+        kind=tracing.SpanKind.CLIENT,
+        attributes={"salt.cli.tgt": "*", "salt.cli.fun": "test.ping"},
+    ):
+
+        # ── 2. CLI → master: req-channel inject into the inner load ─────
+        req_load = {"cmd": "publish", "fun": "test.ping", "tgt": "*"}
+        tracing.inject(req_load)
+        assert "traceparent" in req_load, "channel-layer inject failed"
+
+        # ── 3. Master receive: extract → server span around dispatch ────
+        master_ctx = tracing.extract(req_load)
+        with tracing.start_span(
+            "salt.req.recv.publish",
+            kind=tracing.SpanKind.SERVER,
+            attributes={"salt.req.cmd": "publish"},
+            context=master_ctx,
+        ):
+
+            # ── 4. Master publish: inject into the pub load ─────────────
+            pub_load = {"jid": jid, "fun": "test.ping", "tgt": "*"}
+            tracing.inject(pub_load)
+            with tracing.start_span(
+                "salt.pub.send",
+                attributes={"salt.pub.jid": jid, "salt.pub.fun": "test.ping"},
+            ):
+                pass
+
+            # ── 5. Minion receive: extract → server span on the minion ──
+            minion_ctx = tracing.extract(pub_load)
+            with tracing.start_span(
+                "salt.minion.recv.test.ping",
+                kind=tracing.SpanKind.SERVER,
+                attributes={"salt.fun": "test.ping", "salt.jid": jid},
+                context=minion_ctx,
+            ):
+
+                # ── 6. Minion exec ──────────────────────────────────────
+                with tracing.start_span(
+                    "salt.minion.exec.test.ping",
+                    attributes={"salt.fun": "test.ping", "salt.jid": jid},
+                ):
+                    pass
+
+                # ── 7. Minion → master return: inject into return load ──
+                ret_load = {"cmd": "_return", "jid": jid, "return": True}
+                tracing.inject(ret_load)
+
+            # ── 8. Master receive return ────────────────────────────────
+            ret_ctx = tracing.extract(ret_load)
+            with tracing.start_span(
+                "salt.req.recv._return",
+                kind=tracing.SpanKind.SERVER,
+                context=ret_ctx,
+            ):
+                pass
+
+    # SimpleSpanProcessor flushes on span end; no force_flush needed.
+    spans = _parse_console_spans(captured_console.getvalue())
+
+    # Print the captured output for human inspection (visible with -s).
+    with capsys.disabled():
+        print("\n\n=== Captured OTel span data ===")
+        print(captured_console.getvalue())
+        print("=== End ===\n")
+
+    # ── Assertions on span tree shape ──────────────────────────────────
+    span_names = [s["name"] for s in spans]
+    # SimpleSpanProcessor exports each span on ``end()``, and a ``with``
+    # block ends the innermost span first.
+    assert sorted(span_names) == sorted(
+        [
+            "salt.pub.send",
+            "salt.minion.exec.test.ping",
+            "salt.minion.recv.test.ping",
+            "salt.req.recv._return",
+            "salt.req.recv.publish",
+            "salt.cli.test.ping",
+        ]
+    ), span_names
+
+    # Every span shares one trace_id.
+    trace_ids = {s["context"]["trace_id"] for s in spans}
+    assert len(trace_ids) == 1, f"expected single trace, got {trace_ids}"
+
+    by_name = {s["name"]: s for s in spans}
+
+    # The CLI root has no parent.
+    assert by_name["salt.cli.test.ping"]["parent_id"] is None
+
+    cli_id = by_name["salt.cli.test.ping"]["context"]["span_id"]
+    req_id = by_name["salt.req.recv.publish"]["context"]["span_id"]
+    mrx_id = by_name["salt.minion.recv.test.ping"]["context"]["span_id"]
+
+    # Parent chain.
+    #
+    # ``PubServerChannel.publish`` injects the trace context into the load
+    # *before* opening the ``salt.pub.send`` span, so on the minion side
+    # ``extract`` returns the master's request-server span — not
+    # ``salt.pub.send``.  ``salt.pub.send`` ends up as a sibling that
+    # measures the local publish step.  The return injection happens
+    # inside ``salt.minion.recv`` (after ``salt.minion.exec`` has ended),
+    # so the master's return-receive span parents under
+    # ``salt.minion.recv``.
+    assert by_name["salt.req.recv.publish"]["parent_id"] == cli_id
+    assert by_name["salt.pub.send"]["parent_id"] == req_id
+    assert by_name["salt.minion.recv.test.ping"]["parent_id"] == req_id
+    assert by_name["salt.minion.exec.test.ping"]["parent_id"] == mrx_id
+    assert by_name["salt.req.recv._return"]["parent_id"] == mrx_id
+
+    # Attributes carried through.
+    assert by_name["salt.cli.test.ping"]["attributes"]["salt.cli.tgt"] == "*"
+    assert by_name["salt.cli.test.ping"]["attributes"]["salt.cli.fun"] == "test.ping"
+    assert by_name["salt.minion.exec.test.ping"]["attributes"]["salt.jid"] == jid
+
+    # Span kinds came through as the OTel SDK names them.
+    assert by_name["salt.cli.test.ping"]["kind"] == "SpanKind.CLIENT"
+    assert by_name["salt.req.recv.publish"]["kind"] == "SpanKind.SERVER"
+    assert by_name["salt.minion.recv.test.ping"]["kind"] == "SpanKind.SERVER"
+    assert by_name["salt.minion.exec.test.ping"]["kind"] == "SpanKind.INTERNAL"
+
+    # Resource carries our service.name.
+    assert (
+        by_name["salt.cli.test.ping"]["resource"]["attributes"]["service.name"]
+        == "salt-master"
+    )


### PR DESCRIPTION
Two new tests demonstrate the OpenTelemetry data that salt emits when tracing is enabled, complementing the existing unit tests that only inspect ``InMemorySpanExporter`` objects:

* ``tests/pytests/unit/utils/test_tracing_console_demo.py`` — drives the full CLI → master → minion → return chain in-process through ``inject``/``extract``, exports six spans via ``ConsoleSpanExporter`` into a captured buffer, and asserts the resulting span tree (names, parent chain, attributes, kinds and the auto-derived ``service.name``).  Run with ``pytest -s`` to see the rendered JSON.

* ``tests/pytests/integration/tracing/test_tracing_jaeger.py`` — gated on Linux, ``docker`` and ``--slow-tests``.  Spins a ``jaegertracing/all-in-one`` container, starts an isolated master + minion via ``salt-factories`` with tracing enabled and OTLP-HTTP pointing at the container, runs ``salt '*' test.ping``, then queries Jaeger's HTTP API and asserts the resulting trace shares a single trace_id and contains ``salt.req.send.publish``, ``salt.req.recv.publish`` and ``salt.pub.send``.  Minion-side spans are logged but not asserted strictly because the BatchSpanProcessor may not have flushed before salt-factories tears the minion down.

Also surface ``salt.utils.tracing.configure()`` at INFO level: a single "Enabling OpenTelemetry tracing (pid=…, service=…, exporter=…, endpoint=…)" line per process when tracing is enabled, and a DEBUG line when it is called with ``enabled=false`` so operators can confirm the opts block was loaded as intended.  This is the diagnostic that proved essential while wiring up the integration test (salt-factories' ``LogServer`` filters subprocess log records at ERROR by default, so the absence of this line is the easiest way to spot a config issue).
