### PR TITLE
Fix salt-cloud AttributeError by importing salt.minion (#69281)

### DIFF
--- a/changelog/69281.fixed.md
+++ b/changelog/69281.fixed.md
@@ -1,0 +1,1 @@
+Fix `salt-cloud` failing to start with `AttributeError: module 'salt' has no attribute 'minion'` by importing `salt.minion` in `salt.cloud`.

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -16,6 +16,7 @@ from itertools import groupby
 import salt.client
 import salt.config
 import salt.loader
+import salt.minion
 import salt.syspaths
 import salt.utils.args
 import salt.utils.cloud

--- a/tests/pytests/functional/cli/test_salt_cloud.py
+++ b/tests/pytests/functional/cli/test_salt_cloud.py
@@ -8,6 +8,29 @@ import pytest
 pytest.importorskip("libcloud", reason="salt-cloud requires >= libcloud 0.11.4")
 
 
+def test_map_file_runs_without_attribute_error(salt_cloud_cli, tmp_path):
+    """
+    Regression test for #69281.
+
+    ``salt-cloud -m <mapfile>`` failed on startup with
+    ``AttributeError: module 'salt' has no attribute 'minion'`` because
+    ``salt.cloud.Map.read`` references ``salt.minion.MasterMinion`` but
+    ``salt.cloud`` did not explicitly ``import salt.minion``.
+
+    Invoke the CLI with an empty map file. Without the fix the command
+    aborts during ``Map.__init__`` with the AttributeError. With the fix
+    it gets past ``read()`` and hits the "No nodes defined in this map"
+    early exit.
+    """
+    map_file = tmp_path / "empty.map"
+    map_file.write_text("")
+    ret = salt_cloud_cli.run("-m", str(map_file))
+    combined = (ret.stdout or "") + (ret.stderr or "")
+    assert "AttributeError" not in combined, combined
+    assert "module 'salt' has no attribute 'minion'" not in combined, combined
+    assert "No nodes defined in this map" in combined, combined
+
+
 def test_function_arguments(salt_cloud_cli):
     ret = salt_cloud_cli.run("--function", "show_image", "-h")
     assert ret.returncode != 0

--- a/tests/pytests/unit/cloud/test_map.py
+++ b/tests/pytests/unit/cloud/test_map.py
@@ -6,6 +6,9 @@
 
 import logging
 import os
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -237,6 +240,43 @@ def test_cloud_map_merge_conf(salt_cloud_config_file):
         # ie, the provider->profile->map inheritance works as expected
         map_data = cloud_map.map_data()
         assert map_data == merged_profile
+
+
+def test_salt_minion_imported_when_loading_cloud_module():
+    """
+    Regression test for #69281.
+
+    ``salt.cloud.Map.read`` references ``salt.minion.MasterMinion`` but the
+    ``salt.cloud`` module did not explicitly ``import salt.minion``. Whether
+    the reference resolved depended on other modules transitively importing
+    ``salt.minion`` first, which broke ``salt-cloud`` startup on 3008.0.
+
+    Verify in a fresh interpreter that simply importing ``salt.cloud`` makes
+    ``salt.minion`` available, so ``salt.cloud.Map(...)`` can call
+    ``salt.minion.MasterMinion(...)`` without raising ``AttributeError``.
+    """
+    script = textwrap.dedent(
+        """
+        import salt.cloud
+        assert hasattr(salt.cloud.salt, "minion"), (
+            "salt.cloud must import salt.minion; "
+            "salt.cloud.Map.read uses salt.minion.MasterMinion"
+        )
+        # Confirm the attribute is the real module, not something else.
+        import types
+        assert isinstance(salt.cloud.salt.minion, types.ModuleType)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "Importing salt.cloud failed to make salt.minion accessible.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
 
 
 def test_cloud_map_delete_non_existing_profile(salt_cloud_config_file, caplog):


### PR DESCRIPTION
### What does this PR do?

Adds an explicit `import salt.minion` to `salt/cloud/__init__.py` so salt-cloud doesn't crash at startup.

### What issues does this PR fix or reference?

Fixes #69281

### Previous Behavior

`salt.cloud.Map.__init__` references `salt.minion.MasterMinion` but the module is never imported. On 3007.x the symbol was incidentally populated by other startup-time imports; on 3008.0 the load order changed and salt-cloud crashes immediately on any command that constructs a Map.

### New Behavior

`salt.minion` is imported explicitly. salt-cloud starts normally.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes