### PR TITLE
pkg.list_patches in yumpkg.py  parses tdnf output on Photon OS

### DIFF
--- a/changelog/69229.fixed.md
+++ b/changelog/69229.fixed.md
@@ -1,0 +1,1 @@
+pkg.list_patches in yumpkg.py parses tdnf output on Photon OS

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3466,7 +3466,7 @@ def _get_patches(installed_only=False):
     for line in salt.utils.itertools.split(ret, os.linesep):
         try:
             inst, advisory_id, sev, pkg = re.match(
-                r"([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)", line
+                r"([i|\s])? ?([^\s]+) +([^\s]+) +([^\s]+)", line
             ).groups()
         except Exception:  # pylint: disable=broad-except
             parsing_errors = True

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -544,6 +544,69 @@ def test_list_patches():
             assert _patch in patches["my-fake-patch-installed-1234"]["summary"]
 
 
+def test_list_patches_photon():
+    """
+    Test patches listing for Photon OS.
+
+    ``tdnf updateinfo list all`` emits lines with no leading installed
+    marker, e.g.::
+
+        patch:PHSA-2026-5.0-0802 Security sqlite-libs-3.43.2-6.ph5.x86_64.rpm
+
+    The parser prepends two spaces so the advisory ID lands at position 2,
+    giving inst=' ' (not installed) and advisory_id='patch:PHSA-...'.
+    """
+    tdnf_out = [
+        "patch:PHSA-2026-5.0-0802 Security sqlite-libs-3.43.2-6.ph5.x86_64.rpm",
+        "patch:PHSA-2026-5.0-0801 Security nss-libs-3.78-12.ph5.x86_64.rpm",
+        "patch:PHSA-2026-5.0-0843 Security expat-libs-2.8.0-1.ph5.x86_64.rpm",
+        "patch:PHSA-2026-5.0-0802 Security sqlite-devel-3.43.2-6.ph5.x86_64.rpm",
+    ]
+
+    expected_patches = {
+        "patch:PHSA-2026-5.0-0802": {
+            "installed": False,
+            "summary": [
+                "sqlite-libs-3.43.2-6.ph5.x86_64.rpm",
+                "sqlite-devel-3.43.2-6.ph5.x86_64.rpm",
+            ],
+        },
+        "patch:PHSA-2026-5.0-0801": {
+            "installed": False,
+            "summary": ["nss-libs-3.78-12.ph5.x86_64.rpm"],
+        },
+        "patch:PHSA-2026-5.0-0843": {
+            "installed": False,
+            "summary": ["expat-libs-2.8.0-1.ph5.x86_64.rpm"],
+        },
+    }
+
+    with patch.dict(yumpkg.__grains__, {"osarch": "x86_64"}), patch.dict(
+        yumpkg.__salt__,
+        {"cmd.run_stdout": MagicMock(return_value=os.linesep.join(tdnf_out))},
+    ):
+        patches = yumpkg.list_patches()
+
+        assert len(patches) == 3
+
+        assert patches["patch:PHSA-2026-5.0-0802"]["installed"] is False
+        assert len(patches["patch:PHSA-2026-5.0-0802"]["summary"]) == 2
+        for pkg in expected_patches["patch:PHSA-2026-5.0-0802"]["summary"]:
+            assert pkg in patches["patch:PHSA-2026-5.0-0802"]["summary"]
+
+        assert patches["patch:PHSA-2026-5.0-0801"]["installed"] is False
+        assert (
+            patches["patch:PHSA-2026-5.0-0801"]["summary"]
+            == expected_patches["patch:PHSA-2026-5.0-0801"]["summary"]
+        )
+
+        assert patches["patch:PHSA-2026-5.0-0843"]["installed"] is False
+        assert (
+            patches["patch:PHSA-2026-5.0-0843"]["summary"]
+            == expected_patches["patch:PHSA-2026-5.0-0843"]["summary"]
+        )
+
+
 def test_list_patches_refresh():
     expected = ["spongebob"]
     mock_get_patches = MagicMock(return_value=expected)


### PR DESCRIPTION
### What does this PR do?
Updates `yumpkg.py` to properly handle the output of `tdnf updateinfo list all` on Photon OS. It accommodates the lack of leading spaces or status characters (like `i `) in `tdnf` output so that patches can be successfully parsed.

### What issues does this PR fix or reference?
Fixes [#69229](https://github.com/saltstack/salt/issues/69229)

### Previous Behavior
Running `salt * pkg.list_patches` on a Photon OS minion returned empty or failed to list available patches because the regex parser ignored lines starting flush with `patch:`.

### New Behavior
The `yumpkg.py` module now correctly identifies and returns available patches on Photon OS, while maintaining full parsing compatibility with RHEL/Rocky/Alma `dnf` and `yum` outputs.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
