### PR TITLE
Fix WMI network.interfaces reporting gateway as broadcast on Windows (#68692)

### DIFF
--- a/changelog/68692.fixed.md
+++ b/changelog/68692.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``network.interfaces`` on Windows systems falling back to WMI (i.e. .NET older than 4.7.2): the default gateway is now reported under ``gateway`` instead of being mistakenly emitted as ``broadcast``.

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -486,11 +486,11 @@ def get_interface_info_wmi():
                             i_faces[i_face.Description]["inet"] = []
                         item = {"address": ip, "label": i_face.Description}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
+                            gateway = next(
                                 (i for i in i_face.DefaultIPGateway if "." in i), ""
                             )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             netmask = next((i for i in i_face.IPSubnet if "." in i), "")
                             if netmask:
@@ -501,11 +501,11 @@ def get_interface_info_wmi():
                             i_faces[i_face.Description]["inet6"] = []
                         item = {"address": ip}
                         if i_face.DefaultIPGateway:
-                            broadcast = next(
+                            gateway = next(
                                 (i for i in i_face.DefaultIPGateway if ":" in i), ""
                             )
-                            if broadcast:
-                                item["broadcast"] = broadcast
+                            if gateway:
+                                item["gateway"] = gateway
                         if i_face.IPSubnet:
                             prefixlen = next(
                                 (int(i) for i in i_face.IPSubnet if "." not in i), None

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -495,6 +495,16 @@ def get_interface_info_wmi():
                             netmask = next((i for i in i_face.IPSubnet if "." in i), "")
                             if netmask:
                                 item["netmask"] = netmask
+                                try:
+                                    item["broadcast"] = ipaddress.IPv4Network(
+                                        f"{ip}/{netmask}", strict=False
+                                    ).broadcast_address.compressed
+                                except (ValueError, ipaddress.AddressValueError):
+                                    log.debug(
+                                        "Could not compute broadcast for %s/%s",
+                                        ip,
+                                        netmask,
+                                    )
                         i_faces[i_face.Description]["inet"].append(item)
                     if ":" in ip:
                         if "inet6" not in i_faces[i_face.Description]:

--- a/tests/pytests/unit/utils/test_win_network_wmi.py
+++ b/tests/pytests/unit/utils/test_win_network_wmi.py
@@ -38,6 +38,10 @@ def test_get_interface_info_wmi_gateway_not_reported_as_broadcast():
     """
     The WMI code path must report the default gateway under the ``gateway``
     key, not ``broadcast``. See https://github.com/saltstack/salt/issues/68692.
+
+    It must also compute the real IPv4 broadcast from the address + netmask
+    so the WMI path stays consistent with the .NET path
+    (``get_interface_info_dot_net_formatted``).
     """
     adapter = _adapter()
     wmi_mock = _wmi_module_mock([adapter])
@@ -47,10 +51,11 @@ def test_get_interface_info_wmi_gateway_not_reported_as_broadcast():
         result = win_network.get_interface_info_wmi()
 
     inet = result["vmxnet3 Ethernet Adapter"]["inet"][0]
-    # Gateway must not leak into the broadcast field.
-    assert inet.get("broadcast") != "10.153.31.240"
-    # Gateway must be exposed under the correct key.
+    # Gateway must be exposed under the correct key, not as broadcast.
     assert inet.get("gateway") == "10.153.31.240"
+    # Broadcast must be derived from address + netmask (10.153.30.240/22),
+    # matching the .NET path's behavior.
+    assert inet.get("broadcast") == "10.153.31.255"
 
 
 def test_get_interface_info_wmi_ipv6_gateway_not_reported_as_broadcast():

--- a/tests/pytests/unit/utils/test_win_network_wmi.py
+++ b/tests/pytests/unit/utils/test_win_network_wmi.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for salt.utils.win_network WMI code path.
+
+These tests use mocking to exercise the WMI fallback (used when .NET is older
+than 4.7.2) cross-platform; they do not require Windows.
+"""
+
+import salt.utils.win_network as win_network
+import salt.utils.winapi
+from tests.support.mock import MagicMock, patch
+
+
+def _wmi_module_mock(adapters):
+    wmi_mock = MagicMock()
+    wmi_mock.WMI.return_value.Win32_NetworkAdapterConfiguration.return_value = adapters
+    return wmi_mock
+
+
+def _adapter(
+    description="vmxnet3 Ethernet Adapter",
+    mac_address="00:50:56:83:11:D5",
+    ip_enabled=True,
+    ip_addresses=("10.153.30.240",),
+    gateways=("10.153.31.240",),
+    subnet=("255.255.252.0",),
+):
+    adapter = MagicMock()
+    adapter.Description = description
+    adapter.MACAddress = mac_address
+    adapter.IPEnabled = ip_enabled
+    adapter.IPAddress = list(ip_addresses)
+    adapter.DefaultIPGateway = list(gateways)
+    adapter.IPSubnet = list(subnet)
+    return adapter
+
+
+def test_get_interface_info_wmi_gateway_not_reported_as_broadcast():
+    """
+    The WMI code path must report the default gateway under the ``gateway``
+    key, not ``broadcast``. See https://github.com/saltstack/salt/issues/68692.
+    """
+    adapter = _adapter()
+    wmi_mock = _wmi_module_mock([adapter])
+    with patch.object(win_network, "wmi", wmi_mock, create=True), patch.object(
+        salt.utils.winapi, "Com", MagicMock()
+    ):
+        result = win_network.get_interface_info_wmi()
+
+    inet = result["vmxnet3 Ethernet Adapter"]["inet"][0]
+    # Gateway must not leak into the broadcast field.
+    assert inet.get("broadcast") != "10.153.31.240"
+    # Gateway must be exposed under the correct key.
+    assert inet.get("gateway") == "10.153.31.240"
+
+
+def test_get_interface_info_wmi_ipv6_gateway_not_reported_as_broadcast():
+    """
+    Same as above for IPv6 entries.
+    """
+    adapter = _adapter(
+        ip_addresses=("fe80::1234",),
+        gateways=("fe80::208:a2ff:fe0b:de70",),
+        subnet=("64",),
+    )
+    wmi_mock = _wmi_module_mock([adapter])
+    with patch.object(win_network, "wmi", wmi_mock, create=True), patch.object(
+        salt.utils.winapi, "Com", MagicMock()
+    ):
+        result = win_network.get_interface_info_wmi()
+
+    inet6 = result["vmxnet3 Ethernet Adapter"]["inet6"][0]
+    assert inet6.get("broadcast") != "fe80::208:a2ff:fe0b:de70"
+    assert inet6.get("gateway") == "fe80::208:a2ff:fe0b:de70"


### PR DESCRIPTION
### What does this PR do?
Fix the WMI fallback in `salt.utils.win_network.get_interface_info_wmi()` so that the default gateway is exposed under the `gateway` key — matching the .NET code path — instead of being mis-labelled as `broadcast` on Windows hosts running .NET older than 4.7.2.

### What issues does this PR fix or reference?
Fixes #68692

### Previous Behavior
On Windows hosts that fall back to WMI (e.g. .NET < 4.7.2), `network.interfaces` reported each adapter's default gateway under `broadcast`, producing output like:

```
inet:
  - address: 10.153.30.240
    broadcast: 10.153.31.240   # actually the gateway
    netmask: 255.255.252.0
```

### New Behavior
The gateway is reported correctly:

```
inet:
  - address: 10.153.30.240
    gateway: 10.153.31.240
    netmask: 255.255.252.0
```

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
