### PR TITLE
Fix !!binary YAML tag failing with "Incorrect padding" on Python 3.14

### DIFF
--- a/changelog/69207.fixed.md
+++ b/changelog/69207.fixed.md
@@ -1,0 +1,1 @@
+Fixed `!!binary` YAML tag failing with "Incorrect padding" when base64 padding characters are omitted. Salt's YAML loader now tolerates unpadded base64 values, restoring behavior that worked on Salt 3006 (Python 3.10).

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -2,6 +2,9 @@
 Custom YAML loading in Salt
 """
 
+import base64
+import binascii
+
 import yaml  # pylint: disable=blacklisted-import
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode, SequenceNode
@@ -36,6 +39,9 @@ class SaltYamlSafeLoader(BaseLoader):
             "tag:yaml.org,2002:python/unicode", type(self).construct_unicode
         )
         self.add_constructor("tag:yaml.org,2002:timestamp", type(self).construct_scalar)
+        self.add_constructor(
+            "tag:yaml.org,2002:binary", type(self).construct_yaml_binary
+        )
         self.dictclass = dictclass
 
     def construct_yaml_map(self, node):
@@ -104,6 +110,30 @@ class SaltYamlSafeLoader(BaseLoader):
     def construct_yaml_str(self, node):
         value = self.construct_scalar(node)
         return salt.utils.stringutils.to_unicode(value)
+
+    def construct_yaml_binary(self, node):
+        try:
+            value = self.construct_scalar(node).encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ConstructorError(
+                None,
+                None,
+                f"failed to convert base64 data into ascii: {exc}",
+                node.start_mark,
+            )
+        try:
+            # Add padding if needed to tolerate unpadded base64 (e.g. !!binary a1b2c3)
+            missing = len(value) % 4
+            if missing:
+                value += b"=" * (4 - missing)
+            return base64.decodebytes(value)
+        except binascii.Error as exc:
+            raise ConstructorError(
+                None,
+                None,
+                f"failed to decode base64 data: {exc}",
+                node.start_mark,
+            )
 
     def flatten_mapping(self, node):
         merge = []

--- a/salt/utils/yamlloader_old.py
+++ b/salt/utils/yamlloader_old.py
@@ -2,6 +2,8 @@
 Custom YAML loading in Salt
 """
 
+import base64
+import binascii
 import re
 
 import yaml  # pylint: disable=blacklisted-import
@@ -41,6 +43,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
             "tag:yaml.org,2002:python/unicode", type(self).construct_unicode
         )
         self.add_constructor("tag:yaml.org,2002:timestamp", type(self).construct_scalar)
+        self.add_constructor(
+            "tag:yaml.org,2002:binary", type(self).construct_yaml_binary
+        )
         self.dictclass = dictclass
 
     def construct_yaml_map(self, node):
@@ -114,6 +119,30 @@ class SaltYamlSafeLoader(yaml.SafeLoader):
     def construct_yaml_str(self, node):
         value = self.construct_scalar(node)
         return salt.utils.stringutils.to_unicode(value)
+
+    def construct_yaml_binary(self, node):
+        try:
+            value = self.construct_scalar(node).encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ConstructorError(
+                None,
+                None,
+                f"failed to convert base64 data into ascii: {exc}",
+                node.start_mark,
+            )
+        try:
+            # Add padding if needed to tolerate unpadded base64 (e.g. !!binary a1b2c3)
+            missing = len(value) % 4
+            if missing:
+                value += b"=" * (4 - missing)
+            return base64.decodebytes(value)
+        except binascii.Error as exc:
+            raise ConstructorError(
+                None,
+                None,
+                f"failed to decode base64 data: {exc}",
+                node.start_mark,
+            )
 
     def fetch_plain(self):
         """

--- a/tests/unit/utils/test_yamlloader.py
+++ b/tests/unit/utils/test_yamlloader.py
@@ -135,6 +135,35 @@ class YamlLoaderTestCase(TestCase):
             {"foo": {"b": {"foo": "bar", "one": 1, "list": [1, "two", 3]}}},
         )
 
+    def test_yaml_binary_unpadded(self):
+        """
+        Test that !!binary values without base64 padding are accepted.
+        Regression test for https://github.com/saltstack/salt/issues/69207
+        """
+        # 'a1b2c3' is 6 chars; valid only after adding '==' padding
+        result = self.render_yaml("vdata: !!binary a1b2c3")
+        self.assertEqual(result, {"vdata": b"\x6b\x56\xf6\x73"})
+
+    def test_yaml_binary_padded(self):
+        """
+        Test that !!binary values with correct base64 padding still work.
+        """
+        result = self.render_yaml("vdata: !!binary a1b2c3==")
+        self.assertEqual(result, {"vdata": b"\x6b\x56\xf6\x73"})
+
+    def test_yaml_binary_invalid(self):
+        """
+        Test that invalid data in a !!binary value still raises ConstructorError.
+
+        Non-ASCII characters are used here because they reliably trigger the
+        UnicodeEncodeError path across all Python versions. Testing via the
+        binascii.Error path is not reliable: Python 3.10 silently discards
+        unrecognized ASCII characters in base64 data, while Python 3.14 is
+        stricter. The padding fix itself is covered by test_yaml_binary_unpadded.
+        """
+        with self.assertRaises(ConstructorError):
+            self.render_yaml("vdata: !!binary \xc3\xb1")
+
     def test_not_yaml_monkey_patching(self):
         if hasattr(yaml, "CSafeLoader"):
             assert yaml.SafeLoader != yaml.CSafeLoader


### PR DESCRIPTION
### What does this PR do?
Python 3.14 (bundled with Salt 3008 onedir) is stricter about base64 padding than Python 3.10 (Salt 3006). The !!binary YAML tag calls base64.decodebytes() which requires values to be padded to a multiple of 4 characters. Values like `!!binary a1b2c3` (missing `==`) now raise "Incorrect padding" during SLS rendering.
Override construct_yaml_binary in SaltYamlSafeLoader to add missing `=` padding before decoding, restoring the lenient behavior users relied on in Salt 3006.

### What issues does this PR fix or reference?
Fixes #69207

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
