### PR TITLE
Reconnect stale vCenter service instance on socket-level errors (fixes #61983)

### DIFF
--- a/changelog/61983.fixed.md
+++ b/changelog/61983.fixed.md
@@ -1,0 +1,1 @@
+Fixed `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` errors in the VMware cloud driver by reconnecting when a cached vCenter service instance is found to be stale or corrupted (for example when inherited across a fork by salt-cloud's parallel provider queries).

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -477,9 +477,27 @@ def get_service_instance(
     log.trace("Checking connection is still authenticated")
     try:
         service_instance.CurrentTime()
-    except vim.fault.NotAuthenticated:
-        log.trace("Session no longer authenticating. Reconnecting")
-        Disconnect(service_instance)
+    except (
+        vim.fault.NotAuthenticated,
+        ssl.SSLError,
+        BrokenPipeError,
+        ConnectionResetError,
+    ):
+        # NotAuthenticated means the session expired. The socket-level errors
+        # (SSLError, BrokenPipeError, ConnectionResetError) mean the cached
+        # connection has gone stale or been corrupted - for example when a
+        # cached service instance is inherited across an os.fork() (such as the
+        # multiprocessing.Pool salt-cloud uses in map_providers_parallel) and
+        # the shared TLS socket is used from more than one process. In every
+        # case the fix is the same: drop the dead connection and reconnect.
+        log.trace("Cached connection is stale or unauthenticated. Reconnecting")
+        try:
+            Disconnect(service_instance)
+        except Exception:  # pylint: disable=broad-except
+            # Disconnect performs a logout over the same socket, which can
+            # itself fail when the connection is already broken. Ignore it -
+            # we are about to replace the service instance regardless.
+            pass
         service_instance = _get_service_instance(
             host,
             username,

--- a/tests/pytests/unit/utils/test_vmware.py
+++ b/tests/pytests/unit/utils/test_vmware.py
@@ -1,0 +1,93 @@
+"""
+Tests for connection handling in salt.utils.vmware.get_service_instance
+"""
+
+import ssl
+
+import pytest
+
+import salt.utils.vmware
+from tests.support.mock import MagicMock, patch
+
+try:
+    from pyVmomi import vim  # pylint: disable=no-name-in-module
+
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+pytestmark = [
+    pytest.mark.skipif(not HAS_PYVMOMI, reason="The 'pyvmomi' library is missing"),
+]
+
+
+@pytest.fixture
+def connection_params():
+    return {
+        "host": "fake_host",
+        "username": "fake_username",
+        "password": "fake_password",
+        "protocol": "fake_protocol",
+        "port": 1,
+        "mechanism": "fake_mechanism",
+        "principal": "fake_principal",
+        "domain": "fake_domain",
+    }
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(vim.fault.NotAuthenticated, id="NotAuthenticated"),
+        pytest.param(
+            ssl.SSLError("decryption failed or bad record mac"), id="SSLError"
+        ),
+        pytest.param(BrokenPipeError(), id="BrokenPipeError"),
+        pytest.param(ConnectionResetError(), id="ConnectionResetError"),
+    ],
+)
+def test_stale_service_instance_reconnects(exc, connection_params):
+    """
+    The CurrentTime() probe in get_service_instance detects a dead cached
+    connection. An expired session raises vim.fault.NotAuthenticated, while a
+    connection corrupted at the socket level - for example when salt-cloud's
+    map_providers_parallel inherits the cached service instance across a fork
+    and the shared TLS socket is used from more than one process (issue #61983)
+    - raises ssl.SSLError, BrokenPipeError or ConnectionResetError. In every
+    case the connection should be transparently re-established instead of the
+    error propagating to the caller.
+    """
+    mock_si = MagicMock()
+    mock_si.CurrentTime = MagicMock(side_effect=exc)
+    mock_get_si = MagicMock(return_value=mock_si)
+    mock_disconnect = MagicMock()
+    with patch("salt.utils.vmware.GetSi", MagicMock(return_value=None)), patch(
+        "salt.utils.vmware._get_service_instance", mock_get_si
+    ), patch("salt.utils.vmware.Disconnect", mock_disconnect):
+        # Must not raise
+        salt.utils.vmware.get_service_instance(**connection_params)
+    # The probe ran once and found the connection dead
+    assert mock_si.CurrentTime.call_count == 1
+    # The dead connection was torn down ...
+    assert mock_disconnect.call_count == 1
+    # ... and a fresh one established (initial connect + reconnect)
+    assert mock_get_si.call_count == 2
+
+
+def test_reconnect_when_disconnecting_dead_socket_raises(connection_params):
+    """
+    Disconnect logs out over the same socket, so on an already broken
+    connection it can raise too. That failure must not escape
+    get_service_instance - we drop the connection and reconnect regardless.
+    """
+    mock_si = MagicMock()
+    mock_si.CurrentTime = MagicMock(side_effect=ssl.SSLError("bad record mac"))
+    mock_get_si = MagicMock(return_value=mock_si)
+    mock_disconnect = MagicMock(side_effect=BrokenPipeError())
+    with patch("salt.utils.vmware.GetSi", MagicMock(return_value=None)), patch(
+        "salt.utils.vmware._get_service_instance", mock_get_si
+    ), patch("salt.utils.vmware.Disconnect", mock_disconnect):
+        # Must not raise even though Disconnect itself blew up
+        salt.utils.vmware.get_service_instance(**connection_params)
+    assert mock_disconnect.call_count == 1
+    assert mock_get_si.call_count == 2


### PR DESCRIPTION
### What does this PR do?

Reconnects the cached vCenter/ESXi service instance when its connection has gone stale at the socket level, instead of letting the error escape and fail the operation.

`salt.utils.vmware.get_service_instance` caches the pyVmomi `ServiceInstance` (pyVmomi's process global, `GetSi()`), which holds open, pooled TLS sockets. After fetching it, the function probes the connection with `service_instance.CurrentTime()` and reconnects if the probe fails. That probe only caught `vim.fault.NotAuthenticated`, so a connection that has been broken/corrupted at the socket level raised `ssl.SSLError`, `BrokenPipeError` or `ConnectionResetError` straight through to the caller.

The common trigger is salt-cloud: `Cloud.do_action` calls `map_providers_parallel`, which uses a `multiprocessing.Pool`. On Linux that forks, and the workers inherit the parent's cached service instance and reuse/tear down the shared TLS sockets (the inherited `atexit` Disconnect also runs on worker exit). The parent's next request on those sockets then fails the TLS record MAC check. Because pyVmomi keeps a pool of connections per stub, the request that fails alternates -- which matches the "every other `cloud.present` state ID fails" report in #61983.

This PR treats those socket-level errors the same as an expired session: drop the dead connection and reconnect. The `Disconnect` is guarded because logging out over an already broken socket can raise as well.

This is a recovery-level fix that self-heals every error variant reported. A deeper prevention (not sharing the pyVmomi connection across the pool fork) would be a larger, riskier change; I'm happy to follow up on that separately if the maintainers want it.

Note: if the plan is to retire the VMware code from Salt core in favor of the `saltext.vmware` extension, feel free to discard this PR and close #61983. I checked the extension and it is not affected -- its live modules connect fresh via `connect.get_service_instance` (no `GetSi()` cache) and there is no salt-cloud fork path there; the matching cached `get_service_instance` in `utils/vsphere.py` is unused.

### What issues does this PR fix or reference?
Fixes #61983
References #58869 (same `ssl.SSLError` / `BrokenPipeError` / `ConnectionResetError` symptoms and workarounds).

### Previous Behavior
A cached service instance with a socket-level-broken connection caused `get_service_instance` to raise `ssl.SSLError` (`SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC`), `BrokenPipeError` or `ConnectionResetError`, failing `cloud.present` / `cloud.has_instance` and other vSphere operations.

### New Behavior
Those socket-level errors are caught by the existing reconnect path; the stale connection is dropped and a fresh one is established transparently.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - `changelog/61983.fixed.md`
- [x] Tests written/updated - `tests/pytests/unit/utils/test_vmware.py` (verified failing on current master, passing with this change)

### Commits signed with GPG?
No
