### PR TITLE
Ship requirements/*.in and *.lock in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ include tools/pkg/__init__.py
 include tools/pkg/salt_build_backend.py
 include tests/*.py
 recursive-include tests *
-recursive-include requirements *.txt
+recursive-include requirements *.txt *.in *.lock
 include tests/integration/modules/files/*
 include tests/integration/files/*
 include tests/unit/templates/files/*

--- a/changelog/69244.fixed.md
+++ b/changelog/69244.fixed.md
@@ -1,0 +1,1 @@
+Restore Python dependencies in the PyPI sdist by including ``requirements/*.in`` and ``requirements/**/*.lock`` in ``MANIFEST.in``. After the requirements ``.txt`` → ``.in`` rename, the sdist no longer shipped the files that ``setup.py`` reads to populate ``install_requires``, so ``pip install salt`` produced an installation with no dependencies.


### PR DESCRIPTION
After the requirements .txt -> .in rename, MANIFEST.in still only included requirements/*.txt, so the PyPI sdist no longer shipped the files setup.py reads to populate install_requires. The build backend silently returned an empty list, and `pip install salt==3008.0` installed salt with zero dependencies.

Add *.in and *.lock to the recursive-include so the dependency manifests (and the locked variants used when USE_STATIC_REQUIREMENTS=1) end up in the sdist again.

fixes #69244
