### PR TITLE
GPG: Attempt update if subkey is expired

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -455,8 +455,9 @@ def list_secret_keys(user=None, gnupghome=None, keyring=None):
 def _render_key(_key):
     tmp = {
         "keyid": _key["keyid"],
-        "uids": _key["uids"],
     }
+    if "uids" in _key:
+        tmp["uids"] = _key["uids"]
     if "fingerprint" in _key:
         tmp["fingerprint"] = _key["fingerprint"]
 
@@ -465,6 +466,7 @@ def _render_key(_key):
     length = _key.get("length", None)
     owner_trust = _key.get("ownertrust", None)
     trust = _key.get("trust", None)
+    subkeys = _key.get("subkey_info", {})
 
     if expires:
         tmp["expires"] = time.strftime(
@@ -479,6 +481,8 @@ def _render_key(_key):
         tmp["ownerTrust"] = LETTER_TRUST_DICT[_key["ownertrust"]]
     if trust:
         tmp["trust"] = LETTER_TRUST_DICT[_key["trust"]]
+    for data in subkeys.values():
+        tmp.setdefault("subkeys", []).append(_render_key(data))
     return tmp
 
 

--- a/salt/states/gpg.py
+++ b/salt/states/gpg.py
@@ -7,6 +7,7 @@ Manage GPG keychains
 """
 
 import logging
+from datetime import date
 
 import salt.utils.dictupdate
 import salt.utils.immutabletypes as immutabletypes
@@ -32,6 +33,24 @@ class KeyNotContained(CommandExecutionError):
     """
 
 
+def _expired_subkeys(key, max_days=100):
+    """
+    From a single key of the output of gpg.list_keys, iterate over
+    subkeys and return those that have expired recently.
+    We don't want to keep checking old subkeys for updates.
+    """
+    ret = {}
+    if not max_days:
+        return ret
+    for subkey in key.get("subkeys", []):
+        if subkey.get("expired"):
+            # Only try to refresh subkeys that have expired recently
+            expired_date = date.fromisoformat(subkey["expires"])
+            if (date.today() - expired_date).days <= max_days:
+                ret[subkey["keyid"]] = subkey
+    return ret
+
+
 def present(
     name,
     keys=None,
@@ -43,6 +62,7 @@ def present(
     source=None,
     skip_keyserver=False,
     text=None,
+    subkey_maxage=100,
     **kwargs,
 ):
     """
@@ -109,6 +129,17 @@ def present(
             Requires python-gnupg v0.5.1.
 
         .. versionadded:: 3008.0
+
+    subkey_maxage
+        If the managed key has expired subkeys, this state attempts an update.
+        Since sometimes keys have long expired subkeys, it filters eligible subkeys
+        that trigger the update check.
+        This parameter specifies the maximum number of days since a subkey's
+        expiration for the key to be eligible. Defaults to ``100``, meaning
+        subkeys that have expired more than 100 days ago do not trigger an attempt.
+        Set this to a falsy value to skip the explicit management of subkeys.
+
+        .. versionadded:: 3008.0
     """
 
     ret = {"name": name, "result": True, "changes": {}, "comment": ""}
@@ -132,12 +163,17 @@ def present(
 
     current_keys = {}
     expired_keys = []
+    expired_subkeys = {}
     for key in _current_keys:
         keyid = key["keyid"]
         current_keys[keyid] = {}
         current_keys[keyid]["trust"] = key["trust"]
+        current_keys[keyid]["subkeys"] = key.get("subkeys", {})
         if key.get("expired"):
             expired_keys.append(keyid)
+        key_expired_subs = _expired_subkeys(key, max_days=subkey_maxage)
+        if key_expired_subs:
+            expired_subkeys[keyid] = key_expired_subs
 
     if not keys:
         keys = name
@@ -149,22 +185,34 @@ def present(
     for key in keys:
         key_res[key] = []
         try:
-            refresh = key in expired_keys
+            is_expired = key in expired_keys
+            has_expired_subkeys = key in expired_subkeys
+            refresh = is_expired or has_expired_subkeys
             if key in current_keys and not refresh:
                 key_res[key].append(f"GPG Public Key {key} already in keychain")
                 continue
             if __opts__["test"]:
                 ret["result"] = None
-                key_res[key] = [f"Would have added {key} to GPG keychain"]
-                salt.utils.dictupdate.set_dict_key_value(
-                    ret, f"changes:{key}:added", True
-                )
                 if refresh:
-                    key_res[key][-1] += " (the existing one was expired)"
+                    if is_expired:
+                        key_res[key] = [
+                            f"Would have attempted to update {key} because it is expired"
+                        ]
+                    else:
+                        key_res[key] = [
+                            f"Would have attempted to update {key} because it has expired subkeys:"
+                        ] + [
+                            f"  - {subkey} (expired on {data['expires']})"
+                            for subkey, data in expired_subkeys[key].items()
+                        ]
                     salt.utils.dictupdate.set_dict_key_value(
                         ret, f"changes:{key}:refresh", True
                     )
                 else:
+                    key_res[key] = [f"Would have added {key} to GPG keychain"]
+                    salt.utils.dictupdate.set_dict_key_value(
+                        ret, f"changes:{key}:added", True
+                    )
                     current_keys[key] = {"trust": "unknown"}
                 continue
             result = {}
@@ -185,8 +233,11 @@ def present(
                         result["res"] = any(
                             "updated: new" in x for x in result["message"]
                         )
+                        if not is_expired and not result["res"]:
+                            # Don't fail if we're only updating expired subkeys though
+                            result["res"] = None
                     result["message"] = "\n".join(result["message"])
-                if (not result or result["res"] is False) and source:
+                if (not result or not result["res"]) and source:
                     if not isinstance(source, list):
                         source = [source]
                     prev_msg = ""
@@ -224,23 +275,61 @@ def present(
                     result["message"]
                     + f"\nThe new key {key} could not be retrieved though."
                 )
-            salt.utils.dictupdate.set_dict_key_value(ret, f"changes:{key}:added", True)
+            if not refresh:
+                salt.utils.dictupdate.set_dict_key_value(
+                    ret, f"changes:{key}:added", True
+                )
             if new_key.get("expired"):
                 raise CommandExecutionError(
                     result["message"] + f"\nThe new key {key} is expired though."
                 )
-            key_res[key].append(f"Added {key} to GPG keychain")
-            current_keys[key] = {"trust": new_key["trust"]}
             if refresh:
-                key_res[key][-1] += " (the existing one was expired)"
-                salt.utils.dictupdate.set_dict_key_value(
-                    ret, f"changes:{key}:refresh", True
-                )
+                added_subs = {
+                    subkey["keyid"] for subkey in new_key.get("subkeys", {})
+                } - {subkey["keyid"] for subkey in current_keys[key]["subkeys"]}
+                updated_subs = set()
+                if has_expired_subkeys:
+                    after_expired_subs = _expired_subkeys(
+                        new_key, max_days=subkey_maxage
+                    )
+                    updated_subs = set(expired_subkeys[key]) - set(after_expired_subs)
+
+                if is_expired:
+                    key_res[key].append(f"Updated {key} because it was expired")
+                    salt.utils.dictupdate.set_dict_key_value(
+                        ret, f"changes:{key}:refresh", True
+                    )
+                elif added_subs or updated_subs:
+                    key_res[key].append(
+                        f"Updated {key} because it had expired subkeys."
+                    )
+                    salt.utils.dictupdate.set_dict_key_value(
+                        ret, f"changes:{key}:refresh", True
+                    )
+                    if added_subs:
+                        salt.utils.dictupdate.set_dict_key_value(
+                            ret, f"changes:{key}:subkeys:added", list(added_subs)
+                        )
+                    if updated_subs:
+                        salt.utils.dictupdate.set_dict_key_value(
+                            ret, f"changes:{key}:subkeys:extended", list(updated_subs)
+                        )
+                else:
+                    key_res[key].append(
+                        f"Attempted to update {key} because it has expired subkeys, but no new signatures or keys were found"
+                    )
+            else:
+                key_res[key].append(f"Added {key} to GPG keychain")
+            current_keys[key] = {"trust": new_key["trust"]}
         except (CommandExecutionError, SaltInvocationError) as err:
             ret["result"] = False
-            if refresh:
+            if is_expired:
                 key_res[key].append(
                     "Existing key is expired, tried to fetch updated one"
+                )
+            elif has_expired_subkeys:
+                key_res[key].append(
+                    "Existing key has expired subkeys, tried to refresh"
                 )
             key_res[key].extend(str(err).splitlines())
 

--- a/tests/pytests/functional/states/test_gpg.py
+++ b/tests/pytests/functional/states/test_gpg.py
@@ -200,6 +200,219 @@ G5lpc2BZ/RGsECq/HcbpFIM=
 
 
 @pytest.fixture
+def key_f_pub():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBGoI6v0BCACq5sCkJtDzUtC5eUGA1opAD+1363xYTfuW8/MvxlzPOg5OV3Bx
+Z9a3QyDfjmMwZCCKYz1Avq4vvx+OrqkYi9y87wCXgfEJ90iJtgTxOdfETS/DKBQc
+CJmrLXAVo5UsYLMku17/cv3FF49DW/8iidnQd3YIYt9la0Ep7IoZ9IDL8TLHdSGA
+C7u/C/u7CGcuGB007qHcfKFUbwtYicDfISizmWegCSLLnbHvlO0+ydHAz27tuN6b
+Z7k+IgnWk93Z2nGhOuiv0OOGVbpxt2yl+46tx12KmkPXPfp5E/Uj+1gJp0Ybw5Tx
+zcgGaaNu7jSPd9JfJKheYala0HCunQHGGMxjABEBAAG0L3NhbHRwcm9qZWN0LXRl
+c3QgPHNhbHRwcm9qZWN0QHRlc3QubG9jYWxkb21haW4+iQFRBBMBCAA7FiEEZTmp
+Ue8h12wOdWpSLNeyGbJL1isFAmoI6v0CGwEFCwkIBwICIgIGFQoJCAsCBBYCAwEC
+HgcCF4AACgkQLNeyGbJL1isEKQf/QEGBizj48C2WNXUoLxZRbml99nIk6uQ4ETgm
+/4ZAdVah3FA0aD/xKurmEj5t/Winr6+W8ykS15WBwoqLYIRLMVlynRLVDBLou4Iw
+2mCq9gyPpCjWVV3oG+dyIn9PGEDOsoVKnZ7qYkdoZBj5pvHVztJlPs4GdvBXorJY
+IAWBHC628DCK5rsrFkkMGNbd0DQ0Zz9ULdv5jeffaLMv8vkAjpsrmkUBH/AyTl1d
+Q2YbGz3vYU0AEkZx18N7y6SUYAMBKa0llQlHjThcqNGTUc/FKfJii+AsQ1rB9Whq
+11yDz5CzOuXkq1zlc1qEqnjHPSNV5qpBd0r7Qy80c2ALrJ6q+bkBDQRqCOtYAQgA
+zQhVoezIiQCFZUpr9pA+N1Q9CD9q78wWCzBkHCNSdT2BHOJO9PidlFNlpP5LXhgH
+Z6w+pOX8vZZ4C2Uktn0TRBlqDgb1Y6JYnNQvZ0gAjr7IrFrj7ZvehjnlwEiPnK3e
+E1M9R5zMDEW8sya+zMw7auH7R6KsTvwZj6fQzPWhQGNWS1ZmqineX8OPqG4HK/cv
+8T55AQD6dSyaIlj+QHUUSXbqStY9PXSf3Y/K6VxzRohdEhm56qbSdv4RR7Zc99g9
+dgocFLIhBDNHJPVYqVXTK+YkBrSTNuOv57z3Y8zNZZD53bwTHHSO1xdFjIIkyYgT
+43VcTthgckMQgucgvL7EEQARAQABiQJyBBgBCAAmFiEEZTmpUe8h12wOdWpSLNey
+GbJL1isFAmoI61gCGwIFCQAB98gBQAkQLNeyGbJL1ivAdCAEGQEIAB0WIQRzqb20
+R17OiIgCxVgkR5+7omhUbwUCagjrWAAKCRAkR5+7omhUb8R0B/9/7QbAyPnFOS7L
+4YskDECa0icVGDlE1poryxuDnfLO223P+i00PKT+U4+oldgJSedWndbkwjw3u4gN
+kakOK/0IXzxCwXdaJJScqeodWGrwWYugwT0Lf0qOdt9RZ9SjKQTAZbV+JN23wuHN
+qcZ2UYnEaHTXfnNHKFutJPardVmStQFWGab088QMhI/pTNUKGomcA3s/5GASaO42
+sQrmaLk7T3srGZLabybTN0PlR+/LhT/5UDaozbmhGeKZFMjLrwuqjJ5U3RRGzqR4
+iMmc11l25DjSTfDNhtqCwyzN/8rwbL93IuTIp/izZaCKKcD1mNuu9pXkKBaEbRXg
+eIL9fdGBuR4H+gK20VDL9IncrewGFUIaL4dKWqbT8ngxUvXCb6BMH/G+5vqwAJtJ
+jm4ML6++xmmFs3kuGa5VzQYr0xSSZOMju4WG4y5+b9F4ihheVOII7nXvgtvZZWFL
+ockvGx/gDrolLrktwqKK6jU+FebAnW5sXzjf3hTtGRxlN+u1EtWqIZ9/vF6BJjct
+0HT0ktx8cwh1oeEzONOIp2mieVS6ck/n4JRnqt0hIUEcAZeNMW81PsEC1G1DjU1n
+jmWCznyVJTX5SF4nsKf9kau8L4D9CAW+yNOeRztYnb5Xd7sNWcwWioBDKQx7wjmw
+jQiSkM5kdxZmc3EsIlIHul4eA1ZHGSexr7u5AQ0EagjrbgEIAM8qm6VvmiRjsFye
+MM5935Qc76D374kV8sJojNi7f2YG8QLSRT0tw4ROuWNo5h13rVYybuZG01vThZy0
+0aiylA52IPTL8mppxMFMIRP7ClZBNdUR6usPd7L0CHHZnUqy2VurwTpnd1/TUUs5
+7TSQ+KzCZ3EDGK/5cf6FIloj0ZN0eumv9kBCzZRR6xQQOtvkHbLw4rKwgZqAum+0
+8xpKcttxzGE7Iczi7y9/BCWtUyilbUYEEDMHkDyHXawC96Cy26nTrJJR+G5VkMhy
+UgnD3yGETnN2T9bUgAiUgDnEilNO2dkdQpnyiz7tCdKleHVapE5KYafwPNy57mP+
+NKPVfJEAEQEAAYkBPAQYAQgAJhYhBGU5qVHvIddsDnVqUizXshmyS9YrBQJqCOtu
+AhsMBQkAAfeyAAoJECzXshmyS9YrtFEH/jbPqVt1WLwYkNRWiojWh9AF/YVdMqfe
+wUdZfEWYNVhvdg/siWjIRvdCfH0BSu1Ob3mOFZUJgAK2h9z5J7HkGB+W6/yzg/6R
+9UjtS4t6c0JuZvxMI0P24c7cuWnje89CwTN3G6MRPFG6ISzGXeNDiCBXFLF5BMw6
+mcTHUHEauLT9cUjRf5429ys7Z6f80oGYuvkHpBhfsfqwoYytN/jMWv6PE8aYXxLU
+geue63PhfyoWbYNVDPuNhcDsXva6HmTfR12Px10CTjYoXI4gkHCPIxzsmgNxqjhW
+8powmq1TcvD3gsLPLEiNzrG9C56JWaHdOozgzsVidDjRAZSGq22YBeW5AQ0Eagjr
+dAEIAMYF5+D59x517wNS/ytbiaL86wWYrXbbNRecUCHWcxY3O6xXmMrcUtUp7W+x
+6HIZ7QiAgYgIl77fjFLabSNc3LjAlqi6DQ5R8zcwdxXGTjjn08QB6G8dNcoeHMpZ
+eFKc+PTt48KrTI7mWb4mXnVNcAR55OnjVmMq+RQ4WEETT99ebWQe9EFbTtNQihLf
+WC3Mjkqvb7stBvwIw2vlq2ajWGzaCRnIWCHq/VAf+OBN8/CSGHGWEaAZTRpbSAzf
+KZ6Y99lZLZrYyay8gDwLmRBp3Y9cgIDBFrV2hsCeoQZc+xk4k/jPwtYYpLGARRxF
+3Kyhc4uq09X06BSKjC7Bi2Sd9GcAEQEAAYkBPAQYAQgAJhYhBGU5qVHvIddsDnVq
+UizXshmyS9YrBQJqCOt0AhsgBQkAAfesAAoJECzXshmyS9Yrj4oH/0zK4KdgXT3y
+PHvuixocQ7Nn0uJUoyxBfsH4mqJQE7bd7GI3V1c4EV2XKdGThCujphHIzjrJv8px
+4VayAcSm3usIEAio/EYKokG+gB8wZ3HWhBOA1rWR2W8P2aSxOu6nEWHh5fSS0ris
+dwwfm/WRqTW4Iv3ob1vg7rjrxDjcADhrQsjyYeLWK5XHrCKP0hKH+DpMhSjtYxH7
+zbnPQuJEW1ec5NUk4Kf9uZvpajCPHabUgKptpH1mZ+7qqEUWUjFQVy4Qj4BavOxt
+rzU6/WncagftbLN3Gm4crNzKrgAEXvYl6zIOzwcudaIbaQBg6N+294dnbIOshJOv
+/h1WQBwSVWQ=
+=zuag
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
+
+@pytest.fixture
+def key_f_pub_notexpired():
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBGoI6v0BCACq5sCkJtDzUtC5eUGA1opAD+1363xYTfuW8/MvxlzPOg5OV3Bx
+Z9a3QyDfjmMwZCCKYz1Avq4vvx+OrqkYi9y87wCXgfEJ90iJtgTxOdfETS/DKBQc
+CJmrLXAVo5UsYLMku17/cv3FF49DW/8iidnQd3YIYt9la0Ep7IoZ9IDL8TLHdSGA
+C7u/C/u7CGcuGB007qHcfKFUbwtYicDfISizmWegCSLLnbHvlO0+ydHAz27tuN6b
+Z7k+IgnWk93Z2nGhOuiv0OOGVbpxt2yl+46tx12KmkPXPfp5E/Uj+1gJp0Ybw5Tx
+zcgGaaNu7jSPd9JfJKheYala0HCunQHGGMxjABEBAAG0L3NhbHRwcm9qZWN0LXRl
+c3QgPHNhbHRwcm9qZWN0QHRlc3QubG9jYWxkb21haW4+iQFRBBMBCAA7FiEEZTmp
+Ue8h12wOdWpSLNeyGbJL1isFAmoI6v0CGwEFCwkIBwICIgIGFQoJCAsCBBYCAwEC
+HgcCF4AACgkQLNeyGbJL1isEKQf/QEGBizj48C2WNXUoLxZRbml99nIk6uQ4ETgm
+/4ZAdVah3FA0aD/xKurmEj5t/Winr6+W8ykS15WBwoqLYIRLMVlynRLVDBLou4Iw
+2mCq9gyPpCjWVV3oG+dyIn9PGEDOsoVKnZ7qYkdoZBj5pvHVztJlPs4GdvBXorJY
+IAWBHC628DCK5rsrFkkMGNbd0DQ0Zz9ULdv5jeffaLMv8vkAjpsrmkUBH/AyTl1d
+Q2YbGz3vYU0AEkZx18N7y6SUYAMBKa0llQlHjThcqNGTUc/FKfJii+AsQ1rB9Whq
+11yDz5CzOuXkq1zlc1qEqnjHPSNV5qpBd0r7Qy80c2ALrJ6q+bkBDQRqCOtYAQgA
+zQhVoezIiQCFZUpr9pA+N1Q9CD9q78wWCzBkHCNSdT2BHOJO9PidlFNlpP5LXhgH
+Z6w+pOX8vZZ4C2Uktn0TRBlqDgb1Y6JYnNQvZ0gAjr7IrFrj7ZvehjnlwEiPnK3e
+E1M9R5zMDEW8sya+zMw7auH7R6KsTvwZj6fQzPWhQGNWS1ZmqineX8OPqG4HK/cv
+8T55AQD6dSyaIlj+QHUUSXbqStY9PXSf3Y/K6VxzRohdEhm56qbSdv4RR7Zc99g9
+dgocFLIhBDNHJPVYqVXTK+YkBrSTNuOv57z3Y8zNZZD53bwTHHSO1xdFjIIkyYgT
+43VcTthgckMQgucgvL7EEQARAQABiQJyBBgBCAAmAhsCFiEEZTmpUe8h12wOdWpS
+LNeyGbJL1isFAmoI7HAFCYOUFhgBQMB0IAQZAQgAHRYhBHOpvbRHXs6IiALFWCRH
+n7uiaFRvBQJqCOtYAAoJECRHn7uiaFRvxHQH/3/tBsDI+cU5LsvhiyQMQJrSJxUY
+OUTWmivLG4Od8s7bbc/6LTQ8pP5Tj6iV2AlJ51ad1uTCPDe7iA2RqQ4r/QhfPELB
+d1oklJyp6h1YavBZi6DBPQt/So5231Fn1KMpBMBltX4k3bfC4c2pxnZRicRodNd+
+c0coW60k9qt1WZK1AVYZpvTzxAyEj+lM1QoaiZwDez/kYBJo7jaxCuZouTtPeysZ
+ktpvJtM3Q+VH78uFP/lQNqjNuaEZ4pkUyMuvC6qMnlTdFEbOpHiIyZzXWXbkONJN
+8M2G2oLDLM3/yvBsv3ci5Min+LNloIopwPWY2672leQoFoRtFeB4gv190YEJECzX
+shmyS9YrE20H+gLnWKqylh7KJHQhTSA3ljofx4Jteb+dnpXtPlEDqL0miAvqAYjT
+ZolRE/zB4y1khBpaumMTlR2KHGjXfanThC1tZbMAe8sFx6SoJCy7BTP32hoMDe8I
+/YLSMITPC5pdLWV9pN5d7pwcwMbHx+xgYtVN9Eh/ZL88a+N1JPdyLUnypIbDCl3f
+Q7zzN2VPD9HmKWJ5tguCDKVgKgRRRpxQsN0/m2sM9HyLHLJDK7KbgXo0bjV3GqyQ
+dg7jTTzB63+Ll8rXcLcPumOOam5l4imiNgEnWHGI04+oKphIbb8aolyABU5nS+7T
+SrwQfo4RW+ILMks2hjKh7U/xM6lwpADXTOC5AQ0EagjrbgEIAM8qm6VvmiRjsFye
+MM5935Qc76D374kV8sJojNi7f2YG8QLSRT0tw4ROuWNo5h13rVYybuZG01vThZy0
+0aiylA52IPTL8mppxMFMIRP7ClZBNdUR6usPd7L0CHHZnUqy2VurwTpnd1/TUUs5
+7TSQ+KzCZ3EDGK/5cf6FIloj0ZN0eumv9kBCzZRR6xQQOtvkHbLw4rKwgZqAum+0
+8xpKcttxzGE7Iczi7y9/BCWtUyilbUYEEDMHkDyHXawC96Cy26nTrJJR+G5VkMhy
+UgnD3yGETnN2T9bUgAiUgDnEilNO2dkdQpnyiz7tCdKleHVapE5KYafwPNy57mP+
+NKPVfJEAEQEAAYkBPAQYAQgAJgIbDBYhBGU5qVHvIddsDnVqUizXshmyS9YrBQJq
+COxwBQmDlBYCAAoJECzXshmyS9YrYCEH/jyfl0ME+Jt8qZPNXBNC9J76rf78lHRy
+4jz4spgZtqYucYp2xQQQDigxyd6UaWGWioIjGP53iGpI00laln1I+kB6QLFOtaNF
+KoxOdM3cWaUhd3S1i843Px0ulwtyTjCARm3at236iIeDV0AfqrHxw5RYf7x7lKv/
+3JU2yXW/5OiTAKF9c7WISH/jGEd7WipPW9f9poqdIzG/JjPenSfHE50j4BJDorQI
+fNd0ma91YodauTFxjN8sco8ntqV5aaE9O5b5h1PF5SUtNC6WOwf7R7+Ad50xGbsX
+L/bG7fzIgsXuRXt19jiuhsQOuVbx6VOpk1X6ewVZFgZqjGb0wCyQwTW5AQ0Eagjr
+dAEIAMYF5+D59x517wNS/ytbiaL86wWYrXbbNRecUCHWcxY3O6xXmMrcUtUp7W+x
+6HIZ7QiAgYgIl77fjFLabSNc3LjAlqi6DQ5R8zcwdxXGTjjn08QB6G8dNcoeHMpZ
+eFKc+PTt48KrTI7mWb4mXnVNcAR55OnjVmMq+RQ4WEETT99ebWQe9EFbTtNQihLf
+WC3Mjkqvb7stBvwIw2vlq2ajWGzaCRnIWCHq/VAf+OBN8/CSGHGWEaAZTRpbSAzf
+KZ6Y99lZLZrYyay8gDwLmRBp3Y9cgIDBFrV2hsCeoQZc+xk4k/jPwtYYpLGARRxF
+3Kyhc4uq09X06BSKjC7Bi2Sd9GcAEQEAAYkBPAQYAQgAJgIbIBYhBGU5qVHvIdds
+DnVqUizXshmyS9YrBQJqCOxwBQmDlBX8AAoJECzXshmyS9YrDKYH/3WRudZ5DnRp
+wd2/LhdKwao3lcjm+w2nkXuonBybzdg5qAtTt6WoHKPA5KcZyrw02QLp7gtGzmCI
+isASFzvBr/LZry25xlK4O1qBVDWfeFsrhpw5FoftidrfmggeEptsMypxgBNcjvpq
+BAFy2olDPt65XvIaXeXMDudx781PIalpF8Kojgp/pMfRNkOH3QwQ+KobqVwE1I5c
+c4aZ+ooA63wh9BJmCVWfWBS/YHNMZ1IXkkeI8Myfu5mnswc06QlY1lYqW9eBNPX+
+QjRpvujhBQmJ40NRd6PZb90EonQdlEdYpKEGPWwJ3X0+jSMujPAaInczxTcn7d5c
+oY7iCpnP4fM=
+=zfOS
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
+
+@pytest.fixture
+def key_f_pub_notexpired_partial():
+    """
+    This rotates the signing subkey and extends the encryption one.
+    The auth subkey is still expired.
+    """
+    return """\
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBGoI6v0BCACq5sCkJtDzUtC5eUGA1opAD+1363xYTfuW8/MvxlzPOg5OV3Bx
+Z9a3QyDfjmMwZCCKYz1Avq4vvx+OrqkYi9y87wCXgfEJ90iJtgTxOdfETS/DKBQc
+CJmrLXAVo5UsYLMku17/cv3FF49DW/8iidnQd3YIYt9la0Ep7IoZ9IDL8TLHdSGA
+C7u/C/u7CGcuGB007qHcfKFUbwtYicDfISizmWegCSLLnbHvlO0+ydHAz27tuN6b
+Z7k+IgnWk93Z2nGhOuiv0OOGVbpxt2yl+46tx12KmkPXPfp5E/Uj+1gJp0Ybw5Tx
+zcgGaaNu7jSPd9JfJKheYala0HCunQHGGMxjABEBAAG0L3NhbHRwcm9qZWN0LXRl
+c3QgPHNhbHRwcm9qZWN0QHRlc3QubG9jYWxkb21haW4+iQFRBBMBCAA7FiEEZTmp
+Ue8h12wOdWpSLNeyGbJL1isFAmoI6v0CGwEFCwkIBwICIgIGFQoJCAsCBBYCAwEC
+HgcCF4AACgkQLNeyGbJL1isEKQf/QEGBizj48C2WNXUoLxZRbml99nIk6uQ4ETgm
+/4ZAdVah3FA0aD/xKurmEj5t/Winr6+W8ykS15WBwoqLYIRLMVlynRLVDBLou4Iw
+2mCq9gyPpCjWVV3oG+dyIn9PGEDOsoVKnZ7qYkdoZBj5pvHVztJlPs4GdvBXorJY
+IAWBHC628DCK5rsrFkkMGNbd0DQ0Zz9ULdv5jeffaLMv8vkAjpsrmkUBH/AyTl1d
+Q2YbGz3vYU0AEkZx18N7y6SUYAMBKa0llQlHjThcqNGTUc/FKfJii+AsQ1rB9Whq
+11yDz5CzOuXkq1zlc1qEqnjHPSNV5qpBd0r7Qy80c2ALrJ6q+bkBDQRqCOtuAQgA
+zyqbpW+aJGOwXJ4wzn3flBzvoPfviRXywmiM2Lt/ZgbxAtJFPS3DhE65Y2jmHXet
+VjJu5kbTW9OFnLTRqLKUDnYg9MvyamnEwUwhE/sKVkE11RHq6w93svQIcdmdSrLZ
+W6vBOmd3X9NRSzntNJD4rMJncQMYr/lx/oUiWiPRk3R66a/2QELNlFHrFBA62+Qd
+svDisrCBmoC6b7TzGkpy23HMYTshzOLvL38EJa1TKKVtRgQQMweQPIddrAL3oLLb
+qdOsklH4blWQyHJSCcPfIYROc3ZP1tSACJSAOcSKU07Z2R1CmfKLPu0J0qV4dVqk
+Tkphp/A83LnuY/40o9V8kQARAQABiQE8BBgBCAAmAhsMFiEEZTmpUe8h12wOdWpS
+LNeyGbJL1isFAmoI7PgFCYOUFooACgkQLNeyGbJL1iuXWAf/bvEO1skQNAtREzEo
+T6+HO1BeWD07msaKkn8Zf0zJ0msRwWZNc6yeYhftJEBalV7svvvhQEezDVGsONp+
+1fDRRCNcT6Q0TgqqpANqgmN1yre5AqiA/abBMFz8xZ5j5d0FgjUdeFqV4ed2kt9r
+hzfF8ADKLph13o7YPnM9sKh2D6aPZ2m92/iXkjYKbJKsME9SmVBHzvKeIy/Zfgxc
+GxOK9ssdGQLmXt+QLxs+FTztvKsF3kyueiQmSvZjwD9uEJkSR9c3xtLDlztP7xzb
+Q60B53pfAhUO+qYXQWdoFQyHmbiyN/MuyGC6KiPF8t684eIqTO9T9wysfD42xH/M
+PkRPDLkBDQRqCOt0AQgAxgXn4Pn3HnXvA1L/K1uJovzrBZitdts1F5xQIdZzFjc7
+rFeYytxS1Sntb7HochntCICBiAiXvt+MUtptI1zcuMCWqLoNDlHzNzB3FcZOOOfT
+xAHobx01yh4cyll4Upz49O3jwqtMjuZZviZedU1wBHnk6eNWYyr5FDhYQRNP315t
+ZB70QVtO01CKEt9YLcyOSq9vuy0G/AjDa+WrZqNYbNoJGchYIer9UB/44E3z8JIY
+cZYRoBlNGltIDN8pnpj32VktmtjJrLyAPAuZEGndj1yAgMEWtXaGwJ6hBlz7GTiT
++M/C1hiksYBFHEXcrKFzi6rT1fToFIqMLsGLZJ30ZwARAQABiQE8BBgBCAAmFiEE
+ZTmpUe8h12wOdWpSLNeyGbJL1isFAmoI63QCGyAFCQAB96wACgkQLNeyGbJL1iuP
+igf/TMrgp2BdPfI8e+6LGhxDs2fS4lSjLEF+wfiaolATtt3sYjdXVzgRXZcp0ZOE
+K6OmEcjOOsm/ynHhVrIBxKbe6wgQCKj8RgqiQb6AHzBncdaEE4DWtZHZbw/ZpLE6
+7qcRYeHl9JLSuKx3DB+b9ZGpNbgi/ehvW+DuuOvEONwAOGtCyPJh4tYrlcesIo/S
+Eof4OkyFKO1jEfvNuc9C4kRbV5zk1STgp/25m+lqMI8dptSAqm2kfWZn7uqoRRZS
+MVBXLhCPgFq87G2vNTr9adxqB+1ss3cabhys3MquAARe9iXrMg7PBy51ohtpAGDo
+37b3h2dsg6yEk6/+HVZAHBJVZLkBDQRqCO0aAQgA0K8uDNRNcVytNN0tJIS/N9Xu
+5nQRlbGlhvMtAlmMgNQPA4ZM3pitOnkg4TVCYJlDSXNjQcU6F58BGW3eqkerU2k6
+Cbwa75trq259/JDxDCz+zSFwRjZLfyL2jJN0YM3hDA42PoDF2NRa8d3Lp1yiQFgB
+j+Lim85sc3SgbXhnI3QaoAAyYfl132NYmbLdcFP/SRGtuHRmqXWPxFI2nYV+ckFL
+/zZkY4JL5Ol8pbOLaJIJ0mBH8hpP8OsJz6OpV1GFytlGDyhswvvJQY6NbjO4P/y8
+nq/Dm2V0f/pqn+l/ZJfDxnYEpJveUowoz5DVH5M2HxiFX8SqFSslV4KdWKxOUQAR
+AQABiQJyBBgBCAAmFiEEZTmpUe8h12wOdWpSLNeyGbJL1isFAmoI7RoCGwIFCYOT
+aAYBQAkQLNeyGbJL1ivAdCAEGQEIAB0WIQRJ56vCmVw1JFexl8PIQ5vFZoGymwUC
+agjtGgAKCRDIQ5vFZoGym98tB/9RTUK+tQ1UR9yuXG7zbAsSzQ0N7OsZ7lyBXFdX
+0nXQEMU0M6Oc8EwWwC1cKcJ8WoXDANuw3ZySoau9V4HnUd5I/TcshZDVlrxMsAYh
+V6MYQgP4A/Zysgv/DApeWM0CJcVukFQzeD9B0MUmDfXg5HFUoPmqAOTJ0SMzjZz1
+zfZcKYDkQohQzuWG+EdcH+0LS9Nz/StU2B0XpJKMhCOpji9UYIfKA7exaCxbVRYg
+Uw3X4xE8j+fuTpJQPHL5mSwAJvRqNXCjbf5Qh6RrolnGDt79TyzN7p5++fqGlRqN
+69V8G0NnLE14q7SOEuKPWtz96/qoPOVJYtuscSX2d2Zb1Y/rOhcIAJgHnUXsekiC
+k+D1Ol9qGNyyxNBzJLeVCp9bUO9CZuICg5AqDzlEJ+2GIIGBFfZkzykzOQxnVxq6
+n0JE/JDfrhLanyeN9X8fY8pvWLXo1ECPDxRD5PfZ1+GsNFsCcfVAaRW+93TtA9fm
+E8zBsoF1JdUsz/gUSM87mJVnnt63xUHOvSrDvEpTRSjTTzuSmdvkYHyR0/KTTsWQ
+ysnVd1Wj/8R2CbwK8SChf0NdWOM+TkEB7nOYIn6N7y2/UdV4skx7huq37j+v6ZFJ
+Pu1W99XBZlQrkcucdOejQVELvqgm6MO7svMECMShx3sbK5FScLndf/xhP0ucvmyU
+1BEJqjdXgF8=
+=CkL3
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+
+
+@pytest.fixture
+def key_f_fp():
+    return "6539A951EF21D76C0E756A522CD7B219B24BD62B"
+
+
+@pytest.fixture
 def gnupg(gpghome):
     _gnupg = gnupglib.GPG(gnupghome=str(gpghome), verbose=True)
     _gnupg.gnupghome = _homedir_fix(gpghome)
@@ -653,10 +866,131 @@ def test_gpg_present_expired_key_already_present_refresh(
         )
     assert ret.result is not False
     assert (ret.result is None) is testmode
-    assert "the existing one was expired" in ret.comment
+    assert "because it " + ("is" if testmode else "was") + " expired" in ret.comment
     assert ret.changes
-    assert ret.changes[key_e_fp[-16:]]["added"]
-    assert ret.changes[key_e_fp[-16:]]["refresh"]
+    key_changes = ret.changes[key_e_fp[-16:]]
+    assert "added" not in key_changes
+    assert key_changes["refresh"]
+
+
+@pytest.mark.usefixtures("_pubkeys_present")
+@pytest.mark.parametrize("_pubkeys_present", (("f",),), indirect=True)
+@pytest.mark.parametrize(
+    "method",
+    (
+        "source",
+        pytest.param(
+            "text",
+            marks=pytest.mark.skipif(
+                PYGNUPG_VERSION < (0, 5, 1), reason="Text requires python-gnupg >=0.5.1"
+            ),
+        ),
+    ),
+)
+def test_gpg_present_expired_subkey_refresh(
+    method, gpghome, gpg, gnupg, key_f_fp, key_f_pub_notexpired_partial, testmode
+):
+    """
+    Ensure that when a present key has expired subkeys, an update attempt
+    is performed.
+    """
+
+    def _gen_ctx():
+        if method == "source":
+            ctx = pytest.helpers.temp_file(
+                "keys", contents=key_f_pub_notexpired_partial
+            )
+            params = {}
+        else:
+            ctx = contextlib.nullcontext()
+            params = {"text": key_f_pub_notexpired_partial}
+        return ctx, params
+
+    # Subkey management is disabled. No changes.
+    ctx, params = _gen_ctx()
+    with ctx as inst:
+        if method == "source":
+            params = {"source": [str(inst)]}
+        ret = gpg.present(
+            key_f_fp[-16:],
+            gnupghome=str(gpghome),
+            skip_keyserver=True,
+            subkey_maxage=False,
+            **params,
+            test=testmode,
+        )
+    assert ret.result is True
+    assert not ret.changes
+    assert "already in keychain" in ret.comment
+
+    # This should update the signing subkey
+    ctx, params = _gen_ctx()
+    with ctx as inst:
+        if method == "source":
+            params = {"source": [str(inst)]}
+        ret = gpg.present(
+            key_f_fp[-16:],
+            gnupghome=str(gpghome),
+            skip_keyserver=True,
+            subkey_maxage=25550,
+            **params,
+            test=testmode,
+        )
+    assert ret.result is not False
+    assert (ret.result is None) is testmode
+    assert (
+        "because it " + ("has" if testmode else "had") + " expired subkeys"
+    ) in ret.comment
+    assert ret.changes
+    key_changes = ret.changes[key_f_fp[-16:]]
+    assert "added" not in key_changes
+    assert key_changes["refresh"]
+    if testmode:
+        return
+    assert key_changes["subkeys"] == {
+        "added": ["C8439BC56681B29B"],
+        "extended": ["3638BFFF230FCC4F"],
+    }
+
+    # This should attempt to update encryp/auth subkeys.
+    # No changes should be reported because they cannot be updated from the provided source.
+    ctx, params = _gen_ctx()
+    with ctx as inst:
+        if method == "source":
+            params = {"source": [str(inst)]}
+        ret = gpg.present(
+            key_f_fp[-16:],
+            gnupghome=str(gpghome),
+            skip_keyserver=True,
+            subkey_maxage=25550,
+            **params,
+            test=testmode,
+        )
+    assert ret.result is True
+    assert not ret.changes
+    assert (
+        "because it has expired subkeys, but no new signatures or keys were found"
+        in ret.comment
+    )
+
+    # This should report everything is fine since the
+    # expired subkeys are filtered out (expired longer than 1 day).
+    ctx, params = _gen_ctx()
+    with ctx as inst:
+        if method == "source":
+            params = {"source": [str(inst)]}
+        ret = gpg.present(
+            key_f_fp[-16:],
+            gnupghome=str(gpghome),
+            skip_keyserver=True,
+            subkey_maxage=1,
+            **params,
+            test=testmode,
+        )
+    assert ret.result is True
+    assert not ret.changes
+    assert "already in keychain" in ret.comment
+    assert "subkey" not in ret.comment
 
 
 @pytest.mark.usefixtures("_pubkeys_present")
@@ -680,9 +1014,7 @@ def test_gpg_present_expired_key_trust_change(
     assert ret.result is not False
     assert (ret.result is None) is testmode
     assert ret.changes
-    assert ret.changes == {
-        key_e_fp[-16:]: {"added": True, "refresh": True, "trust": "ultimately"}
-    }
+    assert ret.changes == {key_e_fp[-16:]: {"refresh": True, "trust": "ultimately"}}
     key_info = gnupg.list_keys(keys=key_e_fp)
     assert key_info
     assert (key_info[0]["trust"] == "u") is not testmode


### PR DESCRIPTION
### What does this PR do?
Makes `gpg.present` key refresh behavior account for expired subkeys.

Key refreshes were added in 3008 only (via https://github.com/saltstack/salt/pull/66316), which should have included this behavior from the start. For this reason, I'm considering this PR a follow-up fix to a previously unreleased PR and hence did not create a changelog fragment.

### What issues does this PR fix or reference?
Ref: https://github.com/saltstack/salt/issues/66314

### Previous Behavior
Expired subkeys do not lead to key update

### New Behavior
Recently expired subkeys lead to a key refresh attempt

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes