### PR TITLE
Fix lgpo_reg.delete_value skipping registry cleanup when pol entry absent

### DIFF
--- a/changelog/69203.fixed.md
+++ b/changelog/69203.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``lgpo_reg.value_absent`` failing when the Registry.pol entry was already absent but the registry value still existed. ``lgpo_reg.delete_value`` was returning early before reaching the registry cleanup code, causing the state to see no changes and report failure. The registry value is now removed regardless of whether the pol entry was present.

--- a/salt/modules/win_lgpo_reg.py
+++ b/salt/modules/win_lgpo_reg.py
@@ -484,44 +484,54 @@ def disable_value(key, v_name, policy_class="machine"):
 
     found_key, found_name = _find_value(pol_data, key, v_name)
 
+    pol_modified = False
     if found_key:
         if found_name:
             if "**del." in found_name:
                 log.debug("LGPO_REG Mod: Already disabled: %s", v_name)
-                return None
-            log.debug("LGPO_REG Mod: Disabling value name: %s", v_name)
-            pol_data[found_key].pop(found_name)
-            found_name = f"**del.{found_name}"
-            pol_data[found_key][found_name] = {"data": " ", "type": "REG_SZ"}
+            else:
+                log.debug("LGPO_REG Mod: Disabling value name: %s", v_name)
+                pol_data[found_key].pop(found_name)
+                found_name = f"**del.{found_name}"
+                pol_data[found_key][found_name] = {"data": " ", "type": "REG_SZ"}
+                pol_modified = True
         else:
             log.debug("LGPO_REG Mod: Setting new disabled value name: %s", v_name)
             pol_data[found_key][f"**del.{v_name}"] = {
                 "data": " ",
                 "type": "REG_SZ",
             }
+            pol_modified = True
     else:
         log.debug(
             "LGPO_REG Mod: Adding new key and disabled value name: %s", found_name
         )
         pol_data[key] = {f"**del.{v_name}": {"data": " ", "type": "REG_SZ"}}
+        pol_modified = True
 
     success = True
-    if not write_reg_pol(pol_data, policy_class=policy_class):
-        log.error("LGPO_REG Mod: Failed to write registry.pol file")
-        success = False
+    if pol_modified:
+        if not write_reg_pol(pol_data, policy_class=policy_class):
+            log.error("LGPO_REG Mod: Failed to write registry.pol file")
+            success = False
 
     # We only want to modify the actual registry value if this is machine policy
     # The user policy will be applied by the user registry.pol when the user
     # logs in. Setting it here only sets it on the user running the salt minion,
     # most likely SYSTEM, which doesn't make sense here
+    reg_ret = None
     if policy_class == "Machine":
-        ret = salt.utils.win_reg.delete_value(hive=hive, key=key, vname=v_name)
-        if not ret:
-            if ret is None:
+        reg_ret = salt.utils.win_reg.delete_value(hive=hive, key=key, vname=v_name)
+        if not reg_ret:
+            if reg_ret is None:
                 log.debug("LGPO_REG Mod: Registry key/value already missing")
             else:
                 log.error("LGPO_REG Mod: Failed to remove registry entry")
                 success = False
+
+    # Return None only when pol was already disabled and registry was already absent
+    if not pol_modified and reg_ret is None:
+        return None
 
     return success
 

--- a/salt/modules/win_lgpo_reg.py
+++ b/salt/modules/win_lgpo_reg.py
@@ -576,37 +576,43 @@ def delete_value(key, v_name, policy_class="Machine"):
 
     found_key, found_name = _find_value(pol_data, key, v_name)
 
+    pol_modified = False
     if found_key:
         if found_name:
             log.debug("LGPO_REG Mod: Removing value name: %s", found_name)
             pol_data[found_key].pop(found_name)
+            pol_modified = True
+            if len(pol_data[found_key]) == 0:
+                log.debug("LGPO_REG Mod: Removing empty key: %s", found_key)
+                pol_data.pop(found_key)
         else:
             log.debug("LGPO_REG Mod: Value name not found: %s", v_name)
-            return None
-        if len(pol_data[found_key]) == 0:
-            log.debug("LGPO_REG Mod: Removing empty key: %s", found_key)
-            pol_data.pop(found_key)
     else:
         log.debug("LGPO_REG Mod: Key not found: %s", key)
-        return None
 
     success = True
-    if not write_reg_pol(pol_data, policy_class=policy_class):
-        log.error("LGPO_REG Mod: Failed to write registry.pol file")
-        success = False
+    if pol_modified:
+        if not write_reg_pol(pol_data, policy_class=policy_class):
+            log.error("LGPO_REG Mod: Failed to write registry.pol file")
+            success = False
 
     # We only want to modify the actual registry value if this is machine policy
     # The user policy will be applied by the user registry.pol when the user
     # logs in. Setting it here only sets it on the user running the salt minion,
     # most likely SYSTEM, which doesn't make sense here
+    reg_ret = None
     if policy_class == "Machine":
-        ret = salt.utils.win_reg.delete_value(hive=hive, key=key, vname=v_name)
-        if not ret:
-            if ret is None:
+        reg_ret = salt.utils.win_reg.delete_value(hive=hive, key=key, vname=v_name)
+        if not reg_ret:
+            if reg_ret is None:
                 log.debug("LGPO_REG Mod: Registry key/value already missing")
             else:
                 log.error("LGPO_REG Mod: Failed to remove registry entry")
                 success = False
+
+    # Return None only when there was nothing to do in either pol or registry
+    if not pol_modified and reg_ret is None:
+        return None
 
     return success
 

--- a/tests/pytests/functional/modules/win_lgpo/test_lgpo_reg.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_lgpo_reg.py
@@ -1,6 +1,6 @@
 """
-Functional tests for salt.modules.win_lgpo_reg.delete_value covering all four
-combinations of pol/registry state.
+Functional tests for salt.modules.win_lgpo_reg covering delete_value,
+disable_value, and set_value across the relevant pol/registry state combinations.
 """
 
 import pytest
@@ -19,15 +19,37 @@ TEST_KEY = r"SOFTWARE\Salt\Testing\lgpo_reg"
 TEST_NAME = "TestValue"
 TEST_TYPE = "REG_SZ"
 TEST_DATA = "salt_lgpo_reg_test"
+TEST_DATA_ALT = "salt_lgpo_reg_test_updated"
 POLICY_CLASS = "Machine"
 
 
-def _pol_present():
-    return bool(
-        lgpo_reg_mod.get_value(
-            key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
-        )
+# ---------------------------------------------------------------------------
+# State inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _pol_active():
+    """True when pol has an active (non-disabled) entry for the test value."""
+    result = lgpo_reg_mod.get_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
     )
+    return bool(result) and not str(result.get("data", "")).startswith("**del.")
+
+
+def _pol_disabled():
+    """True when pol has a **del. entry for the test value."""
+    result = lgpo_reg_mod.get_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+    return str(result.get("data", "")).startswith("**del.")
+
+
+def _pol_data():
+    """Return the pol data value, or None if absent."""
+    result = lgpo_reg_mod.get_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+    return result.get("data")
 
 
 def _reg_present():
@@ -35,25 +57,43 @@ def _reg_present():
     return result["success"] and result["vdata"] is not None
 
 
-def _set_pol_and_reg():
-    """Write the value to both the pol file and the registry."""
+def _reg_data():
+    result = salt.utils.win_reg.read_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
+    return result.get("vdata")
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_pol_and_reg(data=TEST_DATA):
+    """Write an active value to both pol and registry."""
     lgpo_reg_mod.set_value(
         key=TEST_KEY,
         v_name=TEST_NAME,
-        v_data=TEST_DATA,
+        v_data=data,
         v_type=TEST_TYPE,
         policy_class=POLICY_CLASS,
     )
 
 
-def _set_reg_only():
-    """Write the value directly to the registry, bypassing the pol file."""
+def _set_reg_only(data=TEST_DATA):
+    """Write a value directly to the registry, bypassing pol."""
     salt.utils.win_reg.set_value(
         hive="HKLM",
         key=TEST_KEY,
         vname=TEST_NAME,
-        vdata=TEST_DATA,
+        vdata=data,
         vtype=TEST_TYPE,
+    )
+
+
+def _set_pol_disabled():
+    """Write **del.name to pol and delete the registry value."""
+    _set_pol_and_reg()
+    lgpo_reg_mod.disable_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
     )
 
 
@@ -69,11 +109,16 @@ def clean_policy():
     _cleanup()
 
 
+# ---------------------------------------------------------------------------
+# delete_value
+# ---------------------------------------------------------------------------
+
+
 def test_delete_value_pol_absent_reg_absent():
     """
     Scenario 1: pol absent, reg absent -> nothing to do, returns None.
     """
-    assert not _pol_present()
+    assert not _pol_active()
     assert not _reg_present()
 
     ret = lgpo_reg_mod.delete_value(
@@ -81,7 +126,7 @@ def test_delete_value_pol_absent_reg_absent():
     )
 
     assert ret is None
-    assert not _pol_present()
+    assert not _pol_active()
     assert not _reg_present()
 
 
@@ -91,7 +136,7 @@ def test_delete_value_pol_absent_reg_present():
     deleted even though pol had nothing to remove.
     """
     _set_reg_only()
-    assert not _pol_present()
+    assert not _pol_active()
     assert _reg_present()
 
     ret = lgpo_reg_mod.delete_value(
@@ -99,7 +144,7 @@ def test_delete_value_pol_absent_reg_present():
     )
 
     assert ret is True
-    assert not _pol_present()
+    assert not _pol_active()
     assert not _reg_present()
 
 
@@ -108,7 +153,7 @@ def test_delete_value_pol_present_reg_present():
     Scenario 3: pol present, reg present -> both removed, returns True.
     """
     _set_pol_and_reg()
-    assert _pol_present()
+    assert _pol_active()
     assert _reg_present()
 
     ret = lgpo_reg_mod.delete_value(
@@ -116,7 +161,7 @@ def test_delete_value_pol_present_reg_present():
     )
 
     assert ret is True
-    assert not _pol_present()
+    assert not _pol_active()
     assert not _reg_present()
 
 
@@ -127,7 +172,7 @@ def test_delete_value_pol_present_reg_absent():
     """
     _set_pol_and_reg()
     salt.utils.win_reg.delete_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
-    assert _pol_present()
+    assert _pol_active()
     assert not _reg_present()
 
     ret = lgpo_reg_mod.delete_value(
@@ -135,5 +180,154 @@ def test_delete_value_pol_present_reg_absent():
     )
 
     assert ret is True
-    assert not _pol_present()
+    assert not _pol_active()
     assert not _reg_present()
+
+
+# ---------------------------------------------------------------------------
+# disable_value
+# ---------------------------------------------------------------------------
+
+
+def test_disable_value_already_disabled_reg_absent():
+    """
+    Scenario 1: pol already has **del. entry, reg absent -> nothing to do,
+    returns None.
+    """
+    _set_pol_disabled()
+    assert _pol_disabled()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.disable_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is None
+    assert _pol_disabled()
+    assert not _reg_present()
+
+
+def test_disable_value_already_disabled_reg_present():
+    """
+    Scenario 2 (the bug): pol already has **del. entry, reg present ->
+    registry entry must be deleted even though pol needed no change.
+    """
+    _set_pol_disabled()
+    _set_reg_only()
+    assert _pol_disabled()
+    assert _reg_present()
+
+    ret = lgpo_reg_mod.disable_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert _pol_disabled()
+    assert not _reg_present()
+
+
+def test_disable_value_pol_active_reg_present():
+    """
+    Scenario 3: pol has active entry, reg present -> pol converted to **del.,
+    registry deleted, returns True.
+    """
+    _set_pol_and_reg()
+    assert _pol_active()
+    assert _reg_present()
+
+    ret = lgpo_reg_mod.disable_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert _pol_disabled()
+    assert not _reg_present()
+
+
+def test_disable_value_pol_active_reg_absent():
+    """
+    Scenario 4: pol has active entry, reg absent -> pol converted to **del.,
+    registry was already gone, returns True.
+    """
+    _set_pol_and_reg()
+    salt.utils.win_reg.delete_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
+    assert _pol_active()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.disable_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert _pol_disabled()
+    assert not _reg_present()
+
+
+# ---------------------------------------------------------------------------
+# set_value
+# ---------------------------------------------------------------------------
+
+
+def test_set_value_pol_absent_reg_absent():
+    """
+    New value: creates entry in both pol and registry, returns True.
+    """
+    assert not _pol_active()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.set_value(
+        key=TEST_KEY,
+        v_name=TEST_NAME,
+        v_data=TEST_DATA,
+        v_type=TEST_TYPE,
+        policy_class=POLICY_CLASS,
+    )
+
+    assert ret is True
+    assert _pol_active()
+    assert _reg_data() == TEST_DATA
+
+
+def test_set_value_update_existing():
+    """
+    Update: overwrites an existing pol and registry entry with new data,
+    returns True.
+    """
+    _set_pol_and_reg(data=TEST_DATA)
+    assert _pol_data() == TEST_DATA
+    assert _reg_data() == TEST_DATA
+
+    ret = lgpo_reg_mod.set_value(
+        key=TEST_KEY,
+        v_name=TEST_NAME,
+        v_data=TEST_DATA_ALT,
+        v_type=TEST_TYPE,
+        policy_class=POLICY_CLASS,
+    )
+
+    assert ret is True
+    assert _pol_data() == TEST_DATA_ALT
+    assert _reg_data() == TEST_DATA_ALT
+
+
+def test_set_value_enable_disabled():
+    """
+    Enable: converts a **del. pol entry back to an active entry and sets the
+    registry value, returns True.
+    """
+    _set_pol_disabled()
+    assert _pol_disabled()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.set_value(
+        key=TEST_KEY,
+        v_name=TEST_NAME,
+        v_data=TEST_DATA,
+        v_type=TEST_TYPE,
+        policy_class=POLICY_CLASS,
+    )
+
+    assert ret is True
+    assert _pol_active()
+    assert not _pol_disabled()
+    assert _reg_data() == TEST_DATA

--- a/tests/pytests/functional/modules/win_lgpo/test_lgpo_reg.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_lgpo_reg.py
@@ -1,0 +1,139 @@
+"""
+Functional tests for salt.modules.win_lgpo_reg.delete_value covering all four
+combinations of pol/registry state.
+"""
+
+import pytest
+
+import salt.modules.win_lgpo_reg as lgpo_reg_mod
+import salt.utils.win_reg
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.destructive_test,
+    pytest.mark.slow_test,
+]
+
+TEST_KEY = r"SOFTWARE\Salt\Testing\lgpo_reg"
+TEST_NAME = "TestValue"
+TEST_TYPE = "REG_SZ"
+TEST_DATA = "salt_lgpo_reg_test"
+POLICY_CLASS = "Machine"
+
+
+def _pol_present():
+    return bool(
+        lgpo_reg_mod.get_value(
+            key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+        )
+    )
+
+
+def _reg_present():
+    result = salt.utils.win_reg.read_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
+    return result["success"] and result["vdata"] is not None
+
+
+def _set_pol_and_reg():
+    """Write the value to both the pol file and the registry."""
+    lgpo_reg_mod.set_value(
+        key=TEST_KEY,
+        v_name=TEST_NAME,
+        v_data=TEST_DATA,
+        v_type=TEST_TYPE,
+        policy_class=POLICY_CLASS,
+    )
+
+
+def _set_reg_only():
+    """Write the value directly to the registry, bypassing the pol file."""
+    salt.utils.win_reg.set_value(
+        hive="HKLM",
+        key=TEST_KEY,
+        vname=TEST_NAME,
+        vdata=TEST_DATA,
+        vtype=TEST_TYPE,
+    )
+
+
+def _cleanup():
+    lgpo_reg_mod.delete_value(key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS)
+    salt.utils.win_reg.delete_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
+
+
+@pytest.fixture(autouse=True)
+def clean_policy():
+    _cleanup()
+    yield
+    _cleanup()
+
+
+def test_delete_value_pol_absent_reg_absent():
+    """
+    Scenario 1: pol absent, reg absent -> nothing to do, returns None.
+    """
+    assert not _pol_present()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.delete_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is None
+    assert not _pol_present()
+    assert not _reg_present()
+
+
+def test_delete_value_pol_absent_reg_present():
+    """
+    Scenario 2 (the bug): pol absent, reg present -> registry entry must be
+    deleted even though pol had nothing to remove.
+    """
+    _set_reg_only()
+    assert not _pol_present()
+    assert _reg_present()
+
+    ret = lgpo_reg_mod.delete_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert not _pol_present()
+    assert not _reg_present()
+
+
+def test_delete_value_pol_present_reg_present():
+    """
+    Scenario 3: pol present, reg present -> both removed, returns True.
+    """
+    _set_pol_and_reg()
+    assert _pol_present()
+    assert _reg_present()
+
+    ret = lgpo_reg_mod.delete_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert not _pol_present()
+    assert not _reg_present()
+
+
+def test_delete_value_pol_present_reg_absent():
+    """
+    Scenario 4: pol present, reg absent -> pol entry removed even though
+    registry value is already gone, returns True.
+    """
+    _set_pol_and_reg()
+    salt.utils.win_reg.delete_value(hive="HKLM", key=TEST_KEY, vname=TEST_NAME)
+    assert _pol_present()
+    assert not _reg_present()
+
+    ret = lgpo_reg_mod.delete_value(
+        key=TEST_KEY, v_name=TEST_NAME, policy_class=POLICY_CLASS
+    )
+
+    assert ret is True
+    assert not _pol_present()
+    assert not _reg_present()


### PR DESCRIPTION
### What does this PR do?
When the Registry.pol entry was already absent but the registry value still existed, delete_value returned None early before reaching the registry cleanup code. This caused the value_absent state to report failure because it saw no changes after calling delete_value. Remove the early returns and track pol changes with a pol_modified flag so the registry deletion always runs for Machine policy regardless of pol state. Return None only when both pol and registry had nothing to remove.
Add functional tests covering all four pol/registry state combinations.

### What issues does this PR fix or reference?
Fixes #69203

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
