### PR TITLE
Add IP/network conversion and subnetting jinja filters

### DIFF
--- a/changelog/69231.added.md
+++ b/changelog/69231.added.md
@@ -1,0 +1,4 @@
+Added the ``ip_to_int``, ``int_to_ipv4``, ``int_to_ipv6``, ``nth_host``,
+``network_subnets``, ``cidr_merge``, and ``slaac`` Jinja filters to
+``salt.utils.network`` for converting between IP addresses and integers and
+for common IPv4/IPv6 network calculations.

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1986,6 +1986,165 @@ Returns:
   ["192.0.2.1", "foo", "bar", "[fe80::]", "[2001:db8::1]/64"]
 
 
+.. jinja_ref:: ip_to_int
+
+``ip_to_int``
+-------------
+
+.. versionadded:: 3009.0
+
+Returns the integer representation of an IPv4 or IPv6 address.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ '10.0.1.2' | ip_to_int }}
+
+Returns:
+
+.. code-block:: python
+
+  167772418
+
+
+.. jinja_ref:: int_to_ipv4
+
+``int_to_ipv4``
+---------------
+
+.. versionadded:: 3009.0
+
+Returns the IPv4 address corresponding to an integer.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ 167772418 | int_to_ipv4 }}
+
+Returns:
+
+.. code-block:: python
+
+  "10.0.1.2"
+
+
+.. jinja_ref:: int_to_ipv6
+
+``int_to_ipv6``
+---------------
+
+.. versionadded:: 3009.0
+
+Returns the IPv6 address corresponding to an integer.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ 42540766411282592856903984951653826561 | int_to_ipv6 }}
+
+Returns:
+
+.. code-block:: python
+
+  "2001:db8::1"
+
+
+.. jinja_ref:: nth_host
+
+``nth_host``
+------------
+
+.. versionadded:: 3009.0
+
+Returns the Nth address within a network. The network address is index ``0``
+and the broadcast address is index ``-1``.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ '10.0.0.0/24' | nth_host(5) }}
+
+Returns:
+
+.. code-block:: python
+
+  "10.0.0.5"
+
+
+.. jinja_ref:: network_subnets
+
+``network_subnets``
+-------------------
+
+.. versionadded:: 3009.0
+
+Splits a network into subnets of the given prefix length. With only a prefix
+length, returns the number of subnets; with an index, returns that subnet.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ '192.168.0.0/16' | network_subnets(24, 1) }}
+
+Returns:
+
+.. code-block:: python
+
+  "192.168.1.0/24"
+
+
+.. jinja_ref:: cidr_merge
+
+``cidr_merge``
+--------------
+
+.. versionadded:: 3009.0
+
+Merges a list of IP addresses and networks. ``action="merge"`` (the default)
+returns the minimal list of covering networks; ``action="span"`` returns the
+single smallest network that contains all of the inputs.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ ['192.168.0.0/24', '192.168.1.0/24'] | cidr_merge }}
+
+Returns:
+
+.. code-block:: python
+
+  ["192.168.0.0/23"]
+
+
+.. jinja_ref:: slaac
+
+``slaac``
+---------
+
+.. versionadded:: 3009.0
+
+Returns the IPv6 SLAAC address for a MAC address within a network, using
+modified EUI-64 for the interface identifier.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ '2001:db8::/64' | slaac('00:50:56:01:02:03') }}
+
+Returns:
+
+.. code-block:: python
+
+  "2001:db8::250:56ff:fe01:203"
+
+
 .. jinja_ref:: network_hosts
 
 ``network_hosts``

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2367,3 +2367,127 @@ def ip_bracket(addr, strip=False):
     addr = addr.rstrip("]")
     addr = ipaddress.ip_address(addr)
     return ("[{}]" if addr.version == 6 and not strip else "{}").format(addr)
+
+
+@jinja_filter("ip_to_int")
+def ip_to_int(addr):
+    """
+    Returns the integer representation of an IPv4 or IPv6 address.
+
+    .. versionadded:: 3009.0
+    """
+    return int(ipaddress.ip_address(str(addr)))
+
+
+@jinja_filter("int_to_ipv4")
+def int_to_ipv4(value):
+    """
+    Returns the IPv4 address corresponding to an integer.
+
+    .. versionadded:: 3009.0
+    """
+    return str(ipaddress.IPv4Address(int(value)))
+
+
+@jinja_filter("int_to_ipv6")
+def int_to_ipv6(value):
+    """
+    Returns the IPv6 address corresponding to an integer.
+
+    .. versionadded:: 3009.0
+    """
+    return str(ipaddress.IPv6Address(int(value)))
+
+
+@jinja_filter("nth_host")
+def nth_host(value, nth):
+    """
+    Returns the Nth address within a network.
+
+    The network address is index ``0`` and the broadcast address is index
+    ``-1``; negative indexes count back from the end. Works for IPv4 and IPv6.
+
+    .. versionadded:: 3009.0
+    """
+    return str(ipaddress.ip_network(str(value), strict=False)[int(nth)])
+
+
+@jinja_filter("network_subnets")
+def network_subnets(value, prefix, index=None):
+    """
+    Splits a network into subnets of the given prefix length.
+
+    When ``index`` is omitted, returns the number of subnets of ``prefix``
+    length that fit within ``value``. When ``index`` is given, returns the
+    subnet at that index as a CIDR string. Works for IPv4 and IPv6.
+
+    .. versionadded:: 3009.0
+    """
+    network = ipaddress.ip_network(str(value), strict=False)
+    new_prefix = int(prefix)
+    if not network.prefixlen <= new_prefix <= network.max_prefixlen:
+        raise ValueError(f"prefix {new_prefix} is out of range for network {network}")
+    count = 2 ** (new_prefix - network.prefixlen)
+    if index is None:
+        return count
+    index = int(index)
+    if index < 0:
+        index += count
+    if not 0 <= index < count:
+        raise IndexError(
+            f"subnet index out of range for /{new_prefix} within {network}"
+        )
+    step = 2 ** (network.max_prefixlen - new_prefix)
+    subnet_address = int(network.network_address) + index * step
+    return str(type(network)((subnet_address, new_prefix)))
+
+
+@jinja_filter("cidr_merge")
+def cidr_merge(value, action="merge"):
+    """
+    Merges a list of IP addresses and networks.
+
+    With ``action="merge"`` (the default), returns the minimal list of CIDR
+    networks that covers the inputs. With ``action="span"``, returns the
+    single smallest network that contains all of the inputs. All inputs must
+    be the same IP version.
+
+    .. versionadded:: 3009.0
+    """
+    networks = [ipaddress.ip_network(str(item), strict=False) for item in value]
+    if not networks:
+        raise ValueError("cidr_merge requires at least one address or network")
+    if action == "merge":
+        return [str(network) for network in ipaddress.collapse_addresses(networks)]
+    if action == "span":
+        first = min(network.network_address for network in networks)
+        last = max(network.broadcast_address for network in networks)
+        prefix = first.max_prefixlen
+        while prefix >= 0:
+            candidate = ipaddress.ip_network(f"{first}/{prefix}", strict=False)
+            if last in candidate:
+                return str(candidate)
+            prefix -= 1
+    raise ValueError(f"Unsupported action: {action}")
+
+
+@jinja_filter("slaac")
+def slaac(value, mac):
+    """
+    Returns the IPv6 SLAAC address for ``mac`` within the network ``value``.
+
+    The interface identifier is derived from the MAC address using modified
+    EUI-64. ``value`` must be an IPv6 network, typically a ``/64``.
+
+    .. versionadded:: 3009.0
+    """
+    network = ipaddress.ip_network(str(value), strict=False)
+    if network.version != 6:
+        raise ValueError("slaac requires an IPv6 network")
+    octets = str(mac).replace(":", "").replace("-", "").replace(".", "")
+    mac_bytes = bytes.fromhex(octets)
+    if len(mac_bytes) != 6:
+        raise ValueError(f"Invalid MAC address: {mac}")
+    eui64 = bytes([mac_bytes[0] ^ 0x02]) + mac_bytes[1:3] + b"\xff\xfe" + mac_bytes[3:]
+    interface_id = int.from_bytes(eui64, "big")
+    return str(ipaddress.IPv6Address(int(network.network_address) | interface_id))

--- a/tests/pytests/unit/utils/test_network.py
+++ b/tests/pytests/unit/utils/test_network.py
@@ -1611,3 +1611,108 @@ def test_ip_addrs(linux_interfaces_dict):
     ):
         ret = network.ip_addrs6("eth0")
         assert ret == ["fe80::e23f:49ff:fe85:6aaf"]
+
+
+@pytest.mark.parametrize(
+    "addr,expected",
+    (
+        ("0.0.0.0", 0),
+        ("10.0.1.2", 167772418),
+        ("255.255.255.255", 4294967295),
+        ("::", 0),
+        ("::1", 1),
+        ("2001:db8::1", 42540766411282592856903984951653826561),
+    ),
+)
+def test_ip_to_int(addr, expected):
+    assert network.ip_to_int(addr) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (0, "0.0.0.0"),
+        (167772418, "10.0.1.2"),
+        (4294967295, "255.255.255.255"),
+    ),
+)
+def test_int_to_ipv4(value, expected):
+    assert network.int_to_ipv4(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (0, "::"),
+        (1, "::1"),
+        (42540766411282592856903984951653826561, "2001:db8::1"),
+    ),
+)
+def test_int_to_ipv6(value, expected):
+    assert network.int_to_ipv6(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,nth,expected",
+    (
+        ("10.0.0.0/24", 0, "10.0.0.0"),
+        ("10.0.0.0/24", 5, "10.0.0.5"),
+        ("10.0.0.0/24", -1, "10.0.0.255"),
+        ("10.0.0.0/8", 305, "10.0.1.49"),
+        ("2001:db8::/64", 1, "2001:db8::1"),
+    ),
+)
+def test_nth_host(value, nth, expected):
+    assert network.nth_host(value, nth) == expected
+
+
+@pytest.mark.parametrize(
+    "value,prefix,index,expected",
+    (
+        ("192.168.0.0/16", 24, None, 256),
+        ("192.168.0.0/16", 24, 0, "192.168.0.0/24"),
+        ("192.168.0.0/16", 24, 1, "192.168.1.0/24"),
+        ("192.168.0.0/16", 24, -1, "192.168.255.0/24"),
+        ("2001:db8::/48", 64, None, 65536),
+        ("2001:db8::/48", 64, 1, "2001:db8:0:1::/64"),
+        ("2001:db8::/32", 64, None, 4294967296),
+        ("2001:db8::/32", 64, 5, "2001:db8:0:5::/64"),
+    ),
+)
+def test_network_subnets(value, prefix, index, expected):
+    assert network.network_subnets(value, prefix, index) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (["192.168.0.0/24", "192.168.1.0/24"], ["192.168.0.0/23"]),
+        (["10.0.0.0/24", "10.0.2.0/24"], ["10.0.0.0/24", "10.0.2.0/24"]),
+        (["2001:db8::/65", "2001:db8:0:0:8000::/65"], ["2001:db8::/64"]),
+    ),
+)
+def test_cidr_merge_merge(value, expected):
+    assert network.cidr_merge(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (["192.168.0.0/24", "192.168.3.0/24"], "192.168.0.0/22"),
+        (["10.0.0.1", "10.0.0.5"], "10.0.0.0/29"),
+    ),
+)
+def test_cidr_merge_span(value, expected):
+    assert network.cidr_merge(value, "span") == expected
+
+
+@pytest.mark.parametrize(
+    "value,mac,expected",
+    (
+        ("2001:db8::/64", "00:50:56:01:02:03", "2001:db8::250:56ff:fe01:203"),
+        ("2001:db8::/64", "0050.5601.0203", "2001:db8::250:56ff:fe01:203"),
+        ("fe80::/64", "52:54:00:12:34:56", "fe80::5054:ff:fe12:3456"),
+    ),
+)
+def test_slaac(value, mac, expected):
+    assert network.slaac(value, mac) == expected


### PR DESCRIPTION
### What does this PR do?

Adds seven Jinja filters to `salt.utils.network`, all implemented with the
standard-library `ipaddress` module:

- `ip_to_int` / `int_to_ipv4` / `int_to_ipv6` — convert between an IPv4/IPv6 address and its integer representation
- `nth_host` — the Nth address within a network (network address is index 0; negative indexes count from the end)
- `network_subnets` — split a network into subnets of a given prefix length; returns the subnet count, or the Nth subnet when an index is given
- `cidr_merge` — merge a list of addresses/networks into the minimal covering set, or (with `action="span"`) the single smallest containing network
- `slaac` — derive an IPv6 SLAAC address from a network and a MAC address using modified EUI-64

### What issues does this PR fix or reference?

None

### New Behavior

Seven new Jinja filters as described above, documented in
`doc/topics/jinja/index.rst`, with unit tests in
`tests/pytests/unit/utils/test_network.py`.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

No