### PR TITLE
Fix git.tag message argument not forwarded to git tag (#69298)

### DIFF
--- a/changelog/69298.fixed.md
+++ b/changelog/69298.fixed.md
@@ -1,0 +1,1 @@
+Fix `git.tag` so that the documented `message` argument is actually forwarded to `git tag`, creating an annotated tag with the supplied message instead of silently producing a lightweight tag.

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -5207,6 +5207,10 @@ def tag(
         raise SaltInvocationError(
             'Tag messages must be passed in the "message" argument'
         )
+    if message is not None:
+        # Create an annotated tag with the supplied message. ``-a`` is implied
+        # by ``-m`` but is added explicitly for clarity in command logs.
+        command.extend(["-a", "-m", message])
     command.extend(formatted_opts)
     command.append(name)
     if "-d" not in formatted_opts and "--delete" not in formatted_opts:

--- a/tests/pytests/unit/modules/test_git.py
+++ b/tests/pytests/unit/modules/test_git.py
@@ -207,3 +207,81 @@ def test__git_run_tmp_wrapper():
             )
 
             file_remove_mock.assert_not_called()
+
+
+def _make_git_run_capture():
+    """
+    Return a mock suitable for patching ``salt.modules.git._git_run`` that
+    records the command list it was called with and returns a successful
+    result. Mirrors the structure of the dict that ``_git_run`` returns so
+    that ``git.tag`` can index ``["stdout"]`` without raising.
+    """
+    return MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+
+
+def test_tag_passes_message_as_annotated_tag(tmp_path):
+    """
+    Regression test for #69298.
+
+    ``git.tag`` documents the ``message`` argument as creating an annotated
+    tag with that message, but the implementation never forwarded it to the
+    underlying ``git tag`` invocation. This test asserts the assembled
+    command contains ``-a -m <message>`` when ``message`` is provided.
+    """
+    git_run_mock = _make_git_run_capture()
+    with patch.object(git_mod, "_git_run", git_run_mock), patch.object(
+        git_mod, "_expand_path", lambda cwd, user: str(cwd)
+    ):
+        git_mod.tag(str(tmp_path), "v1.2", message="Version 1.2")
+
+    assert git_run_mock.call_count == 1
+    command = git_run_mock.call_args.args[0]
+    # The command must be: ['git', 'tag', '-a', '-m', 'Version 1.2', 'v1.2', 'HEAD']
+    assert "-a" in command, f"expected '-a' in command, got {command!r}"
+    assert "-m" in command, f"expected '-m' in command, got {command!r}"
+    m_index = command.index("-m")
+    assert (
+        command[m_index + 1] == "Version 1.2"
+    ), f"expected message argument after '-m', got {command!r}"
+    # -a / -m must come before the tag name and ref so git parses them as
+    # options rather than as positional arguments.
+    assert command.index("-a") < command.index("v1.2")
+    assert command.index("-m") < command.index("v1.2")
+
+
+def test_tag_without_message_creates_lightweight_tag(tmp_path):
+    """
+    Regression test for #69298.
+
+    When ``message`` is not supplied, ``git.tag`` must continue to produce a
+    lightweight tag (no ``-a`` / ``-m`` arguments).
+    """
+    git_run_mock = _make_git_run_capture()
+    with patch.object(git_mod, "_git_run", git_run_mock), patch.object(
+        git_mod, "_expand_path", lambda cwd, user: str(cwd)
+    ):
+        git_mod.tag(str(tmp_path), "v1.2")
+
+    command = git_run_mock.call_args.args[0]
+    assert "-a" not in command, f"unexpected '-a' in command, got {command!r}"
+    assert "-m" not in command, f"unexpected '-m' in command, got {command!r}"
+
+
+def test_tag_rejects_message_in_opts(tmp_path):
+    """
+    Regression guard for #69298.
+
+    ``git.tag`` must continue to refuse ``-m`` / ``--message`` smuggled in via
+    the ``opts`` argument, since the message must be supplied through the
+    dedicated ``message`` parameter.
+    """
+    git_run_mock = _make_git_run_capture()
+    with patch.object(git_mod, "_git_run", git_run_mock), patch.object(
+        git_mod, "_expand_path", lambda cwd, user: str(cwd)
+    ):
+        with pytest.raises(
+            git_mod.SaltInvocationError, match="Tag messages must be passed"
+        ):
+            git_mod.tag(str(tmp_path), "v1.2", opts="-m 'sneaky'")
+
+    git_run_mock.assert_not_called()


### PR DESCRIPTION
### What does this PR do?

`salt.modules.git.tag` now forwards the `message` argument so annotated tags get their message.

### What issues does this PR fix or reference?

Fixes #69298

### Previous Behavior

`git.tag(name, message="x")` accepted `message` but never passed it to `git tag`, producing a lightweight tag with no message. Smuggling `-m` via `opts` was explicitly rejected, so there was no way to set an annotated-tag message.

### New Behavior

`message` is forwarded as `-a -m <message>` to create an annotated tag.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes