### PR TITLE
Fix docs version switcher selecting the wrong active version

### DIFF
--- a/doc/_static/versions.json
+++ b/doc/_static/versions.json
@@ -1,13 +1,18 @@
 [
     {
-        "name": "Latest",
+        "name": "Latest (3008)",
         "version": "latest",
         "url": "https://docs.saltproject.io/en/latest/"
     },
     {
-        "name": "3006.24",
-        "version": "3006.24",
-        "url": "https://docs.saltproject.io/en/3006.24/"
+        "name": "3008",
+        "version": "3008",
+        "url": "https://docs.saltproject.io/en/3008/"
+    },
+    {
+        "name": "3006",
+        "version": "3006",
+        "url": "https://docs.saltproject.io/en/3006/"
     },
     {
         "name": "Master (Dev)",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -333,7 +333,15 @@ if html_theme == "pydata_sphinx_theme":
         "check_switcher": False,  # Disable to avoid warnings about local json file
         "switcher": {
             "json_url": "https://docs.saltproject.io/en/latest/_static/versions.json",
-            "version_match": "master",
+            # Match an entry in versions.json by BUILD_TYPE: the published
+            # /en/latest/ build is "latest"; dev/master is "master"; release
+            # branches publish to /en/<major>/ (e.g. /en/3006/) and match the
+            # major version derived from `release`.
+            "version_match": (
+                "master"
+                if build_type == repo_primary_branch or build_type == "next"
+                else "latest" if build_type == "latest" else release.split(".", 1)[0]
+            ),
         },
     }
     html_sidebars = {"**": ["globaltoc.html", "sidebar-ethical-ads"]}


### PR DESCRIPTION
doc/conf.py hard-coded "version_match": "master", so every published build (including the 3008.0 release at /en/latest/) emitted DOCUMENTATION_OPTIONS.theme_switcher_version_match = 'master' and the dropdown always highlighted "Master (Dev)" as the current version.

Make version_match dynamic so it matches a versions.json entry by BUILD_TYPE:
  - master / next       -> "master"
  - latest              -> "latest"
  - previous / other    -> release.split(".", 1)[0]  (e.g. "3006")

Also fix the dropdown URLs in doc/_static/versions.json. The 3006.24 entry pointed at /en/3006.24/ which returns 404; the served URL pattern is /en/<major>/ (e.g. /en/3006/, /en/3008/). Rewrite the entries to use major-only paths and add a 3008 entry, since the latest release at docs.saltproject.io is now 3008.0.

Note: doc/conf.py points every build at the absolute json_url https://docs.saltproject.io/en/latest/_static/versions.json, so the served versions.json is whichever branch publishes /en/latest/. Updating versions.json here is harmless on 3006.x but only takes effect site-wide when the same change reaches the branch that builds /en/latest/.

Verified locally with the CI invocation under a python3.14 venv built from requirements/static/ci/py3.14/docs.lock:
  cd doc && make clean && make html SPHINXOPTS='-W -j auto --keep-going --color'
  cd doc && make clean && BUILD_TYPE=latest make html SPHINXOPTS='-W -j auto --keep-going --color'
Rendered contents.html emits:
  theme_switcher_version_match = 'master'   (default)
  theme_switcher_version_match = 'latest'   (BUILD_TYPE=latest)
