### PR TITLE
Fix master_job_cache: redis_return KeyError (#68663)

### DIFF
--- a/changelog/68663.fixed.md
+++ b/changelog/68663.fixed.md
@@ -1,0 +1,1 @@
+Fixed `master_job_cache: redis_return` raising `KeyError: 'redis_return.prep_jid'` by registering the `redis` returner under both `redis` and `redis_return` virtual names, matching the documented `--return redis_return` usage and the module's file name.

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -125,6 +125,13 @@ REDIS_POOL = None
 # Define the module's virtual name
 __virtualname__ = "redis"
 
+# Allow this returner to also be referenced by its file name. The module is
+# named ``redis_return.py`` and the docs (and ``--return redis_return``
+# examples) refer to it as ``redis_return`` even though ``__virtualname__``
+# loads it as ``redis``. Without an alias, ``master_job_cache: redis_return``
+# fails with ``KeyError: redis_return.prep_jid`` in ``salt/utils/job.py``.
+__virtual_aliases__ = ("redis_return",)
+
 
 def __virtual__():
     """

--- a/tests/pytests/unit/returners/test_redis_return.py
+++ b/tests/pytests/unit/returners/test_redis_return.py
@@ -11,6 +11,8 @@ lost all returner data.
 
 import pytest
 
+import salt.config
+import salt.loader
 import salt.returners.redis_return as redis_return
 from tests.support.mock import MagicMock, patch
 
@@ -494,3 +496,35 @@ def test_get_fun_no_minions_returns_empty():
     assert result == {}
     serv.get.assert_not_called()
     serv.hget.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #68663 regression: returner registers under both `redis` and `redis_return`
+# ---------------------------------------------------------------------------
+
+
+def test_virtual_aliases_register_redis_return_name(tmp_path):
+    """
+    Regression test for #68663.
+
+    The redis_return.py returner sets ``__virtualname__ = "redis"`` so the
+    module loads as ``redis`` only. However, documentation and historical
+    usage refer to this returner as ``redis_return`` (the file name), and
+    users naturally configure ``master_job_cache: redis_return``. Prior to
+    the fix this raised ``KeyError: 'redis_return.prep_jid'`` from
+    ``salt/utils/job.py``. The module declares
+    ``__virtual_aliases__ = ("redis_return",)`` so the loader exposes the
+    returner under both ``redis.*`` and ``redis_return.*`` names.
+    """
+    opts = salt.config.DEFAULT_MASTER_OPTS.copy()
+    opts["extension_modules"] = str(tmp_path)
+    opts["cachedir"] = str(tmp_path)
+    minion_mods = salt.loader.minion_mods(opts)
+    returners = salt.loader.returners(opts, minion_mods)
+    # Both names must resolve to the same set of functions
+    assert "redis.prep_jid" in returners
+    assert "redis_return.prep_jid" in returners
+    assert "redis.save_load" in returners
+    assert "redis_return.save_load" in returners
+    assert "redis.returner" in returners
+    assert "redis_return.returner" in returners


### PR DESCRIPTION
### What does this PR do?

Registers the `redis` returner under both `redis` and `redis_return`
virtual names so `master_job_cache: redis_return` no longer raises
`KeyError: 'redis_return.prep_jid'`. The module file is
`salt/returners/redis_return.py` and the Salt docs (e.g.
`doc/ref/returners/index.rst:34`) tell users to invoke it as
`--return redis_return`, but `__virtualname__` was set to `"redis"`
only, so `redis_return.*` lookups never resolved.

### What issues does this PR fix or reference?

Fixes #68663

### Previous Behavior

```
master_job_cache: redis_return
```

```
[ERROR] Returner 'redis_return' does not support function prep_jid
KeyError: "Returner 'redis_return' does not support function prep_jid"
```

### New Behavior

Both `master_job_cache: redis` and `master_job_cache: redis_return`
work. The returner is exposed under both names via
`__virtual_aliases__ = ("redis_return",)`, the same pattern used by
`salt/modules/dockermod.py` (`("dockerng", "moby")`).

Note: `redis_return.py` was purged from 3008.x and master into the
`saltstack/saltext-redis` extension by commit `dc526dc2b17`, so this
PR targets 3006.x as the oldest still-supported branch carrying the
file. Merge-forward propagates to 3007.x. The 3008.x+/master side
needs a separate fix in `saltstack/saltext-redis`.

### Merge requirements satisfied?

- [x] Docs (no doc change needed; the alias makes the existing
  `--return redis_return` examples work as documented)
- [x] Changelog (`changelog/68663.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/returners/test_redis_return.py`)

### Commits signed with GPG?

Yes
