### PR TITLE
Set TTL on redis_return <minion>:<fun> pointer keys (#69038)

### DIFF
--- a/changelog/69038.fixed.md
+++ b/changelog/69038.fixed.md
@@ -1,0 +1,1 @@
+Fixed `redis_return` returner leaking `<minion>:<fun>` last-jid pointer keys into Redis indefinitely. The keys are now written with the same `keep_jobs_seconds` TTL as the rest of the returner data, so they expire alongside `ret:<jid>` instead of accumulating without bound.

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -214,7 +214,7 @@ def returner(ret):
     minion, jid = ret["id"], ret["jid"]
     pipeline.hset(f"ret:{jid}", minion, salt.utils.json.dumps(ret))
     pipeline.expire(f"ret:{jid}", _get_ttl())
-    pipeline.set("{}:{}".format(minion, ret["fun"]), jid)
+    pipeline.set("{}:{}".format(minion, ret["fun"]), jid, ex=_get_ttl())
     pipeline.sadd("minions", minion)
     pipeline.execute()
 

--- a/tests/pytests/unit/returners/test_redis_return.py
+++ b/tests/pytests/unit/returners/test_redis_return.py
@@ -1,0 +1,62 @@
+"""
+Tests for salt.returners.redis_return
+"""
+
+import pytest
+
+import salt.returners.redis_return as redis_return
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        redis_return: {
+            "__opts__": {},
+        },
+    }
+
+
+def test_returner_sets_minion_fun_key_with_ttl():
+    """
+    Regression test for #69038.
+
+    The ``<minion>:<fun>`` last-jid pointer key written by ``returner`` must
+    carry the same TTL as the rest of the returner data (``keep_jobs_seconds``);
+    otherwise these keys accumulate in Redis indefinitely.
+    """
+    ttl = 1234
+    ret = {
+        "id": "minion-1",
+        "jid": "20260504000000000001",
+        "fun": "test.ping",
+        "return": True,
+        "success": True,
+    }
+
+    pipeline = MagicMock()
+    serv = MagicMock()
+    serv.pipeline.return_value = pipeline
+
+    with patch.object(redis_return, "_get_serv", return_value=serv), patch.object(
+        redis_return, "_get_ttl", return_value=ttl
+    ):
+        redis_return.returner(ret)
+
+    # The <minion>:<fun> key must be written with an expiry equal to the TTL
+    # used for the rest of the returner data. Accept either the kwarg form
+    # ``ex=ttl`` or the legacy second-positional-arg form, so the fix can use
+    # whichever idiom the module prefers.
+    found_with_ttl = False
+    for c in pipeline.set.call_args_list:
+        args, kwargs = c
+        if not args or args[0] != "minion-1:test.ping":
+            continue
+        if kwargs.get("ex") == ttl:
+            found_with_ttl = True
+            break
+    assert found_with_ttl, (
+        "returner() must call pipeline.set('minion-1:test.ping', jid, ex=<ttl>) "
+        "so the key inherits keep_jobs_seconds; saw calls: "
+        f"{pipeline.set.call_args_list!r}"
+    )


### PR DESCRIPTION
### What does this PR do?

Pass `ex=_get_ttl()` to the `pipeline.set` call that records the last
jid for each `(minion, fun)` pair in the redis_return returner so the
`<minion>:<fun>` pointer key expires on the same `keep_jobs_seconds`
TTL as the rest of the returner data.

### What issues does this PR fix or reference?

Fixes #69038

### Previous Behavior

`returner()` wrote `<minion>:<fun> -> <jid>` with bare `SET` and no TTL.
The key sat in Redis with `TTL=-1` forever, only ever overwritten when
the same `(minion, fun)` ran again. For a fleet of O(1k) minions and
O(50) distinct funs, that leaked ~50k orphan keys per master lifetime
once those funs stopped being scheduled.

### New Behavior

`returner()` calls `SET ... EX <keep_jobs_seconds>`. The pointer key
expires at the same time as the `ret:<jid>` hash and the `load:<jid>`
entry that the rest of the returner writes. No public API or
configuration changes. Operators relying on these keys never expiring
(undocumented behaviour) will see them expire.

### Merge requirements satisfied?

- [x] Docs (no doc change — behaviour was never documented as
  permanent)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

No
