### PR TITLE
fix: ensure apt keyring files are world-readable (chmod 0o644)

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2196,6 +2196,7 @@ def add_repo_key(
                 if keyfile.endswith(".decrypted"):
                     keyfile = keyfile[:-10]
             shutil.copyfile(str(key), str(keydir / keyfile))
+            os.chmod(str(keydir / keyfile), 0o644)
             return True
         else:
             cmd.extend(["add", cached_source_path])


### PR DESCRIPTION
## Problem

When using `pkgrepo.managed` with `aptkey: False` to manage APT repositories on systems hardened with a default `umask 077`, the GPG key files are saved to `/usr/share/keyrings/` (or `/etc/apt/keyrings/`) with excessively restrictive permissions (`0o600` instead of `0o644`).

This causes `apt-get update` to fail with:
```
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ...
```

According to the [Debian sources.list manpage](https://manpages.ubuntu.com/manpages/noble/en/man5/sources.list.5.html), keyring files must be accessible and readable for the `_apt` system user, so everyone needs read-permissions on the file.

## Root Cause

In `salt/modules/aptpkg.py`, the `add_repo_key()` function uses `shutil.copyfile()` to save the decrypted key file to the keyring directory. `shutil.copyfile()` creates the destination file with permissions determined by the current umask. On systems with `umask 077`, the resulting file has `0o600` permissions.

## Changes

Added `os.chmod(str(keydir / keyfile), 0o644)` after `shutil.copyfile()` to explicitly set world-readable permissions on saved keyring files, regardless of the system umask.

## Testing

- Manual verification: key files are now created with `0o644` permissions regardless of umask
- A new test could verify the permissions, but this is a single-line fix following the existing pattern

## Closes

Closes #66731