### PR TITLE
Add regression test for bare-string pillar response handling (#69228)

### DIFF
--- a/changelog/69228.fixed.md
+++ b/changelog/69228.fixed.md
@@ -1,0 +1,1 @@
+Added a regression test covering the `TypeError: string indices must be integers` crash in `AsyncReqChannel.crypted_transfer_decode_dictentry` when the master returns a bare-string error payload for a pillar request. The crash itself was already fixed on master by the layered `isinstance(ret, dict)` guards in `salt/channel/client.py`; the test pins that behavior.


### PR DESCRIPTION
### What does this PR do?

Adds a regression test for the bare-string pillar response guard in `AsyncReqChannel.crypted_transfer_decode_dictentry`.

### What issues does this PR fix or reference?

Fixes #69228

### Previous Behavior

When the master returned a bare-string error for a pillar request, the decode path raised `TypeError: string indices must be integers`. The guard was added by 2efc32ea883 on master and b776f67cc43 on 3006.x, but master/3008.x had no regression test. 3007.x is missing the guard entirely (separate backport).

### New Behavior

`test_req_chan_decode_data_dict_entry_string_response` covers the three known bare-string payloads. Test fails without the guard, passes with it.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes