### PR TITLE
Preserve user-supplied slspath in file.managed templates (#68754)

### DIFF
--- a/changelog/68754.fixed.md
+++ b/changelog/68754.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``file.managed`` (and other template-rendering callers) silently overwriting user-supplied ``slspath``, ``sls_path``, ``slsdotpath`` and ``slscolonpath`` values in ``defaults``/``context`` with values regenerated from the caller's ``sls`` key.

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -182,7 +182,11 @@ def wrap_tmpl_func(render_str):
 
         if "sls" in context:
             sls_context = generate_sls_context(tmplpath, context["sls"])
-            context.update(sls_context)
+            # Caller-supplied values (e.g. ``defaults`` / ``context`` on
+            # ``file.managed``) take precedence over values derived from
+            # ``sls`` — see issue #68754.
+            for key, value in sls_context.items():
+                context.setdefault(key, value)
 
         if isinstance(tmplsrc, str):
             if from_str:

--- a/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
+++ b/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
@@ -61,6 +61,47 @@ def test_sls_context_no_call(tmp_path):
         generate_sls_context.assert_not_called()
 
 
+def test_user_supplied_sls_context_is_preserved_68754():
+    """Caller-supplied sls/slspath/etc. must not be overwritten by
+    generate_sls_context (Issue #68754).
+
+    When ``file.managed`` is given a templated source via ``defaults`` (or
+    ``context``) that includes its own ``sls`` plus the derived ``slspath``,
+    ``sls_path``, ``slsdotpath`` and ``slscolonpath``, the rendering pipeline
+    used to regenerate those derived values from the user-supplied ``sls`` and
+    silently clobber the caller's overrides. The user's explicit values must
+    win.
+    """
+    render = MockRender()
+    user_context = {
+        "opts": {},
+        "saltenv": "base",
+        "sls": "test.basic.output",
+        "slspath": "test/basic",
+        "sls_path": "test_basic",
+        "slsdotpath": "test.basic",
+        "slscolonpath": "test:basic",
+        "tplpath": "/var/cache/salt/minion/files/base/test/basic/output.sls",
+        "tplfile": "test/basic/output.sls",
+        "tpldir": "test/basic",
+        "tpldot": "test.basic",
+    }
+    wrapped = wrap_tmpl_func(render)
+    wrapped("hello", from_str=True, to_str=True, context=user_context)
+    assert render.context["sls"] == "test.basic.output"
+    assert render.context["slspath"] == "test/basic"
+    assert render.context["sls_path"] == "test_basic"
+    assert render.context["slsdotpath"] == "test.basic"
+    assert render.context["slscolonpath"] == "test:basic"
+    assert (
+        render.context["tplpath"]
+        == "/var/cache/salt/minion/files/base/test/basic/output.sls"
+    )
+    assert render.context["tplfile"] == "test/basic/output.sls"
+    assert render.context["tpldir"] == "test/basic"
+    assert render.context["tpldot"] == "test.basic"
+
+
 def test_generate_sls_context__top_level():
     """generate_sls_context - top_level Use case"""
     _test_generated_sls_context(


### PR DESCRIPTION
### What does this PR do?
Stops `file.managed` (and any other caller of the template rendering pipeline) from silently overwriting user-supplied `slspath`, `sls_path`, `slsdotpath` and `slscolonpath` values forwarded via `defaults` or `context`.

### What issues does this PR fix or reference?
Fixes #68754

### Previous Behavior
When a user passed their own `sls`, `slspath`, `sls_path`, `slsdotpath` and `slscolonpath` keys to `file.managed` via `defaults:` (or `context:`), the rendering pipeline regenerated those derived names from the user-supplied `sls` and clobbered the user's values. The reporter's diagnostic — appending `--` to just `sls` and seeing it propagate to every other `sls*` variable — pinned the regeneration site.

### New Behavior
`wrap_tmpl_func` now fills in the `generate_sls_context` values with `setdefault`, so caller-supplied keys win. SLS state compilation is unaffected because callers there don't pre-populate the derived names.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
