### PR TITLE
Fix premature deletion of auth tokens on localfs cache driver (#69307)

### DIFF
--- a/changelog/69307.fixed.md
+++ b/changelog/69307.fixed.md
@@ -1,0 +1,1 @@
+Fixed auth tokens being deleted from the `localfs` cache driver within one master `loop_interval` (default 60s) of being minted: `Cache.clean_expired`'s fallback path now consults the cache-level `_expires` envelope instead of file mtime, and `LoadAuth.mk_token` passes a relative duration to `Cache.store(expires=...)` rather than an absolute epoch.

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -253,7 +253,15 @@ class LoadAuth:
             new_token = str(hash_type(os.urandom(512)).hexdigest())
             tdata["token"] = new_token
             try:
-                self.cache.store("tokens", new_token, tdata, expires=tdata["expire"])
+                # ``Cache.store``'s ``expires`` is a *relative* duration in
+                # seconds, not an absolute epoch. Passing ``tdata["expire"]``
+                # here -- which is ``time.time() + token_expire`` -- caused
+                # the envelope ``_expires`` to be set to ``now + (now +
+                # token_expire)`` (~ year 4090), and combined with the
+                # broken ``Cache.clean_expired`` fallback resulted in tokens
+                # being deleted within a single master loop interval.
+                # Issue #69307.
+                self.cache.store("tokens", new_token, tdata, expires=token_expire)
             except salt.exceptions.SaltCacheError as err:
                 log.error(
                     "Cannot mk_token from tokens cache using %s: %s",

--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -332,14 +332,32 @@ class Cache:
         clean_expired = f"{self.driver}.clean_expired"
         if clean_expired in self.modules:
             self.modules[clean_expired](bank, *args, **{**self.kwargs, **kwargs})
-        else:
-            list_ = f"{self.driver}.list"
-            updated = f"{self.driver}.updated"
-            flush = f"{self.driver}.flush"
-            for key in self.modules[list_](bank, **self.kwargs):
-                ts = self.modules[updated](bank, key, **self.kwargs)
-                if ts is not None and ts <= time.time():
-                    self.modules[flush](bank, key, **self.kwargs)
+            return
+
+        # Fallback for drivers without native clean_expired. Use the
+        # ``_expires`` envelope written by ``Cache.store`` when ``expires``
+        # is supplied; entries without that envelope have no cache-level
+        # expiry and are left alone. (Previously this path treated the
+        # driver's ``updated()`` value -- the file mtime for ``localfs`` --
+        # as an absolute expiry epoch, which deleted every entry whose
+        # mtime was in the past, i.e. every entry. Issue #69307.)
+        list_ = f"{self.driver}.list"
+        fetch = f"{self.driver}.fetch"
+        flush = f"{self.driver}.flush"
+        now = time.time()
+        for key in self.modules[list_](bank, **self.kwargs):
+            try:
+                raw = self.modules[fetch](bank, key, **self.kwargs)
+            except SaltCacheError:
+                # Best-effort: don't let one unreadable key abort the sweep.
+                log.debug("clean_expired: unable to read %s/%s; skipping", bank, key)
+                continue
+            if (
+                isinstance(raw, dict)
+                and set(raw.keys()) == {"data", "_expires"}
+                and raw["_expires"] <= now
+            ):
+                self.modules[flush](bank, key, **self.kwargs)
 
 
 class MemCache(Cache):

--- a/tests/pytests/functional/cache/test_localfs.py
+++ b/tests/pytests/functional/cache/test_localfs.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import time
 from pathlib import Path
 
 import pytest
@@ -82,3 +83,49 @@ def test_contains_is_constrained_to_cachedir(cache, tmp_path, key):
     if key is not None:
         (tmp_path / f"{key}.p").touch()
     assert not cache.contains(str(tmp_path), key)
+
+
+def test_clean_expired_does_not_drop_unexpired_entries_69307(cache):
+    """
+    Regression test for issue #69307.
+
+    ``Cache.clean_expired`` falls back to ``driver.updated()`` for backends
+    (like ``localfs``) that don't expose their own ``clean_expired``. The
+    fallback previously compared ``updated()`` (the file mtime, an epoch
+    in the past) against ``time.time()`` and flushed every key whose
+    mtime had passed -- i.e. every key on disk. That deleted freshly
+    minted auth tokens within one master ``loop_interval`` (default 60s),
+    regardless of the token's actual expiry.
+
+    A freshly stored entry with a ``_expires`` envelope that points into
+    the future, and a plain entry with no envelope at all, must both
+    survive ``clean_expired``.
+    """
+    bank = "tokens"
+    key_with_envelope = "tok-with-envelope"
+    key_plain = "tok-plain"
+
+    # Plain store: no expires kwarg -> no envelope.
+    cache.store(bank, key_plain, {"name": "alice", "expire": time.time() + 12 * 3600})
+
+    # Store with a far-future expires duration (12 hours).
+    cache.store(
+        bank,
+        key_with_envelope,
+        {"name": "bob", "expire": time.time() + 12 * 3600},
+        expires=12 * 3600,
+    )
+
+    assert cache.contains(bank, key_plain)
+    assert cache.contains(bank, key_with_envelope)
+
+    cache.clean_expired(bank)
+
+    assert cache.contains(bank, key_plain), (
+        "Plain (non-enveloped) token was flushed by clean_expired even "
+        "though it has no expiry information; the fallback must not "
+        "treat file mtime as an absolute expiry epoch (issue #69307)."
+    )
+    assert cache.contains(bank, key_with_envelope), (
+        "Token with future expiry was flushed by clean_expired " "(issue #69307)."
+    )

--- a/tests/pytests/unit/test_auth.py
+++ b/tests/pytests/unit/test_auth.py
@@ -936,6 +936,63 @@ async def test_acl_simple_deny(auth_acl_clear_funcs, auth_acl_valid_load):
         ]
 
 
+def test_mk_token_survives_clean_expired_tokens_69307(tmp_path):
+    """
+    Regression test for issue #69307.
+
+    A freshly minted token must not be wiped by the very next iteration
+    of the master ``clean_expired_tokens`` loop. The bug: ``Cache.store``
+    expects ``expires`` to be a relative duration in seconds, but
+    ``LoadAuth.mk_token`` was passing the absolute epoch
+    ``time.time() + token_expire``. Worse, ``Cache.clean_expired``'s
+    fallback used the file mtime as if it were an absolute expiry
+    epoch, so every token on disk was flushed unconditionally.
+
+    With the fix:
+    - ``LoadAuth.mk_token`` passes a relative duration to ``Cache.store``.
+    - ``Cache.clean_expired``'s fallback respects the stored token's
+      ``expire`` (or the ``_expires`` envelope) rather than file mtime.
+    The token must still be retrievable after
+    ``clean_expired_tokens()``.
+    """
+    opts = {
+        "extension_modules": "",
+        "optimization_order": [0, 1, 2],
+        # Long-lived token (12 hours) — the default.
+        "token_expire": 12 * 60 * 60,
+        "keep_acl_in_token": False,
+        "eauth_tokens": "localfs",
+        "cachedir": str(tmp_path),
+        "token_expire_user_override": False,
+        "external_auth": {"auto": {"foo": []}},
+        "eauth_tokens.cache_driver": None,
+        "eauth_tokens.cluster_id": None,
+        "cluster_id": None,
+        "hash_type": "sha256",
+    }
+    auth = salt.auth.LoadAuth(opts)
+    load = {"eauth": "auto", "username": "foo", "password": "foo"}
+
+    tdata = auth.mk_token(load)
+    assert tdata, "mk_token should return the token data on success"
+    token = tdata["token"]
+    # Sanity: the token should be retrievable straight away.
+    assert auth.get_tok(token).get("token") == token
+
+    # Simulate the master loop that runs every ``loop_interval`` seconds
+    # and calls ``LoadAuth.clean_expired_tokens()`` on the auth backend.
+    # With the bug, this call deletes the token from disk even though
+    # its real ``expire`` is 12 hours away.
+    auth.clean_expired_tokens()
+
+    surviving = auth.get_tok(token)
+    assert surviving, (
+        "Token was deleted by clean_expired_tokens even though it was "
+        "just minted with a 12-hour expiry. Issue #69307."
+    )
+    assert surviving.get("token") == token
+
+
 def test_cve_2021_3244(tmp_path):
     token_dir = tmp_path
     opts = {


### PR DESCRIPTION
### What does this PR do?

Fixes premature deletion of auth tokens on the default localfs cache driver, introduced by #68039.

### What issues does this PR fix or reference?

Fixes #69307
Fixes #68999

### Previous Behavior

Two bugs combined:
1. `Cache.clean_expired` fallback used `driver.updated()` (file mtime) as if it were an absolute expiry epoch, flushing every entry where `mtime <= time.time()` — i.e. all of them.
2. `LoadAuth.mk_token` passed `expires=tdata["expire"]` (absolute epoch) to `Cache.store`, whose `expires` is documented as a relative duration.

Result: every token was deleted ~60s after creation by the master's expiry loop.

### New Behavior

- `Cache.clean_expired` fallback reads each entry's `_expires` envelope and only flushes when that has elapsed. Entries without the envelope are left alone.
- `mk_token` passes the relative `token_expire` duration.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes