### PR TITLE
docs: fix compatibility spelling in docs

### DIFF
--- a/doc/topics/transports/ssl.rst
+++ b/doc/topics/transports/ssl.rst
@@ -11,7 +11,7 @@ wrapped in a TLS connection. Enabling this is simple, the master and minion need
 to be using the tcp connection, then the ``ssl``  option is enabled. The ``ssl``
 option is passed as a dict and roughly corresponds to the options passed to the
 Python `ssl.wrap_socket <https://docs.python.org/3/library/ssl.html#ssl.wrap_socket>`_
-function for backwards compatability.
+function for backwards compatibility.
 
 .. versionadded:: 3007.0
 


### PR DESCRIPTION
Changes:
- `compatability` -> `compatibility` in `doc/topics/transports/ssl.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
