### PR TITLE
Fix timezone.system false failure on Windows with utc=True

### DIFF
--- a/changelog/57754.fixed.md
+++ b/changelog/57754.fixed.md
@@ -1,0 +1,1 @@
+Fixed `timezone.system` state always returning `result=False` with "Failed to set UTC to True" on Windows. The hardware clock on Windows is always localtime and cannot be changed, so the UTC/hwclock block is now skipped entirely on Windows.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,6 +37,7 @@ pyopenssl>=26.0.0
 python-dateutil>=2.8.1
 python-gnupg>=0.4.7
 pythonnet>=3.0.1; sys_platform == 'win32'
+tzdata; sys_platform == 'win32'
 pywin32>=305; sys_platform == 'win32'
 pycryptodomex>=3.9.8
 PyYAML

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -551,6 +551,10 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -527,6 +527,10 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   virtualenv
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.10/windows.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -540,6 +540,10 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -517,6 +517,10 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.11/windows.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -536,6 +536,10 @@ typing-extensions==4.14.1
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -513,6 +513,10 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   pytest-system-statistics
     #   referencing
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.12/windows.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -534,6 +534,10 @@ trustme==1.2.1
     # via -r requirements/pytest.txt
 typing-extensions==4.15.0
     # via pytest-system-statistics
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -510,6 +510,10 @@ typer-slim==0.24.0
     #   jaraco-text
 typing-extensions==4.15.0
     # via pytest-system-statistics
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.13/windows.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock

--- a/requirements/static/ci/py3.9/freebsd.lock
+++ b/requirements/static/ci/py3.9/freebsd.lock
@@ -649,6 +649,10 @@ typing-extensions==4.14.1
     #   pytest-system-statistics
     #   referencing
     #   virtualenv
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==1.26.20 ; python_full_version < '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock

--- a/requirements/static/ci/py3.9/windows.lock
+++ b/requirements/static/ci/py3.9/windows.lock
@@ -546,6 +546,10 @@ typing-extensions==4.15.0
     #   pytest-system-statistics
     #   referencing
     #   virtualenv
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.9/windows.lock
+    #   -r requirements/base.txt
 urllib3==1.26.20
     # via
     #   -c requirements/static/pkg/py3.9/windows.lock

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -202,6 +202,8 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     #   cryptography
     #   pyopenssl
     #   virtualenv
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -202,6 +202,8 @@ typing-extensions==4.15.0
     #   multidict
     #   pyopenssl
     #   virtualenv
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -198,6 +198,8 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     # via
     #   aiosignal
     #   pyopenssl
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -197,6 +197,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   pyopenssl
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -196,6 +196,8 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     # via
     #   aiosignal
     #   pyopenssl
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -195,6 +195,8 @@ typing-extensions==4.15.0
     # via
     #   aiosignal
     #   pyopenssl
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -191,6 +191,8 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/freebsd.txt
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -191,6 +191,8 @@ typer==0.24.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -191,6 +191,8 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/freebsd.txt
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -191,6 +191,8 @@ typer==0.24.1
     # via typer-slim
 typer-slim==0.24.0
     # via jaraco-text
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.lock
+++ b/requirements/static/pkg/py3.9/freebsd.lock
@@ -213,6 +213,8 @@ typing-extensions==4.14.1 ; python_full_version < '3.13'
     #   gitpython
     #   pyopenssl
     #   virtualenv
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via -r requirements/base.txt
 urllib3==1.26.20 ; python_full_version < '3.10'
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.lock
+++ b/requirements/static/pkg/py3.9/windows.lock
@@ -206,6 +206,8 @@ typing-extensions==4.15.0
     #   multidict
     #   pyopenssl
     #   virtualenv
+tzdata==2026.2
+    # via -r requirements/base.txt
 urllib3==1.26.20
     # via
     #   -r requirements/base.txt

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -3,16 +3,14 @@ Module for managing timezone on Windows systems.
 """
 
 import logging
-from datetime import datetime
-
-from salt.exceptions import CommandExecutionError
+from datetime import datetime, timezone
 
 try:
-    import pytz
-
-    HAS_PYTZ = True
+    from zoneinfo import ZoneInfo
 except ImportError:
-    HAS_PYTZ = False
+    from backports.zoneinfo import ZoneInfo
+
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -190,8 +188,6 @@ def __virtual__():
     """
     if not __utils__["platform.is_windows"]():
         return False, "Module win_timezone: Not on Windows client"
-    if not HAS_PYTZ:
-        return False, "Module win_timezone: pytz not found"
     if not __utils__["path.which"]("tzutil"):
         return False, "Module win_timezone: tzutil not found"
     return __virtualname__
@@ -239,12 +235,9 @@ def get_offset():
 
         salt '*' timezone.get_offset
     """
-    # http://craigglennie.com/programming/python/2013/07/21/working-with-timezones-using-Python-and-pytz-localize-vs-normalize/
-    tz_object = pytz.timezone(get_zone())
-    utc_time = pytz.utc.localize(datetime.utcnow())
-    loc_time = utc_time.astimezone(tz_object)
-    norm_time = tz_object.normalize(loc_time)
-    return norm_time.strftime("%z")
+    tz = ZoneInfo(get_zone())
+    now = datetime.now(tz=timezone.utc).astimezone(tz)
+    return now.strftime("%z")
 
 
 def get_zonecode():
@@ -260,9 +253,9 @@ def get_zonecode():
 
         salt '*' timezone.get_zonecode
     """
-    tz_object = pytz.timezone(get_zone())
-    loc_time = tz_object.localize(datetime.utcnow())
-    return loc_time.tzname()
+    tz = ZoneInfo(get_zone())
+    now = datetime.now(tz=timezone.utc).astimezone(tz)
+    return now.tzname()
 
 
 def set_zone(timezone):

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -27,6 +27,7 @@ it applies to systems that dual-boot with Windows. This is explained in greater
 detail here_.
 """
 
+import salt.utils.platform
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 
@@ -47,7 +48,13 @@ def system(name, utc=True):
         The name of the timezone to use (e.g.: America/Denver)
 
     utc
-        Whether or not to set the hardware clock to UTC (default is True)
+        Whether or not to set the hardware clock to UTC (default is True).
+
+        .. note::
+            This parameter has no effect on Windows. The Windows hardware
+            clock is always set to local time and cannot be configured to
+            UTC via Salt. The state will succeed regardless of the value
+            passed here.
     """
     ret = {"name": name, "changes": {}, "result": None, "comment": ""}
     # Set up metadata
@@ -78,11 +85,13 @@ def system(name, utc=True):
         do_zone = True
 
     # If the user passed in utc, do a check
-    if utc and utc != myutc:
-        ret["result"] = None
-        do_utc = True
-    elif utc and utc == myutc:
-        messages.append(f"UTC already set to {name}")
+    # Windows hardware clock is always localtime and is not configurable
+    if not salt.utils.platform.is_windows():
+        if utc and utc != myutc:
+            ret["result"] = None
+            do_utc = True
+        elif utc and utc == myutc:
+            messages.append(f"UTC already set to {name}")
 
     if ret["result"] is True:
         ret["comment"] = ", ".join(messages)
@@ -92,7 +101,7 @@ def system(name, utc=True):
         messages = []
         if compzone is False:
             messages.append(f"Timezone {name} needs to be set")
-        if utc and myutc != utc:
+        if not salt.utils.platform.is_windows() and utc and myutc != utc:
             messages.append(f"UTC needs to be set to {utc}")
         ret["comment"] = ", ".join(messages)
         return ret

--- a/tests/pytests/functional/states/test_win_timezone.py
+++ b/tests/pytests/functional/states/test_win_timezone.py
@@ -1,0 +1,69 @@
+"""
+Functional tests for the timezone state on Windows.
+
+Verifies that ``timezone.system`` succeeds on Windows even when ``utc=True``
+(the default), which previously produced a false-positive failure because
+Windows hardware clock is always localtime and cannot be changed.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+    pytest.mark.slow_test,
+    pytest.mark.destructive_test,
+]
+
+
+@pytest.fixture(scope="module")
+def timezone_state(states):
+    return states.timezone
+
+
+@pytest.fixture(scope="module")
+def timezone_mod(modules):
+    return modules.timezone
+
+
+@pytest.fixture
+def _reset_zone(timezone_mod):
+    original = timezone_mod.get_zone()
+    try:
+        yield
+    finally:
+        timezone_mod.set_zone(original)
+
+
+@pytest.mark.usefixtures("_reset_zone")
+def test_system_utc_true(timezone_state):
+    """
+    timezone.system with utc=True (the default) must succeed on Windows.
+
+    Previously the state returned result=False with "Failed to set UTC to True"
+    because win_timezone.set_hwclock always returns False. The fix skips the
+    hwclock block entirely on Windows.
+    """
+    ret = timezone_state.system("America/New_York", utc=True)
+    assert ret.result is True, ret.comment
+
+
+@pytest.mark.usefixtures("_reset_zone")
+def test_system_utc_false(timezone_state):
+    """
+    timezone.system with utc=False must also succeed on Windows.
+    """
+    ret = timezone_state.system("America/New_York", utc=False)
+    assert ret.result is True, ret.comment
+
+
+@pytest.mark.usefixtures("_reset_zone")
+def test_system_already_set(timezone_state, timezone_mod):
+    """
+    Calling timezone.system a second time when the timezone is already correct
+    must return result=True (idempotent).
+    """
+    timezone_mod.set_zone("America/Denver")
+    ret = timezone_state.system("America/Denver", utc=True)
+    assert ret.result is True, ret.comment
+    assert ret.changes == {}

--- a/tests/pytests/unit/modules/test_win_timezone.py
+++ b/tests/pytests/unit/modules/test_win_timezone.py
@@ -2,15 +2,17 @@
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
+import importlib.util
+
 import pytest
 
 import salt.modules.win_timezone as win_timezone
 from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
 
-pytestmark = [
-    pytest.mark.skipif(not win_timezone.HAS_PYTZ, reason="This test requires pytz"),
-]
+requires_tzdata = pytest.mark.skipif(
+    not importlib.util.find_spec("tzdata"), reason="requires tzdata"
+)
 
 
 @pytest.fixture
@@ -117,9 +119,11 @@ def test_get_zone_error():
             win_timezone.get_zone()
 
 
+@requires_tzdata
 def test_get_offset():
     """
-    Test if it get current numeric timezone offset from UCT (i.e. +0530)
+    India Standard Time is a fixed +05:30 offset with no DST, so the result
+    is predictable regardless of when the test runs.
     """
     mock_read = MagicMock(
         return_value={
@@ -129,14 +133,48 @@ def test_get_offset():
             "stdout": "India Standard Time",
         }
     )
-
     with patch.dict(win_timezone.__salt__, {"cmd.run_all": mock_read}):
         assert win_timezone.get_offset() == "+0530"
 
 
+@requires_tzdata
+def test_get_offset_negative():
+    """
+    Hawaiian Standard Time is a fixed -10:00 offset with no DST.
+    """
+    mock_read = MagicMock(
+        return_value={
+            "pid": 78,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "Hawaiian Standard Time",
+        }
+    )
+    with patch.dict(win_timezone.__salt__, {"cmd.run_all": mock_read}):
+        assert win_timezone.get_offset() == "-1000"
+
+
+@requires_tzdata
+def test_get_offset_utc():
+    """
+    UTC maps to Etc/GMT which is always +0000.
+    """
+    mock_read = MagicMock(
+        return_value={
+            "pid": 78,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "UTC",
+        }
+    )
+    with patch.dict(win_timezone.__salt__, {"cmd.run_all": mock_read}):
+        assert win_timezone.get_offset() == "+0000"
+
+
+@requires_tzdata
 def test_get_zonecode():
     """
-    Test if it get current timezone (i.e. PST, MDT, etc)
+    India Standard Time uses the fixed abbreviation IST.
     """
     mock_read = MagicMock(
         return_value={
@@ -146,9 +184,25 @@ def test_get_zonecode():
             "stdout": "India Standard Time",
         }
     )
-
     with patch.dict(win_timezone.__salt__, {"cmd.run_all": mock_read}):
         assert win_timezone.get_zonecode() == "IST"
+
+
+@requires_tzdata
+def test_get_zonecode_hawaii():
+    """
+    Hawaiian Standard Time uses the fixed abbreviation HST (no DST).
+    """
+    mock_read = MagicMock(
+        return_value={
+            "pid": 78,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "Hawaiian Standard Time",
+        }
+    )
+    with patch.dict(win_timezone.__salt__, {"cmd.run_all": mock_read}):
+        assert win_timezone.get_zonecode() == "HST"
 
 
 def test_set_zone():

--- a/tests/pytests/unit/states/test_timezone.py
+++ b/tests/pytests/unit/states/test_timezone.py
@@ -16,7 +16,7 @@ def configure_loader_modules():
 
 def test_system():
     """
-    Test to set the timezone for the system.
+    Test to set the timezone for the system (non-Windows / Linux path).
     """
     ret = {"name": "salt", "changes": {}, "result": True, "comment": ""}
     mock = MagicMock(side_effect=[CommandExecutionError, True, True, True])
@@ -29,7 +29,7 @@ def test_system():
             "timezone.get_hwclock": mock1,
             "timezone.set_hwclock": mock2,
         },
-    ):
+    ), patch("salt.utils.platform.is_windows", return_value=False):
         ret.update(
             {
                 "comment": (
@@ -55,3 +55,53 @@ def test_system():
         with patch.dict(timezone.__opts__, {"test": False}):
             ret.update({"comment": "Failed to set UTC to True", "result": False})
             assert timezone.system("salt") == ret
+
+
+def test_system_windows():
+    """
+    Test that on Windows the UTC/hwclock block is skipped entirely and the
+    state succeeds even when utc=True (the default).
+    """
+    mock_zone_compare = MagicMock(return_value=False)
+    mock_get_hwclock = MagicMock(return_value="localtime")
+    mock_set_hwclock = MagicMock(return_value=False)
+    mock_set_zone = MagicMock(return_value=True)
+    with patch.dict(
+        timezone.__salt__,
+        {
+            "timezone.zone_compare": mock_zone_compare,
+            "timezone.get_hwclock": mock_get_hwclock,
+            "timezone.set_hwclock": mock_set_hwclock,
+            "timezone.set_zone": mock_set_zone,
+        },
+    ), patch.dict(timezone.__opts__, {"test": False}), patch(
+        "salt.utils.platform.is_windows", return_value=True
+    ):
+        ret = timezone.system("America/New_York", utc=True)
+        assert ret["result"] is True
+        assert ret["changes"] == {"timezone": "America/New_York"}
+        mock_set_hwclock.assert_not_called()
+
+
+def test_system_windows_already_set():
+    """
+    Test that on Windows, when the timezone is already correct, the state
+    succeeds and reports already-set without touching the hwclock.
+    """
+    mock_zone_compare = MagicMock(return_value=True)
+    mock_get_hwclock = MagicMock(return_value="localtime")
+    mock_set_hwclock = MagicMock(return_value=False)
+    with patch.dict(
+        timezone.__salt__,
+        {
+            "timezone.zone_compare": mock_zone_compare,
+            "timezone.get_hwclock": mock_get_hwclock,
+            "timezone.set_hwclock": mock_set_hwclock,
+        },
+    ), patch.dict(timezone.__opts__, {"test": False}), patch(
+        "salt.utils.platform.is_windows", return_value=True
+    ):
+        ret = timezone.system("America/New_York", utc=True)
+        assert ret["result"] is True
+        assert ret["changes"] == {}
+        mock_set_hwclock.assert_not_called()


### PR DESCRIPTION
### What does this PR do?
Windows hardware clock is always localtime and cannot be configured to UTC. Skip the hwclock block entirely on Windows so the state does not call set_hwclock (which unconditionally returns False) and incorrectly report failure.

### What issues does this PR fix or reference?
Fixes #57754 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
