### PR TITLE
Bump redis version for ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -746,7 +746,7 @@ repos:
       - id: pip-compile
         alias: compile-ci-linux-3.14-zmq-requirements
         name: Linux CI Py3.14 ZeroMQ Requirements
-        files: ^requirements/(constraints\.lock|(base|zeromq|pytest)\.lock|static/((ci|pkg)/(linux\.in|common\.in)|py3\.13/linux\.lock))$
+        files: ^requirements/(constraints\.lock|(base|zeromq|pytest)\.lock|static/((ci|pkg)/(linux\.in|common\.in)|py3\.14/linux\.lock))$
         pass_filenames: false
         additional_dependencies: ["pip<26.0"]
         args:

--- a/requirements/static/ci/py3.10/lint.lock
+++ b/requirements/static/ci/py3.10/lint.lock
@@ -53,6 +53,7 @@ async-timeout==4.0.3
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   aiohttp
+    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
@@ -623,7 +624,7 @@ pyzmq==25.1.2
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/zeromq.in
-redis==3.5.3
+redis==7.4.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/linux.lock
+++ b/requirements/static/ci/py3.10/linux.lock
@@ -37,6 +37,7 @@ async-timeout==4.0.3
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   aiohttp
+    #   redis
 attrs==23.2.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -513,7 +514,7 @@ pyzmq==25.1.2
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/zeromq.in
     #   pytest-salt-factories
-redis==3.5.3
+redis==7.4.0
     # via -r requirements/static/ci/linux.in
 requests==2.31.0
     # via

--- a/requirements/static/ci/py3.14/lint.lock
+++ b/requirements/static/ci/py3.14/lint.lock
@@ -606,7 +606,7 @@ pyzmq==27.1.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/zeromq.in
-redis==3.5.3
+redis==7.4.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.14/linux.lock
+++ b/requirements/static/ci/py3.14/linux.lock
@@ -502,7 +502,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/zeromq.in
     #   pytest-salt-factories
-redis==3.5.3
+redis==7.4.0
     # via -r requirements/static/ci/linux.in
 referencing==0.37.0
     # via


### PR DESCRIPTION
### What does this PR do?

I rebased and merged this to accelerate the 3008.0 release https://github.com/saltstack/salt/pull/68819

Turns out the rebase didn't catch the redis version update which broke a test durring the release :/
