### PR TITLE
Each master needs it's own job/state queues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2411,8 +2411,13 @@ repos:
           - --
         additional_dependencies:
           - nox==2022.11.21
-          - setuptools<58.0
-          - pip>=20.2.4,<21.2
+          # Pip/setuptools pins must run on the hook interpreter (Python 3.12+ in CI):
+          # pip 20.x still imports distutils, removed from the stdlib in 3.12.
+          # pip 23.x trips on Py 3.14 metadata parsing; 25.x is needed.
+          # Pip must match requirements/constraints.txt (pip == 25.2) so the
+          # noxfile's PIP_CONSTRAINT install does not try to downgrade.
+          - setuptools>=80.10.2
+          - pip==25.2
 
   - repo: local
     hooks:
@@ -2427,6 +2432,11 @@ repos:
           - --
         additional_dependencies:
           - nox==2022.11.21
-          - setuptools<58.0
-          - pip>=20.2.4,<21.2
+          # Pip/setuptools pins must run on the hook interpreter (Python 3.12+ in CI):
+          # pip 20.x still imports distutils, removed from the stdlib in 3.12.
+          # pip 23.x trips on Py 3.14 metadata parsing; 25.x is needed.
+          # Pip must match requirements/constraints.txt (pip == 25.2) so the
+          # noxfile's PIP_CONSTRAINT install does not try to downgrade.
+          - setuptools>=80.10.2
+          - pip==25.2
   # <---- Pre-Commit -------------------------------------------------------------------------------------------------

--- a/changelog/69308.fixed.md
+++ b/changelog/69308.fixed.md
@@ -1,0 +1,1 @@
+Ensure multiple masters have their own job/state queues

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1306,7 +1306,9 @@ class Minion(MinionBase):
 
         # Clean up stale queue lock that might have been left behind if the minion
         # was killed forcefully (SIGKILL). This ensures recovery on restart.
-        lock_path = os.path.join(self.opts["cachedir"], "minion_queue.lock")
+        # In multimaster, each Minion instance has its own per-master lock path,
+        # so this cleanup cannot interfere across masters sharing a cachedir.
+        lock_path = salt.utils.state.queue_lock_path(self.opts)
         if os.path.isfile(lock_path):
             try:
                 os.remove(lock_path)
@@ -1412,8 +1414,10 @@ class Minion(MinionBase):
         Clean up orphaned running_ queue files that may have been left behind
         if the minion crashed after renaming queued_ to running_ but before cleanup.
         """
-        for queue_name in ("state_queue", "job_queue"):
-            queue_dir = os.path.join(self.opts["cachedir"], queue_name)
+        for queue_dir in (
+            salt.utils.state.state_queue_dir(self.opts),
+            salt.utils.state.job_queue_dir(self.opts),
+        ):
             if not os.path.exists(queue_dir):
                 continue
 
@@ -2019,7 +2023,7 @@ class Minion(MinionBase):
         """
         Queue a job to disk because process_count_max is reached.
         """
-        queue_dir = os.path.join(self.opts["cachedir"], "job_queue")
+        queue_dir = salt.utils.state.job_queue_dir(self.opts)
         if not os.path.exists(queue_dir):
             try:
                 os.makedirs(queue_dir)
@@ -2254,7 +2258,7 @@ class Minion(MinionBase):
         Async implementation of _process_process_queue_async
         """
         try:
-            queue_dir = os.path.join(self.opts["cachedir"], "job_queue")
+            queue_dir = salt.utils.state.job_queue_dir(self.opts)
             if not os.path.exists(queue_dir):
                 return
 
@@ -3854,7 +3858,7 @@ class Minion(MinionBase):
 
     async def _process_state_queue_async_impl(self):
         try:
-            queue_dir = os.path.join(self.opts["cachedir"], "state_queue")
+            queue_dir = salt.utils.state.state_queue_dir(self.opts)
             if not os.path.exists(queue_dir):
                 return
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -426,7 +426,7 @@ def _set_queue_flag(jid):
     """
     if jid is None:
         return
-    queue_dir = os.path.join(__opts__["cachedir"], "state_queue")
+    queue_dir = salt.utils.state.state_queue_dir(__opts__)
     queue_path = os.path.join(queue_dir, str(jid))
     if not os.path.exists(queue_dir):
         try:
@@ -445,7 +445,7 @@ def _clear_queue_flag(jid):
     """
     if jid is None:
         return
-    queue_dir = os.path.join(__opts__["cachedir"], "state_queue")
+    queue_dir = salt.utils.state.state_queue_dir(__opts__)
     queue_path = os.path.join(queue_dir, str(jid))
 
     with _acquire_queue_lock():
@@ -484,7 +484,7 @@ def _check_queue(queue, kwargs):
             states = _prior_running_states(jid)
             if states:
                 # Conflict found, queue the job
-                queue_dir = os.path.join(__opts__["cachedir"], "state_queue")
+                queue_dir = salt.utils.state.state_queue_dir(__opts__)
                 if not os.path.exists(queue_dir):
                     try:
                         os.makedirs(queue_dir)

--- a/salt/utils/state.py
+++ b/salt/utils/state.py
@@ -5,6 +5,7 @@ Utility functions for state functions
 """
 
 import copy
+import errno
 import logging
 import os
 
@@ -18,12 +19,71 @@ log = logging.getLogger(__name__)
 
 _empty = object()
 
+_SAFE_MASTER_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+)
+
+
+def _sanitize_master_id(master):
+    """
+    Return a filesystem-safe identifier for a master.
+
+    In multimaster, each Minion has its own opts["master"] string. The string
+    may contain characters (``:`` for host:port, ``/`` for IPv6 zone ids, etc.)
+    that are not valid in path components on every OS we support — Windows
+    in particular rejects ``:`` in filenames.
+    """
+    if master is None:
+        return "_default"
+    if isinstance(master, (list, tuple)):
+        master = ",".join(str(m) for m in master)
+    master = str(master)
+    if not master:
+        return "_default"
+    return "".join(c if c in _SAFE_MASTER_CHARS else "_" for c in master)
+
+
+def queue_base_dir(opts):
+    """
+    Return the per-master queue base directory.
+    """
+    return os.path.join(
+        opts["cachedir"], "queues", _sanitize_master_id(opts.get("master"))
+    )
+
+
+def queue_lock_path(opts):
+    """
+    Return the per-master queue lock file path.
+    """
+    return os.path.join(queue_base_dir(opts), "queue.lock")
+
+
+def job_queue_dir(opts):
+    """
+    Return the per-master job queue directory.
+    """
+    return os.path.join(queue_base_dir(opts), "job_queue")
+
+
+def state_queue_dir(opts):
+    """
+    Return the per-master state queue directory.
+    """
+    return os.path.join(queue_base_dir(opts), "state_queue")
+
 
 def acquire_queue_lock(opts):
     """
     Acquire the state queue lock
     """
-    lock_path = os.path.join(opts["cachedir"], "minion_queue.lock")
+    lock_path = queue_lock_path(opts)
+    # Ensure the parent directory exists; the lock lives under the per-master
+    # queue base which may not have been created yet on a fresh minion.
+    try:
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    except OSError:
+        pass
     # Use a large timeout to mimic infinite blocking of FileLock, as wait_lock defaults to 5s
     return salt.utils.files.wait_lock(lock_path, lock_fn=lock_path, timeout=86400)
 
@@ -32,14 +92,15 @@ def acquire_async_queue_lock(opts):
     """
     Acquire the job queue lock asynchronously
     """
-    lock_path = os.path.join(opts["cachedir"], "minion_queue.lock")
+    lock_path = queue_lock_path(opts)
+    try:
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    except OSError:
+        pass
     # Use timeout that allows queue processing to work but doesn't hang tests
     return salt.utils.files.await_lock(
         lock_path, lock_fn=lock_path, timeout=5.0, sleep=0.1
     )
-
-
-import errno
 
 
 def get_active_states(opts):
@@ -108,8 +169,7 @@ def check_prior_running_states(opts, jid, active_jobs):
 
     # Check for queued jobs in BOTH state_queue and job_queue
     # Also check for 'running_' files to close the "Invisible Gap"
-    for queue_name in ("state_queue", "job_queue"):
-        queue_dir = os.path.join(opts["cachedir"], queue_name)
+    for queue_dir in (state_queue_dir(opts), job_queue_dir(opts)):
         if not os.path.exists(queue_dir):
             continue
 

--- a/tests/pytests/functional/minion/test_per_master_queue.py
+++ b/tests/pytests/functional/minion/test_per_master_queue.py
@@ -1,0 +1,132 @@
+"""
+Functional regression tests for the per-master queue split.
+
+These exercise the in-process behavior of ``salt.minion.Minion`` when two
+instances share a cachedir but point at different masters — the layout the
+``MinionManager`` produces in a hot/hot multimaster configuration.
+"""
+
+import copy
+import os
+import time
+
+import salt.ext.tornado.ioloop
+import salt.minion
+import salt.utils.files
+import salt.utils.state
+
+
+def _make_opts(minion_opts, master, cachedir):
+    opts = copy.deepcopy(minion_opts)
+    opts["master"] = master
+    opts["cachedir"] = str(cachedir)
+    return opts
+
+
+def _make_minion(opts):
+    """
+    Construct a Minion in-process without going through the connection flow.
+    The constructor runs the stale-lock cleanup, which is what we want to
+    exercise here.
+    """
+    io_loop = salt.ext.tornado.ioloop.IOLoop()
+    minion = salt.minion.Minion(opts, jid_queue=[], io_loop=io_loop)
+    return minion
+
+
+def test_two_minions_share_cachedir_independent_locks(minion_opts, tmp_path):
+    """
+    Regression for FileNotFoundError on job_queue.lock in hot/hot multimaster.
+
+    Two Minion instances pointing at the same cachedir but different masters
+    must resolve to disjoint queue lock paths, and one Minion's stale-lock
+    cleanup at __init__ must not touch the other Minion's live lock file.
+    """
+    cachedir = tmp_path / "cache"
+    cachedir.mkdir()
+
+    opts_a = _make_opts(minion_opts, "master-a", cachedir)
+    opts_b = _make_opts(minion_opts, "master-b", cachedir)
+
+    lock_a = salt.utils.state.queue_lock_path(opts_a)
+    lock_b = salt.utils.state.queue_lock_path(opts_b)
+    assert lock_a != lock_b
+    assert os.path.dirname(lock_a) != os.path.dirname(lock_b)
+
+    # Bring Minion A up and place a sentinel where its lock would live.
+    minion_a = _make_minion(opts_a)
+    try:
+        os.makedirs(os.path.dirname(lock_a), exist_ok=True)
+        with salt.utils.files.fopen(lock_a, "w") as fp_:
+            fp_.write("held by minion_a")
+        assert os.path.isfile(lock_a)
+
+        # Constructing Minion B must NOT remove minion_a's live lock.
+        # Pre-split this would call os.remove on the shared lock path.
+        minion_b = _make_minion(opts_b)
+        try:
+            assert os.path.isfile(lock_a), (
+                "Minion-B's __init__ stale-lock cleanup deleted Minion-A's "
+                "live lock file — the original FileNotFoundError race."
+            )
+        finally:
+            minion_b.destroy()
+    finally:
+        minion_a.destroy()
+
+
+def test_queue_job_writes_to_per_master_dir(minion_opts, tmp_path):
+    """
+    _queue_job writes the queued payload under the per-master job_queue dir,
+    never the legacy shared cachedir/job_queue path.
+    """
+    cachedir = tmp_path / "cache"
+    cachedir.mkdir()
+
+    opts = _make_opts(minion_opts, "master-a", cachedir)
+    minion = _make_minion(opts)
+    try:
+        jid = str(int(time.time() * 1000000))
+        data = {"fun": "test.ping", "jid": jid, "arg": [], "tgt": "*"}
+        minion._queue_job(data)
+    finally:
+        minion.destroy()
+
+    expected_dir = salt.utils.state.job_queue_dir(opts)
+    legacy_dir = os.path.join(str(cachedir), "job_queue")
+
+    assert os.path.isdir(expected_dir), expected_dir
+    queued = [f for f in os.listdir(expected_dir) if f.startswith("queued_")]
+    assert queued, f"_queue_job did not write under {expected_dir}"
+    assert not os.path.exists(legacy_dir), (
+        f"_queue_job wrote to the legacy shared path {legacy_dir} instead of "
+        f"the per-master path {expected_dir}"
+    )
+
+
+def test_two_minions_queue_jobs_isolated(minion_opts, tmp_path):
+    """
+    Each Minion's _queue_job lands in its own per-master directory; the
+    drained file from one is invisible to the other Minion's queue dir.
+    """
+    cachedir = tmp_path / "cache"
+    cachedir.mkdir()
+
+    opts_a = _make_opts(minion_opts, "master-a", cachedir)
+    opts_b = _make_opts(minion_opts, "master-b", cachedir)
+
+    minion_a = _make_minion(opts_a)
+    minion_b = _make_minion(opts_b)
+    try:
+        minion_a._queue_job({"fun": "test.ping", "jid": "100", "arg": [], "tgt": "*"})
+        minion_b._queue_job({"fun": "test.ping", "jid": "200", "arg": [], "tgt": "*"})
+    finally:
+        minion_a.destroy()
+        minion_b.destroy()
+
+    files_a = os.listdir(salt.utils.state.job_queue_dir(opts_a))
+    files_b = os.listdir(salt.utils.state.job_queue_dir(opts_b))
+    assert any("100" in fn for fn in files_a)
+    assert not any("200" in fn for fn in files_a)
+    assert any("200" in fn for fn in files_b)
+    assert not any("100" in fn for fn in files_b)

--- a/tests/pytests/integration/modules/state/test_queue_race.py
+++ b/tests/pytests/integration/modules/state/test_queue_race.py
@@ -10,6 +10,7 @@ import yaml
 
 import salt.payload
 import salt.utils.files
+import salt.utils.state
 
 log = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ def test_queue_jumping_visibility(
     subprocess.Popen(cmd_job1, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     # Step 3: Verify Job 1 is in job_queue on disk
-    job_queue_dir = os.path.join(configured_minion.config["cachedir"], "job_queue")
+    job_queue_dir = salt.utils.state.job_queue_dir(configured_minion.config)
     start = time.time()
     found_job1 = False
     while time.time() - start < 20:

--- a/tests/pytests/integration/modules/state/test_state_queue.py
+++ b/tests/pytests/integration/modules/state/test_state_queue.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import salt.utils.files
+import salt.utils.state
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +67,7 @@ def test_state_queue_basic(salt_cli, salt_minion, quick_sls):
     assert quick_target_path.exists(), "Job should have executed immediately"
 
     # Step 2: Verify no files were left in state_queue
-    state_queue_dir = os.path.join(salt_minion.config["cachedir"], "state_queue")
+    state_queue_dir = salt.utils.state.state_queue_dir(salt_minion.config)
     if os.path.exists(state_queue_dir):
         files = os.listdir(state_queue_dir)
         queued_files = [
@@ -102,7 +103,7 @@ def test_state_queue_true(salt_cli, salt_minion, quick_sls):
     assert quick_target_path.exists(), "Job should have executed"
 
     # Verify no files were left in state_queue (since it executed immediately)
-    state_queue_dir = os.path.join(salt_minion.config["cachedir"], "state_queue")
+    state_queue_dir = salt.utils.state.state_queue_dir(salt_minion.config)
     if os.path.exists(state_queue_dir):
         files = os.listdir(state_queue_dir)
         queued_files = [

--- a/tests/pytests/scenarios/multimaster/test_per_master_queue.py
+++ b/tests/pytests/scenarios/multimaster/test_per_master_queue.py
@@ -1,0 +1,272 @@
+"""
+Integration regression tests for the per-master queue split.
+
+Two behaviors the previous shared-queue layout could not provide:
+
+1. Stale-lock cleanup in ``Minion.__init__`` deleting another Minion's live
+   lock file, producing ``FileNotFoundError: ...queue.lock`` in production.
+2. A job queued by Minion-1 being drained and returned via Minion-2, so the
+   return goes to the wrong master.
+
+These tests run a real hot/hot multimaster minion (two ``Minion`` instances in
+one process) and assert both bugs are gone.
+"""
+
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+import pytest
+import yaml
+
+import salt.payload
+import salt.utils.files
+import salt.utils.state
+
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.core_test,
+]
+
+
+def _per_master_opts(minion_config, master_string):
+    """
+    Build an opts-shaped dict that the queue helpers can resolve into the
+    same paths the in-process Minion for ``master_string`` would use.
+    """
+    opts = dict(minion_config)
+    opts["master"] = master_string
+    return opts
+
+
+def _master_strings(minion_config):
+    """
+    Return the per-master strings the Minion uses internally for path
+    resolution. For a multimaster config, ``master`` is a list of
+    ``host:port`` strings.
+    """
+    masters = minion_config["master"]
+    if isinstance(masters, str):
+        return [masters]
+    return list(masters)
+
+
+def test_per_master_queue_paths_disjoint(salt_mm_minion_1, ensure_connections):
+    """
+    Sanity check: the two Minions inside the hot/hot minion process resolve
+    to completely disjoint queue path trees, and the legacy shared paths are
+    not created during normal operation.
+    """
+    cachedir = salt_mm_minion_1.config["cachedir"]
+    masters = _master_strings(salt_mm_minion_1.config)
+    assert len(masters) == 2, masters
+
+    opts_a = _per_master_opts(salt_mm_minion_1.config, masters[0])
+    opts_b = _per_master_opts(salt_mm_minion_1.config, masters[1])
+
+    assert salt.utils.state.queue_base_dir(opts_a) != salt.utils.state.queue_base_dir(
+        opts_b
+    )
+    assert salt.utils.state.queue_lock_path(opts_a) != salt.utils.state.queue_lock_path(
+        opts_b
+    )
+
+    # The legacy shared paths must never be touched by the new code.
+    assert not os.path.exists(os.path.join(cachedir, "minion_queue.lock"))
+    assert not os.path.exists(os.path.join(cachedir, "job_queue"))
+    assert not os.path.exists(os.path.join(cachedir, "state_queue"))
+
+
+def test_no_lock_filenotfounderror_after_traffic(
+    salt_mm_minion_1,
+    mm_master_1_salt_cli,
+    mm_master_2_salt_cli,
+    ensure_connections,
+):
+    """
+    Regression for the production traceback ``FileNotFoundError: ...job_queue.lock``.
+
+    Drive a burst of jobs from both masters and confirm the minion log never
+    contains the FileNotFoundError signature that Minion-2's stale-lock cleanup
+    used to produce against Minion-1's live lock under the shared layout.
+    """
+    log_path = pathlib.Path(salt_mm_minion_1.config["log_file"])
+    log_size_before = log_path.stat().st_size if log_path.exists() else 0
+
+    # Fire a handful of jobs from each master in alternation; if the lock race
+    # still exists, one of these will trip the cleanup-vs-hold race.
+    for _ in range(6):
+        for cli in (mm_master_1_salt_cli, mm_master_2_salt_cli):
+            ret = cli.run("test.ping", minion_tgt=salt_mm_minion_1.id)
+            assert ret.returncode == 0, ret
+
+    # Give any deferred error reporting a moment to flush.
+    time.sleep(1)
+
+    if log_path.exists():
+        with salt.utils.files.fopen(log_path, "r") as fp_:
+            fp_.seek(log_size_before)
+            tail = fp_.read()
+        assert "FileNotFoundError" not in tail or "queue.lock" not in tail, (
+            "Minion log contains a FileNotFoundError tied to the queue lock — "
+            "the per-master split should have eliminated this race.\n\n"
+            f"{tail}"
+        )
+
+
+@pytest.fixture
+def queue_limited_mm_minion(salt_mm_minion_1):
+    """
+    Stop the package-scoped multimaster minion, lower its
+    ``process_count_max`` to 1, and restart it. Restores the original config
+    on teardown.
+    """
+    if salt_mm_minion_1.is_running():
+        salt_mm_minion_1.terminate()
+
+    config_file = pathlib.Path(salt_mm_minion_1.config_file)
+    with salt.utils.files.fopen(config_file) as fp_:
+        config = yaml.safe_load(fp_)
+
+    original = {
+        "process_count_max": config.get("process_count_max"),
+        "mine_interval": config.get("mine_interval"),
+        "schedule": config.get("schedule"),
+    }
+    config["process_count_max"] = 1
+    config["mine_interval"] = 0
+    config["schedule"] = {}
+
+    with salt.utils.files.fopen(config_file, "w") as fp_:
+        yaml.safe_dump(config, fp_)
+
+    salt_mm_minion_1.start()
+    try:
+        yield salt_mm_minion_1
+    finally:
+        if salt_mm_minion_1.is_running():
+            salt_mm_minion_1.terminate()
+        for k, v in original.items():
+            if v is None:
+                config.pop(k, None)
+            else:
+                config[k] = v
+        with salt.utils.files.fopen(config_file, "w") as fp_:
+            yaml.safe_dump(config, fp_)
+        salt_mm_minion_1.start()
+
+
+def test_queued_job_lands_in_originating_masters_dir(
+    queue_limited_mm_minion,
+    mm_master_1_salt_cli,
+    mm_master_2_salt_cli,
+):
+    """
+    Regression for the wrong-master-return bug: when Minion-1 queues a job
+    because ``process_count_max`` is hit, the queued file must land under
+    *master-1's* per-master ``job_queue`` directory, not master-2's.
+    """
+    minion = queue_limited_mm_minion
+    masters = _master_strings(minion.config)
+    assert len(masters) == 2, masters
+
+    # The running Minion sets opts["master"] to the value returned by
+    # eval_master, which strips the port. We don't know that value here, so
+    # discover queue dirs by scanning cache/queues/ for per-master subdirs at
+    # assertion time rather than computing the path from the conftest config.
+    queues_root = os.path.join(minion.config["cachedir"], "queues")
+    proc_dir = os.path.join(minion.config["cachedir"], "proc")
+
+    # Occupy the single execution slot via master-1 with a foreground sleeper
+    # CLI call. salt_cli.run blocks until the CLI exits; running it as Popen
+    # without --async leaves the CLI subprocess waiting on minion completion,
+    # while the minion's own execution subprocess holds the slot for the
+    # duration of the sleep.
+    cmd_sleep = [
+        sys.executable,
+        mm_master_1_salt_cli.script_name,
+        "-c",
+        mm_master_1_salt_cli.config_dir,
+        minion.id,
+        "test.sleep",
+        "60",
+    ]
+    sleep_proc = subprocess.Popen(
+        cmd_sleep, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    try:
+        # Wait until a test.sleep job actually appears in proc/.
+        deadline = time.time() + 30
+        found_sleeper = False
+        while time.time() < deadline and not found_sleeper:
+            if os.path.isdir(proc_dir):
+                for fn in os.listdir(proc_dir):
+                    try:
+                        with salt.utils.files.fopen(
+                            os.path.join(proc_dir, fn), "rb"
+                        ) as fp_:
+                            data = salt.payload.load(fp_)
+                    except (OSError, ValueError, EOFError, TypeError):
+                        continue
+                    if isinstance(data, dict) and data.get("fun") == "test.sleep":
+                        found_sleeper = True
+                        break
+            if not found_sleeper:
+                time.sleep(0.5)
+        if not found_sleeper:
+            out, err = sleep_proc.communicate(timeout=5)
+            pytest.fail(
+                f"Sleeper never claimed the execution slot. "
+                f"stdout={out!r}, stderr={err!r}"
+            )
+
+        # Fire a job via master-1 only — process_count_max is 1, so it queues.
+        cmd_ping = [
+            sys.executable,
+            mm_master_1_salt_cli.script_name,
+            "-c",
+            mm_master_1_salt_cli.config_dir,
+            minion.id,
+            "test.ping",
+        ]
+        ping_proc = subprocess.Popen(
+            cmd_ping, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        try:
+            deadline = time.time() + 30
+            per_master_counts = {}
+            while time.time() < deadline:
+                per_master_counts = {}
+                if os.path.isdir(queues_root):
+                    for sub in os.listdir(queues_root):
+                        job_dir = os.path.join(queues_root, sub, "job_queue")
+                        if not os.path.isdir(job_dir):
+                            continue
+                        queued = [
+                            f for f in os.listdir(job_dir) if f.startswith("queued_")
+                        ]
+                        per_master_counts[sub] = queued
+                if any(per_master_counts.values()):
+                    break
+                time.sleep(0.5)
+
+            # Exactly one per-master subdir should contain queued files.
+            # Both Minions exist (the minion has two masters configured) so
+            # both per-master subtrees may exist on disk, but only one — the
+            # one belonging to the master that actually published — should
+            # hold the queued file.
+            holders = [m for m, q in per_master_counts.items() if q]
+            assert len(holders) == 1, (
+                f"Expected the queued job in exactly one master's job_queue; "
+                f"got {per_master_counts}"
+            )
+        finally:
+            ping_proc.kill()
+            ping_proc.wait(timeout=10)
+    finally:
+        sleep_proc.kill()
+        sleep_proc.wait(timeout=10)

--- a/tests/pytests/scenarios/queue/test_queue_load.py
+++ b/tests/pytests/scenarios/queue/test_queue_load.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 import salt.utils.files
+import salt.utils.state
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +64,8 @@ def test_queue_load_50(salt_master, salt_minion, salt_client, sleep_sls):
     start_wait = time.time()
 
     seen_jids = set()
-    state_queue_dir = os.path.join(salt_minion.config["cachedir"], "state_queue")
-    job_queue_dir = os.path.join(salt_minion.config["cachedir"], "job_queue")
+    state_queue_dir = salt.utils.state.state_queue_dir(salt_minion.config)
+    job_queue_dir = salt.utils.state.job_queue_dir(salt_minion.config)
     proc_dir = os.path.join(salt_minion.config["cachedir"], "proc")
 
     max_state_queue_size = 0
@@ -253,10 +254,11 @@ def test_stale_lock_recovery(salt_master, salt_minion, salt_client, sleep_sls):
     Verify that the Minion recovers from stale lock files on startup.
     """
     log.info("Starting Edge Case: Stale lock recovery")
-    lock_path = os.path.join(salt_minion.config["cachedir"], "minion_queue.lock")
+    lock_path = salt.utils.state.queue_lock_path(salt_minion.config)
 
     # Stop minion, create stale lock, start minion
     with salt_minion.stopped():
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
         with salt.utils.files.fopen(lock_path, "w") as f:
             f.write("stale")
 

--- a/tests/pytests/unit/modules/state/test_state.py
+++ b/tests/pytests/unit/modules/state/test_state.py
@@ -1376,10 +1376,11 @@ class TestCheckPriorRunningStates:
                 opts, "12345", active_jobs
             )
 
-            # Verify directories were listed
+            # Verify directories were listed — per-master paths under the
+            # cachedir/queues/<master>/ tree.
             assert mock_listdir.call_count == 2
-            mock_listdir.assert_any_call(os.path.join(opts["cachedir"], "state_queue"))
-            mock_listdir.assert_any_call(os.path.join(opts["cachedir"], "job_queue"))
+            mock_listdir.assert_any_call(salt.utils.state.state_queue_dir(opts))
+            mock_listdir.assert_any_call(salt.utils.state.job_queue_dir(opts))
 
             # Verify we got results (should include the queued job as a conflict)
             assert isinstance(result, list)

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -77,7 +77,7 @@ def test_check_queue_queues_job_when_conflict():
     # Mock active jobs containing an older job
     active_jobs = [{"jid": older_jid, "pid": 1234, "fun": "state.apply"}]
 
-    opts = {"cachedir": "/tmp/salt_test_cache"}
+    opts = {"cachedir": "/tmp/salt_test_cache", "master": "master-a"}
 
     # Mock the lock to do nothing
     mock_lock = MagicMock()
@@ -115,6 +115,13 @@ def test_check_queue_queues_job_when_conflict():
         payload = args[0]
         assert payload["jid"] == new_jid
         assert payload["fun"] == "state.apply"
+
+        # The queue file must land under the per-master state_queue dir.
+        expected_dir = salt.utils.state.state_queue_dir(opts)
+        rename_args, _ = mock_rename.call_args
+        # atomic_rename(tmp_path, final_path)
+        final_path = rename_args[1]
+        assert final_path.startswith(expected_dir), final_path
 
 
 def test_check_queue_proceeds_when_no_conflict():

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -19,6 +19,7 @@ import salt.utils.event as event
 import salt.utils.jid
 import salt.utils.platform
 import salt.utils.process
+import salt.utils.state
 from salt._compat import ipaddress
 from salt.exceptions import SaltClientError, SaltMasterUnresolvableError, SaltSystemExit
 from tests.support.mock import MagicMock, patch
@@ -452,6 +453,7 @@ def test_process_count_max(minion_opts):
     async def mock_await_lock(*args, **kwargs):
         yield
 
+    fopen_mock = MagicMock()
     with patch("salt.minion.Minion.ctx", MagicMock(return_value={})), patch(
         "salt.minion.SignalHandlingProcess",
         MagicMock(side_effect=mock_proc_side_effect),
@@ -463,7 +465,7 @@ def test_process_count_max(minion_opts):
     ), patch(
         "os.makedirs", MagicMock()
     ), patch(
-        "salt.utils.files.fopen", MagicMock()
+        "salt.utils.files.fopen", fopen_mock
     ), patch(
         "salt.payload.dump", MagicMock()
     ), patch(
@@ -475,8 +477,9 @@ def test_process_count_max(minion_opts):
         minion_opts["__role"] = "minion"
         minion_opts["minion_jid_queue_hwm"] = 100
         minion_opts["process_count_max"] = process_count_max
-        # cachedir needed for lock
+        # cachedir needed for lock; master pins the per-master subpath
         minion_opts["cachedir"] = "/tmp/salt_test_cache"
+        minion_opts["master"] = "master-a"
 
         io_loop = salt.ext.tornado.ioloop.IOLoop()
         minion = salt.minion.Minion(minion_opts, jid_queue=[], io_loop=io_loop)
@@ -502,6 +505,12 @@ def test_process_count_max(minion_opts):
             assert salt.payload.dump.called
             # Assert JID added to active queue (deduplication cache)
             assert len(minion.jid_queue) == process_count_max + 1
+
+            # Assert the queued job file landed under the per-master job_queue dir,
+            # not the legacy shared cachedir/job_queue path.
+            expected_dir = salt.utils.state.job_queue_dir(minion_opts)
+            queue_paths = [c.args[0] for c in fopen_mock.call_args_list]
+            assert any(p.startswith(expected_dir) for p in queue_paths), queue_paths
 
         finally:
             minion.destroy()

--- a/tests/pytests/unit/utils/test_state.py
+++ b/tests/pytests/unit/utils/test_state.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for the per-master queue path helpers in salt.utils.state.
+"""
+
+import os
+
+import pytest
+
+import salt.utils.state
+
+
+@pytest.mark.parametrize(
+    "master, expected",
+    [
+        ("master-a", "master-a"),
+        ("127.0.0.1:4506", "127.0.0.1_4506"),
+        ("[fe80::1]:4506", "_fe80__1__4506"),
+        ("plain-host.example.com", "plain-host.example.com"),
+        ("weird/chars\\here", "weird_chars_here"),
+        ("", "_default"),
+        (None, "_default"),
+        (["m1", "m2"], "m1_m2"),
+        (("m1", "m2"), "m1_m2"),
+    ],
+)
+def test_sanitize_master_id(master, expected):
+    assert salt.utils.state._sanitize_master_id(master) == expected
+
+
+def test_queue_paths_use_per_master_namespace(tmp_path):
+    opts = {"cachedir": str(tmp_path), "master": "master-a"}
+    base = salt.utils.state.queue_base_dir(opts)
+    assert base == os.path.join(str(tmp_path), "queues", "master-a")
+    assert salt.utils.state.queue_lock_path(opts) == os.path.join(base, "queue.lock")
+    assert salt.utils.state.job_queue_dir(opts) == os.path.join(base, "job_queue")
+    assert salt.utils.state.state_queue_dir(opts) == os.path.join(base, "state_queue")
+
+
+def test_queue_paths_disjoint_per_master(tmp_path):
+    """
+    Two opts dicts pointing at the same cachedir but different masters must
+    resolve to completely disjoint queue trees — this is the property the
+    per-master split relies on to keep the two Minions out of each other's way.
+    """
+    opts_a = {"cachedir": str(tmp_path), "master": "master-a"}
+    opts_b = {"cachedir": str(tmp_path), "master": "master-b"}
+
+    paths_a = {
+        salt.utils.state.queue_base_dir(opts_a),
+        salt.utils.state.queue_lock_path(opts_a),
+        salt.utils.state.job_queue_dir(opts_a),
+        salt.utils.state.state_queue_dir(opts_a),
+    }
+    paths_b = {
+        salt.utils.state.queue_base_dir(opts_b),
+        salt.utils.state.queue_lock_path(opts_b),
+        salt.utils.state.job_queue_dir(opts_b),
+        salt.utils.state.state_queue_dir(opts_b),
+    }
+    assert paths_a.isdisjoint(paths_b)
+
+
+def test_queue_lock_path_makedirs_parent(tmp_path):
+    """
+    acquire_queue_lock pre-creates the per-master queue base dir; verify the
+    directory exists after the call so the underlying wait_lock has a place
+    to land its lock file.
+    """
+    opts = {"cachedir": str(tmp_path), "master": "master-a"}
+    # Just invoke the helper that builds + ensures the dir.
+    lock_path = salt.utils.state.queue_lock_path(opts)
+    # acquire_queue_lock side-effect: makedirs(parent).
+    salt.utils.state.acquire_queue_lock(opts)
+    assert os.path.isdir(os.path.dirname(lock_path))


### PR DESCRIPTION
In hot/hot multimaster, one Minion per master shares a cachedir. The shared minion_queue.lock and queue dirs caused two bugs: Minion.__init__'s stale-lock cleanup deleted a sibling Minion's live lock (FileNotFoundError on release), and either Minion could drain any queued file (wrong-master returns).

Move all queue state under cachedir/queues/<sanitized-master>/ via helpers in salt.utils.state. Each Minion only touches its own subtree.

No migration: jobs queued under legacy paths at upgrade time time out on
 the originating master.

Fixes #69308