### PR TITLE
fix: correct typo 'adresses' to 'addresses' in network.py docstring

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1431,7 +1431,7 @@ def _ip_addrs(
     interface=None, include_loopback=False, interface_data=None, proto="inet"
 ):
     """
-    Return the full list of IP adresses matching the criteria
+    Return the full list of IP addresses matching the criteria
 
     proto = inet|inet6
     """


### PR DESCRIPTION
## Summary
Correct a spelling error in the `_ip_addrs` function docstring: "adresses" → "addresses".

## Root Cause
Simple typo in the docstring of `salt/utils/network.py`.

## Fix
- `salt/utils/network.py`: Changed "adresses" to "addresses" in the `_ip_addrs` function docstring (line 1434).

## Testing
- No functional changes — docstring-only fix.
- No tests affected.

Closes #66731