### PR TITLE
Fix dnf5 versionlock support in pkg.hold and pkg.list_holds (#69181)

### DIFF
--- a/changelog/69181.fixed.md
+++ b/changelog/69181.fixed.md
@@ -1,0 +1,5 @@
+Fixed ``pkg.hold`` and ``pkg.list_holds`` on dnf5 systems (e.g. Fedora 42+):
+``pkg.hold`` now calls ``dnf5 versionlock add <pkg>`` (the bare
+``versionlock <pkg>`` form was rejected by dnf5), and ``pkg.list_holds``
+reads ``/etc/dnf/versionlock.toml`` directly so ``pkg.installed`` with
+``hold: true`` is again idempotent.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2314,14 +2314,12 @@ def hold(
                 ret[target].update(result=None)
                 ret[target]["comment"] = f"Package {target} is set to be held."
             else:
-                if _yum() == "dnf5":
-                    # dnf5's ``versionlock`` requires an explicit
-                    # ``add`` sub-command; the bare invocation aborts with
-                    # ``Unknown argument "<pkg>" for command "versionlock"``.
-                    cmd = ["versionlock", "add", target]
-                else:
-                    cmd = ["versionlock", target]
-                out = _call_yum(cmd)
+                # The explicit ``add`` sub-command is supported by all
+                # versionlock plugins (yum, dnf, dnf5); dnf5 *requires*
+                # it ("Unknown argument" otherwise) so use it
+                # unconditionally to mirror the ``versionlock delete``
+                # form used by ``unhold``.
+                out = _call_yum(["versionlock", "add", target])
                 if out["retcode"] == 0:
                     ret[target].update(result=True)
                     ret[target]["comment"] = "Package {} is now being held.".format(
@@ -2447,10 +2445,10 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
         Function renamed from ``pkg.get_locked_pkgs`` to ``pkg.list_holds``.
 
     .. note::
-        On dnf5 systems, holds are read directly from
-        ``/etc/dnf/versionlock.toml`` because ``dnf5 versionlock list``
+        On dnf5 (and any newer dnf) systems, holds are read directly
+        from ``/etc/dnf/versionlock.toml`` because ``versionlock list``
         no longer emits the legacy text format. The ``pattern`` argument
-        is ignored for dnf5.
+        is ignored in that case.
 
     List information on locked packages
 
@@ -2477,7 +2475,11 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
     """
     _check_versionlock()
 
-    if _yum() == "dnf5":
+    # Backends that still emit the legacy ``name-epoch:ver-rel.arch.*``
+    # text format from ``versionlock list``. Anything else (dnf5 today,
+    # and presumably any future dnf6+) is assumed to use the structured
+    # TOML store at ``/etc/dnf/versionlock.toml``.
+    if _yum() not in ("yum", "dnf", "tdnf"):
         return _list_holds_dnf5(full=full)
 
     out = __salt__["cmd.run"]([_yum(), "versionlock", "list"], python_shell=False)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -47,6 +47,11 @@ log = logging.getLogger(__name__)
 
 __HOLD_PATTERN = r"[\w+]+(?:[.-][^-]+)*"
 
+# dnf5 stores version locks in a TOML file rather than the legacy plain
+# text output exposed by ``dnf versionlock list``. The path is fixed in
+# upstream dnf5; tests override this constant.
+_DNF5_VERSIONLOCK_PATH = "/etc/dnf/versionlock.toml"
+
 PKG_ARCH_SEPARATOR = "."
 
 # Define the module's virtual name
@@ -2309,7 +2314,14 @@ def hold(
                 ret[target].update(result=None)
                 ret[target]["comment"] = f"Package {target} is set to be held."
             else:
-                out = _call_yum(["versionlock", target])
+                if _yum() == "dnf5":
+                    # dnf5's ``versionlock`` requires an explicit
+                    # ``add`` sub-command; the bare invocation aborts with
+                    # ``Unknown argument "<pkg>" for command "versionlock"``.
+                    cmd = ["versionlock", "add", target]
+                else:
+                    cmd = ["versionlock", target]
+                out = _call_yum(cmd)
                 if out["retcode"] == 0:
                     ret[target].update(result=True)
                     ret[target]["comment"] = "Package {} is now being held.".format(
@@ -2434,6 +2446,12 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
     .. versionchanged:: 2015.5.10,2015.8.4,2016.3.0
         Function renamed from ``pkg.get_locked_pkgs`` to ``pkg.list_holds``.
 
+    .. note::
+        On dnf5 systems, holds are read directly from
+        ``/etc/dnf/versionlock.toml`` because ``dnf5 versionlock list``
+        no longer emits the legacy text format. The ``pattern`` argument
+        is ignored for dnf5.
+
     List information on locked packages
 
     .. note::
@@ -2459,12 +2477,80 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
     """
     _check_versionlock()
 
+    if _yum() == "dnf5":
+        return _list_holds_dnf5(full=full)
+
     out = __salt__["cmd.run"]([_yum(), "versionlock", "list"], python_shell=False)
     ret = []
     for line in salt.utils.itertools.split(out, "\n"):
         match = _get_hold(line, pattern=pattern, full=full)
         if match is not None:
             ret.append(match)
+    return ret
+
+
+def _list_holds_dnf5(full=True):
+    """
+    Parse ``/etc/dnf/versionlock.toml`` to enumerate dnf5 version locks.
+
+    dnf5's ``versionlock list`` writes a structured human-readable format
+    rather than the legacy ``name-epoch:ver-rel.arch.*`` token that
+    ``_get_hold`` expects, so we read the on-disk configuration directly
+    via the salt TOML serializer (already a dependency of salt's RPM
+    tooling).
+    """
+    # Import inside the function so the top-level import graph stays
+    # unchanged for systems without a TOML library.
+    import salt.serializers as serializers
+    import salt.serializers.tomlmod as tomlmod
+
+    try:
+        with salt.utils.files.fopen(_DNF5_VERSIONLOCK_PATH) as fp_:
+            data = tomlmod.deserialize(fp_)
+    except OSError:
+        log.debug(
+            "dnf5 versionlock file %s is missing; no holds to report",
+            _DNF5_VERSIONLOCK_PATH,
+        )
+        return []
+    except serializers.DeserializationError as exc:
+        log.warning(
+            "Failed to parse dnf5 versionlock file %s: %s",
+            _DNF5_VERSIONLOCK_PATH,
+            exc,
+        )
+        return []
+
+    pkgs = data.get("packages", []) or []
+    if not full:
+        # Preserve insertion order while deduplicating.
+        seen = set()
+        names = []
+        for pkg in pkgs:
+            name = pkg.get("name")
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            names.append(name)
+        return names
+
+    ret = []
+    for pkg in pkgs:
+        name = pkg.get("name")
+        if not name:
+            continue
+        evr = None
+        for cond in pkg.get("conditions", []) or []:
+            if cond.get("key") == "evr" and cond.get("comparator") == "=":
+                evr = cond.get("value")
+                break
+        if evr is None:
+            # Without a concrete EVR there is no legacy-form token to
+            # emit; skip rather than report a partial entry.
+            continue
+        if ":" not in evr:
+            evr = "0:" + evr
+        ret.append(f"{name}-{evr}.*")
     return ret
 
 

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2152,7 +2152,7 @@ def test_pkg_hold_yum():
     ):
         yumpkg.hold("foo")
         cmd.assert_called_once_with(
-            ["yum", "versionlock", "foo"],
+            ["yum", "versionlock", "add", "foo"],
             env={},
             output_loglevel="trace",
             python_shell=False,
@@ -2173,7 +2173,7 @@ def test_pkg_hold_yum():
     ):
         yumpkg.hold("foo")
         cmd.assert_called_once_with(
-            ["yum", "versionlock", "foo"],
+            ["yum", "versionlock", "add", "foo"],
             env={},
             output_loglevel="trace",
             python_shell=False,
@@ -2471,7 +2471,7 @@ def test_pkg_hold_dnf():
     ):
         yumpkg.hold("foo")
         cmd.assert_called_once_with(
-            ["dnf", "versionlock", "foo"],
+            ["dnf", "versionlock", "add", "foo"],
             env={},
             output_loglevel="trace",
             python_shell=False,
@@ -2492,7 +2492,7 @@ def test_pkg_hold_dnf():
     ):
         yumpkg.hold("foo")
         cmd.assert_called_once_with(
-            ["dnf", "versionlock", "foo"],
+            ["dnf", "versionlock", "add", "foo"],
             env={},
             output_loglevel="trace",
             python_shell=False,
@@ -2518,7 +2518,7 @@ def test_pkg_hold_dnf():
     ):
         yumpkg.hold("foo")
         cmd.assert_called_once_with(
-            ["dnf", "versionlock", "foo"],
+            ["dnf", "versionlock", "add", "foo"],
             env={},
             output_loglevel="trace",
             python_shell=False,

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2525,6 +2525,98 @@ def test_pkg_hold_dnf():
         )
 
 
+def test_pkg_hold_dnf5_uses_versionlock_add_69181():
+    """
+    Regression test for #69181: on dnf5 the ``versionlock`` command requires
+    an explicit ``add`` sub-command; the legacy ``dnf versionlock <pkg>``
+    invocation fails with ``Unknown argument "<pkg>" for command
+    "versionlock"``.
+    """
+    list_pkgs_mock = {
+        "python3-dnf-plugin-versionlock": "0:1.0.0-0.n.fc41",
+    }
+
+    cmd = MagicMock(return_value={"retcode": 0})
+    with patch.dict(yumpkg.__context__, {"yum_bin": "dnf5"}), patch.dict(
+        yumpkg.__grains__, {"os": "Fedora", "osrelease": 44}
+    ), patch.object(
+        yumpkg, "list_pkgs", MagicMock(return_value=list_pkgs_mock)
+    ), patch.object(
+        yumpkg, "list_holds", MagicMock(return_value=[])
+    ), patch.dict(
+        yumpkg.__salt__, {"cmd.run_all": cmd}
+    ), patch(
+        "salt.utils.systemd.has_scope", MagicMock(return_value=False)
+    ):
+        yumpkg.hold("foo")
+        cmd.assert_called_once_with(
+            ["dnf5", "versionlock", "add", "foo"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+
+
+def test_list_holds_dnf5_parses_versionlock_toml_69181(tmp_path):
+    """
+    Regression test for #69181: dnf5 stores version locks in
+    ``/etc/dnf/versionlock.toml`` and its ``versionlock list`` text output is
+    not the legacy ``name-epoch:ver-rel.arch.*`` format that ``_get_hold``
+    parses. Read the TOML file directly instead.
+    """
+    versionlock_toml = tmp_path / "versionlock.toml"
+    versionlock_toml.write_text(
+        'version = "1.0"\n'
+        "\n"
+        "[[packages]]\n"
+        'name = "salt-minion"\n'
+        "\n"
+        "[[packages.conditions]]\n"
+        'key = "evr"\n'
+        'comparator = "="\n'
+        'value = "3007.14-0"\n'
+        "\n"
+        "[[packages]]\n"
+        'name = "vim-enhanced"\n'
+        "\n"
+        "[[packages.conditions]]\n"
+        'key = "evr"\n'
+        'comparator = "="\n'
+        'value = "2:9.0.1-1.fc44"\n'
+    )
+
+    patch_versionlock = patch.object(yumpkg, "_check_versionlock", MagicMock())
+    patch_yum = patch.object(yumpkg, "_yum", MagicMock(return_value="dnf5"))
+    patch_path = patch.object(yumpkg, "_DNF5_VERSIONLOCK_PATH", str(versionlock_toml))
+
+    with patch_versionlock, patch_yum, patch_path:
+        full = yumpkg.list_holds()
+        names = yumpkg.list_holds(full=False)
+
+    assert full == [
+        "salt-minion-0:3007.14-0.*",
+        "vim-enhanced-2:9.0.1-1.fc44.*",
+    ]
+    assert sorted(names) == ["salt-minion", "vim-enhanced"]
+
+
+def test_list_holds_dnf5_missing_versionlock_toml_69181(tmp_path):
+    """
+    Regression test for #69181: when dnf5's ``/etc/dnf/versionlock.toml`` is
+    missing (no holds configured), ``list_holds`` returns an empty list
+    rather than raising.
+    """
+    missing_path = tmp_path / "does-not-exist.toml"
+
+    patch_versionlock = patch.object(yumpkg, "_check_versionlock", MagicMock())
+    patch_yum = patch.object(yumpkg, "_yum", MagicMock(return_value="dnf5"))
+    patch_path = patch.object(yumpkg, "_DNF5_VERSIONLOCK_PATH", str(missing_path))
+
+    with patch_versionlock, patch_yum, patch_path:
+        assert yumpkg.list_holds() == []
+        assert yumpkg.list_holds(full=False) == []
+
+
 def test_get_yum_config_no_config():
     with patch("os.path.exists", MagicMock(return_value=False)):
         with pytest.raises(CommandExecutionError):


### PR DESCRIPTION
### What does this PR do?

`pkg.hold` and `pkg.list_holds` now work with dnf5's versionlock plugin.

### What issues does this PR fix or reference?

Fixes #69181

### Previous Behavior

`pkg.installed ... hold: true` failed on Fedora 42+ (dnf5):
- `dnf versionlock <pkg>` was rejected because dnf5 requires the `add` subcommand.
- `dnf5 versionlock list` no longer emits the legacy text format that `list_holds` parsed.

### New Behavior

On dnf5, `hold()` shells out as `versionlock add`, and `list_holds()` reads `/etc/dnf/versionlock.toml` via `salt.serializers.tomlmod`, returning the legacy form so `unhold` and the `pkg.installed` glue keep working.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes