### PR TITLE
Log cache version mismatch at debug, not warning (#69106)

### DIFF
--- a/changelog/69106.fixed.md
+++ b/changelog/69106.fixed.md
@@ -1,0 +1,1 @@
+Lowered the "Cache version mismatch clearing" log message in ``salt.utils.cache.verify_cache_version`` from ``WARNING`` to ``DEBUG``; the cache is rebuilt as part of normal operation after upgrades or when an ephemeral cache directory has been removed, and does not warrant user attention.

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -365,7 +365,7 @@ def verify_cache_version(cache_path):
         file.seek(0)
         data = "\n".join(file.readlines())
         if data != salt.version.__version__:
-            log.warning("Cache version mismatch clearing: %s", repr(cache_path))
+            log.debug("Cache version mismatch clearing: %s", repr(cache_path))
             file.truncate(0)
             file.write(salt.version.__version__)
             for item in os.listdir(cache_path):

--- a/tests/pytests/functional/utils/test_cache.py
+++ b/tests/pytests/functional/utils/test_cache.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -81,3 +82,34 @@ def test_verify_cache_version(tmp_path):
     for _ in range(3):
         assert salt.utils.cache.verify_cache_version(tmp_path) is True
         assert _dummy_files_exists(tmp_path) is True
+
+
+def test_verify_cache_version_mismatch_logged_at_debug(tmp_path, caplog):
+    """
+    Clearing a stale cache because of a version mismatch is a routine
+    side effect of upgrades and ephemeral cache directories; it must be
+    logged at DEBUG, not WARNING (see issue #69106).
+    """
+    cache_path = str(salt.utils.path.join(str(tmp_path), "work", "salt"))
+    cache_version = salt.utils.path.join(cache_path, "cache_version")
+
+    # Prime the cache directory with a stale version so the next call
+    # exercises the "mismatch -> clear" branch.
+    os.makedirs(cache_path)
+    with salt.utils.files.fopen(cache_version, "w") as file:
+        file.write("-1")
+
+    with caplog.at_level(logging.DEBUG, logger="salt.utils.cache"):
+        assert salt.utils.cache.verify_cache_version(cache_path) is False
+
+    mismatch_records = [
+        record
+        for record in caplog.records
+        if "Cache version mismatch clearing" in record.getMessage()
+    ]
+    assert mismatch_records, "expected a 'Cache version mismatch clearing' log record"
+    for record in mismatch_records:
+        assert record.levelno == logging.DEBUG, (
+            f"'Cache version mismatch clearing' was logged at "
+            f"{record.levelname}, expected DEBUG"
+        )


### PR DESCRIPTION
### What does this PR do?
Lowers the `Cache version mismatch clearing` log message in
`salt.utils.cache.verify_cache_version` from `WARNING` to `DEBUG`. Rebuilding
the cache is a routine side effect of upgrading Salt or running with an
ephemeral cache directory (e.g. `salt-ssh` rooted under `TMPDIR`); there is
nothing for the user to act on.

### What issues does this PR fix or reference?
Fixes #69106

### Previous Behavior
Every Salt upgrade and every `salt-ssh` run with a wiped cache directory
printed:

```
[WARNING ] Cache version mismatch clearing: '.../var/cache/salt/master/gitfs'
```

### New Behavior
The same message is now emitted at `DEBUG`. Normal upgrades and ephemeral
cache directories produce no warnings.

### Merge requirements satisfied?
- [x] Docs (no user-facing docs change required)
- [x] Changelog (`changelog/69106.fixed.md`)
- [x] Tests written/updated (`tests/pytests/functional/utils/test_cache.py::test_verify_cache_version_mismatch_logged_at_debug`)

### Commits signed with GPG?
Yes
