### PR TITLE
Add dsc_resource execution and state modules for Invoke-DscResource

### DIFF
--- a/changelog/43718.added.md
+++ b/changelog/43718.added.md
@@ -1,0 +1,5 @@
+Added ``dsc_resource`` execution module and state module for invoking individual
+PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling
+a MOF file or involving the Local Configuration Manager. The
+``dsc_resource.managed`` state provides idiomatic Salt state management for any
+installed DSC resource module.

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -245,6 +245,7 @@ execution modules
     win_dism
     win_dns_client
     win_dsc
+    win_dsc_resource
     win_event
     win_file
     win_firewall

--- a/doc/ref/modules/all/salt.modules.win_dsc_resource.rst
+++ b/doc/ref/modules/all/salt.modules.win_dsc_resource.rst
@@ -1,0 +1,5 @@
+salt.modules.win_dsc_resource
+=============================
+
+.. automodule:: salt.modules.win_dsc_resource
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -118,6 +118,7 @@ state modules
     win_dacl
     win_dism
     win_dns_client
+    win_dsc_resource
     win_firewall
     win_iis
     win_lgpo

--- a/doc/ref/states/all/salt.states.win_dsc_resource.rst
+++ b/doc/ref/states/all/salt.states.win_dsc_resource.rst
@@ -1,0 +1,5 @@
+salt.states.win_dsc_resource
+============================
+
+.. automodule:: salt.states.win_dsc_resource
+    :members:

--- a/salt/modules/win_dsc_resource.py
+++ b/salt/modules/win_dsc_resource.py
@@ -1,0 +1,266 @@
+"""
+Module for invoking individual PowerShell DSC Resources directly using
+``Invoke-DscResource``.
+
+This module allows Salt to apply, test, and retrieve the state of any
+installed PowerShell DSC resource without compiling a MOF file or involving
+the Local Configuration Manager (LCM).
+
+Use the ``psget`` module to install DSC resource modules from the PowerShell
+Gallery before using them here.
+
+:depends:
+    - pythonnet
+    - PowerShell 5.0
+"""
+
+import logging
+
+import salt.utils.platform
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "dsc_resource"
+
+__func_alias__ = {
+    "set_": "set",
+}
+
+try:
+    from salt.utils.win_pwsh import HAS_CLR, HAS_PWSH_SDK, PowerShellSession
+except ImportError:
+    HAS_CLR = False
+    HAS_PWSH_SDK = False
+
+
+def __virtual__():
+    """
+    Only load on Windows with pythonnet and the PowerShell SDK available.
+    """
+    if not salt.utils.platform.is_windows():
+        return False, "DSC Resource: Only available on Windows systems"
+    if not HAS_CLR:
+        return False, "DSC Resource: Requires pythonnet (pip install pythonnet)"
+    if not HAS_PWSH_SDK:
+        return (
+            False,
+            "DSC Resource: Requires the PowerShell SDK"
+            " (System.Management.Automation)",
+        )
+    return __virtualname__
+
+
+def _dict_to_ps_hashtable(data):
+    """
+    Convert a Python dict to a PowerShell ``@{Key = Value}`` hashtable string.
+
+    Type mappings:
+
+    - ``bool``         → ``$true`` / ``$false``
+    - ``int`` / ``float`` → bare number
+    - ``None``         → ``$null``
+    - ``list``         → ``@('a', 'b')``
+    - ``str``          → ``'value'`` with internal single-quotes doubled
+
+    Args:
+        data (dict): The dictionary to convert.
+
+    Returns:
+        str: A PowerShell hashtable string, e.g. ``@{Name = 'foo'; Count = 1}``.
+    """
+    parts = []
+    for key, value in data.items():
+        if isinstance(value, bool):
+            ps_value = "$true" if value else "$false"
+        elif isinstance(value, (int, float)):
+            ps_value = str(value)
+        elif value is None:
+            ps_value = "$null"
+        elif isinstance(value, list):
+            items = ", ".join(
+                f"'{str(item).replace(chr(39), chr(39) * 2)}'" for item in value
+            )
+            ps_value = f"@({items})"
+        else:
+            escaped = str(value).replace("'", "''")
+            ps_value = f"'{escaped}'"
+        parts.append(f"{key} = {ps_value}")
+    return "@{" + "; ".join(parts) + "}"
+
+
+def get(name, module_name, properties):
+    r"""
+    Return the current state of a DSC resource by calling
+    ``Invoke-DscResource -Method Get``.
+
+    Args:
+
+        name (str):
+            The name of the DSC resource to query. For example,
+            ``WindowsFeature`` or ``File``. Required.
+
+        module_name (str):
+            The name of the PowerShell module that contains the resource. For
+            built-in resources use ``PSDesiredStateConfiguration``. Required.
+
+        properties (dict):
+            A dictionary of resource properties sufficient to identify the
+            resource instance. The required keys vary by resource. Required.
+
+    Returns:
+        dict: A dictionary of the resource's current property values as
+        reported by the DSC resource's ``Get`` method.
+
+    Raises:
+        CommandExecutionError: If the PowerShell call fails.
+        SaltInvocationError: If required arguments are missing or invalid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.get File PSDesiredStateConfiguration \
+            properties="{'DestinationPath': 'C:\\Temp\\test.txt', 'Ensure': 'Present'}"
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.get WindowsFeature PSDesiredStateConfiguration \
+            properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+    """
+    if not name:
+        raise SaltInvocationError("name is required")
+    if not module_name:
+        raise SaltInvocationError("module_name is required")
+    if not isinstance(properties, dict):
+        raise SaltInvocationError("properties must be a dict")
+
+    ps_prop = _dict_to_ps_hashtable(properties)
+    cmd = (
+        f"Invoke-DscResource"
+        f" -Name '{name}'"
+        f" -ModuleName '{module_name}'"
+        f" -Method Get"
+        f" -Property {ps_prop}"
+        f" | Select-Object * -ExcludeProperty Cim*, PSComputerName"
+    )
+    log.debug("DSC Resource get: %s", cmd)
+    with PowerShellSession() as session:
+        return session.run_json(cmd)
+
+
+def test(name, module_name, properties):
+    r"""
+    Test whether a DSC resource is in the desired state by calling
+    ``Invoke-DscResource -Method Test``.
+
+    Args:
+
+        name (str):
+            The name of the DSC resource to test. Required.
+
+        module_name (str):
+            The name of the PowerShell module that contains the resource.
+            Required.
+
+        properties (dict):
+            A dictionary of the desired resource properties. Required.
+
+    Returns:
+        bool: ``True`` if the resource is already in the desired state,
+        ``False`` if changes are needed.
+
+    Raises:
+        CommandExecutionError: If the PowerShell call fails.
+        SaltInvocationError: If required arguments are missing or invalid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.test File PSDesiredStateConfiguration \
+            properties="{'DestinationPath': 'C:\\Temp\\test.txt', 'Ensure': 'Present'}"
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.test WindowsFeature PSDesiredStateConfiguration \
+            properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+    """
+    if not name:
+        raise SaltInvocationError("name is required")
+    if not module_name:
+        raise SaltInvocationError("module_name is required")
+    if not isinstance(properties, dict):
+        raise SaltInvocationError("properties must be a dict")
+
+    ps_prop = _dict_to_ps_hashtable(properties)
+    cmd = (
+        f"(Invoke-DscResource"
+        f" -Name '{name}'"
+        f" -ModuleName '{module_name}'"
+        f" -Method Test"
+        f" -Property {ps_prop}).InDesiredState"
+    )
+    log.debug("DSC Resource test: %s", cmd)
+    with PowerShellSession() as session:
+        result = session.run(cmd)
+    if isinstance(result, bool):
+        return result
+    return str(result).lower() == "true"
+
+
+def set_(name, module_name, properties):
+    r"""
+    Apply a DSC resource to the desired state by calling
+    ``Invoke-DscResource -Method Set``.
+
+    Args:
+
+        name (str):
+            The name of the DSC resource to apply. Required.
+
+        module_name (str):
+            The name of the PowerShell module that contains the resource.
+            Required.
+
+        properties (dict):
+            A dictionary of the desired resource properties. Required.
+
+    Returns:
+        bool: ``True`` if the resource was applied successfully.
+
+    Raises:
+        CommandExecutionError: If the resource failed to apply.
+        SaltInvocationError: If required arguments are missing or invalid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.set File PSDesiredStateConfiguration \
+            properties="{'DestinationPath': 'C:\\Temp\\test.txt', 'Ensure': 'Present', 'Contents': 'hello'}"
+
+    .. code-block:: bash
+
+        salt '*' dsc_resource.set WindowsFeature PSDesiredStateConfiguration \
+            properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+    """
+    if not name:
+        raise SaltInvocationError("name is required")
+    if not module_name:
+        raise SaltInvocationError("module_name is required")
+    if not isinstance(properties, dict):
+        raise SaltInvocationError("properties must be a dict")
+
+    ps_prop = _dict_to_ps_hashtable(properties)
+    cmd = (
+        f"Invoke-DscResource"
+        f" -Name '{name}'"
+        f" -ModuleName '{module_name}'"
+        f" -Method Set"
+        f" -Property {ps_prop}"
+    )
+    log.debug("DSC Resource set: %s", cmd)
+    with PowerShellSession() as session:
+        session.run_strict(cmd)
+    return True

--- a/salt/modules/win_dsc_resource.py
+++ b/salt/modules/win_dsc_resource.py
@@ -105,7 +105,7 @@ def _dict_to_ps_hashtable(data):
     Returns:
         str: A PowerShell hashtable string, e.g. ``@{Name = 'foo'; Count = 1}``.
     """
-    parts = [f"{key} = {_ps_value(value)}" for key, value in data.items()]
+    parts = [f"'{_ps_quote(key)}' = {_ps_value(value)}" for key, value in data.items()]
     return "@{" + "; ".join(parts) + "}"
 
 

--- a/salt/modules/win_dsc_resource.py
+++ b/salt/modules/win_dsc_resource.py
@@ -53,17 +53,51 @@ def __virtual__():
     return __virtualname__
 
 
-def _dict_to_ps_hashtable(data):
+def _ps_value(value):
     """
-    Convert a Python dict to a PowerShell ``@{Key = Value}`` hashtable string.
+    Convert a single Python value to its PowerShell literal representation.
 
     Type mappings:
 
     - ``bool``            -> ``$true`` / ``$false``
     - ``int`` / ``float`` -> bare number
     - ``None``            -> ``$null``
-    - ``list``            -> ``@('a', 'b')``
+    - ``dict``            -> ``@{Key = Value}`` (recursive)
+    - ``list``            -> ``@(item, ...)`` with each element typed (recursive)
     - ``str``             -> ``'value'`` with internal single-quotes doubled
+
+    Args:
+        value: The value to convert.
+
+    Returns:
+        str: The PowerShell literal for *value*.
+    """
+    if isinstance(value, bool):
+        return "$true" if value else "$false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if value is None:
+        return "$null"
+    if isinstance(value, dict):
+        return _dict_to_ps_hashtable(value)
+    if isinstance(value, list):
+        items = ", ".join(_ps_value(item) for item in value)
+        return f"@({items})"
+    escaped = str(value).replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _dict_to_ps_hashtable(data):
+    """
+    Convert a Python dict to a PowerShell ``@{Key = Value}`` hashtable string.
+
+    Delegates per-value conversion to :func:`_ps_value`, which handles bools,
+    numbers, ``None``, nested dicts, lists (with full type support per element),
+    and strings. Supported property types:
+
+    - Scalar: ``str``, ``int``, ``float``, ``bool``, ``None``
+    - Array: ``list`` of any of the above, or of nested ``dict``
+    - Nested hashtable: ``dict``
 
     Args:
         data (dict): The dictionary to convert.
@@ -71,23 +105,7 @@ def _dict_to_ps_hashtable(data):
     Returns:
         str: A PowerShell hashtable string, e.g. ``@{Name = 'foo'; Count = 1}``.
     """
-    parts = []
-    for key, value in data.items():
-        if isinstance(value, bool):
-            ps_value = "$true" if value else "$false"
-        elif isinstance(value, (int, float)):
-            ps_value = str(value)
-        elif value is None:
-            ps_value = "$null"
-        elif isinstance(value, list):
-            items = ", ".join(
-                f"'{str(item).replace(chr(39), chr(39) * 2)}'" for item in value
-            )
-            ps_value = f"@({items})"
-        else:
-            escaped = str(value).replace("'", "''")
-            ps_value = f"'{escaped}'"
-        parts.append(f"{key} = {ps_value}")
+    parts = [f"{key} = {_ps_value(value)}" for key, value in data.items()]
     return "@{" + "; ".join(parts) + "}"
 
 

--- a/salt/modules/win_dsc_resource.py
+++ b/salt/modules/win_dsc_resource.py
@@ -57,11 +57,11 @@ def _dict_to_ps_hashtable(data):
 
     Type mappings:
 
-    - ``bool``         → ``$true`` / ``$false``
-    - ``int`` / ``float`` → bare number
-    - ``None``         → ``$null``
-    - ``list``         → ``@('a', 'b')``
-    - ``str``          → ``'value'`` with internal single-quotes doubled
+    - ``bool``            -> ``$true`` / ``$false``
+    - ``int`` / ``float`` -> bare number
+    - ``None``            -> ``$null``
+    - ``list``            -> ``@('a', 'b')``
+    - ``str``             -> ``'value'`` with internal single-quotes doubled
 
     Args:
         data (dict): The dictionary to convert.

--- a/salt/modules/win_dsc_resource.py
+++ b/salt/modules/win_dsc_resource.py
@@ -9,6 +9,8 @@ the Local Configuration Manager (LCM).
 Use the ``psget`` module to install DSC resource modules from the PowerShell
 Gallery before using them here.
 
+.. versionadded:: 3008.1
+
 :depends:
     - pythonnet
     - PowerShell 5.0
@@ -89,6 +91,20 @@ def _dict_to_ps_hashtable(data):
     return "@{" + "; ".join(parts) + "}"
 
 
+def _ps_quote(s):
+    """
+    Escape a string for safe interpolation inside a PowerShell single-quoted
+    string by doubling any embedded single-quote characters.
+
+    Args:
+        s (str): The string to escape.
+
+    Returns:
+        str: The escaped string (without surrounding quotes).
+    """
+    return str(s).replace("'", "''")
+
+
 def get(name, module_name, properties):
     r"""
     Return the current state of a DSC resource by calling
@@ -127,6 +143,8 @@ def get(name, module_name, properties):
 
         salt '*' dsc_resource.get WindowsFeature PSDesiredStateConfiguration \
             properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+
+    .. versionadded:: 3008.1
     """
     if not name:
         raise SaltInvocationError("name is required")
@@ -138,8 +156,8 @@ def get(name, module_name, properties):
     ps_prop = _dict_to_ps_hashtable(properties)
     cmd = (
         f"Invoke-DscResource"
-        f" -Name '{name}'"
-        f" -ModuleName '{module_name}'"
+        f" -Name '{_ps_quote(name)}'"
+        f" -ModuleName '{_ps_quote(module_name)}'"
         f" -Method Get"
         f" -Property {ps_prop}"
         f" | Select-Object * -ExcludeProperty Cim*, PSComputerName"
@@ -185,6 +203,8 @@ def test(name, module_name, properties):
 
         salt '*' dsc_resource.test WindowsFeature PSDesiredStateConfiguration \
             properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+
+    .. versionadded:: 3008.1
     """
     if not name:
         raise SaltInvocationError("name is required")
@@ -196,8 +216,8 @@ def test(name, module_name, properties):
     ps_prop = _dict_to_ps_hashtable(properties)
     cmd = (
         f"(Invoke-DscResource"
-        f" -Name '{name}'"
-        f" -ModuleName '{module_name}'"
+        f" -Name '{_ps_quote(name)}'"
+        f" -ModuleName '{_ps_quote(module_name)}'"
         f" -Method Test"
         f" -Property {ps_prop}).InDesiredState"
     )
@@ -244,6 +264,8 @@ def set_(name, module_name, properties):
 
         salt '*' dsc_resource.set WindowsFeature PSDesiredStateConfiguration \
             properties="{'Name': 'Web-Server', 'Ensure': 'Present'}"
+
+    .. versionadded:: 3008.1
     """
     if not name:
         raise SaltInvocationError("name is required")
@@ -255,8 +277,8 @@ def set_(name, module_name, properties):
     ps_prop = _dict_to_ps_hashtable(properties)
     cmd = (
         f"Invoke-DscResource"
-        f" -Name '{name}'"
-        f" -ModuleName '{module_name}'"
+        f" -Name '{_ps_quote(name)}'"
+        f" -ModuleName '{_ps_quote(module_name)}'"
         f" -Method Set"
         f" -Property {ps_prop}"
     )

--- a/salt/states/win_dsc_resource.py
+++ b/salt/states/win_dsc_resource.py
@@ -38,6 +38,8 @@ Example:
             DestinationPath: C:\\App\\config.txt
             Ensure: Present
             Contents: managed by Salt
+
+.. versionadded:: 3008.1
 """
 
 import logging
@@ -136,6 +138,8 @@ def managed(name, module_name, properties):
                 DestinationPath: C:\\Temp\\hello.txt
                 Ensure: Present
                 Contents: Hello from Salt
+
+    .. versionadded:: 3008.1
     """
     ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 

--- a/salt/states/win_dsc_resource.py
+++ b/salt/states/win_dsc_resource.py
@@ -1,0 +1,195 @@
+"""
+State module for managing Windows PowerShell DSC Resources via
+``Invoke-DscResource``.
+
+This module manages individual DSC resources without compiling a MOF file or
+involving the Local Configuration Manager (LCM). Salt controls the idempotency:
+it calls the resource's ``Test`` method first, and only calls ``Set`` if a
+change is needed.
+
+Use the ``psget`` module to install DSC resource modules from the PowerShell
+Gallery before referencing them in states.
+
+Example:
+
+.. code-block:: yaml
+
+    ensure_web_server:
+      dsc_resource.managed:
+        - name: WindowsFeature
+        - module_name: PSDesiredStateConfiguration
+        - properties:
+            Name: Web-Server
+            Ensure: Present
+
+    remove_telnet:
+      dsc_resource.managed:
+        - name: WindowsFeature
+        - module_name: PSDesiredStateConfiguration
+        - properties:
+            Name: Telnet-Client
+            Ensure: Absent
+
+    create_config_file:
+      dsc_resource.managed:
+        - name: File
+        - module_name: PSDesiredStateConfiguration
+        - properties:
+            DestinationPath: C:\\App\\config.txt
+            Ensure: Present
+            Contents: managed by Salt
+"""
+
+import logging
+
+import salt.utils.data
+import salt.utils.platform
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "dsc_resource"
+
+
+def __virtual__():
+    """
+    Only load on Windows.
+    """
+    if salt.utils.platform.is_windows():
+        return __virtualname__
+    return False, "DSC Resource: Only available on Windows systems"
+
+
+def _normalize_str_values(data):
+    """
+    Recursively lowercase all string values in a dict.
+
+    DSC property values are case-insensitive (e.g. ``"Present"`` and
+    ``"present"`` are equivalent), but Python string comparison is not.
+    Normalizing before calling ``recursive_diff`` prevents case-only
+    differences from appearing as changes in the state output.
+    """
+    if isinstance(data, dict):
+        return {k: _normalize_str_values(v) for k, v in data.items()}
+    if isinstance(data, str):
+        return data.lower()
+    return data
+
+
+def managed(name, module_name, properties):
+    r"""
+    Ensure a DSC resource is in the desired state.
+
+    Calls ``dsc_resource.test`` to check whether changes are needed. If the
+    resource is already in the desired state, returns immediately with no
+    changes. Otherwise calls ``dsc_resource.set`` to apply the configuration,
+    then verifies the result with another ``dsc_resource.test`` call.
+
+    The ``changes`` dictionary uses the actual before and after values returned
+    by ``dsc_resource.get``, giving a real diff of the resource properties.
+
+    Args:
+
+        name (str):
+            The name of the DSC resource to manage, for example
+            ``WindowsFeature`` or ``File``. This also serves as the state ID.
+            Required.
+
+        module_name (str):
+            The name of the PowerShell module that contains the resource. For
+            built-in resources use ``PSDesiredStateConfiguration``. Required.
+
+        properties (dict):
+            A dictionary of the desired resource properties. The required and
+            optional keys vary by DSC resource. Required.
+
+    Returns:
+        dict: A standard Salt state return with ``name``, ``result``,
+        ``changes``, and ``comment`` keys.
+
+        ``result`` values:
+
+        - ``True``  — no changes were needed, or changes were applied
+          successfully.
+        - ``None``  — running in test mode and changes would be made.
+        - ``False`` — an error occurred or changes could not be verified.
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        install_iis:
+          dsc_resource.managed:
+            - name: WindowsFeature
+            - module_name: PSDesiredStateConfiguration
+            - properties:
+                Name: Web-Server
+                Ensure: Present
+
+    .. code-block:: yaml
+
+        write_hosts_entry:
+          dsc_resource.managed:
+            - name: File
+            - module_name: PSDesiredStateConfiguration
+            - properties:
+                DestinationPath: C:\\Temp\\hello.txt
+                Ensure: Present
+                Contents: Hello from Salt
+    """
+    ret = {"name": name, "result": False, "changes": {}, "comment": ""}
+
+    # Capture current state for before/after reporting
+    try:
+        old_state = __salt__["dsc_resource.get"](name, module_name, properties)
+    except CommandExecutionError as exc:
+        ret["comment"] = f"Failed to get state of DSC resource {name!r}: {exc}"
+        return ret
+
+    # Check whether changes are needed
+    try:
+        in_desired_state = __salt__["dsc_resource.test"](name, module_name, properties)
+    except CommandExecutionError as exc:
+        ret["comment"] = f"Failed to test DSC resource {name!r}: {exc}"
+        return ret
+
+    if in_desired_state:
+        ret["result"] = True
+        ret["comment"] = f"DSC resource {name!r} is already in the desired state."
+        return ret
+
+    # Test mode: report what would change without applying
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"DSC resource {name!r} would be applied."
+        ret["changes"] = salt.utils.data.recursive_diff(
+            _normalize_str_values(old_state), _normalize_str_values(properties)
+        )
+        return ret
+
+    # Apply the resource
+    try:
+        __salt__["dsc_resource.set"](name, module_name, properties)
+    except CommandExecutionError as exc:
+        ret["comment"] = f"Failed to apply DSC resource {name!r}: {exc}"
+        return ret
+
+    # Verify the change took effect and collect the new state
+    try:
+        in_desired_state = __salt__["dsc_resource.test"](name, module_name, properties)
+        new_state = __salt__["dsc_resource.get"](name, module_name, properties)
+    except CommandExecutionError as exc:
+        ret["comment"] = f"Failed to verify DSC resource {name!r}: {exc}"
+        return ret
+
+    if in_desired_state:
+        ret["result"] = True
+        ret["changes"] = salt.utils.data.recursive_diff(
+            _normalize_str_values(old_state), _normalize_str_values(new_state)
+        )
+        ret["comment"] = f"DSC resource {name!r} applied successfully."
+    else:
+        ret["result"] = False
+        ret["comment"] = f"Failed to apply DSC resource {name!r}."
+
+    return ret

--- a/salt/states/win_dsc_resource.py
+++ b/salt/states/win_dsc_resource.py
@@ -64,15 +64,20 @@ def __virtual__():
 
 def _normalize_str_values(data):
     """
-    Recursively lowercase all string values in a dict.
+    Recursively lowercase all string keys and values in a dict.
 
-    DSC property values are case-insensitive (e.g. ``"Present"`` and
-    ``"present"`` are equivalent), but Python string comparison is not.
-    Normalizing before calling ``recursive_diff`` prevents case-only
-    differences from appearing as changes in the state output.
+    DSC property names and values are case-insensitive (e.g. ``"Ensure"`` and
+    ``"ensure"`` refer to the same property, ``"Present"`` and ``"present"``
+    are the same value), but Python string comparison is not. Normalizing both
+    keys and values before calling ``recursive_diff`` prevents case-only
+    differences — such as pillar-supplied lowercase keys vs. DSC's capitalized
+    output — from appearing as spurious changes in the state diff.
     """
     if isinstance(data, dict):
-        return {k: _normalize_str_values(v) for k, v in data.items()}
+        return {
+            (k.lower() if isinstance(k, str) else k): _normalize_str_values(v)
+            for k, v in data.items()
+        }
     if isinstance(data, str):
         return data.lower()
     return data

--- a/tests/pytests/functional/modules/test_win_dsc_resource.py
+++ b/tests/pytests/functional/modules/test_win_dsc_resource.py
@@ -1,0 +1,117 @@
+"""
+Functional tests for the dsc_resource execution module.
+
+These tests use the built-in ``File`` DSC resource from the
+``PSDesiredStateConfiguration`` module, which is available on all supported
+Windows versions with no external dependencies.
+"""
+
+import os
+
+import pytest
+
+import salt.utils.files
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.slow_test,
+]
+
+FILE_RESOURCE = "File"
+FILE_MODULE = "PSDesiredStateConfiguration"
+
+
+@pytest.fixture(scope="module")
+def dsc_resource(modules):
+    return modules.dsc_resource
+
+
+@pytest.fixture
+def temp_file_path(tmp_path):
+    """
+    Provide a temp file path that does not exist at the start of each test.
+    Any file created at this path is removed after the test.
+    """
+    path = str(tmp_path / "salt_dsc_resource_test.txt")
+    yield path
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def test_get_returns_dict(dsc_resource, temp_file_path):
+    """
+    get() should return a dict with at least a DestinationPath key regardless
+    of whether the file exists.
+    """
+    result = dsc_resource.get(
+        FILE_RESOURCE,
+        FILE_MODULE,
+        {"DestinationPath": temp_file_path, "Ensure": "Present"},
+    )
+    assert isinstance(result, dict)
+    assert "DestinationPath" in result
+
+
+def test_test_returns_false_when_file_absent(dsc_resource, temp_file_path):
+    """
+    test() should return False when the file does not exist and Ensure=Present.
+    """
+    assert not os.path.exists(temp_file_path)
+    result = dsc_resource.test(
+        FILE_RESOURCE,
+        FILE_MODULE,
+        {"DestinationPath": temp_file_path, "Ensure": "Present"},
+    )
+    assert result is False
+
+
+def test_test_returns_true_when_file_present(dsc_resource, temp_file_path):
+    """
+    test() should return True when the file exists and Ensure=Present.
+    """
+    with salt.utils.files.fopen(temp_file_path, "w") as fh:
+        fh.write("salt test content")
+    result = dsc_resource.test(
+        FILE_RESOURCE,
+        FILE_MODULE,
+        {"DestinationPath": temp_file_path, "Ensure": "Present"},
+    )
+    assert result is True
+
+
+@pytest.mark.destructive_test
+def test_set_creates_file(dsc_resource, temp_file_path):
+    """
+    set() should create the file when Ensure=Present and the file is absent.
+    """
+    assert not os.path.exists(temp_file_path)
+    result = dsc_resource.set(
+        FILE_RESOURCE,
+        FILE_MODULE,
+        {
+            "DestinationPath": temp_file_path,
+            "Ensure": "Present",
+            "Contents": "Hello from Salt",
+        },
+    )
+    assert result is True
+    assert os.path.exists(temp_file_path)
+
+
+@pytest.mark.destructive_test
+def test_set_removes_file(dsc_resource, temp_file_path):
+    """
+    set() should remove the file when Ensure=Absent and the file is present.
+    """
+    with salt.utils.files.fopen(temp_file_path, "w") as fh:
+        fh.write("salt test content")
+    assert os.path.exists(temp_file_path)
+
+    result = dsc_resource.set(
+        FILE_RESOURCE,
+        FILE_MODULE,
+        {"DestinationPath": temp_file_path, "Ensure": "Absent"},
+    )
+    assert result is True
+    assert not os.path.exists(temp_file_path)

--- a/tests/pytests/functional/states/test_win_dsc_resource.py
+++ b/tests/pytests/functional/states/test_win_dsc_resource.py
@@ -1,0 +1,125 @@
+"""
+Functional tests for the dsc_resource state module.
+
+These tests use the built-in ``File`` DSC resource from the
+``PSDesiredStateConfiguration`` module, which is available on all supported
+Windows versions with no external dependencies.
+"""
+
+import os
+
+import pytest
+
+import salt.utils.files
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.slow_test,
+]
+
+FILE_RESOURCE = "File"
+FILE_MODULE = "PSDesiredStateConfiguration"
+
+
+@pytest.fixture(scope="module")
+def dsc_resource(states):
+    return states.dsc_resource
+
+
+@pytest.fixture
+def temp_file_path(tmp_path):
+    """
+    Provide a temp file path that does not exist at the start of each test.
+    Any file created at this path is removed after the test.
+    """
+    path = str(tmp_path / "salt_dsc_state_test.txt")
+    yield path
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def test_managed_already_in_desired_state(dsc_resource, temp_file_path):
+    """
+    managed() should return result=True and no changes when the resource is
+    already in the desired state (live mode).
+    """
+    with salt.utils.files.fopen(temp_file_path, "w") as fh:
+        fh.write("salt test content")
+
+    ret = dsc_resource.managed(
+        name=FILE_RESOURCE,
+        module_name=FILE_MODULE,
+        properties={"DestinationPath": temp_file_path, "Ensure": "Present"},
+    )
+    assert ret.result is True
+    assert ret.changes == {}
+    assert "already in the desired state" in ret.comment
+
+
+@pytest.mark.destructive_test
+def test_managed_applies_changes(dsc_resource, temp_file_path):
+    """
+    managed() should return result=True and a populated changes dict when the
+    resource is not in the desired state (live mode).
+    """
+    assert not os.path.exists(temp_file_path)
+
+    ret = dsc_resource.managed(
+        name=FILE_RESOURCE,
+        module_name=FILE_MODULE,
+        properties={
+            "DestinationPath": temp_file_path,
+            "Ensure": "Present",
+            "Contents": "Hello from Salt",
+        },
+    )
+    assert ret.result is True
+    assert ret.changes != {}
+    assert "Ensure" in ret.changes.get("old", {})
+    assert "Ensure" in ret.changes.get("new", {})
+    assert os.path.exists(temp_file_path)
+
+
+def test_managed_test_mode_no_changes_needed(dsc_resource, temp_file_path):
+    """
+    managed() should return result=True and no changes when the resource is
+    already in the desired state and test=True.
+    """
+    with salt.utils.files.fopen(temp_file_path, "w") as fh:
+        fh.write("salt test content")
+
+    ret = dsc_resource.managed(
+        name=FILE_RESOURCE,
+        module_name=FILE_MODULE,
+        properties={"DestinationPath": temp_file_path, "Ensure": "Present"},
+        test=True,
+    )
+    assert ret.result is True
+    assert ret.changes == {}
+
+
+@pytest.mark.destructive_test
+def test_managed_test_mode_changes_needed(dsc_resource, temp_file_path):
+    """
+    managed() should return result=None and a populated changes dict when the
+    resource is not in the desired state and test=True. No actual change should
+    be made to the system.
+    """
+    assert not os.path.exists(temp_file_path)
+
+    ret = dsc_resource.managed(
+        name=FILE_RESOURCE,
+        module_name=FILE_MODULE,
+        properties={
+            "DestinationPath": temp_file_path,
+            "Ensure": "Present",
+            "Contents": "Hello from Salt",
+        },
+        test=True,
+    )
+    assert ret.result is None
+    assert ret.changes != {}
+    assert "Ensure" in ret.changes.get("old", {})
+    assert "Ensure" in ret.changes.get("new", {})
+    assert not os.path.exists(temp_file_path)

--- a/tests/pytests/functional/states/test_win_dsc_resource.py
+++ b/tests/pytests/functional/states/test_win_dsc_resource.py
@@ -76,8 +76,8 @@ def test_managed_applies_changes(dsc_resource, temp_file_path):
     )
     assert ret.result is True
     assert ret.changes != {}
-    assert "Ensure" in ret.changes.get("old", {})
-    assert "Ensure" in ret.changes.get("new", {})
+    assert "ensure" in ret.changes.get("old", {})
+    assert "ensure" in ret.changes.get("new", {})
     assert os.path.exists(temp_file_path)
 
 
@@ -97,6 +97,33 @@ def test_managed_test_mode_no_changes_needed(dsc_resource, temp_file_path):
     )
     assert ret.result is True
     assert ret.changes == {}
+
+
+@pytest.mark.destructive_test
+def test_managed_idempotent(dsc_resource, temp_file_path):
+    """
+    managed() should apply changes on the first call and return no changes on
+    a second call with the same arguments (idempotency).
+    """
+    assert not os.path.exists(temp_file_path)
+    props = {
+        "DestinationPath": temp_file_path,
+        "Ensure": "Present",
+        "Contents": "Hello from Salt",
+    }
+
+    first = dsc_resource.managed(
+        name=FILE_RESOURCE, module_name=FILE_MODULE, properties=props
+    )
+    assert first.result is True
+    assert first.changes != {}
+
+    second = dsc_resource.managed(
+        name=FILE_RESOURCE, module_name=FILE_MODULE, properties=props
+    )
+    assert second.result is True
+    assert second.changes == {}
+    assert "already in the desired state" in second.comment
 
 
 @pytest.mark.destructive_test
@@ -120,6 +147,6 @@ def test_managed_test_mode_changes_needed(dsc_resource, temp_file_path):
     )
     assert ret.result is None
     assert ret.changes != {}
-    assert "Ensure" in ret.changes.get("old", {})
-    assert "Ensure" in ret.changes.get("new", {})
+    assert "ensure" in ret.changes.get("old", {})
+    assert "ensure" in ret.changes.get("new", {})
     assert not os.path.exists(temp_file_path)

--- a/tests/pytests/unit/modules/test_win_dsc_resource.py
+++ b/tests/pytests/unit/modules/test_win_dsc_resource.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the _dict_to_ps_hashtable helper in win_dsc_resource.
+
+These tests have no platform or Windows dependencies and require no mocking.
+"""
+
+import salt.modules.win_dsc_resource as win_dsc_resource
+
+
+class TestDictToPsHashtable:
+    """Tests for _dict_to_ps_hashtable type conversion."""
+
+    def test_empty_dict(self):
+        assert win_dsc_resource._dict_to_ps_hashtable({}) == "@{}"
+
+    def test_string_value(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Key": "Value"})
+        assert result == "@{Key = 'Value'}"
+
+    def test_string_escapes_single_quotes(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Key": "It's here"})
+        assert result == "@{Key = 'It''s here'}"
+
+    def test_string_escapes_multiple_single_quotes(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Key": "don't won't"})
+        assert result == "@{Key = 'don''t won''t'}"
+
+    def test_bool_true(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Enabled": True})
+        assert result == "@{Enabled = $true}"
+
+    def test_bool_false(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Enabled": False})
+        assert result == "@{Enabled = $false}"
+
+    def test_bool_is_not_confused_with_int(self):
+        # bool is a subclass of int in Python; ensure bools are handled first
+        result_true = win_dsc_resource._dict_to_ps_hashtable({"Val": True})
+        result_one = win_dsc_resource._dict_to_ps_hashtable({"Val": 1})
+        assert result_true == "@{Val = $true}"
+        assert result_one == "@{Val = 1}"
+
+    def test_integer_value(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Count": 42})
+        assert result == "@{Count = 42}"
+
+    def test_zero(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Count": 0})
+        assert result == "@{Count = 0}"
+
+    def test_float_value(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Ratio": 1.5})
+        assert result == "@{Ratio = 1.5}"
+
+    def test_none_value(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Value": None})
+        assert result == "@{Value = $null}"
+
+    def test_list_of_strings(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Items": ["a", "b", "c"]})
+        assert result == "@{Items = @('a', 'b', 'c')}"
+
+    def test_list_escapes_single_quotes(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Items": ["it's"]})
+        assert result == "@{Items = @('it''s')}"
+
+    def test_empty_list(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Items": []})
+        assert result == "@{Items = @()}"
+
+    def test_multiple_keys(self):
+        result = win_dsc_resource._dict_to_ps_hashtable(
+            {"Name": "Web-Server", "Ensure": "Present"}
+        )
+        assert result == "@{Name = 'Web-Server'; Ensure = 'Present'}"
+
+    def test_mixed_types(self):
+        result = win_dsc_resource._dict_to_ps_hashtable(
+            {"Name": "test", "Count": 3, "Enabled": True, "Tag": None}
+        )
+        assert result == "@{Name = 'test'; Count = 3; Enabled = $true; Tag = $null}"

--- a/tests/pytests/unit/modules/test_win_dsc_resource.py
+++ b/tests/pytests/unit/modules/test_win_dsc_resource.py
@@ -1,10 +1,30 @@
 """
-Unit tests for the _dict_to_ps_hashtable helper in win_dsc_resource.
+Unit tests for the _dict_to_ps_hashtable and _ps_quote helpers in
+win_dsc_resource.
 
 These tests have no platform or Windows dependencies and require no mocking.
 """
 
 import salt.modules.win_dsc_resource as win_dsc_resource
+
+
+class TestPsQuote:
+    """Tests for _ps_quote single-quote escaping."""
+
+    def test_plain_string(self):
+        assert win_dsc_resource._ps_quote("hello") == "hello"
+
+    def test_single_quote_doubled(self):
+        assert win_dsc_resource._ps_quote("it's") == "it''s"
+
+    def test_multiple_single_quotes(self):
+        assert win_dsc_resource._ps_quote("don't won't") == "don''t won''t"
+
+    def test_empty_string(self):
+        assert win_dsc_resource._ps_quote("") == ""
+
+    def test_non_string_coerced(self):
+        assert win_dsc_resource._ps_quote(42) == "42"
 
 
 class TestDictToPsHashtable:

--- a/tests/pytests/unit/modules/test_win_dsc_resource.py
+++ b/tests/pytests/unit/modules/test_win_dsc_resource.py
@@ -52,7 +52,7 @@ class TestPsValue:
         assert win_dsc_resource._ps_value("it's") == "'it''s'"
 
     def test_nested_dict(self):
-        assert win_dsc_resource._ps_value({"A": 1}) == "@{A = 1}"
+        assert win_dsc_resource._ps_value({"A": 1}) == "@{'A' = 1}"
 
     def test_list_of_strings(self):
         assert win_dsc_resource._ps_value(["a", "b"]) == "@('a', 'b')"
@@ -61,10 +61,13 @@ class TestPsValue:
         assert win_dsc_resource._ps_value([1, 2, 3]) == "@(1, 2, 3)"
 
     def test_list_of_mixed_types(self):
-        assert win_dsc_resource._ps_value([True, 1, None, "x"]) == "@($true, 1, $null, 'x')"
+        assert (
+            win_dsc_resource._ps_value([True, 1, None, "x"])
+            == "@($true, 1, $null, 'x')"
+        )
 
     def test_list_of_dicts(self):
-        assert win_dsc_resource._ps_value([{"K": "v"}]) == "@(@{K = 'v'})"
+        assert win_dsc_resource._ps_value([{"K": "v"}]) == "@(@{'K' = 'v'})"
 
     def test_empty_list(self):
         assert win_dsc_resource._ps_value([]) == "@()"
@@ -78,81 +81,98 @@ class TestDictToPsHashtable:
 
     def test_string_value(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Key": "Value"})
-        assert result == "@{Key = 'Value'}"
+        assert result == "@{'Key' = 'Value'}"
 
     def test_string_escapes_single_quotes(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Key": "It's here"})
-        assert result == "@{Key = 'It''s here'}"
+        assert result == "@{'Key' = 'It''s here'}"
 
     def test_string_escapes_multiple_single_quotes(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Key": "don't won't"})
-        assert result == "@{Key = 'don''t won''t'}"
+        assert result == "@{'Key' = 'don''t won''t'}"
+
+    def test_key_with_single_quote_is_escaped(self):
+        # A key containing a single quote must be doubled, not break the hashtable
+        result = win_dsc_resource._dict_to_ps_hashtable({"It's": "value"})
+        assert result == "@{'It''s' = 'value'}"
+
+    def test_key_injection_attempt(self):
+        # A key containing '}' must be contained inside the quoted key string,
+        # not allowed to close the hashtable and inject a new PS statement.
+        result = win_dsc_resource._dict_to_ps_hashtable(
+            {"} ; Remove-Item C:\\Windows ; $x = @{dummy": "val"}
+        )
+        # The key is wrapped in single quotes, so the whole thing is one literal.
+        assert result == "@{'} ; Remove-Item C:\\Windows ; $x = @{dummy' = 'val'}"
 
     def test_bool_true(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Enabled": True})
-        assert result == "@{Enabled = $true}"
+        assert result == "@{'Enabled' = $true}"
 
     def test_bool_false(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Enabled": False})
-        assert result == "@{Enabled = $false}"
+        assert result == "@{'Enabled' = $false}"
 
     def test_bool_is_not_confused_with_int(self):
         # bool is a subclass of int in Python; ensure bools are handled first
         result_true = win_dsc_resource._dict_to_ps_hashtable({"Val": True})
         result_one = win_dsc_resource._dict_to_ps_hashtable({"Val": 1})
-        assert result_true == "@{Val = $true}"
-        assert result_one == "@{Val = 1}"
+        assert result_true == "@{'Val' = $true}"
+        assert result_one == "@{'Val' = 1}"
 
     def test_integer_value(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Count": 42})
-        assert result == "@{Count = 42}"
+        assert result == "@{'Count' = 42}"
 
     def test_zero(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Count": 0})
-        assert result == "@{Count = 0}"
+        assert result == "@{'Count' = 0}"
 
     def test_float_value(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Ratio": 1.5})
-        assert result == "@{Ratio = 1.5}"
+        assert result == "@{'Ratio' = 1.5}"
 
     def test_none_value(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Value": None})
-        assert result == "@{Value = $null}"
+        assert result == "@{'Value' = $null}"
 
     def test_list_of_strings(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Items": ["a", "b", "c"]})
-        assert result == "@{Items = @('a', 'b', 'c')}"
+        assert result == "@{'Items' = @('a', 'b', 'c')}"
 
     def test_list_escapes_single_quotes(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Items": ["it's"]})
-        assert result == "@{Items = @('it''s')}"
+        assert result == "@{'Items' = @('it''s')}"
 
     def test_empty_list(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Items": []})
-        assert result == "@{Items = @()}"
+        assert result == "@{'Items' = @()}"
 
     def test_multiple_keys(self):
         result = win_dsc_resource._dict_to_ps_hashtable(
             {"Name": "Web-Server", "Ensure": "Present"}
         )
-        assert result == "@{Name = 'Web-Server'; Ensure = 'Present'}"
+        assert result == "@{'Name' = 'Web-Server'; 'Ensure' = 'Present'}"
 
     def test_mixed_types(self):
         result = win_dsc_resource._dict_to_ps_hashtable(
             {"Name": "test", "Count": 3, "Enabled": True, "Tag": None}
         )
-        assert result == "@{Name = 'test'; Count = 3; Enabled = $true; Tag = $null}"
+        assert (
+            result
+            == "@{'Name' = 'test'; 'Count' = 3; 'Enabled' = $true; 'Tag' = $null}"
+        )
 
     def test_nested_dict(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Props": {"A": 1, "B": "x"}})
-        assert result == "@{Props = @{A = 1; B = 'x'}}"
+        assert result == "@{'Props' = @{'A' = 1; 'B' = 'x'}}"
 
     def test_list_of_ints(self):
         result = win_dsc_resource._dict_to_ps_hashtable({"Ports": [80, 443]})
-        assert result == "@{Ports = @(80, 443)}"
+        assert result == "@{'Ports' = @(80, 443)}"
 
     def test_list_of_dicts(self):
         result = win_dsc_resource._dict_to_ps_hashtable(
             {"Items": [{"Key": "a"}, {"Key": "b"}]}
         )
-        assert result == "@{Items = @(@{Key = 'a'}, @{Key = 'b'})}"
+        assert result == "@{'Items' = @(@{'Key' = 'a'}, @{'Key' = 'b'})}"

--- a/tests/pytests/unit/modules/test_win_dsc_resource.py
+++ b/tests/pytests/unit/modules/test_win_dsc_resource.py
@@ -1,6 +1,6 @@
 """
-Unit tests for the _dict_to_ps_hashtable and _ps_quote helpers in
-win_dsc_resource.
+Unit tests for the _ps_value, _dict_to_ps_hashtable, and _ps_quote helpers
+in win_dsc_resource.
 
 These tests have no platform or Windows dependencies and require no mocking.
 """
@@ -25,6 +25,49 @@ class TestPsQuote:
 
     def test_non_string_coerced(self):
         assert win_dsc_resource._ps_quote(42) == "42"
+
+
+class TestPsValue:
+    """Tests for _ps_value type dispatch."""
+
+    def test_bool_true(self):
+        assert win_dsc_resource._ps_value(True) == "$true"
+
+    def test_bool_false(self):
+        assert win_dsc_resource._ps_value(False) == "$false"
+
+    def test_integer(self):
+        assert win_dsc_resource._ps_value(42) == "42"
+
+    def test_float(self):
+        assert win_dsc_resource._ps_value(1.5) == "1.5"
+
+    def test_none(self):
+        assert win_dsc_resource._ps_value(None) == "$null"
+
+    def test_string(self):
+        assert win_dsc_resource._ps_value("hello") == "'hello'"
+
+    def test_string_escapes_single_quotes(self):
+        assert win_dsc_resource._ps_value("it's") == "'it''s'"
+
+    def test_nested_dict(self):
+        assert win_dsc_resource._ps_value({"A": 1}) == "@{A = 1}"
+
+    def test_list_of_strings(self):
+        assert win_dsc_resource._ps_value(["a", "b"]) == "@('a', 'b')"
+
+    def test_list_of_ints(self):
+        assert win_dsc_resource._ps_value([1, 2, 3]) == "@(1, 2, 3)"
+
+    def test_list_of_mixed_types(self):
+        assert win_dsc_resource._ps_value([True, 1, None, "x"]) == "@($true, 1, $null, 'x')"
+
+    def test_list_of_dicts(self):
+        assert win_dsc_resource._ps_value([{"K": "v"}]) == "@(@{K = 'v'})"
+
+    def test_empty_list(self):
+        assert win_dsc_resource._ps_value([]) == "@()"
 
 
 class TestDictToPsHashtable:
@@ -99,3 +142,17 @@ class TestDictToPsHashtable:
             {"Name": "test", "Count": 3, "Enabled": True, "Tag": None}
         )
         assert result == "@{Name = 'test'; Count = 3; Enabled = $true; Tag = $null}"
+
+    def test_nested_dict(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Props": {"A": 1, "B": "x"}})
+        assert result == "@{Props = @{A = 1; B = 'x'}}"
+
+    def test_list_of_ints(self):
+        result = win_dsc_resource._dict_to_ps_hashtable({"Ports": [80, 443]})
+        assert result == "@{Ports = @(80, 443)}"
+
+    def test_list_of_dicts(self):
+        result = win_dsc_resource._dict_to_ps_hashtable(
+            {"Items": [{"Key": "a"}, {"Key": "b"}]}
+        )
+        assert result == "@{Items = @(@{Key = 'a'}, @{Key = 'b'})}"


### PR DESCRIPTION
### What does this PR do?
Add win_dsc_resource execution module (dsc_resource.*) and state module (dsc_resource.managed) to invoke individual PowerShell DSC resources directly via Invoke-DscResource, without compiling a MOF file or involving the Local Configuration Manager.
Uses PowerShellSession from salt.utils.win_pwsh for in-process execution. Supports any installed DSC resource module from the PowerShell Gallery. The managed state calls Test before Set for idempotency, reports a case-insensitive before/after diff via salt.utils.data.recursive_diff, and filters CIM internal properties from get() output. Includes unit tests for the property type converter and functional tests for both modules using the built-in File DSC resource.

### What issues does this PR fix or reference?
Fixes #43718

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
