### PR TITLE
Fix #68998: drain cancelled tasks on TCP PublishClient close

### DIFF
--- a/changelog/68998.fixed.md
+++ b/changelog/68998.fixed.md
@@ -1,0 +1,1 @@
+Drain cancelled tasks on PublishClient close so the TCP transport no longer prints `[ERROR ] Task was destroyed but it is pending!` at the end of every salt command.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -135,6 +135,38 @@ def _set_tcp_keepalive(sock, opts):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 0)
 
 
+def _drain_cancelled_tasks(loop, tasks):
+    """
+    Run the event loop just enough to let ``task.cancel()`` actually deliver
+    ``CancelledError`` to each coroutine, so the tasks transition out of the
+    ``cancelling`` state. Without this, sync teardown paths leak the task and
+    asyncio prints ``Task was destroyed but it is pending!`` on stderr.
+    Issue #68998.
+    """
+    tasks = [t for t in tasks if t is not None and not t.done()]
+    if not tasks:
+        return
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+    if running is loop or loop.is_running() or loop.is_closed():
+        # Can't synchronously drive the loop from here. Mark the tasks so
+        # asyncio's Task.__del__ doesn't log when they're GC'd; the running
+        # loop will deliver the cancellation on its next iteration.
+        for task in tasks:
+            task._log_destroy_pending = False
+        return
+    try:
+        loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+    except RuntimeError:
+        # Loop refused to run (e.g., started shutting down on another
+        # thread). Fall back to suppressing the GC warning.
+        for task in tasks:
+            if not task.done():
+                task._log_destroy_pending = False
+
+
 class LoadBalancerServer(salt.utils.process.SignalHandlingProcess):
     """
     Raw TCP server which runs in its own process and will listen
@@ -281,26 +313,32 @@ class PublishClient(salt.transport.base.PublishClient):
         if self._closing:
             return
         self._closing = True
-        if self.on_recv_task:
-            # Suppress "Task was destroyed but it is pending!" if the
-            # caller's event loop is torn down before the cancellation
-            # completes (sync close cannot await the cancel).
-            self.on_recv_task._log_destroy_pending = False
+
+        # Collect tasks we need to wind down so we can drain them after the
+        # stream is closed. Without draining, ``salt`` CLI shutdown left
+        # them in the "cancelling" state and asyncio surfaced
+        # ``Task was destroyed but it is pending!`` on stderr (#68998).
+        pending = []
+        if self.on_recv_task is not None:
             self.on_recv_task.cancel()
+            pending.append(self.on_recv_task)
             self.on_recv_task = None
-        # Close the stream first so an in-flight ``read_bytes`` raises
-        # ``StreamClosedError`` and ``_read_into_unpacker`` returns False
-        # naturally, instead of leaving the read task in a "cancelling"
-        # state that surfaces ``Task was destroyed but it is pending!`` on
-        # stderr -- breaks tests that assert ``not cmd.stderr``.
+
+        # Close the stream so an in-flight ``read_bytes`` resolves with
+        # ``StreamClosedError`` and ``_read_into_unpacker`` can exit on its
+        # own instead of being abandoned mid-cancel.
         stream = self._stream
         self._stream = None
         if stream is not None:
             stream.close()
+
         if self._read_task is not None and not self._read_task.done():
-            self._read_task._log_destroy_pending = False
             self._read_task.cancel()
+            pending.append(self._read_task)
         self._read_task = None
+
+        _drain_cancelled_tasks(self.io_loop, pending)
+
         # Close TCP client to release file descriptors
         if hasattr(self, "_tcp_client") and self._tcp_client is not None:
             try:
@@ -575,12 +613,9 @@ class PublishClient(salt.transport.base.PublishClient):
         Register a callback for received messages (that we didn't initiate)
         """
         if self.on_recv_task:
-            # XXX: We are not awaiting this canceled task. This still needs to
-            # be addressed. Suppress the "Task was destroyed but it is pending!"
-            # warning that surfaces if the loop tears down before the cancel
-            # completes (e.g. salt CLI shutdown).
-            self.on_recv_task._log_destroy_pending = False
-            self.on_recv_task.cancel()
+            old_task = self.on_recv_task
+            old_task.cancel()
+            _drain_cancelled_tasks(self.io_loop, [old_task])
         if callback is None:
             self.on_recv_task = None
         else:

--- a/tests/pytests/unit/transport/test_publish_client.py
+++ b/tests/pytests/unit/transport/test_publish_client.py
@@ -337,3 +337,71 @@ async def test_recv_timeout_zero():
             await client._read_task
         except (asyncio.CancelledError, Exception):  # pylint: disable=broad-except
             pass
+
+
+def test_close_does_not_leak_pending_read_task(caplog):
+    """
+    Regression test for #68998.
+
+    ``salt 'minion' cmd.run ...`` was printing
+    ``[ERROR   ] Task was destroyed but it is pending!`` after every
+    command. The leak was the in-flight ``_read_into_unpacker`` task on
+    ``PublishClient``: the CLI tears down its event loop on the *sync*
+    side, so ``close()`` is called from a thread where the loop is not
+    running. Just calling ``task.cancel()`` then closing the loop leaves
+    the task in the ``cancelling`` state -- the GC then logs the warning
+    when the task is destroyed.
+
+    The fix drains the cancelled tasks before returning from ``close()``
+    when the loop is available and idle.
+    """
+    host = "127.0.0.1"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, 0))
+        sock.listen(5)
+        port = sock.getsockname()[1]
+
+        loop = asyncio.new_event_loop()
+
+        async def setup():
+            client = salt.transport.tcp.PublishClient(
+                {"master_ip": host}, loop, host=host, port=port
+            )
+            await client.connect(timeout=5)
+            client._ensure_read_task()
+            # Let the coroutine actually reach the read_bytes await.
+            await asyncio.sleep(0.05)
+            assert client._read_task is not None
+            assert not client._read_task.done()
+            return client
+
+        try:
+            client = loop.run_until_complete(setup())
+            read_task = client._read_task
+            # Close from outside the running loop, exactly like the CLI
+            # shutdown path.
+            with caplog.at_level(logging.ERROR, logger="asyncio"):
+                client.close()
+                # The cancelled read task must be done by the time close()
+                # returns -- otherwise GC will log the warning.
+                assert read_task.done(), (
+                    "PublishClient.close() left _read_into_unpacker task in"
+                    f" state {read_task._state}; will leak as 'Task was"
+                    " destroyed but it is pending!'"
+                )
+        finally:
+            loop.close()
+
+        # Belt-and-braces: nothing in the asyncio logger about a leak.
+        leak_lines = [
+            r.getMessage()
+            for r in caplog.records
+            if "Task was destroyed but it is pending" in r.getMessage()
+        ]
+        assert (
+            not leak_lines
+        ), "PublishClient.close() leaked pending tasks: " + "\n".join(leak_lines)
+    finally:
+        sock.close()


### PR DESCRIPTION
salt CLI was printing "[ERROR   ] Task was destroyed but it is pending!"
after every command because PublishClient.close() cancelled the in-flight
_read_into_unpacker task but never awaited it. Since close() runs from
sync teardown after the loop has stopped, the task got GC'd in the
"cancelling" state and asyncio logged the warning. The previous fix
muted it via task._log_destroy_pending = False without addressing the
underlying leak.

Add a _drain_cancelled_tasks helper that runs the idle loop just long enough to deliver CancelledError to each coroutine, falling back to the suppression flag only when no synchronous drain is possible (loop is running on another thread, already closed, or close() is itself called from inside the loop). Use it from PublishClient.close() and from on_recv() when swapping callbacks.

Also pin tests/pytests/unit/transport/test_zeromq.py::test_client_timeout_msg to a random unused localhost port so it does not silently connect to a real salt-master listening on 4506 and skip the timeout path.


Fixes: #68998 
