### PR TITLE
Fix grain targeting matching minions missing from cache (#68976)

### DIFF
--- a/changelog/68976.fixed.md
+++ b/changelog/68976.fixed.md
@@ -1,0 +1,1 @@
+Fixed grain and pillar targeting matching minions whose data cache entry was missing. ``CkMinions._check_cache_minions`` now excludes accepted minions that have no cached grains/pillar data from greedy target results, instead of silently including them as candidates.

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -288,10 +288,18 @@ class CkMinions:
         self, expr, delimiter, greedy, search_type, regex_match=False, exact_match=False
     ):
         """
-        Helper function to search for minions in master caches If 'greedy',
-        then return accepted minions matched by the condition or those absent
-        from the cache.  If not 'greedy' return the only minions have cache
-        data and matched by the condition.
+        Helper function to search for minions in master caches.
+
+        Return only minions whose cached ``search_type`` data exists and
+        matches the expression. Minions with no cache entry are excluded
+        from the result regardless of ``greedy`` — otherwise grain/pillar
+        targeting silently matches any offline minion whose cache directory
+        has been pruned (#68976).
+
+        ``greedy`` still controls which minions are *considered*: when
+        greedy, every accepted minion key is considered (and any without
+        cached data is dropped); when not greedy, only minions that already
+        have a cache entry are considered.
         """
         cache_enabled = self.opts.get("minion_data_cache", False)
 
@@ -318,15 +326,20 @@ class CkMinions:
             else:
                 cminions = minions
             if not cminions:
-                return {"minions": minions, "missing": []}
+                return {"minions": [], "missing": []}
             minions = set(minions)
+            # Track which accepted minions have cache data we can evaluate.
+            # Any accepted minion not present in ``cminions`` has no cache
+            # entry and must be excluded; otherwise grain/pillar targeting
+            # would match every minion whose cache dir is missing (#68976).
+            evaluated = set()
             for id_ in cminions:
-                if greedy and id_ not in minions:
+                if id_ not in minions:
                     continue
+                evaluated.add(id_)
                 mdata = self.cache.fetch(f"minions/{id_}", "data")
                 if mdata is None:
-                    if not greedy:
-                        minions.remove(id_)
+                    minions.discard(id_)
                     continue
                 search_results = mdata.get(search_type)
                 if not salt.utils.data.subdict_match(
@@ -336,7 +349,9 @@ class CkMinions:
                     regex_match=regex_match,
                     exact_match=exact_match,
                 ):
-                    minions.remove(id_)
+                    minions.discard(id_)
+            # Drop minions that were never evaluated (no cache entry at all).
+            minions &= evaluated
             minions = list(minions)
         return {"minions": minions, "missing": []}
 

--- a/tests/pytests/integration/cli/test_matcher.py
+++ b/tests/pytests/integration/cli/test_matcher.py
@@ -381,10 +381,14 @@ def _check_skip(grains):
 @pytest.mark.skip_initial_gh_actions_failure(skip=_check_skip)
 def test_grains_targeting_minion_id_disconnected(salt_master, salt_minion, salt_cli):
     """
-    Tests return of minion using grains targeting on a disconnected minion.
-    """
-    expected_output = "Minion did not return. [No response]"
+    Tests grains targeting against a disconnected minion (#68976).
 
+    A minion whose key has been accepted but which has never returned grain
+    data to the master must not match any grain expression, because the
+    master has no grain data to evaluate against. The CLI should report
+    "No return received" (exit code 2) instead of silently including the
+    disconnected minion in the "expected returners" wait set.
+    """
     # Create a minion key, but do not start the "fake" minion. This mimics a
     # disconnected minion.
     disconnected_minion_id = "disconnected"
@@ -402,9 +406,10 @@ def test_grains_targeting_minion_id_disconnected(salt_master, salt_minion, salt_
             minion_tgt=f"id:{disconnected_minion_id}",
             _timeout=30,
         )
-        assert ret.returncode == 1
-        assert disconnected_minion_id in ret.data
-        assert expected_output in ret.data[disconnected_minion_id]
+        # No minion returned, so the CLI emits "No return received" and exits 2.
+        assert ret.returncode == 2
+        assert ret.data == {}
+        assert "No return received" in ret.stderr
 
 
 def test_regrain(salt_cli, salt_minion, salt_sub_minion):

--- a/tests/pytests/unit/utils/test_minions.py
+++ b/tests/pytests/unit/utils/test_minions.py
@@ -116,3 +116,65 @@ def test_validate_tgt_should_return_true_when_all_minions_are_found_in_valid_min
             "fnord", "fnord", "fnord", minions=target_minions
         )
         assert result is True
+
+
+def test_grain_target_excludes_minions_missing_from_cache(tmp_path):
+    """
+    Regression test for #68976: grain targeting must not include minions
+    whose grain cache entry is missing.
+
+    When the master receives ``salt -G 'asd:def' ...`` and a minion has an
+    accepted key but no entry in the master's grain cache (e.g. the minion
+    has been offline long enough that its cache directory was pruned, or
+    has never returned data), ``CkMinions._check_cache_minions`` with the
+    default ``greedy=True`` previously added that minion to the result set
+    regardless of the grain expression. The minion would then be added to
+    the "missing returners" wait list and reported as not returning.
+
+    Only minions whose cached grains actually match the expression should
+    be returned.
+    """
+    pki_dir = tmp_path / "pki"
+    minions_dir = pki_dir / "minions"
+    minions_dir.mkdir(parents=True)
+    matching_minion = "matching_minion"
+    nonmatching_minion = "nonmatching_minion"
+    uncached_minion = "uncached_minion"
+    for mid in (matching_minion, nonmatching_minion, uncached_minion):
+        (minions_dir / mid).write_text("")
+
+    opts = {
+        "pki_dir": str(pki_dir),
+        "minion_data_cache": True,
+        "key_cache": False,
+        "transport": "zeromq",
+        "extension_modules": str(tmp_path / "extmods"),
+        "cachedir": str(tmp_path / "cache"),
+    }
+
+    cache_data = {
+        matching_minion: {"grains": {"asd": "def"}},
+        nonmatching_minion: {"grains": {"asd": "other"}},
+        # uncached_minion intentionally absent
+    }
+
+    def fake_list(bank):
+        return list(cache_data)
+
+    def fake_fetch(bank, key):
+        # Bank is "minions/<id>", key is "data" on 3006.x
+        mid = bank.split("/", 1)[1] if "/" in bank else bank
+        return cache_data.get(mid)
+
+    ckminions = salt.utils.minions.CkMinions(opts)
+    with patch.object(ckminions.cache, "list", side_effect=fake_list), patch.object(
+        ckminions.cache, "fetch", side_effect=fake_fetch
+    ):
+        result = ckminions.check_minions("asd:def", "grain")
+
+    assert uncached_minion not in result["minions"], (
+        "Minion with no cached grain data should not be included in grain "
+        "target matches (#68976)"
+    )
+    assert nonmatching_minion not in result["minions"]
+    assert matching_minion in result["minions"]


### PR DESCRIPTION
### What does this PR do?

`CkMinions._check_cache_minions` with the default `greedy=True` previously
included any accepted minion whose grain/pillar cache entry was missing in
the result. This PR drops minions that have no cached data from the match
result, so grain/pillar targeting only matches minions whose cache actually
satisfies the expression.

### What issues does this PR fix or reference?

Fixes #68976
Fixes #69017
Likely also resolves #69017 (same root cause: greedy `check_minions` keeps
minions with no cache entry in the "expected returners" wait set).

### Previous Behavior

`salt -G 'asd:def' test.ping` matched every minion whose
`/var/cache/salt/master/minions/<id>` directory was missing, regardless
of whether their grains actually had `asd: def`. Those minions then
appeared in the "did not return" list, causing the noisy returner
behavior described in #69017.

### New Behavior

A minion with no cached grain (or pillar) data is no longer treated as a
match. Only minions whose cached data exists and satisfies the
expression are returned from `check_minions`.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes