### PR TITLE
Fix misleading proxymodule init/shutdown error message (#69139)

### DIFF
--- a/changelog/69139.fixed.md
+++ b/changelog/69139.fixed.md
@@ -1,0 +1,1 @@
+Surface the real cause of a proxymodule load failure in salt-proxy's abort message. The misleading "Proxymodule X is missing an init() or a shutdown() or both" wording is now only used when init/shutdown really are missing from a loaded module; if the module failed to load (for example because its ``__virtual__`` returned False), the underlying reason is included in the error.

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -174,10 +174,7 @@ def post_master_init(self, master):
         proxy_init_func_name not in self.proxy
         or proxy_shutdown_func_name not in self.proxy
     ):
-        errmsg = (
-            "Proxymodule {} is missing an init() or a shutdown() or both. "
-            "Check your proxymodule.  Salt-proxy aborted.".format(fq_proxyname)
-        )
+        errmsg = salt.minion.proxy_load_failure_message(self.proxy, fq_proxyname)
         log.error(errmsg)
         self._running = False
         raise SaltSystemExit(code=-1, msg=errmsg)

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -169,12 +169,7 @@ def post_master_init(self, master):
         f"{fq_proxyname}.init" not in self.proxy
         or f"{fq_proxyname}.shutdown" not in self.proxy
     ):
-        errmsg = (
-            "Proxymodule {} is missing an init() or a shutdown() or both. ".format(
-                fq_proxyname
-            )
-            + "Check your proxymodule.  Salt-proxy aborted."
-        )
+        errmsg = salt.minion.proxy_load_failure_message(self.proxy, fq_proxyname)
         log.error(errmsg)
         self._running = False
         raise SaltSystemExit(code=-1, msg=errmsg)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -4843,6 +4843,47 @@ class ProxyMinionManager(MinionManager):
         )
 
 
+def proxy_load_failure_message(proxy_loader, fq_proxyname):
+    """
+    Build the error message a proxy minion should abort with when its
+    proxymodule's ``init`` and/or ``shutdown`` are unavailable.
+
+    Historically all three call sites (``salt.metaproxy.proxy``,
+    ``salt.metaproxy.deltaproxy`` and ``salt.minion.ProxyMinion``) emitted
+    a single hard-coded sentence — "Proxymodule X is missing an init() or
+    a shutdown() or both" — regardless of *why* those functions weren't
+    in the loader. In practice that wording is wrong far more often than
+    it is right: a missing dependency, an ``ImportError`` while loading
+    the proxymodule, or any ``__virtual__()`` returning ``False`` all
+    surface the same misleading message even though the module itself
+    defines both functions.
+
+    This helper inspects the proxy ``LazyLoader`` and distinguishes the
+    two situations:
+
+    * If the proxymodule itself never loaded (it is in the loader's
+      ``missing_modules``), surface the underlying reason via
+      :meth:`LazyLoader.missing_fun_string` so the operator can see the
+      real cause (e.g. a failed ``__virtual__`` or import error).
+    * Otherwise keep the historical "missing an init() or a shutdown()"
+      wording — that case really does indicate a malformed proxymodule.
+
+    Both branches end with the same "Salt-proxy aborted." suffix that
+    callers and external log scrapers may rely on.
+    """
+    proxy_init_func_name = f"{fq_proxyname}.init"
+    if fq_proxyname not in proxy_loader.loaded_modules:
+        reason = proxy_loader.missing_fun_string(proxy_init_func_name)
+        return (
+            f"Proxymodule {fq_proxyname} could not be loaded: {reason}. "
+            "Salt-proxy aborted."
+        )
+    return (
+        f"Proxymodule {fq_proxyname} is missing an init() or a shutdown() "
+        "or both. Check your proxymodule.  Salt-proxy aborted."
+    )
+
+
 def _metaproxy_call(opts, fn_name):
     loaded_base_name = "{}.{}".format(opts["id"], salt.loader.lazy.LOADED_BASE_NAME)
     metaproxy = salt.loader.metaproxy(opts, loaded_base_name=loaded_base_name)
@@ -5023,12 +5064,7 @@ class SProxyMinion(SMinion):
             f"{fq_proxyname}.init" not in self.proxy
             or f"{fq_proxyname}.shutdown" not in self.proxy
         ):
-            errmsg = (
-                "Proxymodule {} is missing an init() or a shutdown() or both. ".format(
-                    fq_proxyname
-                )
-                + "Check your proxymodule.  Salt-proxy aborted."
-            )
+            errmsg = proxy_load_failure_message(self.proxy, fq_proxyname)
             log.error(errmsg)
             self._running = False
             raise SaltSystemExit(code=salt.defaults.exitcodes.EX_GENERIC, msg=errmsg)

--- a/tests/pytests/unit/test_proxy_minion.py
+++ b/tests/pytests/unit/test_proxy_minion.py
@@ -1,0 +1,139 @@
+import textwrap
+
+import pytest
+
+import salt.loader.lazy
+import salt.minion
+
+# ---------------------------------------------------------------------------
+# Regression for #69139
+# ---------------------------------------------------------------------------
+
+PROXY_MODULE_WITH_BAD_VIRTUAL = textwrap.dedent(
+    """
+    __proxyenabled__ = ["*"]
+
+    def __virtual__():
+        return (
+            False,
+            "NAPALM is not installed: ``pip install napalm``",
+        )
+
+    def init(opts):
+        return True
+
+    def shutdown(opts):
+        return True
+    """
+)
+
+PROXY_MODULE_VIRTUAL_FALSE_NO_REASON = textwrap.dedent(
+    """
+    __proxyenabled__ = ["*"]
+
+    def __virtual__():
+        return False
+
+    def init(opts):
+        return True
+
+    def shutdown(opts):
+        return True
+    """
+)
+
+PROXY_MODULE_NO_INIT = textwrap.dedent(
+    """
+    __proxyenabled__ = ["*"]
+
+    def __virtual__():
+        return True
+
+    def shutdown(opts):
+        return True
+    """
+)
+
+
+@pytest.fixture
+def proxy_loader_factory(tmp_path):
+    """
+    Build a proxy LazyLoader from a temp directory containing a single
+    module file. Returns a callable that takes module contents and
+    returns a configured LazyLoader.
+    """
+
+    def _make(name, contents):
+        mod_dir = tmp_path / name
+        mod_dir.mkdir()
+        (mod_dir / f"{name}.py").write_text(contents)
+        opts = {
+            "optimization_order": [0, 1, 2],
+            "proxy": {"proxytype": name},
+        }
+        return salt.loader.lazy.LazyLoader(
+            [str(mod_dir)],
+            opts,
+            tag="proxy",
+        )
+
+    return _make
+
+
+def test_proxy_load_failure_message_surfaces_virtual_reason(proxy_loader_factory):
+    """
+    Regression for #69139.
+
+    When a proxy module's ``__virtual__()`` returns ``(False, reason)``
+    (for example because a required dependency could not be imported),
+    salt-proxy used to abort with the misleading message "Proxymodule X
+    is missing an init() or a shutdown() or both" even when the module
+    defined both ``init()`` and ``shutdown()``. The user had no way to
+    learn the real cause was the failed ``__virtual__()``.
+
+    The helper must surface the ``__virtual__`` reason so the operator
+    can act on it (e.g. install the missing dependency).
+    """
+    loader = proxy_loader_factory("napalm", PROXY_MODULE_WITH_BAD_VIRTUAL)
+
+    # Sanity: the module is not loaded and the reason is recorded.
+    assert "napalm.init" not in loader
+    assert "napalm" in loader.missing_modules
+
+    errmsg = salt.minion.proxy_load_failure_message(loader, "napalm")
+
+    # The misleading wording must not be the *only* thing the user sees.
+    assert "NAPALM is not installed" in errmsg, errmsg
+    assert "could not be loaded" in errmsg or "__virtual__" in errmsg, errmsg
+    assert "Salt-proxy aborted" in errmsg
+
+
+def test_proxy_load_failure_message_virtual_false_no_reason(proxy_loader_factory):
+    """
+    A ``__virtual__()`` that returns plain ``False`` still produces a
+    message that indicates the module did not load (rather than claiming
+    init/shutdown were missing).
+    """
+    loader = proxy_loader_factory("zilch", PROXY_MODULE_VIRTUAL_FALSE_NO_REASON)
+    assert "zilch.init" not in loader
+
+    errmsg = salt.minion.proxy_load_failure_message(loader, "zilch")
+    assert "could not be loaded" in errmsg or "__virtual__" in errmsg, errmsg
+    assert "Salt-proxy aborted" in errmsg
+
+
+def test_proxy_load_failure_message_truly_missing_init(proxy_loader_factory):
+    """
+    The original "missing an init() or a shutdown()" wording is still
+    used when the proxy module *did* load but really is missing one of
+    the required functions. This preserves the historical message for
+    its actual use case.
+    """
+    loader = proxy_loader_factory("noinit", PROXY_MODULE_NO_INIT)
+    # The module loaded (shutdown is exposed), but init isn't.
+    assert "noinit.shutdown" in loader
+    assert "noinit.init" not in loader
+
+    errmsg = salt.minion.proxy_load_failure_message(loader, "noinit")
+    assert "missing an init() or a shutdown()" in errmsg
+    assert "Salt-proxy aborted" in errmsg


### PR DESCRIPTION
### What does this PR do?
Surface the real reason a proxymodule failed to load instead of always reporting "missing an init() or a shutdown()".

### What issues does this PR fix or reference?
Fixes #69139

### Previous Behavior
All three salt-proxy bootstrap paths (`salt.metaproxy.proxy`, `salt.metaproxy.deltaproxy`, `salt.minion.SProxyMinion`) emitted the same hard-coded message whenever `init`/`shutdown` weren't in the proxy `LazyLoader`, regardless of why the module wasn't loaded. The real cause (e.g. `__virtual__` returning `(False, "NAPALM is not installed")` or an `ImportError`) sat in `LazyLoader.missing_modules` but the call sites ignored it.

### New Behavior
A new helper, `salt.minion.proxy_load_failure_message`, used by all three call sites, consults the proxy `LazyLoader` and surfaces `missing_fun_string()` when the module never loaded, so operators see the actual reason (e.g. the failed `__virtual__` message). The historical "missing an init() or a shutdown()" wording is preserved verbatim for the case it was actually intended for. The trailing "Salt-proxy aborted." suffix is kept for log scrapers.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes