### PR TITLE
Handle SaltDeserializationError in grains cache loading (#68678)

### DIFF
--- a/changelog/68678.fixed.md
+++ b/changelog/68678.fixed.md
@@ -1,0 +1,3 @@
+Fixed unhandled `SaltDeserializationError` when the cached grains file is
+corrupted; `_load_cached_grains` now treats a corrupt cache the same as a
+missing one and lets grains regenerate.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -26,7 +26,7 @@ import salt.utils.lazy
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import LoaderError
+from salt.exceptions import LoaderError, SaltDeserializationError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -1067,7 +1067,7 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except OSError:
+    except (OSError, SaltDeserializationError):
         return None
 
 

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1694,6 +1694,30 @@ class LoaderLoadCachedGrainsTest(TestCase):
         osrelease_info = grains["osrelease_info"]
         assert isinstance(osrelease_info, tuple), osrelease_info
 
+    def test_deserialization_error_caught(self):
+        """
+        Test that _load_cached_grains catches SaltDeserializationError.
+
+        When msgpack encounters corrupted cache data, it raises
+        SaltDeserializationError. This should be caught and return None
+        so grains can be regenerated.
+        """
+        import time
+
+        import salt.exceptions
+
+        with patch("os.path.isfile", return_value=True), patch(
+            "os.path.getmtime", return_value=time.time()
+        ), patch("salt.utils.files.fopen"), patch(
+            "salt.payload.load",
+            side_effect=salt.exceptions.SaltDeserializationError(
+                "Could not deserialize msgpack message"
+            ),
+        ):
+            result = salt.loader._load_cached_grains(self.opts, "/fake/path")
+            # Should return None, not raise exception
+            self.assertIsNone(result)
+
 
 class LazyLoaderRefreshFileMappingTest(TestCase):
     """


### PR DESCRIPTION
### What does this PR do?

Backports the `_load_cached_grains()` exception-handling fix from PR
#68674 (merged on master / 3008.x) to the 3006.x release branch (and via
merge-forward to 3007.x).

A corrupted msgpack grains cache file raises
`salt.exceptions.SaltDeserializationError` from `salt.payload.load()`.
`_load_cached_grains()` only caught `OSError`, so the exception
propagated and produced repeated CRITICAL minion connection failures.

This change catches `SaltDeserializationError` alongside `OSError`, so a
corrupt cache is treated like a missing cache: return `None` and let the
grains be regenerated and the cache file overwritten.

### What issues does this PR fix or reference?

Fixes #68678
Related: #68725

PR #68674 fixed the same bug on master / 3008.x but was never backported
to 3006.x / 3007.x. The reporter and other users confirm the bug is
still hitting them on 3007.11 and 3007.12 (issue #68678 comments), and
on 3006.20 (issue #68725).

### Previous Behavior

Only `OSError` was handled in `_load_cached_grains()`. A corrupt grains
cache raised `SaltDeserializationError`, which propagated up to
`minion._connect_minion` (or `masterapi.clean_old_jobs` on the master)
and produced a CRITICAL traceback. Affected minions logged the error
"many, many times per day" and required disabling the grains cache as a
workaround.

### New Behavior

If the grains cache is corrupt and won't deserialize, the exception is
caught and `_load_cached_grains()` returns `None`. Callers then
regenerate grains and overwrite the corrupt cache file, recovering
without manual intervention.

### Merge requirements satisfied?

- [x] Docs (no documented behavior changes)
- [x] Changelog (`changelog/68678.fixed.md`)
- [x] Tests written/updated
  (`tests/unit/test_loader.py::LoaderLoadCachedGrainsTest::test_deserialization_error_caught`)

### Commits signed with GPG?

No (matches recent commit history on 3006.x; signing not enforced by
the branch).
