### PR TITLE
Honor env_order during pillar merging (#68785)

### DIFF
--- a/changelog/68785.fixed.md
+++ b/changelog/68785.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``env_order`` not being honored when merging pillar data across environments. ``Pillar.render_pillar`` now iterates matched environments in the configured ``env_order`` so that, with ``top_file_merging_strategy: merge_all``, the last environment in ``env_order`` wins on conflicting pillar keys instead of the result depending on dict insertion order.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -1075,7 +1075,21 @@ class Pillar:
         pillar = copy.copy(self.pillar_override)
         if errors is None:
             errors = []
-        for saltenv, pstates in matches.items():
+        # When ``env_order`` is configured, iterate the matched environments
+        # in that order so the last environment in ``env_order`` wins on
+        # conflicting pillar keys (matches the documented behavior and the
+        # state-compilation logic in ``salt/state.py``). Any environments
+        # present in ``matches`` but not listed in ``env_order`` are appended
+        # afterwards in their existing insertion order so they are not
+        # silently dropped.
+        env_order = self.opts.get("env_order") or []
+        if env_order:
+            ordered_envs = [env for env in env_order if env in matches]
+            ordered_envs.extend(env for env in matches if env not in ordered_envs)
+            ordered_matches = [(env, matches[env]) for env in ordered_envs]
+        else:
+            ordered_matches = list(matches.items())
+        for saltenv, pstates in ordered_matches:
             pstatefiles = []
             mods = {}
             for sls_match in pstates:

--- a/tests/pytests/functional/pillar/test_env_order_68785.py
+++ b/tests/pytests/functional/pillar/test_env_order_68785.py
@@ -1,0 +1,116 @@
+"""
+Functional regression test for issue #68785.
+
+When the master option ``env_order`` is configured, pillar merging must
+iterate the matched environments in that order so the last environment
+listed in ``env_order`` wins on conflicting pillar keys, instead of the
+result depending on dict insertion order of the matched environments.
+"""
+
+import pytest
+
+import salt.pillar
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture
+def env_order_pillar_tree(tmp_path):
+    """
+    Build a multi-env pillar tree with each environment having a top.sls
+    declaring a single conflicting ``shared.sls`` for the ``*`` target. The
+    same key is written with a different value per environment so that the
+    last-merged environment is observable in the final pillar.
+    """
+    base_root = tmp_path / "base"
+    dev_root = tmp_path / "dev"
+    prod_root = tmp_path / "prod"
+    for root in (base_root, dev_root, prod_root):
+        root.mkdir()
+
+    # Each environment's top.sls only declares the environment that
+    # contains it; the default ``smart`` pillar source merging strategy
+    # then gives us a ``matches`` dict with all three envs.
+    (base_root / "top.sls").write_text(
+        "base:\n  '*':\n    - shared\n", encoding="utf-8"
+    )
+    (dev_root / "top.sls").write_text("dev:\n  '*':\n    - shared\n", encoding="utf-8")
+    (prod_root / "top.sls").write_text(
+        "prod:\n  '*':\n    - shared\n", encoding="utf-8"
+    )
+
+    (base_root / "shared.sls").write_text("winner: base\n", encoding="utf-8")
+    (dev_root / "shared.sls").write_text("winner: dev\n", encoding="utf-8")
+    (prod_root / "shared.sls").write_text("winner: prod\n", encoding="utf-8")
+
+    return {
+        "base": [str(base_root)],
+        "dev": [str(dev_root)],
+        "prod": [str(prod_root)],
+    }
+
+
+def _make_opts(salt_master, pillar_roots, env_order=None):
+    opts = salt_master.config.copy()
+    opts["pillar_roots"] = pillar_roots
+    opts["file_roots"] = pillar_roots
+    # Force the same env list to be considered for both pillar source
+    # merging and top-file collection.
+    opts["pillarenv"] = None
+    opts["pillar_source_merging_strategy"] = "smart"
+    opts["top_file_merging_strategy"] = "merge"
+    if env_order is not None:
+        opts["env_order"] = env_order
+    return opts
+
+
+def test_env_order_pillar_last_env_wins(salt_master, env_order_pillar_tree, grains):
+    """
+    With ``env_order: [base, dev, prod]`` configured, the ``prod`` value
+    of the conflicting key must win, because ``prod`` is the last
+    environment in ``env_order``.
+
+    Before the fix in PR #69350, ``render_pillar`` iterated the
+    ``matches`` dict in insertion order. ``matches`` is built from a
+    ``set`` of environments inside ``get_tops`` so the resulting order
+    is not guaranteed to match ``env_order``. The fix re-orders the
+    iteration so the last env in ``env_order`` is processed last and
+    therefore wins on conflicting keys.
+    """
+    opts = _make_opts(
+        salt_master,
+        env_order_pillar_tree,
+        env_order=["base", "dev", "prod"],
+    )
+    pillar_obj = salt.pillar.Pillar(opts, grains, "minion", "base")
+    ret = pillar_obj.compile_pillar()
+    assert ret.get("_errors") is None, ret.get("_errors")
+    assert ret.get("winner") == "prod", (
+        "env_order [base, dev, prod] requires prod to win on conflicting "
+        f"pillar keys, got winner={ret.get('winner')!r}. Full pillar: {ret!r}"
+    )
+
+
+def test_env_order_pillar_reversed_order(salt_master, env_order_pillar_tree, grains):
+    """
+    Reversing ``env_order`` must reverse which environment wins on a
+    conflicting key. ``base`` is listed last so ``base`` must win.
+
+    This rules out the trivial pass-mode where ``base`` happens to come
+    out of ``matches`` last by coincidence: by switching ``env_order``
+    we drive the winner in the opposite direction.
+    """
+    opts = _make_opts(
+        salt_master,
+        env_order_pillar_tree,
+        env_order=["prod", "dev", "base"],
+    )
+    pillar_obj = salt.pillar.Pillar(opts, grains, "minion", "base")
+    ret = pillar_obj.compile_pillar()
+    assert ret.get("_errors") is None, ret.get("_errors")
+    assert ret.get("winner") == "base", (
+        "env_order [prod, dev, base] requires base to win on conflicting "
+        f"pillar keys, got winner={ret.get('winner')!r}. Full pillar: {ret!r}"
+    )

--- a/tests/pytests/unit/test_pillar.py
+++ b/tests/pytests/unit/test_pillar.py
@@ -777,6 +777,147 @@ def test_topfile_order():
     _run_test(nodegroup_order=2, glob_order=1, expected="foo")
 
 
+def _env_keyed_render_pillar_opts():
+    return {
+        "optimization_order": [0, 1, 2],
+        "renderer": "json",
+        "renderer_blacklist": [],
+        "renderer_whitelist": [],
+        "state_top": "",
+        "pillar_roots": {},
+        "file_roots": {},
+        "extension_modules": "",
+        "fileserver_backend": "roots",
+        "cachedir": "",
+    }
+
+
+def _env_keyed_render_pillar_grains():
+    return {
+        "os": "Ubuntu",
+        "os_family": "Debian",
+        "oscodename": "raring",
+        "osfullname": "Ubuntu",
+        "osrelease": "13.04",
+        "kernel": "Linux",
+    }
+
+
+def _patch_render_pstate_per_env(pillar, env_to_pstate):
+    """
+    Patch ``pillar.render_pstate`` so that it returns env-keyed data
+    irrespective of processing order. The fix being tested only changes the
+    *order* in which environments are processed, so this isolates the
+    behavior under test from the order in which ``compile_template`` would
+    have been called.
+    """
+
+    # pylint: disable=unused-argument
+    def fake_render_pstate(sls, saltenv, mods, defer_errors=False):
+        return env_to_pstate[saltenv], mods, []
+
+    # pylint: enable=unused-argument
+
+    pillar.render_pstate = fake_render_pstate
+
+
+def test_render_pillar_honors_env_order_68785():
+    """
+    Regression test for #68785. When ``env_order`` is set, render_pillar must
+    iterate the ``matches`` environments in that order so that the last
+    environment in ``env_order`` wins on conflicting pillar keys, instead of
+    using the (insertion) order of the ``matches`` dict.
+    """
+    opts = _env_keyed_render_pillar_opts()
+    opts["env_order"] = ["base", "development", "staging", "production"]
+    grains = _env_keyed_render_pillar_grains()
+    avail = {"base": ["foo"], "staging": ["foo"]}
+    with patch.object(
+        salt.pillar.Pillar,
+        "_Pillar__gather_avail",
+        MagicMock(return_value=avail),
+    ):
+        pillar = salt.pillar.Pillar(opts, grains, "mocked-minion", "base")
+        # Insertion order of ``matches`` puts ``staging`` before ``base``,
+        # which under the old dict-iteration behavior would have made
+        # ``base`` (processed last) win. ``env_order`` lists ``staging``
+        # after ``base``, so ``staging`` (uid 1014) must win.
+        _patch_render_pstate_per_env(
+            pillar,
+            {
+                "base": {"users": {"myuser": {"uid": 9002}}},
+                "staging": {"users": {"myuser": {"uid": 1014}}},
+            },
+        )
+        matches = {"staging": ["foo.sls"], "base": ["foo.sls"]}
+        result, errors = pillar.render_pillar(matches)
+        assert errors == []
+        assert result == {"users": {"myuser": {"uid": 1014}}}
+
+
+def test_render_pillar_env_order_unset_preserves_matches_order_68785():
+    """
+    When ``env_order`` is not set, render_pillar must preserve the existing
+    behavior of iterating ``matches`` in its insertion order.
+    """
+    opts = _env_keyed_render_pillar_opts()
+    grains = _env_keyed_render_pillar_grains()
+    avail = {"base": ["foo"], "staging": ["foo"]}
+    with patch.object(
+        salt.pillar.Pillar,
+        "_Pillar__gather_avail",
+        MagicMock(return_value=avail),
+    ):
+        pillar = salt.pillar.Pillar(opts, grains, "mocked-minion", "base")
+        _patch_render_pstate_per_env(
+            pillar,
+            {
+                "base": {"users": {"myuser": {"uid": 9002}}},
+                "staging": {"users": {"myuser": {"uid": 1014}}},
+            },
+        )
+        # No env_order. Last environment in the matches dict wins.
+        matches = {"base": ["foo.sls"], "staging": ["foo.sls"]}
+        result, errors = pillar.render_pillar(matches)
+        assert errors == []
+        assert result == {"users": {"myuser": {"uid": 1014}}}
+
+
+def test_render_pillar_env_order_with_extra_unlisted_env_68785():
+    """
+    Environments present in ``matches`` but missing from ``env_order`` must
+    still be processed (appended after the ordered ones).
+    """
+    opts = _env_keyed_render_pillar_opts()
+    opts["env_order"] = ["base", "staging"]
+    grains = _env_keyed_render_pillar_grains()
+    avail = {"base": ["foo"], "staging": ["foo"], "extra": ["foo"]}
+    with patch.object(
+        salt.pillar.Pillar,
+        "_Pillar__gather_avail",
+        MagicMock(return_value=avail),
+    ):
+        pillar = salt.pillar.Pillar(opts, grains, "mocked-minion", "base")
+        _patch_render_pstate_per_env(
+            pillar,
+            {
+                "base": {"users": {"myuser": {"uid": 1}}},
+                "staging": {"users": {"myuser": {"uid": 2}}},
+                "extra": {"extra_key": "x"},
+            },
+        )
+        # ``extra`` is not in ``env_order``; it should still be processed
+        # (appended), and unique keys from it should appear in the result.
+        # Processing order: base, staging, extra.
+        matches = {"extra": ["foo.sls"], "base": ["foo.sls"], "staging": ["foo.sls"]}
+        result, errors = pillar.render_pillar(matches)
+        assert errors == []
+        assert result == {
+            "users": {"myuser": {"uid": 2}},
+            "extra_key": "x",
+        }
+
+
 def test_relative_include(tmp_path):
     join = os.path.join
     with fopen(join(str(tmp_path), "top.sls"), "w") as f:


### PR DESCRIPTION
### What does this PR do?

Makes `Pillar.render_pillar` iterate matched environments in the configured `env_order` so that, with `top_file_merging_strategy: merge_all` and conflicting pillar keys across multiple environments, the last environment in `env_order` wins instead of the result depending on dict insertion order.

### What issues does this PR fix or reference?

Fixes #68785

### Previous Behavior

`render_pillar` iterated `matches.items()` in dict-insertion order, so `env_order` was silently ignored when merging pillar data across environments. The "winning" pillar value for conflicting keys depended on top-file iteration order. The state-compilation logic in `salt/state.py` already honors `env_order`; pillar processing did not.

### New Behavior

When `env_order` is set, `render_pillar` iterates matched environments in that order. Environments present in `matches` but missing from `env_order` are appended (in their existing order) so they are not silently dropped. When `env_order` is unset, behavior is unchanged.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
