### PR TITLE
Handle corrupted grains cache in master Maintenance loop (#68725)

### DIFF
--- a/changelog/68725.fixed.md
+++ b/changelog/68725.fixed.md
@@ -1,0 +1,4 @@
+Fixed master Maintenance process crash when the cached grains file is
+corrupted: `SaltDeserializationError` from `_load_cached_grains` is now
+caught and treated as a missing cache, so grains are regenerated instead
+of taking the Maintenance worker down with an unhandled exception.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -26,7 +26,7 @@ import salt.utils.lazy
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import LoaderError
+from salt.exceptions import LoaderError, SaltDeserializationError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -1067,7 +1067,11 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except OSError:
+    except (OSError, SaltDeserializationError):
+        log.debug(
+            "Grains cache was not readable or did not deserialize and might be corrupted. Refreshing.",
+            exc_info=True,
+        )
         return None
 
 

--- a/tests/pytests/unit/loader/test_grains_cache.py
+++ b/tests/pytests/unit/loader/test_grains_cache.py
@@ -1,0 +1,47 @@
+"""
+Regression tests for _load_cached_grains exception handling.
+
+Validates that a corrupted grains cache file does not crash the loader
+(or, by extension, the master Maintenance process) but is treated the
+same as a missing cache: return None so callers regenerate grains.
+"""
+
+import msgpack
+import pytest
+
+import salt.config
+import salt.loader
+import salt.utils.files
+
+
+@pytest.fixture
+def minion_opts(tmp_path):
+    """
+    Minion options pointing at a temporary cachedir with grains_cache on.
+    """
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["cachedir"] = str(tmp_path)
+    opts["grains_cache"] = True
+    # Cache must not be considered expired during the test.
+    opts["grains_cache_expiration"] = 86400
+    return opts
+
+
+def test_load_cached_grains_handles_corrupted_cache_68725(minion_opts, tmp_path):
+    """
+    A grains cache file containing extra trailing bytes after a valid
+    msgpack frame must not raise SaltDeserializationError out of
+    _load_cached_grains; it must return None so callers refresh.
+
+    See https://github.com/saltstack/salt/issues/68725 — the uncaught
+    SaltDeserializationError crashes the master Maintenance worker via
+    clean_old_jobs -> MasterMinion -> mminion_config -> salt.loader.grains.
+    """
+    cfn = str(tmp_path / "grains.cache.p")
+    valid_payload = msgpack.packb({"os": "Linux"})
+    with salt.utils.files.fopen(cfn, "wb") as fp:
+        # Valid msgpack frame followed by trailing garbage -> msgpack.ExtraData
+        fp.write(valid_payload + b"EXTRA-GARBAGE-BYTES")
+
+    # Must not raise; corrupted cache should be treated like a missing one.
+    assert salt.loader._load_cached_grains(minion_opts, cfn) is None


### PR DESCRIPTION
### What does this PR do?
Backports the `SaltDeserializationError` handler in `_load_cached_grains()` to 3006.x. A corrupted grains cache file no longer crashes the master Maintenance worker — the cache is treated as missing and regenerated.

### What issues does this PR fix or reference?
Fixes #68725
Fixes #68678

The same fix already shipped in master/3008.x via #68674.

### Previous Behavior
A corrupted `grains.cache.p` raised `SaltDeserializationError` from `salt.payload.load()`. The exception was not caught in `_load_cached_grains` (which only handled `OSError`), so it propagated out through `salt.loader.grains` -> `MasterMinion.__init__` -> `salt.daemons.masterapi.clean_old_jobs`, taking down the master Maintenance process with a CRITICAL log and an "un-handled exception from the multiprocessing process 'Maintenance'" error.

### New Behavior
`SaltDeserializationError` is caught alongside `OSError`, logged at debug with `exc_info`, and `None` is returned — same path as a missing cache. Grains are regenerated and the corrupted cache is overwritten.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
No