### PR TITLE
Ship requirements/*.in and *.lock in sdist (fixes #69244)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ include tools/pkg/__init__.py
 include tools/pkg/salt_build_backend.py
 include tests/*.py
 recursive-include tests *
-recursive-include requirements *.txt
+recursive-include requirements *.txt *.in *.lock
 include tests/integration/modules/files/*
 include tests/integration/files/*
 include tests/unit/templates/files/*


### PR DESCRIPTION
After the requirements .txt -> .in rename, MANIFEST.in still only included requirements/*.txt, so the PyPI sdist no longer shipped the files setup.py reads to populate install_requires. The build backend silently returned an empty list, and `pip install salt` from a sdist built off this branch would install salt with zero dependencies.

Add *.in and *.lock to the recursive-include so the dependency manifests (and the locked variants used when USE_STATIC_REQUIREMENTS=1) end up in the sdist again. Backport of the 3008.x fix; changelog lives on the forward branch.
