### PR TITLE
Fix sanitize_host stripping colons from IPv6 addresses (#68995)

### DIFF
--- a/changelog/68995.fixed.md
+++ b/changelog/68995.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.utils.network.sanitize_host` stripping colons from IPv6 addresses, which broke `network.ping` and any other caller that passed an IPv6 host.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -72,7 +72,18 @@ def sanitize_host(host):
     """
     Sanitize host string.
     https://tools.ietf.org/html/rfc1123#section-2.1
+
+    If ``host`` is already a valid IP address (IPv4 or IPv6) it is returned
+    unchanged so that characters like ``:`` in IPv6 addresses are not
+    stripped.
     """
+    if isinstance(host, str):
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            return host
     RFC952_characters = ascii_letters + digits + ".-_"
     return "".join([c for c in host[0:255] if c in RFC952_characters])
 

--- a/tests/pytests/unit/utils/test_network.py
+++ b/tests/pytests/unit/utils/test_network.py
@@ -224,6 +224,30 @@ def test_sanitize_host_name():
     assert ret == "foo_bar"
 
 
+def test_sanitize_host_ipv6():
+    """
+    Should preserve colons in IPv6 addresses (regression for #68995).
+    """
+    ret = network.sanitize_host("2607:f8b0:4004:c19::66")
+    assert ret == "2607:f8b0:4004:c19::66"
+
+
+def test_sanitize_host_ipv6_full():
+    """
+    Should preserve a fully-expanded IPv6 address.
+    """
+    ret = network.sanitize_host("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+    assert ret == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+
+def test_sanitize_host_ipv6_loopback():
+    """
+    Should preserve the IPv6 loopback address.
+    """
+    ret = network.sanitize_host("::1")
+    assert ret == "::1"
+
+
 def test_host_to_ips():
     """
     NOTE: When this test fails it's usually because the IP address has


### PR DESCRIPTION
### What does this PR do?
`salt.utils.network.sanitize_host` filtered IPv6 addresses through the RFC952 character set, which deleted the colons. After this change, a string that parses as `ipaddress.ip_address` (IPv4 or IPv6) is returned untouched, so `network.ping '2607:f8b0:4004:c19::66'` no longer ends up calling `ping 2607f8b04004c1966`.

### What issues does this PR fix or reference?
Fixes #68995

### Previous Behavior
```
# salt-call network.ping '2607:f8b0:4004:c19::66'
local:
    ping: 2607f8b04004c1966: Name or service not known
```

### New Behavior
`sanitize_host` returns the IPv6 (or IPv4) address verbatim when the input is a valid address; non-address hostnames continue to be filtered against the RFC952 character set as before.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change beyond the docstring noted in the diff)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
