### PR TITLE
Salt-SSH: Fix internal modules being synced as external ones

### DIFF
--- a/changelog/69199.fixed.md
+++ b/changelog/69199.fixed.md
@@ -1,0 +1,1 @@
+Fixed Salt-SSH syncing internal modules as extmods

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1742,6 +1742,10 @@ def mod_data(fsclient):
                 if not os.path.isdir(mod_dir):
                     continue
 
+                # Skip internal salt modules - they should be in the thin/relenv tarball
+                if mod_dir.startswith(str(salt.loader.SALT_BASE_PATH)):
+                    continue
+
                 for fn_ in os.listdir(mod_dir):
                     if fn_.endswith((".py", ".so", ".pyx")) and not fn_.startswith(
                         "__"

--- a/tests/pytests/unit/client/ssh/test_extmods.py
+++ b/tests/pytests/unit/client/ssh/test_extmods.py
@@ -1,0 +1,17 @@
+import re
+
+import salt.client.ssh
+import salt.fileclient
+from tests.support.mock import MagicMock, patch
+
+
+def test_internal_modules_are_not_synced_as_extmods(master_opts):
+    fsclient = salt.fileclient.FSClient(master_opts)
+    tar = MagicMock()
+    with patch("tarfile.open", return_value=tar):
+        salt.client.ssh.mod_data(fsclient)
+    ptrn = re.compile(
+        r".*/salt/(modules|states|grains|renderers|returners|utils)/\w+\.py$"
+    )
+    for call in tar.add.call_args_list:
+        assert not ptrn.match(call[0][0])


### PR DESCRIPTION
### What does this PR do?
Skips internal modules when looking for external ones for syncing.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/69199

### Previous Behavior
All internal modules of the synced module types are included in the ext_mods tarball.

### New Behavior
Only external modules are included.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes