### PR TITLE
Improve "Malformed topfile" error to name saltenv and matcher (#68792)

### DIFF
--- a/changelog/68792.fixed.md
+++ b/changelog/68792.fixed.md
@@ -1,0 +1,1 @@
+Improved the "Malformed topfile" error from ``HighState.verify_tops`` to name the saltenv and the matcher whose state declarations were not formed as a list, so users can locate the offending entry in their ``top.sls``.

--- a/salt/state.py
+++ b/salt/state.py
@@ -4256,10 +4256,12 @@ class BaseHighState:
                     "The top file matches for saltenv {} are not "
                     "formatted as a dict".format(saltenv)
                 )
-            for slsmods in matches.values():
+            for match, slsmods in matches.items():
                 if not isinstance(slsmods, list):
                     errors.append(
-                        "Malformed topfile (state declarations not formed as a list)"
+                        "Malformed topfile: state declarations for matcher"
+                        " {!r} in saltenv {!r} are not formed as a list (got"
+                        " {})".format(match, saltenv, type(slsmods).__name__)
                     )
                     continue
                 for slsmod in slsmods:

--- a/tests/pytests/unit/state/test_state_highstate.py
+++ b/tests/pytests/unit/state/test_state_highstate.py
@@ -392,7 +392,26 @@ def test_verify_tops_sls_not_list(highstate):
     tops["base"] = OrderedDict([("*", "test test2")])
     matches = highstate.verify_tops(tops)
     # [] means there where no errors when verifying tops
-    assert matches == ["Malformed topfile (state declarations not formed as a list)"]
+    assert matches == [
+        "Malformed topfile: state declarations for matcher '*' in saltenv"
+        " 'base' are not formed as a list (got str)"
+    ]
+
+
+def test_verify_tops_sls_none(highstate):
+    """
+    Regression test for #68792: when a top.sls target has no listed
+    states (e.g. ``'rhel9*':`` with nothing under it, which parses as
+    ``None``), the error must name the offending saltenv and target so
+    the user can locate the bad declaration.
+    """
+    tops = DefaultOrderedDict(OrderedDict)
+    tops["base"] = OrderedDict([("*", ["common"]), ("rhel9*", None)])
+    matches = highstate.verify_tops(tops)
+    assert matches == [
+        "Malformed topfile: state declarations for matcher 'rhel9*' in"
+        " saltenv 'base' are not formed as a list (got NoneType)"
+    ]
 
 
 def test_verify_tops_match(highstate):


### PR DESCRIPTION
### What does this PR do?

Widens the `verify_tops` error from `HighState` so it names the saltenv
and the matcher whose state declarations are not formed as a list,
instead of the bare "Malformed topfile (state declarations not formed
as a list)".

### What issues does this PR fix or reference?

Fixes #68792

### Previous Behavior

A `top.sls` like
```yaml
base:
  '*':
    - common
  'rhel9*':
```
yields the error `Malformed topfile (state declarations not formed as
a list)` with no saltenv or matcher, forcing the user to bisect their
top file by hand.

### New Behavior

The error now reads e.g.
`Malformed topfile: state declarations for matcher 'rhel9*' in saltenv
'base' are not formed as a list (got NoneType)`.

### Merge requirements satisfied?

- [x] Docs (no documented behavior changed)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
