### PR TITLE
fix(resources): make merge-fun state.* work for bare-id targets

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -4907,21 +4907,24 @@ class Minion(MinionBase):
 
         resource_targets = self._resolve_resource_targets(load)
         load["resource_targets"] = resource_targets
-        # For pure resource targets (e.g. ``T@dummy:dummy-01``) the managing
-        # minion would normally NOT count as a target — the operator is
-        # addressing resources, not the minion.  But merge-mode functions
-        # (state.apply, state.highstate, …) run resources INLINE inside the
-        # managing minion's own job and produce ONE combined response.  The
-        # managing minion therefore has to execute the function (its
-        # ``_thread_return`` is what folds resource results into the parent
-        # state dict); skipping it here would silently drop the entire job.
+        # For pure resource targets (e.g. ``T@dummy:dummy-01`` or a bare
+        # resource id glob like ``salt 'dummy-01' state.single``) the
+        # managing minion would normally NOT count as a target — the
+        # operator is addressing resources, not the minion.  But
+        # merge-mode functions (state.apply, state.highstate, …) run
+        # resources INLINE inside the managing minion and emit one
+        # return per resource. The managing minion therefore has to
+        # execute the publish whenever ``is_merge_fun`` and
+        # ``resource_targets`` are set — even when its own id didn't
+        # match ``tgt`` — otherwise nothing runs and the job silently
+        # produces no return.
         fun = load.get("fun")
         is_merge_fun = isinstance(fun, str) and fun in self._MERGE_RESOURCE_FUNS
         is_pure_resource = self._is_pure_resource_target(load)
         load["pure_resource_target"] = is_pure_resource
-        load["minion_is_target"] = bool(minion_matches) and (
-            is_merge_fun or not is_pure_resource
-        )
+        load["minion_is_target"] = (
+            bool(minion_matches) and (is_merge_fun or not is_pure_resource)
+        ) or (is_merge_fun and bool(resource_targets))
 
         if not load["minion_is_target"] and not resource_targets:
             return False
@@ -4929,18 +4932,37 @@ class Minion(MinionBase):
 
     def _is_pure_resource_target(self, load):
         """
-        Return True when the target expression contains only T@/M@ engines with
-        no glob/grain/pillar/list terms that would match the minion itself.
+        Return True when the target expression addresses only Salt
+        Resources — not the managing minion itself.
+
+        Two shapes count as pure-resource:
+
+        * Compound expressions whose every term is a ``T@`` or ``M@``
+          engine (with the usual boolean operators).
+        * Bare-id glob targets (no wildcards) whose ``tgt`` matches a
+          managed resource id. ``salt 'dummy-01' state.single …``
+          looks like an ordinary glob to the master but is logically a
+          pure-resource target from the managing minion's point of
+          view — the bare id is the resource, not the minion.
         """
         tgt = load.get("tgt", "")
         tgt_type = load.get("tgt_type", "glob")
-        if tgt_type != "compound":
-            return False
-        words = tgt.split() if isinstance(tgt, str) else list(tgt)
-        opers = {"and", "or", "not", "(", ")"}
-        return all(
-            w in opers or w.startswith("T@") or w.startswith("M@") for w in words
-        )
+        if tgt_type == "compound":
+            words = tgt.split() if isinstance(tgt, str) else list(tgt)
+            opers = {"and", "or", "not", "(", ")"}
+            return all(
+                w in opers or w.startswith("T@") or w.startswith("M@") for w in words
+            )
+        if (
+            tgt_type == "glob"
+            and isinstance(tgt, str)
+            and not any(c in tgt for c in ("*", "?", "["))
+        ):
+            resources = self.opts.get("resources", {})
+            for rids in resources.values():
+                if tgt in rids:
+                    return True
+        return False
 
     # Functions that are internal Salt plumbing and should never be dispatched
     # to managed resources.  Resources don't participate in job-status queries,

--- a/tests/pytests/integration/resources/test_dummy_resource.py
+++ b/tests/pytests/integration/resources/test_dummy_resource.py
@@ -585,3 +585,68 @@ def test_state_single_against_bare_type_returns_per_resource(salt_minion, salt_c
         assert isinstance(body, dict), f"{rid!r} body not dict: {body!r}"
         chunk_keys = [k for k in body if k.endswith("_|-nop")]
         assert chunk_keys, f"No test.nop chunk under {rid!r}: {body!r}"
+
+
+def test_state_single_against_bare_resource_id_keyed_by_resource_id(
+    salt_minion, salt_cli
+):
+    """
+    Regression: ``salt 'dummy-01' state.single test.nop ...`` (bare
+    resource id, ``tgt_type=glob``, no wildcards) must return under
+    the resource id — same shape as ``salt 'dummy-01' test.ping``.
+
+    The minion-side bug: for a bare-id glob target, ``minion_matches``
+    is False (the target string isn't the managing minion's id) so
+    ``minion_is_target`` would normally be False; meanwhile
+    ``_is_pure_resource_target`` only recognised compound ``T@`` /
+    ``M@`` expressions as pure-resource, so the merge-fold + per-resource
+    fan-out logic both got skipped. A bare-id glob with a merge-mode
+    state function ran nothing on the managing minion and produced no
+    return — only the master's "did not return" timeout.
+
+    The fix is two-sided in ``salt/minion.py``:
+
+    * ``_is_pure_resource_target`` recognises an exact (no-wildcard)
+      glob whose ``tgt`` names a managed resource as a pure-resource
+      target.
+    * ``_target_load`` treats the managing minion as a target whenever
+      ``is_merge_fun and resource_targets``, regardless of whether the
+      glob also matched the minion's own id — the managing minion has
+      to run the inline merge for the resource.
+
+    Non-merge funs (``test.ping``) already worked through the
+    per-resource fan-out path; this test asserts merge funs now work
+    too with the same shape.
+    """
+    target_id = DUMMY_RESOURCES[0]
+    ret = salt_cli.run(
+        "state.single",
+        "test.nop",
+        "name=bare-id-keyed-state-return",
+        minion_tgt=target_id,
+    )
+    assert ret.returncode == 0, ret
+
+    data = _salt_cli_json_dict(ret)
+    # Salt-factories unwraps single-key envelopes when ``minion_tgt``
+    # is the only response key; accept both shapes.
+    if isinstance(data, dict) and target_id in data:
+        body = data[target_id]
+        # Managing minion must not appear at the top level.
+        assert salt_minion.id not in data, (
+            f"Managing minion {salt_minion.id!r} appears as response key; "
+            f"bare-id merge-fun state returns must be keyed by resource id."
+        )
+    else:
+        # Unwrapped envelope: body IS the resource's payload.
+        body = data
+    assert isinstance(body, dict), f"Resource body must be dict, got: {body!r}"
+
+    chunk_keys = [k for k in body if k.endswith("_|-nop")]
+    assert chunk_keys, f"No test.nop chunk in resource body: {body!r}"
+    # No phantom "did not return" entries.
+    if isinstance(data, dict):
+        for key, value in data.items():
+            assert not (
+                isinstance(value, str) and "did not return" in value.lower()
+            ), f"Phantom 'did not return' under {key!r}: {value!r}"


### PR DESCRIPTION
Bug: ``salt 'dummy-01' state.single test.nop name=...`` (bare resource id as a glob target with no wildcards, against a merge-mode state function) ran nothing on the managing minion and produced no return — only the master's "did not return" timeout.

Trace (managing minion side):

* ``_resolve_resource_targets`` correctly identifies the bare id as one of its managed resources and sets ``resource_targets=[{id, type}]``.
* ``_is_pure_resource_target`` only recognised compound ``T@``/``M@`` expressions, so it returned False for the glob target.
* ``_target_load`` computed ``minion_is_target = bool(False) and (is_merge_fun or not is_pure_resource) = False`` because the bare id is not the minion's own name.
* In ``_handle_payload``: ``minion_is_target=False`` skipped the inline merge dispatch; ``is_merge_fun=True`` skipped the per-resource fan-out. Nothing ran.

Non-merge funs (``test.ping``) already worked because the per-resource fan-out branch handled them. Compound targets (``T@dummy:dummy-01``) worked because ``_is_pure_resource_target`` recognised them and the merge-fun override let the minion run inline. Only bare-id + merge-fun hit the gap.

Fix (two-sided in ``salt/minion.py``):

* ``_is_pure_resource_target`` now also returns True for a glob target with no wildcards whose ``tgt`` names a managed resource id. The bare id is logically a pure-resource target from the managing minion's point of view.
* ``_target_load`` now sets ``minion_is_target = True`` whenever ``is_merge_fun and resource_targets`` — regardless of whether the publish target also matched the minion's own id. The managing minion has to run the inline merge to produce per-resource returns; skipping it because the bare id isn't the minion's name silently drops the job.

Regression test in tests/pytests/integration/resources/test_dummy_resource.py:
  test_state_single_against_bare_resource_id_keyed_by_resource_id

Full smoke list: 324 passed.
