### PR TITLE
Dependabot ci fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/requirements/static/ci"
+      - "/requirements/static/pkg"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: master
     labels:
       - "test:full"
@@ -14,9 +17,12 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/requirements/static/ci"
+      - "/requirements/static/pkg"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: 3008.x
     labels:
       - "test:full"
@@ -27,9 +33,12 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/requirements/static/ci"
+      - "/requirements/static/pkg"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: 3007.x
     labels:
       - "test:full"
@@ -40,9 +49,12 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/requirements/static/ci"
+      - "/requirements/static/pkg"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: 3006.x
     labels:
       - "test:full"

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -44,6 +44,8 @@ jobs:
           echo "Running pip-compile hooks..."
           # Running 'pip-compile' ID once triggers ALL hooks with that ID
           pre-commit run --all-files pip-compile --show-diff-on-failure --color=always || true
+          # Run a second time to ensure cross-dependencies (like base locks acting as constraints) are fully resolved
+          pre-commit run --all-files pip-compile --show-diff-on-failure --color=always || true
 
       - name: Commit and Push changes
         run: |


### PR DESCRIPTION
### What does this PR do?

- Only run all dependencies on a weekly basis.
-  CVE updates will happen as needed outside of the weekly schedule.