### PR TITLE
Fix TypeError on bare-string master responses to pillar requests 

### DIFF
--- a/changelog/69228.fixed.md
+++ b/changelog/69228.fixed.md
@@ -1,0 +1,1 @@
+Fixed `TypeError: string indices must be integers` in the minion when the master returns a bare string error response (e.g. `"bad load"`, `"Some exception handling minion payload"`) for a pillar request. The minion now raises a clean `AuthenticationError` instead of crashing, allowing the caller to retry or fail gracefully.

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -238,6 +238,20 @@ class AsyncReqChannel:
                 tries,
                 timeout,
             )
+        if not isinstance(ret, dict) or "key" not in ret:
+            # The master is still not returning a usable session key.  This
+            # happens when a clustered master defers requests with a
+            # ``cluster_retry`` flag while its Raft node is still catching
+            # up.  Surface a clean error instead of the KeyError that would
+            # otherwise blow up at ``ret["key"]`` below.
+            raise salt.crypt.AuthenticationError(
+                "Master did not return a session key for pillar request"
+                + (
+                    " (cluster not ready)"
+                    if isinstance(ret, dict) and ret.get("cluster_retry")
+                    else ""
+                )
+            )
         aes = key.decrypt(ret["key"], self.opts["encryption_algorithm"])
 
         # Decrypt using the public key.

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1018,6 +1018,102 @@ async def test_req_chan_decode_data_dict_entry_v2_bad_signature(
         transport.close()
 
 
+@pytest.mark.parametrize(
+    "bad_response",
+    [
+        "bad load",
+        "Some exception handling minion payload",
+        "Server-side exception handling payload",
+    ],
+)
+async def test_req_chan_decode_data_dict_entry_string_response(
+    pki_dir, minion_opts, master_opts, bad_response
+):
+    """
+    Regression test for #69228.
+
+    When the master rejects a pillar request it can return a bare string
+    payload (e.g. "bad load" or "Some exception handling minion payload")
+    rather than the {"key": ..., dictkey: ...} dict the minion expects.
+    The minion's ``crypted_transfer_decode_dictentry`` must not blow up
+    with ``TypeError: string indices must be integers`` when this happens;
+    it should surface a clean ``AuthenticationError`` so the caller can
+    fail or retry.
+    """
+    mockloop = MagicMock()
+    minion_opts.update(
+        {
+            "master_uri": "tcp://127.0.0.1:4506",
+            "interface": "127.0.0.1",
+            "ret_port": 4506,
+            "ipv6": False,
+            "sock_dir": ".",
+            "pki_dir": str(pki_dir.joinpath("minion")),
+            "id": "minion",
+            "__role": "minion",
+            "keysize": 4096,
+            "acceptance_wait_time": 3,
+            "acceptance_wait_time_max": 3,
+        }
+    )
+    master_opts.update(pki_dir=str(pki_dir.joinpath("master")))
+    server = salt.channel.server.ReqServerChannel.factory(master_opts)
+    client = salt.channel.client.AsyncReqChannel.factory(minion_opts, io_loop=mockloop)
+
+    target = "minion"
+
+    auth = client.auth
+    auth._crypticle = salt.crypt.Crypticle(minion_opts, AES_KEY)
+    auth._session_crypticle = salt.crypt.Crypticle(
+        minion_opts, server.session_key(target)
+    )
+    client.auth = MagicMock()
+    client.auth.mpub = auth.mpub
+    client.auth.authenticated = True
+    client.auth.get_keys = auth.get_keys
+    client.auth.gen_token = auth.gen_token
+    client.auth.crypticle.dumps = auth.crypticle.dumps
+    client.auth.crypticle.loads = auth.crypticle.loads
+    client.auth.session_crypticle.dumps = auth.session_crypticle.dumps
+    client.auth.session_crypticle.loads = auth.session_crypticle.loads
+    transport = client.transport
+    client.transport = MagicMock()
+
+    @salt.ext.tornado.gen.coroutine
+    def mockauthenticate():
+        pass
+
+    client.auth.authenticate = MagicMock(wraps=mockauthenticate)
+
+    @salt.ext.tornado.gen.coroutine
+    def mocksend(msg, timeout=60, tries=3):
+        raise salt.ext.tornado.gen.Return(bad_response)
+
+    client.transport.send = mocksend
+
+    load = {
+        "id": target,
+        "grains": {},
+        "saltenv": "base",
+        "pillarenv": "base",
+        "pillar_override": True,
+        "extra_minion_data": {},
+        "ver": "3",
+        "cmd": "_pillar",
+    }
+
+    try:
+        with pytest.raises(salt.crypt.AuthenticationError):
+            await client.crypted_transfer_decode_dictentry(  # pylint: disable=E1121,E1123
+                load,
+                dictkey="pillar",
+            )
+    finally:
+        server.close()
+        client.close()
+        transport.close()
+
+
 async def test_req_chan_decode_data_dict_entry_v2_bad_key(
     pki_dir, minion_opts, master_opts
 ):


### PR DESCRIPTION
fixes #69228

When the master returns a bare string error ("bad load", "Some exception handling minion payload",
"Server-side exception handling payload") for a pillar request, the minion's crypted_transfer_decode_dictentry crashed with "TypeError: string indices must be integers" at ret["key"]. The "key" not in ret guard accidentally passed for strings (substring check), the post-reauth retry returned the same string, and the indexing blew up.

Raise a clean AuthenticationError when the post-reauth response is still not a dict containing "key", so the caller can fail or retry instead of crashing. Matches the cluster_retry-decorated guard already on 3008.x / master (commit 2efc32ea883).

Add a parametrized regression test covering all three server-side string error returns.
