### PR TITLE
Restore reclass ext_pillar adapter module (#69018)

### DIFF
--- a/changelog/69018.fixed.md
+++ b/changelog/69018.fixed.md
@@ -1,0 +1,4 @@
+Restore the ``reclass`` ext_pillar adapter (``salt.pillar.reclass_adapter``)
+that was dropped when community extensions were purged from the 3008 tree.
+Existing ``ext_pillar: - reclass:`` master configurations work again on
+3008.x without downgrading.

--- a/doc/ref/pillar/all/index.rst
+++ b/doc/ref/pillar/all/index.rst
@@ -18,5 +18,6 @@ pillar modules
     gpg
     nodegroups
     postgres
+    reclass_adapter
     sql_base
     stack

--- a/doc/ref/pillar/all/salt.pillar.reclass_adapter.rst
+++ b/doc/ref/pillar/all/salt.pillar.reclass_adapter.rst
@@ -1,0 +1,5 @@
+salt.pillar.reclass_adapter
+===========================
+
+.. automodule:: salt.pillar.reclass_adapter
+    :members:

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -1,0 +1,129 @@
+"""
+Use the "reclass" database as a Pillar source
+
+.. |reclass| replace:: **reclass**
+
+This ``ext_pillar`` plugin provides access to the |reclass| database, such
+that Pillar data for a specific minion are fetched using |reclass|.
+
+You can find more information about |reclass| at
+http://reclass.pantsfullofunix.net.
+
+To use the plugin, add it to the ``ext_pillar`` list in the Salt master config
+and tell |reclass| by way of a few options how and where to find the
+inventory:
+
+.. code-block:: yaml
+
+    ext_pillar:
+        - reclass:
+            storage_type: yaml_fs
+            inventory_base_uri: /srv/salt
+
+This would cause |reclass| to read the inventory from YAML files in
+``/srv/salt/nodes`` and ``/srv/salt/classes``.
+
+If you are also using |reclass| as ``master_tops`` plugin, and you want to
+avoid having to specify the same information for both, use YAML anchors (take
+note of the differing data types for ``ext_pillar`` and ``master_tops``):
+
+.. code-block:: yaml
+
+    reclass: &reclass
+        storage_type: yaml_fs
+        inventory_base_uri: /srv/salt
+        reclass_source_path: ~/code/reclass
+
+    ext_pillar:
+        - reclass: *reclass
+
+    master_tops:
+        reclass: *reclass
+
+If you want to run reclass from source, rather than installing it, you can
+either let the master know via the ``PYTHONPATH`` environment variable, or by
+setting the configuration option, like in the example above.
+"""
+
+# This file cannot be called reclass.py, because then the module import would
+# not work. Thanks to the __virtual__ function, however, the plugin still
+# responds to the name 'reclass'.
+
+
+from salt.exceptions import SaltInvocationError
+from salt.utils.reclass import (
+    filter_out_source_path_option,
+    prepend_reclass_source_path,
+    set_inventory_base_uri_default,
+)
+
+# Define the module's virtual name
+__virtualname__ = "reclass"
+
+
+def __virtual__(retry=False):
+    try:
+        import reclass  # pylint: disable=unused-import
+
+        return __virtualname__
+
+    except ImportError as e:
+        if retry:
+            return False
+
+        for pillar in __opts__.get("ext_pillar", []):
+            if "reclass" not in pillar:
+                continue
+
+            # each pillar entry is a single-key hash of name -> options
+            opts = next(iter(pillar.values()))
+            prepend_reclass_source_path(opts)
+            break
+
+        return __virtual__(retry=True)
+
+
+def ext_pillar(minion_id, pillar, **kwargs):
+    """
+    Obtain the Pillar data from **reclass** for the given ``minion_id``.
+    """
+
+    # If reclass is installed, __virtual__ put it onto the search path, so we
+    # don't need to protect against ImportError:
+    # pylint: disable=3rd-party-module-not-gated,no-name-in-module
+    from reclass.adapters.salt import ext_pillar as reclass_ext_pillar
+    from reclass.errors import ReclassException
+
+    # pylint: enable=3rd-party-module-not-gated,no-name-in-module
+
+    try:
+        # the source path we used above isn't something reclass needs to care
+        # about, so filter it:
+        filter_out_source_path_option(kwargs)
+
+        # if no inventory_base_uri was specified, initialize it to the first
+        # file_roots of class 'base' (if that exists):
+        set_inventory_base_uri_default(__opts__, kwargs)
+
+        # I purposely do not pass any of __opts__ or __salt__ or __grains__
+        # to reclass, as I consider those to be Salt-internal and reclass
+        # should not make any assumptions about it.
+        return reclass_ext_pillar(minion_id, pillar, **kwargs)
+
+    except TypeError as e:
+        if "unexpected keyword argument" in str(e):
+            arg = str(e).split()[-1]
+            raise SaltInvocationError("ext_pillar.reclass: unexpected option: " + arg)
+        else:
+            raise
+
+    except KeyError as e:
+        if "id" in str(e):
+            raise SaltInvocationError(
+                "ext_pillar.reclass: __opts__ does not define minion ID"
+            )
+        else:
+            raise
+
+    except ReclassException as e:
+        raise SaltInvocationError(f"ext_pillar.reclass: {e}")

--- a/tests/pytests/unit/pillar/test_reclass_adapter.py
+++ b/tests/pytests/unit/pillar/test_reclass_adapter.py
@@ -1,0 +1,94 @@
+"""
+Tests for the reclass ext_pillar adapter.
+
+This module was historically removed during the community-extensions purge
+that landed on the 3008 branch.  The tests guard against another regression
+of that kind by exercising:
+
+* The module imports cleanly under the ``salt.pillar.reclass_adapter`` name.
+* The ``__virtualname__`` is the documented ``reclass`` so the loader binds
+  ``ext_pillar: - reclass:`` entries to the adapter.
+* ``__virtual__`` reports a clean failure (rather than raising) when the
+  ``reclass`` third-party package is unavailable.
+* ``ext_pillar`` delegates to the bundled ``reclass.adapters.salt`` entry
+  point and forwards the per-minion arguments unchanged.
+"""
+
+import sys
+import types
+
+import pytest
+
+import salt.pillar.reclass_adapter as reclass_adapter
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {reclass_adapter: {"__opts__": {"ext_pillar": []}}}
+
+
+def test_virtualname_is_reclass():
+    """
+    The loader matches ``ext_pillar`` entries by ``__virtualname__``; the
+    documented name has always been ``reclass`` (the module is named
+    ``reclass_adapter`` only because ``reclass`` would shadow the upstream
+    package on import).
+    """
+    assert reclass_adapter.__virtualname__ == "reclass"
+
+
+def test_virtual_returns_false_without_reclass_package():
+    """
+    When the upstream ``reclass`` package is not importable and no source
+    path is configured, ``__virtual__`` must return ``False`` instead of
+    raising.  A raising ``__virtual__`` would crash the loader scan.
+    """
+    with patch.dict(sys.modules, {"reclass": None}):
+        assert reclass_adapter.__virtual__() is False
+
+
+def test_ext_pillar_delegates_to_reclass_adapter():
+    """
+    ``ext_pillar`` must call ``reclass.adapters.salt.ext_pillar`` with the
+    minion id, current pillar, and any keyword options passed through from
+    the master config.
+    """
+    fake_reclass = types.ModuleType("reclass")
+    fake_adapters = types.ModuleType("reclass.adapters")
+    fake_salt = types.ModuleType("reclass.adapters.salt")
+    fake_errors = types.ModuleType("reclass.errors")
+
+    class ReclassException(Exception):
+        pass
+
+    fake_errors.ReclassException = ReclassException
+    expected = {"pillar": "data"}
+    fake_salt.ext_pillar = MagicMock(return_value=expected)
+
+    modules = {
+        "reclass": fake_reclass,
+        "reclass.adapters": fake_adapters,
+        "reclass.adapters.salt": fake_salt,
+        "reclass.errors": fake_errors,
+    }
+
+    with patch.dict(sys.modules, modules), patch.dict(
+        reclass_adapter.__opts__,
+        {"ext_pillar": [], "file_roots": {}},
+        clear=False,
+    ):
+        result = reclass_adapter.ext_pillar(
+            "minion-1",
+            {"existing": "pillar"},
+            storage_type="yaml_fs",
+            inventory_base_uri="/srv/salt",
+        )
+
+    assert result == expected
+    fake_salt.ext_pillar.assert_called_once_with(
+        "minion-1",
+        {"existing": "pillar"},
+        storage_type="yaml_fs",
+        inventory_base_uri="/srv/salt",
+    )


### PR DESCRIPTION
### What does this PR do?
Restores `salt.pillar.reclass_adapter`, the `ext_pillar` interface for the
`reclass` inventory backend, which was dropped from the 3008 tree by the
community-extensions purge. Existing `ext_pillar: - reclass:` master configs
work again on 3008.x.

### What issues does this PR fix or reference?
Fixes #69018

### Previous Behavior
On 3008.0rc1 the salt-master logs `CRITICAL: ext_pillar interface named
reclass is unavailable` and the `reclass` ext_pillar returns no data. The
documented module page also 404s on `latest`. Workaround: downgrade to
3007.14.

### New Behavior
The module is reinstated as a core ext_pillar. The loader binds
`ext_pillar: - reclass:` to it via `__virtualname__ = "reclass"`. The
`salt/utils/reclass.py` helpers and `salt/tops/reclass_adapter.py` that
were already in the tree continue to work alongside it. Reference docs are
restored under `doc/ref/pillar/all/`.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
