### PR TITLE
Fix PAM auth using system Python instead of Salt's bundled Python (#69303)

### DIFF
--- a/changelog/69303.fixed.md
+++ b/changelog/69303.fixed.md
@@ -1,0 +1,1 @@
+Fix PAM authentication always returning 401 on relenv/onedir installs by preferring `sys.executable` over `/usr/bin/python3` when launching the PAM helper subprocess.

--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -50,6 +50,8 @@ from ctypes import (
 )
 from ctypes.util import find_library
 
+import salt.utils.package
+
 HAS_USER = True
 try:
     import salt.utils.user
@@ -228,17 +230,27 @@ def authenticate(username, password):
         """
         Provides the path to the Python interpreter to use.
 
-        First option: the system's Python 3 interpreter
-        If not found, it fallback to use the running Python interpreter (sys.executable)
+        Priority:
 
-        This can be overwritten via "auth.pam.python" configuration parameter.
+        1. ``auth.pam.python`` config override, when set.
+        2. ``sys.executable`` when Salt is running from a relenv/onedir
+           bundle. The system ``/usr/bin/python3`` on such a host does not
+           have salt or ``python-pam`` available and will exit non-zero,
+           causing every PAM auth attempt to return 401 (see #69303).
+        3. ``/usr/bin/python3`` if it exists. This branch matters for
+           non-bundled installs (e.g. pip-installed Salt running in a venv
+           whose interpreter lacks the system PAM bindings) where the
+           historical behavior of shelling out to the system Python is
+           still the right call.
+        4. ``sys.executable`` as a last resort.
         """
         if __opts__.get("auth.pam.python"):
             return __opts__.get("auth.pam.python")
-        elif os.path.exists("/usr/bin/python3"):
-            return "/usr/bin/python3"
-        else:
+        if salt.utils.package.bundled():
             return sys.executable
+        if os.path.exists("/usr/bin/python3"):
+            return "/usr/bin/python3"
+        return sys.executable
 
     env = os.environ.copy()
     env["SALT_PAM_USERNAME"] = username

--- a/tests/pytests/unit/auth/test_pam.py
+++ b/tests/pytests/unit/auth/test_pam.py
@@ -77,3 +77,69 @@ def test_if_sys_executable_is_used_to_call_pam_auth(mock_pam):
             username="fnord", password="fnord", service="login", encoding="utf-8"
         )
         assert f.name in run_mock.call_args_list[0][0][0]
+
+
+def test_bundled_install_uses_sys_executable_not_system_python_69303(mock_pam):
+    """
+    Regression test for #69303.
+
+    When Salt is running from a relenv/onedir bundle, ``authenticate()`` must
+    launch the PAM helper subprocess with ``sys.executable`` (Salt's bundled
+    interpreter), not the system ``/usr/bin/python3``. The system Python on
+    an onedir-only install does not have ``salt`` or ``python-pam``
+    available, so the subprocess exits 1 and every login attempt returns
+    401.
+    """
+    import os
+    import sys
+
+    import salt.utils.package
+
+    class Ret:
+        returncode = 0
+
+    real_exists = os.path.exists
+
+    # Pretend ``/usr/bin/python3`` exists (so the old heuristic would have
+    # picked it) but assert we picked ``sys.executable`` anyway because
+    # ``salt.utils.package.bundled()`` reports we are running from a relenv
+    # onedir build.
+    def fake_exists(path):
+        if str(path) == "/usr/bin/python3":
+            return True
+        return real_exists(path)
+
+    # Force ``bundled()`` to report we are running from an onedir/relenv
+    # install. ``hasattr(sys, "RELENV")`` is the canonical relenv probe;
+    # setting it for the duration of the test is the simplest knob.
+    had_relenv = hasattr(sys, "RELENV")
+    saved_relenv = getattr(sys, "RELENV", None)
+    sys.RELENV = "/opt/saltstack/salt"
+    try:
+        assert salt.utils.package.bundled() is True
+        with patch(
+            "salt.auth.pam.subprocess.run", return_value=Ret
+        ) as run_mock, tempfile.NamedTemporaryFile() as f, patch(
+            "salt.auth.pam.sys.executable", f.name
+        ), patch(
+            "os.path.exists", side_effect=fake_exists
+        ):
+            assert salt.auth.pam.auth(
+                username="fnord",
+                password="fnord",
+                service="login",
+                encoding="utf-8",
+            )
+            called_cmd = run_mock.call_args_list[0][0][0]
+            assert f.name in called_cmd, (
+                f"Expected bundled Python {f.name!r} in subprocess argv, "
+                f"got {called_cmd!r}. __find_pyexe() incorrectly preferred "
+                "the system Python on a relenv/onedir install (regression "
+                "of #69303)."
+            )
+            assert "/usr/bin/python3" not in called_cmd
+    finally:
+        if had_relenv:
+            sys.RELENV = saved_relenv
+        else:
+            del sys.RELENV


### PR DESCRIPTION
### What does this PR do?

`salt.auth.pam.__find_pyexe` now uses `sys.executable` on bundled (onedir) installs so PAM auth works against Salt's own Python.

### What issues does this PR fix or reference?

Fixes #69303

### Previous Behavior

On a 3008 onedir install, `__find_pyexe()` preferred `/usr/bin/python3`. The system Python lacks the salt package and python-pam, so the PAM helper subprocess exits 1 and every login returns 401.

### New Behavior

When `salt.utils.package.bundled()` is True, `__find_pyexe()` returns `sys.executable`. Source/pip installs still use `/usr/bin/python3`; `auth.pam.python` override still wins.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes