### PR TITLE
Fix accumulating GPG dotlock files in the gpg renderer (#68869)

### DIFF
--- a/changelog/68869.fixed.md
+++ b/changelog/68869.fixed.md
@@ -1,0 +1,1 @@
+Removed orphaned GnuPG dotlock files (``.#lk<addr>.<host>.<pid>``) from ``gpg_keydir`` before each decrypt in the ``gpg`` renderer so they no longer accumulate when a gpg subprocess is killed mid-operation.

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -402,6 +402,54 @@ def _get_cache():
     return GPG_CACHE
 
 
+# Matches GnuPG ``dotlock`` files of the form ``.#lk<addr>.<host>.<pid>``.
+# These are temporary files created during lock acquisition; gpg renames
+# them to the final ``<file>.lock`` name on success and removes them on
+# clean exit. If the gpg process is killed (for example when its parent
+# salt-master worker is terminated mid-decrypt), the dotlock is orphaned
+# and accumulates in the keydir.
+_GPG_DOTLOCK_RE = re.compile(r"^\.#lk[0-9a-fA-Fx]+\..+\.(?P<pid>\d+)$")
+
+
+def _cleanup_stale_lockfiles(gpg_keydir):
+    """
+    Remove orphaned GnuPG dotlock files from ``gpg_keydir``.
+
+    A dotlock is considered stale when the PID embedded in its filename
+    no longer corresponds to a running process. Live locks and any other
+    files are left untouched. All errors are swallowed: this is a best-
+    effort cleanup and must never prevent the renderer from running.
+    """
+    if not gpg_keydir:
+        return
+    try:
+        entries = os.listdir(gpg_keydir)
+    except OSError:
+        return
+    for entry in entries:
+        match = _GPG_DOTLOCK_RE.match(entry)
+        if not match:
+            continue
+        try:
+            pid = int(match.group("pid"))
+        except (TypeError, ValueError):
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            # PID is not running; the lock is stale.
+            try:
+                os.unlink(os.path.join(gpg_keydir, entry))
+            except OSError as exc:
+                log.debug("Could not remove stale GPG lock file %s: %s", entry, exc)
+        except PermissionError:
+            # PID exists and belongs to another user; treat as live.
+            continue
+        except OSError:
+            # Unexpected; leave the file alone.
+            continue
+
+
 def _decrypt_ciphertext(cipher):
     """
     Given a block of ciphertext as a string, and a gpg object, try to decrypt
@@ -418,10 +466,12 @@ def _decrypt_ciphertext(cipher):
         cache = _get_cache()
         if cipher in cache:
             return cache[cipher]
+    key_dir = _get_key_dir()
+    _cleanup_stale_lockfiles(key_dir)
     cmd = [
         _get_gpg_exec(),
         "--homedir",
-        _get_key_dir(),
+        key_dir,
         "--status-fd",
         "2",
         "--no-tty",

--- a/tests/pytests/unit/renderers/test_gpg.py
+++ b/tests/pytests/unit/renderers/test_gpg.py
@@ -9,6 +9,16 @@ from salt.exceptions import SaltRenderError
 from tests.support.mock import MagicMock, Mock, call, patch
 
 
+def _find_unused_pid():
+    """Return a PID that is (almost certainly) not currently running."""
+    for candidate in (4194303, 4194302, 4194301, 999999, 888888):
+        try:
+            os.kill(candidate, 0)
+        except OSError:
+            return candidate
+    raise RuntimeError("Unable to locate an unused PID for testing")
+
+
 @pytest.fixture
 def configure_loader_modules(minion_opts):
     """
@@ -254,6 +264,75 @@ def test_render_without_cache():
                     stdout=PIPE,
                 )
                 popen_mock.assert_has_calls([gpg_call] * 3)
+
+
+def test_cleanup_stale_lockfiles_removes_dead_pid_locks_68869(tmp_path):
+    """
+    Regression test for #68869.
+
+    GnuPG writes ``dotlock`` files (``.#lk<addr>.<host>.<pid>``) when
+    acquiring a lock on a keyring file. If the gpg process is killed before
+    it can rename the dotlock to its final ``<file>.lock`` name (for example
+    when its parent salt-master worker is terminated mid-decrypt), the
+    dotlock is orphaned. Over time these accumulate in ``gpg_keydir``.
+
+    The cleanup helper must remove dotlock files whose owning PID is no
+    longer running, and must leave any other files (including a dotlock
+    owned by a live PID) alone.
+    """
+    dead_pid = _find_unused_pid()
+    live_pid = os.getpid()
+
+    # Layout mirrors the report in the issue: ``host pid`` payload, padded
+    # to ``host.pid`` style filenames.
+    stale = tmp_path / f".#lk0x00005fead0da9180.salt.{dead_pid}"
+    stale.write_text(f"salt {dead_pid}")
+    live = tmp_path / f".#lk0x00005fead0da9181.salt.{live_pid}"
+    live.write_text(f"salt {live_pid}")
+    unrelated = tmp_path / "pubring.kbx"
+    unrelated.write_text("not a lock")
+
+    gpg._cleanup_stale_lockfiles(str(tmp_path))
+
+    assert not stale.exists()
+    assert live.exists()
+    assert unrelated.exists()
+
+
+def test_cleanup_stale_lockfiles_handles_missing_keydir_68869(tmp_path):
+    """
+    The helper must not raise if the keydir does not exist or is not a
+    directory; the renderer is called before any keys are configured in
+    some setups.
+    """
+    missing = tmp_path / "does-not-exist"
+    # Should be a no-op rather than raising.
+    gpg._cleanup_stale_lockfiles(str(missing))
+    gpg._cleanup_stale_lockfiles(None)
+
+
+def test__decrypt_ciphertext_cleans_stale_lockfiles_68869():
+    """
+    Regression test for #68869: ``_decrypt_ciphertext`` must run the
+    stale-lockfile cleanup against the keydir before invoking ``gpg``.
+    """
+    key_dir = "/etc/salt/gpgkeys"
+    secret = "Use more salt."
+    crypted = "-----BEGIN PGP MESSAGE-----!@#$%^&*()_+-----END PGP MESSAGE-----"
+
+    class GPGDecrypt:
+        def communicate(self, *args, **kwargs):
+            return [secret, None]
+
+    with patch(
+        "salt.renderers.gpg._get_key_dir", MagicMock(return_value=key_dir)
+    ), patch("salt.utils.path.which", MagicMock()), patch(
+        "salt.renderers.gpg.Popen", MagicMock(return_value=GPGDecrypt())
+    ), patch(
+        "salt.renderers.gpg._cleanup_stale_lockfiles"
+    ) as cleanup_mock:
+        gpg._decrypt_ciphertexts(crypted)
+        cleanup_mock.assert_called_with(key_dir)
 
 
 def test_render_with_cache(minion_opts):


### PR DESCRIPTION
### What does this PR do?
Removes orphaned GnuPG dotlock files (`.#lk<addr>.<host>.<pid>`) from `gpg_keydir` before each decrypt so they no longer accumulate when a gpg subprocess is killed mid-operation (for example when its parent salt-master worker is terminated mid-decrypt).

### What issues does this PR fix or reference?
Fixes #68869

### Previous Behavior
`gpg_keydir` slowly filled with orphaned dotlock files. The reporter showed dotlock files dating from 2020 to 2026 still present in the keydir.

### New Behavior
Before invoking `gpg` to decrypt, the renderer sweeps the keydir for dotlock files whose owning PID is no longer running and removes them. Live locks and unrelated files are left untouched; all errors are swallowed so cleanup can never block the renderer.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
