### PR TITLE
Fix postgres_local_cache duplicate JID errors in active-active multi-master (#69214)

### DIFF
--- a/changelog/69214.fixed.md
+++ b/changelog/69214.fixed.md
@@ -1,0 +1,1 @@
+Fixed `postgres_local_cache.save_load` raising `psycopg2.errors.UniqueViolation` when more than one master in an active-active multi-master cluster persists the same JID; the INSERT is now idempotent via `ON CONFLICT (jid) DO NOTHING` on PostgreSQL >= 9.5, and the duplicate is tolerated on older servers.

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -116,6 +116,7 @@ import salt.utils.json
 
 try:
     import psycopg2
+    import psycopg2.errors
 
     HAS_POSTGRES = True
 except ImportError:
@@ -280,28 +281,53 @@ def save_load(jid, clear_load, minions=None):
     if conn is None:
         return None
     cur = conn.cursor()
-    sql = (
-        """INSERT INTO jids """
-        """(jid, started, tgt_type, cmd, tgt, kwargs, ret, username, arg,"""
-        """ fun) """
-        """VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
-    )
+    # In active-active multi-master setups, more than one master may try to
+    # persist the same JID concurrently (see #69214). Use ON CONFLICT to make
+    # the duplicate insert a no-op on PostgreSQL >= 9.5; on older servers fall
+    # back to a plain INSERT and tolerate the resulting UniqueViolation in the
+    # except clause below.
+    if conn.server_version >= 90500:
+        sql = (
+            """INSERT INTO jids """
+            """(jid, started, tgt_type, cmd, tgt, kwargs, ret, username, arg,"""
+            """ fun) """
+            """VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+            """ ON CONFLICT (jid) DO NOTHING"""
+        )
+    else:
+        sql = (
+            """INSERT INTO jids """
+            """(jid, started, tgt_type, cmd, tgt, kwargs, ret, username, arg,"""
+            """ fun) """
+            """VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+        )
 
-    cur.execute(
-        sql,
-        (
-            jid,
-            salt.utils.jid.jid_to_time(jid),
-            str(clear_load.get("tgt_type")),
-            str(clear_load.get("cmd")),
-            str(clear_load.get("tgt")),
-            str(clear_load.get("kwargs")),
-            str(clear_load.get("ret")),
-            str(clear_load.get("user")),
-            str(salt.utils.json.dumps(clear_load.get("arg"))),
-            str(clear_load.get("fun")),
-        ),
-    )
+    try:
+        cur.execute(
+            sql,
+            (
+                jid,
+                salt.utils.jid.jid_to_time(jid),
+                str(clear_load.get("tgt_type")),
+                str(clear_load.get("cmd")),
+                str(clear_load.get("tgt")),
+                str(clear_load.get("kwargs")),
+                str(clear_load.get("ret")),
+                str(clear_load.get("user")),
+                str(salt.utils.json.dumps(clear_load.get("arg"))),
+                str(clear_load.get("fun")),
+            ),
+        )
+    except psycopg2.errors.UniqueViolation:
+        # PG >= 9.5 takes the ON CONFLICT path and never lands here; this
+        # branch covers PG < 9.5 and the (rare) race where a second master
+        # inserts the same jid between this connection's snapshot and the
+        # write. Tolerate it — other IntegrityErrors (FK, NOT NULL, CHECK)
+        # are not caught and surface as real bugs.
+        log.debug("save_load: duplicate jid %s ignored", jid)
+        conn.rollback()
+        conn.close()
+        return
     # TODO: Add Metadata support when it is merged from develop
     _close_conn(conn)
 

--- a/tests/pytests/functional/returners/test_postgres_local_cache.py
+++ b/tests/pytests/functional/returners/test_postgres_local_cache.py
@@ -1,0 +1,238 @@
+"""
+Functional tests for the ``postgres_local_cache`` returner.
+
+These spin up a real PostgreSQL server in a container so the
+``ON CONFLICT (jid) DO NOTHING`` and ``psycopg2.errors.UniqueViolation``
+code paths added for #69214 are exercised against a live database
+rather than a mock.
+"""
+
+import logging
+import time
+
+import pytest
+
+import salt.returners.postgres_local_cache as postgres_local_cache
+
+docker = pytest.importorskip("docker")
+psycopg2 = pytest.importorskip("psycopg2")
+import psycopg2.errors  # isort:skip  pylint: disable=3rd-party-module-not-gated
+
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("docker", "dockerd", check_all=False),
+]
+
+
+# The schema is documented in ``salt.returners.postgres_local_cache``'s
+# module docstring; keep this aligned with that block.
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS jids (
+  jid     varchar(20) PRIMARY KEY,
+  started TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  tgt_type text NOT NULL,
+  cmd text NOT NULL,
+  tgt text NOT NULL,
+  kwargs text NOT NULL,
+  ret text NOT NULL,
+  username text NOT NULL,
+  arg text NOT NULL,
+  fun text NOT NULL
+);
+CREATE TABLE IF NOT EXISTS salt_returns (
+  added     TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  fun       text NOT NULL,
+  jid       varchar(20) NOT NULL,
+  return    text NOT NULL,
+  id        text NOT NULL,
+  success   boolean
+);
+CREATE TABLE IF NOT EXISTS salt_events (
+  id SERIAL,
+  tag text NOT NULL,
+  data text NOT NULL,
+  alter_time TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  master_id text NOT NULL
+);
+"""
+
+
+def _check_postgres_ready(timeout_at, container, db_user, db_passwd, db_name):
+    sleeptime = 0.5
+    while time.time() <= timeout_at:
+        try:
+            if not container.is_running():
+                log.warning("%s is no longer running", container)
+                return False
+            ret = container.run(
+                "psql",
+                f"--username={db_user}",
+                f"--dbname={db_name}",
+                "-c",
+                "SELECT 1",
+                environment={"PGPASSWORD": db_passwd},
+            )
+            if ret.returncode == 0:
+                break
+        except docker.errors.APIError:
+            log.exception("psql readiness check failed")
+        time.sleep(sleeptime)
+        sleeptime = min(sleeptime * 2, 5)
+    else:
+        return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def postgres_credentials():
+    return {
+        "user": "salt",
+        "passwd": "Pa55w0rd!",
+        "db": "salt",
+    }
+
+
+@pytest.fixture(scope="module")
+def postgres_container(salt_factories, postgres_credentials):
+    environment = {
+        "POSTGRES_USER": postgres_credentials["user"],
+        "POSTGRES_PASSWORD": postgres_credentials["passwd"],
+        "POSTGRES_DB": postgres_credentials["db"],
+    }
+    container = salt_factories.get_container(
+        "postgres-local-cache-69214",
+        # Pin to a release that supports ON CONFLICT (>= 9.5) so the
+        # primary new code path is exercised. 14 is current LTS at the
+        # time of writing.
+        image_name="postgres:14",
+        pull_before_start=True,
+        skip_on_pull_failure=True,
+        skip_if_docker_client_not_connectable=True,
+        container_run_kwargs={
+            "ports": {"5432/tcp": None},
+            "environment": environment,
+        },
+    )
+    container.container_start_check(
+        _check_postgres_ready,
+        container,
+        postgres_credentials["user"],
+        postgres_credentials["passwd"],
+        postgres_credentials["db"],
+    )
+    with container.started() as factory:
+        yield factory
+
+
+@pytest.fixture(scope="module")
+def postgres_port(postgres_container):
+    return postgres_container.get_host_port_binding(5432, protocol="tcp", ipv6=False)
+
+
+@pytest.fixture
+def postgres_opts(minion_opts, postgres_credentials, postgres_port):
+    opts = minion_opts.copy()
+    opts.update(
+        {
+            "master_job_cache.postgres.host": "127.0.0.1",
+            "master_job_cache.postgres.port": postgres_port,
+            "master_job_cache.postgres.user": postgres_credentials["user"],
+            "master_job_cache.postgres.passwd": postgres_credentials["passwd"],
+            "master_job_cache.postgres.db": postgres_credentials["db"],
+        }
+    )
+    return opts
+
+
+@pytest.fixture
+def configure_loader_modules(postgres_opts):
+    return {
+        postgres_local_cache: {
+            "__opts__": postgres_opts,
+        },
+    }
+
+
+@pytest.fixture
+def schema(postgres_opts):
+    """Create the schema and truncate between tests for isolation."""
+    conn = psycopg2.connect(
+        host=postgres_opts["master_job_cache.postgres.host"],
+        port=postgres_opts["master_job_cache.postgres.port"],
+        user=postgres_opts["master_job_cache.postgres.user"],
+        password=postgres_opts["master_job_cache.postgres.passwd"],
+        database=postgres_opts["master_job_cache.postgres.db"],
+    )
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(_SCHEMA)
+                cur.execute("TRUNCATE jids, salt_returns, salt_events")
+        yield conn
+    finally:
+        conn.close()
+
+
+def _load(fun="test.ping"):
+    return {
+        "tgt_type": "glob",
+        "cmd": "publish",
+        "tgt": "*",
+        "kwargs": {},
+        "ret": "",
+        "user": "root",
+        "arg": [],
+        "fun": fun,
+    }
+
+
+def test_save_load_persists_row(schema, postgres_opts):
+    """A single save_load writes the row and returns the same load via
+    get_load."""
+    jid = "20260606120000000001"
+    postgres_local_cache.save_load(jid, _load("test.ping"))
+
+    loaded = postgres_local_cache.get_load(jid)
+    assert loaded["jid"] == jid
+    assert loaded["fun"] == "test.ping"
+
+
+def test_save_load_duplicate_jid_is_idempotent(schema, postgres_opts):
+    """
+    Regression test for #69214.
+
+    In an active-active multi-master cluster both masters race to
+    persist the same JID. The second save_load must not raise; the row
+    written by the first master must remain intact. This exercises
+    ``ON CONFLICT (jid) DO NOTHING`` on PostgreSQL >= 9.5 against a
+    real server.
+    """
+    jid = "20260606120000000002"
+    postgres_local_cache.save_load(jid, _load("test.ping"))
+
+    # Second master writes the same jid with a different fun -- must
+    # not raise and must not overwrite the first row (DO NOTHING).
+    postgres_local_cache.save_load(jid, _load("state.apply"))
+
+    with schema.cursor() as cur:
+        cur.execute("SELECT count(*), max(fun) FROM jids WHERE jid = %s", (jid,))
+        count, fun = cur.fetchone()
+    assert count == 1
+    assert fun == "test.ping"
+
+
+def test_save_load_uses_on_conflict_on_pg_95_or_newer(schema, postgres_opts):
+    """
+    Sanity check that the running container is on a PostgreSQL version
+    that exercises the ON CONFLICT path (the whole point of this
+    functional test). If this fails the test image needs to be bumped.
+    """
+    with schema.cursor() as cur:
+        cur.execute("SHOW server_version_num")
+        server_version = int(cur.fetchone()[0])
+    assert server_version >= 90500, (
+        f"functional test image must be PG >= 9.5 to exercise the ON "
+        f"CONFLICT path; got {server_version}"
+    )

--- a/tests/pytests/unit/returners/test_postgres_local_cache.py
+++ b/tests/pytests/unit/returners/test_postgres_local_cache.py
@@ -9,6 +9,10 @@ import pytest
 import salt.returners.postgres_local_cache as postgres_local_cache
 from tests.support.mock import MagicMock, patch
 
+if postgres_local_cache.HAS_POSTGRES:
+    import psycopg2
+    import psycopg2.errors
+
 
 @pytest.fixture
 def configure_loader_modules(tmp_path):
@@ -57,6 +61,123 @@ def test_returner():
 
         assert return_val is not None, None
         assert return_val == expected
+
+
+@pytest.mark.skipif(
+    not postgres_local_cache.HAS_POSTGRES, reason="psycopg2 not installed"
+)
+def test_save_load_swallows_duplicate_jid_unique_violation():
+    """
+    Regression test for #69214.
+
+    In an active-active multi-master setup, both masters may call
+    ``save_load`` for the same JID. The second INSERT into the ``jids``
+    table hits the ``jids_pkey`` unique constraint and psycopg2 raises
+    ``UniqueViolation``. That is an expected steady-state in multi-master
+    deployments — it must be tolerated silently rather than raised up to
+    the caller (where ``salt.utils.job.store_job`` only logs it as a
+    CRITICAL stack trace).
+
+    This exercises the legacy code path for PostgreSQL < 9.5 where the
+    ON CONFLICT clause is not available and we rely on the exception
+    handler to absorb the duplicate. PG >= 9.5 takes the ON CONFLICT
+    path (covered by ``test_save_load_uses_upsert_sql_on_pg_95_or_newer``)
+    and never raises.
+    """
+    conn = MagicMock()
+    conn.server_version = 90400  # PG < 9.5: only path that reaches the catch.
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+    cur.execute.side_effect = psycopg2.errors.UniqueViolation(
+        'duplicate key value violates unique constraint "jids_pkey"'
+    )
+
+    load = {
+        "tgt_type": "glob",
+        "cmd": "publish",
+        "tgt": "*",
+        "kwargs": {},
+        "ret": "",
+        "user": "root",
+        "arg": [],
+        "fun": "test.ping",
+    }
+
+    with patch.object(postgres_local_cache, "_get_conn", return_value=conn):
+        # Must not raise — both masters writing the same jid is the
+        # whole point of an active-active master cluster.
+        postgres_local_cache.save_load("20260522093640648950", load)
+
+    cur.execute.assert_called_once()
+
+
+@pytest.mark.skipif(
+    not postgres_local_cache.HAS_POSTGRES, reason="psycopg2 not installed"
+)
+def test_save_load_propagates_other_integrity_errors():
+    """
+    Only ``UniqueViolation`` on the jids primary key is the multi-master
+    benign case. Other integrity errors (foreign-key, NOT NULL, CHECK)
+    are real bugs and must propagate to the caller — silently swallowing
+    them would hide schema-mismatch issues.
+    """
+    conn = MagicMock()
+    conn.server_version = 90500
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+    cur.execute.side_effect = psycopg2.errors.ForeignKeyViolation("fk violation")
+
+    load = {"fun": "test.ping"}
+
+    with patch.object(postgres_local_cache, "_get_conn", return_value=conn):
+        with pytest.raises(psycopg2.IntegrityError):
+            postgres_local_cache.save_load("20260522093640648950", load)
+
+
+@pytest.mark.skipif(
+    not postgres_local_cache.HAS_POSTGRES, reason="psycopg2 not installed"
+)
+def test_save_load_uses_upsert_sql_on_pg_95_or_newer():
+    """
+    On PostgreSQL >= 9.5 the INSERT must use ``ON CONFLICT (jid) DO NOTHING``
+    so duplicate-jid writes from a peer master are tolerated at the database
+    layer rather than raising.
+    """
+    conn = MagicMock()
+    conn.server_version = 90500
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+
+    load = {"fun": "test.ping"}
+
+    with patch.object(postgres_local_cache, "_get_conn", return_value=conn):
+        postgres_local_cache.save_load("20260522093640648950", load)
+
+    sql = cur.execute.call_args.args[0]
+    assert "ON CONFLICT" in sql
+
+
+@pytest.mark.skipif(
+    not postgres_local_cache.HAS_POSTGRES, reason="psycopg2 not installed"
+)
+def test_save_load_uses_plain_insert_on_pre_pg_95():
+    """
+    On PostgreSQL < 9.5 ``ON CONFLICT`` is not available; ``save_load`` must
+    issue the plain INSERT and let the UniqueViolation exception handler
+    absorb duplicate-jid writes.
+    """
+    conn = MagicMock()
+    conn.server_version = 90400
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+
+    load = {"fun": "test.ping"}
+
+    with patch.object(postgres_local_cache, "_get_conn", return_value=conn):
+        postgres_local_cache.save_load("20260522093640648950", load)
+
+    sql = cur.execute.call_args.args[0]
+    assert "ON CONFLICT" not in sql
 
 
 def test_returner_unicode_exception():


### PR DESCRIPTION
### What does this PR do?

Makes `postgres_local_cache.save_load` idempotent so an active-active multi-master cluster no longer logs a CRITICAL `UniqueViolation` traceback on every published job.

### What issues does this PR fix or reference?

Fixes #69214

### Previous Behavior

Both masters legitimately process the same JID. The second `INSERT INTO jids` collides with `jids_pkey`, psycopg2 raises `UniqueViolation`, and `save_load` lets it propagate — `salt.utils.job.store_job` logs a CRITICAL stack trace on every job.

### New Behavior

`save_load` is idempotent:
- PostgreSQL >= 9.5: `INSERT ... ON CONFLICT (jid) DO NOTHING`
- Older: plain INSERT with `UniqueViolation` swallowed (rollback + close)

Other `IntegrityError` subclasses still propagate.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes