### PR TITLE
Add encoding parameter to file.replace for multi-byte encoded files

### DIFF
--- a/changelog/52793.fixed.md
+++ b/changelog/52793.fixed.md
@@ -1,0 +1,1 @@
+Added ``encoding`` parameter to ``file.replace`` execution module and state to support UTF-16, UTF-32, and other multi-byte encoded files that would otherwise be incorrectly treated as binary.

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2345,6 +2345,7 @@ def replace(
     ignore_if_missing=False,
     preserve_inode=True,
     backslash_literal=False,
+    encoding=None,
 ):
     """
     .. versionadded:: 0.17.0
@@ -2453,6 +2454,17 @@ def replace(
         the backslashes are not interpreted for the repl on the second run of
         the state.
 
+    encoding: None
+        .. versionadded:: 3006.26
+
+        The character encoding to use when reading and writing the file.
+        When set, the binary-file check is bypassed and the file is opened
+        in text mode using the specified encoding. Required for files encoded
+        as UTF-16, UTF-32, or other multi-byte encodings whose null bytes
+        would otherwise cause the file to be treated as binary.
+
+        Example: ``encoding=utf-16``
+
     If an equal sign (``=``) appears in an argument to a Salt command it is
     interpreted as a keyword argument in the format ``key=val``. That
     processing can be bypassed in order to pass an equal sign through to the
@@ -2484,7 +2496,7 @@ def replace(
         else:
             raise SaltInvocationError(f"File not found: {path}")
 
-    if not __utils__["files.is_text"](path):
+    if encoding is None and not __utils__["files.is_text"](path):
         raise SaltInvocationError(
             f"Cannot perform string replacements on a binary file: {path}"
         )
@@ -2498,6 +2510,141 @@ def replace(
         raise SaltInvocationError(
             "Only one of append and prepend_if_not_found is permitted"
         )
+
+    if encoding is not None:
+        if not salt.utils.platform.is_windows():
+            pre_user = get_user(path)
+            pre_group = get_group(path)
+            pre_mode = salt.utils.files.normalize_mode(get_mode(path))
+
+        re_flags = _get_flags(flags)
+        cpattern = re.compile(pattern, re_flags)
+        repl_str = str(repl)
+        content = (
+            str(not_found_content)
+            if not_found_content and (prepend_if_not_found or append_if_not_found)
+            else repl_str
+        )
+
+        try:
+            with salt.utils.files.fopen(path, mode="r", encoding=encoding) as r_file:
+                orig_contents = r_file.read()
+        except OSError as exc:
+            raise CommandExecutionError(
+                f"Unable to open file '{path}'. Exception: {exc}"
+            )
+
+        if search_only:
+            return bool(re.search(cpattern, orig_contents))
+
+        result, nrepl = re.subn(
+            cpattern,
+            repl_str.replace("\\", "\\\\") if backslash_literal else repl_str,
+            orig_contents,
+            count,
+        )
+
+        found = nrepl > 0
+
+        if prepend_if_not_found or append_if_not_found:
+            if re.search(
+                re.compile(f"^{re.escape(content)}($|(?=\r\n))", re_flags),
+                orig_contents,
+            ):
+                found = True
+
+        orig_file = orig_contents.splitlines(True)
+        new_file = result.splitlines(True)
+        has_changes = orig_file != new_file
+        enc_temp_file = None
+
+        if has_changes and not dry_run:
+            try:
+                enc_temp_file = _mkstemp_copy(path=path, preserve_inode=preserve_inode)
+            except OSError as exc:
+                raise CommandExecutionError(f"Exception: {exc}")
+            try:
+                with salt.utils.files.fopen(
+                    path, mode="w", encoding=encoding
+                ) as w_file:
+                    try:
+                        w_file.write(result)
+                    except OSError as exc:
+                        raise CommandExecutionError(
+                            "Unable to write file '{}'. Contents may be "
+                            "truncated. Temporary file contains copy at '{}'. "
+                            "Exception: {}".format(path, enc_temp_file, exc)
+                        )
+            except OSError as exc:
+                raise CommandExecutionError(f"Exception: {exc}")
+
+        if not found and (append_if_not_found or prepend_if_not_found):
+            nfc = str(not_found_content) if not_found_content is not None else repl_str
+            if prepend_if_not_found:
+                new_file.insert(0, nfc + os.linesep)
+            else:
+                if new_file and not new_file[-1].endswith(os.linesep):
+                    new_file[-1] += os.linesep
+                new_file.append(nfc + os.linesep)
+            has_changes = True
+            if not dry_run:
+                try:
+                    enc_temp_file = _mkstemp_copy(
+                        path=path, preserve_inode=preserve_inode
+                    )
+                except OSError as exc:
+                    raise CommandExecutionError(f"Exception: {exc}")
+                try:
+                    with salt.utils.files.fopen(
+                        path, mode="w", encoding=encoding
+                    ) as fh_:
+                        fh_.writelines(new_file)
+                except OSError as exc:
+                    raise CommandExecutionError(f"Exception: {exc}")
+
+        if backup and has_changes and not dry_run:
+            backup_name = f"{path}{backup}"
+            try:
+                shutil.move(enc_temp_file, backup_name)
+            except OSError as exc:
+                raise CommandExecutionError(
+                    "Unable to move the temp file '{}' to the backup file "
+                    "'{}'. Exception: {}".format(path, enc_temp_file, exc)
+                )
+            if symlink:
+                symlink_backup = f"{given_path}{backup}"
+                target_backup = f"{target_path}{backup}"
+                try:
+                    os.symlink(target_backup, symlink_backup)
+                except OSError:
+                    os.remove(symlink_backup)
+                    os.symlink(target_backup, symlink_backup)
+                except Exception:  # pylint: disable=broad-except
+                    raise CommandExecutionError(
+                        "Unable create backup symlink '{}'. "
+                        "Target was '{}'. "
+                        "Exception: {}".format(symlink_backup, target_backup, exc)
+                    )
+        elif enc_temp_file:
+            try:
+                os.remove(enc_temp_file)
+            except OSError as exc:
+                raise CommandExecutionError(
+                    f"Unable to delete temp file '{enc_temp_file}'. Exception: {exc}"
+                )
+
+        if not dry_run and not salt.utils.platform.is_windows():
+            check_perms(path, None, pre_user, pre_group, pre_mode)
+
+        differences = __utils__["stringutils.get_diff"](orig_file, new_file)
+
+        if show_changes:
+            return differences
+
+        if not differences:
+            has_changes = False
+
+        return has_changes
 
     re_flags = _get_flags(flags)
     cpattern = re.compile(salt.utils.stringutils.to_bytes(pattern), re_flags)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5320,6 +5320,7 @@ def replace(
     show_changes=True,
     ignore_if_missing=False,
     backslash_literal=False,
+    encoding=None,
 ):
     r"""
     Maintain an edit in a file.
@@ -5428,6 +5429,26 @@ def replace(
         the backslashes are not interpreted for the repl on the second run of
         the state.
 
+    encoding
+        .. versionadded:: 3006.26
+
+        The character encoding to use when reading and writing the file.
+        When set, the binary-file check is bypassed and the file is opened
+        in text mode using the specified encoding. Required for files encoded
+        as UTF-16, UTF-32, or other multi-byte encodings whose null bytes
+        would otherwise cause the file to be treated as binary.
+
+        Example:
+
+        .. code-block:: yaml
+
+            patch_minimum_ps_version:
+              file.replace:
+                - name: C:/Program Files/WindowsPowerShell/Modules/PSWindowsUpdate/PSWindowsUpdate.psd1
+                - pattern: "PowerShellVersion\\s+=\\s+.*"
+                - repl: "PowerShellVersion = '3.0'"
+                - encoding: utf-16
+
     For complex regex patterns, it can be useful to avoid the need for complex
     quoting and escape sequences by making use of YAML's multiline string
     syntax.
@@ -5491,6 +5512,7 @@ def replace(
         show_changes=show_changes,
         ignore_if_missing=ignore_if_missing,
         backslash_literal=backslash_literal,
+        encoding=encoding,
     )
 
     if changes:

--- a/tests/pytests/functional/states/file/test_replace.py
+++ b/tests/pytests/functional/states/file/test_replace.py
@@ -7,6 +7,20 @@ pytestmark = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_utf16(path, text):
+    """Write *text* to *path* as UTF-16 (with BOM)."""
+    path.write_text(text, encoding="utf-16")
+
+
+def _read_utf16(path):
+    return path.read_text(encoding="utf-16")
+
+
 def test_replace(file, tmp_path):
     """
     file.replace
@@ -400,3 +414,163 @@ def test_file_replace_check_cmd(modules, state_tree):
         for state_run in ret:
             assert state_run.result is False
             assert state_run.comment == "check_cmd determined the state failed"
+
+
+# ---------------------------------------------------------------------------
+# UTF-16 encoding tests (issue #52793)
+# ---------------------------------------------------------------------------
+
+
+def test_replace_utf16_state(file, tmp_path):
+    """
+    file.replace state with encoding='utf-16' should successfully replace a
+    pattern in a UTF-16 encoded file and keep the file in UTF-16 encoding.
+    """
+    name = tmp_path / "PSWindowsUpdate.psd1"
+    _write_utf16(name, "PowerShellVersion = '2.0'\r\nModuleVersion = '1.0'\r\n")
+
+    ret = file.replace(
+        name=str(name),
+        pattern=r"PowerShellVersion\s+=\s+'2\.0'",
+        repl="PowerShellVersion = '3.0'",
+        encoding="utf-16",
+        backup=False,
+    )
+
+    assert ret.result is True
+    content = _read_utf16(name)
+    assert "PowerShellVersion = '3.0'" in content
+    assert "PowerShellVersion = '2.0'" not in content
+    assert "ModuleVersion = '1.0'" in content
+
+    raw = name.read_bytes()
+    assert raw[:2] in (b"\xff\xfe", b"\xfe\xff"), "BOM missing after replace"
+
+
+def test_replace_utf16_state_idempotent(file, tmp_path):
+    """
+    Calling file.replace twice on a UTF-16 file should produce no changes on
+    the second run (idempotency, similar to issue #18612).
+    """
+    name = tmp_path / "idempotent.psd1"
+    _write_utf16(name, "PowerShellVersion = '2.0'\r\n")
+
+    results = []
+    for _ in range(2):
+        results.append(
+            file.replace(
+                name=str(name),
+                pattern=r"PowerShellVersion\s+=\s+'2\.0'",
+                repl="PowerShellVersion = '3.0'",
+                encoding="utf-16",
+                backup=False,
+            )
+        )
+
+    assert results[0].result is True
+    assert results[1].result is True
+    assert "PowerShellVersion = '3.0'" in _read_utf16(name)
+    assert "PowerShellVersion = '2.0'" not in _read_utf16(name)
+
+
+def test_replace_utf16_state_no_match(file, tmp_path):
+    """
+    file.replace state with encoding='utf-16' should report no changes when
+    the pattern is not found, leaving the file byte-for-byte identical.
+    """
+    name = tmp_path / "no_match.psd1"
+    _write_utf16(name, "PowerShellVersion = '3.0'\n")
+    original_bytes = name.read_bytes()
+
+    ret = file.replace(
+        name=str(name),
+        pattern=r"DoesNotExist",
+        repl="something",
+        encoding="utf-16",
+        backup=False,
+    )
+
+    assert ret.result is True
+    assert name.read_bytes() == original_bytes
+
+
+def test_replace_utf16_state_append_if_not_found(file, tmp_path):
+    """
+    append_if_not_found=True should append content to a UTF-16 file when the
+    pattern is absent, and not grow the file on subsequent runs.
+    """
+    name = tmp_path / "append.psd1"
+    _write_utf16(name, "ModuleVersion = '1.0'\r\n")
+
+    results = []
+    for _ in range(3):
+        results.append(
+            file.replace(
+                name=str(name),
+                pattern=r"^PowerShellVersion\s*=.*$",
+                repl="PowerShellVersion = '3.0'",
+                append_if_not_found=True,
+                encoding="utf-16",
+                backup=False,
+            )
+        )
+
+    for ret in results:
+        assert ret.result is True
+
+    content = _read_utf16(name)
+    assert content.count("PowerShellVersion") == 1
+    assert "ModuleVersion = '1.0'" in content
+
+
+def test_replace_utf32_state(file, tmp_path):
+    """
+    file.replace state with encoding='utf-32' should successfully replace a
+    pattern in a UTF-32 encoded file and keep the file in UTF-32 encoding.
+    """
+    name = tmp_path / "test_utf32.txt"
+    name.write_text("key = old_value\n", encoding="utf-32")
+
+    ret = file.replace(
+        name=str(name),
+        pattern=r"key = old_value",
+        repl="key = new_value",
+        encoding="utf-32",
+        backup=False,
+    )
+
+    assert ret.result is True
+    content = name.read_text(encoding="utf-32")
+    assert "key = new_value" in content
+    assert "key = old_value" not in content
+
+    raw = name.read_bytes()
+    assert raw[:4] in (
+        b"\xff\xfe\x00\x00",
+        b"\x00\x00\xfe\xff",
+    ), "BOM missing after replace: file is no longer UTF-32"
+
+
+def test_replace_utf16_execution_module(modules, tmp_path):
+    """
+    The file.replace execution module called directly should handle UTF-16
+    files when encoding is specified.
+    """
+    name = tmp_path / "exec_module.psd1"
+    _write_utf16(name, "PowerShellVersion = '2.0'\r\nModuleVersion = '1.0'\r\n")
+
+    result = modules.file.replace(
+        path=str(name),
+        pattern=r"PowerShellVersion\s+=\s+'2\.0'",
+        repl="PowerShellVersion = '3.0'",
+        encoding="utf-16",
+        show_changes=False,
+    )
+
+    assert result is True
+    content = _read_utf16(name)
+    assert "PowerShellVersion = '3.0'" in content
+    assert "PowerShellVersion = '2.0'" not in content
+
+    raw = name.read_bytes()
+    assert raw[:2] in (b"\xff\xfe", b"\xfe\xff"), "BOM missing after replace"

--- a/tests/pytests/unit/modules/file/test_file_replace.py
+++ b/tests/pytests/unit/modules/file/test_file_replace.py
@@ -1,0 +1,250 @@
+"""
+Tests for file.replace with encoding support (issue #52793).
+
+Verifies that UTF-16 and other multi-byte encoded files can be handled by
+file.replace when an explicit encoding is provided.
+"""
+
+import logging
+
+import pytest
+
+import salt.modules.cmdmod as cmdmod
+import salt.modules.file as filemod
+import salt.utils.files
+import salt.utils.platform
+import salt.utils.stringutils
+from salt.exceptions import SaltInvocationError
+from tests.support.mock import MagicMock
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    if salt.utils.platform.is_windows():
+        grains = {"kernel": "Windows"}
+    else:
+        grains = {"kernel": "Linux"}
+    opts = {
+        "test": False,
+        "file_roots": {"base": "tmp"},
+        "pillar_roots": {"base": "tmp"},
+        "cachedir": "tmp",
+        "grains": grains,
+    }
+    return {
+        filemod: {
+            "__salt__": {
+                "config.manage_mode": MagicMock(),
+                "cmd.run": cmdmod.run,
+                "cmd.run_all": cmdmod.run_all,
+            },
+            "__opts__": opts,
+            "__grains__": grains,
+            "__utils__": {
+                "files.is_text": salt.utils.files.is_text,
+                "stringutils.get_diff": salt.utils.stringutils.get_diff,
+            },
+        }
+    }
+
+
+@pytest.fixture
+def utf16_file(tmp_path):
+    """A UTF-16 encoded file with a known pattern to replace."""
+    p = tmp_path / "test.psd1"
+    content = "PowerShellVersion = '2.0'\r\nModuleVersion = '1.0'\r\n"
+    p.write_text(content, encoding="utf-16")
+    return p
+
+
+@pytest.fixture
+def utf8_file(tmp_path):
+    """A plain UTF-8 text file."""
+    p = tmp_path / "test.txt"
+    p.write_text("hello world\n", encoding="utf-8")
+    return p
+
+
+def test_replace_utf16_matches_and_rewrites(utf16_file):
+    """
+    file.replace with encoding='utf-16' should find and replace a pattern in a
+    UTF-16 encoded file and write the result back in the same encoding.
+    """
+    result = filemod.replace(
+        str(utf16_file),
+        pattern=r"PowerShellVersion = '2\.0'",
+        repl="PowerShellVersion = '3.0'",
+        encoding="utf-16",
+        show_changes=False,
+    )
+    assert result is True
+    updated = utf16_file.read_text(encoding="utf-16")
+    assert "PowerShellVersion = '3.0'" in updated
+    assert "PowerShellVersion = '2.0'" not in updated
+    assert "ModuleVersion = '1.0'" in updated
+
+
+def test_replace_utf16_no_match_returns_false(utf16_file):
+    """
+    file.replace with encoding='utf-16' should return False (no changes) when
+    the pattern is not found.
+    """
+    result = filemod.replace(
+        str(utf16_file),
+        pattern=r"DoesNotExist",
+        repl="something",
+        encoding="utf-16",
+        show_changes=False,
+    )
+    assert result is False
+    assert "PowerShellVersion = '2.0'" in utf16_file.read_text(encoding="utf-16")
+
+
+def test_replace_utf16_preserves_encoding(utf16_file):
+    """
+    After file.replace with encoding='utf-16', the file must remain valid
+    UTF-16 (not silently re-encoded as UTF-8/ANSI).
+    """
+    filemod.replace(
+        str(utf16_file),
+        pattern=r"ModuleVersion = '1\.0'",
+        repl="ModuleVersion = '2.0'",
+        encoding="utf-16",
+        show_changes=False,
+    )
+    raw = utf16_file.read_bytes()
+    assert raw[:2] in (
+        b"\xff\xfe",
+        b"\xfe\xff",
+    ), "BOM missing: file is no longer UTF-16"
+    content = utf16_file.read_text(encoding="utf-16")
+    assert "ModuleVersion = '2.0'" in content
+
+
+def test_replace_utf16_search_only(utf16_file):
+    """
+    search_only=True should return True when the pattern is found in a UTF-16
+    file without modifying it.
+    """
+    original_bytes = utf16_file.read_bytes()
+    result = filemod.replace(
+        str(utf16_file),
+        pattern=r"PowerShellVersion",
+        repl="irrelevant",
+        encoding="utf-16",
+        search_only=True,
+    )
+    assert result is True
+    assert utf16_file.read_bytes() == original_bytes
+
+
+def test_replace_utf16_search_only_no_match(utf16_file):
+    """
+    search_only=True should return False when the pattern is absent.
+    """
+    result = filemod.replace(
+        str(utf16_file),
+        pattern=r"NotPresent",
+        repl="irrelevant",
+        encoding="utf-16",
+        search_only=True,
+    )
+    assert result is False
+
+
+def test_replace_utf16_show_changes_returns_diff(utf16_file):
+    """
+    show_changes=True (the default) should return a non-empty unified diff
+    string when a substitution is made.
+    """
+    result = filemod.replace(
+        str(utf16_file),
+        pattern=r"PowerShellVersion = '2\.0'",
+        repl="PowerShellVersion = '3.0'",
+        encoding="utf-16",
+    )
+    assert isinstance(result, str)
+    assert result != ""
+
+
+def test_replace_utf16_dry_run_does_not_write(utf16_file):
+    """
+    dry_run=True should report changes without modifying the file byte-for-byte.
+    """
+    original_bytes = utf16_file.read_bytes()
+    filemod.replace(
+        str(utf16_file),
+        pattern=r"PowerShellVersion = '2\.0'",
+        repl="PowerShellVersion = '3.0'",
+        encoding="utf-16",
+        dry_run=True,
+        show_changes=False,
+    )
+    assert utf16_file.read_bytes() == original_bytes
+
+
+def test_replace_utf16_append_if_not_found(tmp_path):
+    """
+    append_if_not_found=True should append the repl text when the pattern is
+    absent from a UTF-16 file.
+    """
+    p = tmp_path / "append_test.txt"
+    p.write_text("existing line\r\n", encoding="utf-16")
+
+    filemod.replace(
+        str(p),
+        pattern=r"MissingLine",
+        repl="NewLine",
+        encoding="utf-16",
+        append_if_not_found=True,
+        show_changes=False,
+    )
+    content = p.read_text(encoding="utf-16")
+    assert "existing line" in content
+    assert "NewLine" in content
+
+
+def test_replace_utf32_matches_and_rewrites(tmp_path):
+    """
+    file.replace with encoding='utf-32' should find and replace a pattern in a
+    UTF-32 encoded file and write the result back in the same encoding.
+    """
+    p = tmp_path / "test.txt"
+    p.write_text("key = old_value\n", encoding="utf-32")
+
+    result = filemod.replace(
+        str(p),
+        pattern=r"key = old_value",
+        repl="key = new_value",
+        encoding="utf-32",
+        show_changes=False,
+    )
+
+    assert result is True
+    content = p.read_text(encoding="utf-32")
+    assert "key = new_value" in content
+    assert "key = old_value" not in content
+
+    raw = p.read_bytes()
+    assert raw[:4] in (
+        b"\xff\xfe\x00\x00",
+        b"\x00\x00\xfe\xff",
+    ), "BOM missing: file is no longer UTF-32"
+
+
+def test_replace_binary_without_encoding_raises(tmp_path):
+    """
+    A file containing null bytes should still raise SaltInvocationError when
+    no encoding is specified (existing behaviour is preserved).
+    """
+    p = tmp_path / "binary.bin"
+    p.write_bytes(b"\x00\x01\x02\x03binary data")
+
+    with pytest.raises(SaltInvocationError, match="binary file"):
+        filemod.replace(
+            str(p),
+            pattern=r"binary",
+            repl="text",
+        )


### PR DESCRIPTION
### What does this PR do?
UTF-16 and UTF-32 files contain null bytes which cause is_text() to classify them as binary, making file.replace raise SaltInvocationError. Add an encoding parameter to both the execution module and state. When set, the binary check is bypassed and the file is read/written in text mode with the specified encoding, preserving line endings and the BOM.

### What issues does this PR fix or reference?
Fixes #52793

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
