### PR TITLE
Surface every __virtual__ False reason on virtualname collisions (#68625)

### DIFF
--- a/changelog/68625.fixed.md
+++ b/changelog/68625.fixed.md
@@ -1,0 +1,1 @@
+Fixed the loader masking failure reasons when multiple modules declare the same `__virtualname__` and each `__virtual__()` returns False, so users now see every reason (e.g. both x509 v1's "Superseded, using x509_v2" and x509_v2's "Could not load cryptography") instead of only the first one recorded.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -1013,10 +1013,27 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
                 # if _process_virtual returned a non-True value then we are
                 # supposed to not process this module
-                if virtual_ret is not True and module_name not in self.missing_modules:
-                    # If a module has information about why it could not be loaded, record it
-                    self.missing_modules[module_name] = virtual_err
+                if virtual_ret is not True:
+                    # Always record the per-file reason; `name` is unique.
                     self.missing_modules[name] = virtual_err
+                    # The virtualname (module_name) can collide when multiple
+                    # files declare the same __virtualname__ (e.g. x509 and
+                    # x509_v2 both use "x509"). If we've already recorded a
+                    # reason for this virtualname, append the new one so the
+                    # user sees every failure, not just the first.
+                    if module_name not in self.missing_modules:
+                        self.missing_modules[module_name] = virtual_err
+                    elif virtual_err is not None:
+                        existing = self.missing_modules[module_name]
+                        if existing is None:
+                            self.missing_modules[module_name] = virtual_err
+                        else:
+                            existing_str = str(existing)
+                            new_str = str(virtual_err)
+                            if new_str and new_str not in existing_str.split("; "):
+                                self.missing_modules[module_name] = (
+                                    f"{existing_str}; {new_str}"
+                                )
                     return False
         else:
             virtual_aliases = ()
@@ -1264,6 +1281,16 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             mod.__name__,
                             module_name,
                         )
+
+                    # If the module explicitly declares __virtualname__, report
+                    # the failure under that name so the caller can detect
+                    # collisions with other modules claiming the same name.
+                    if (
+                        hasattr(mod, "__virtualname__")
+                        and isinstance(virtualname, str)
+                        and virtualname
+                    ):
+                        module_name = virtualname
 
                     return (False, module_name, error_reason, virtual_aliases)
 

--- a/tests/pytests/unit/loader/test_lazy.py
+++ b/tests/pytests/unit/loader/test_lazy.py
@@ -3,6 +3,7 @@ Tests for salt.loader.lazy
 """
 
 import sys
+import textwrap
 
 import pytest
 
@@ -163,3 +164,55 @@ def test_loaded_func_ensures_test_boolean(loader_dir, test_value, expected):
     loaded_fun = loader["mod_a.get_opts"]
     ret = loaded_fun("test")
     assert ret is expected
+
+
+def test_virtualname_collision_surfaces_all_reasons(tmp_path):
+    """
+    When two modules declare the same __virtualname__ and both __virtual__()
+    return False, the loader should surface every failure reason under the
+    shared virtualname instead of only the first one seen.
+
+    Regression test for #68625, where salt-ssh users running x509 functions
+    saw only the v1 "Superseded, using x509_v2" message and never the
+    underlying x509_v2 "Could not load cryptography" reason.
+    """
+    (tmp_path / "x509.py").write_text(
+        textwrap.dedent(
+            """
+            __virtualname__ = "x509"
+
+            def __virtual__():
+                return (False, "Superseded, using x509_v2")
+
+            def expires(*args, **kwargs):
+                return True
+            """
+        )
+    )
+    (tmp_path / "x509_v2.py").write_text(
+        textwrap.dedent(
+            """
+            __virtualname__ = "x509"
+
+            def __virtual__():
+                return (False, "Could not load cryptography")
+
+            def expires(*args, **kwargs):
+                return True
+            """
+        )
+    )
+
+    opts = {"optimization_order": [0, 1, 2]}
+    loader = salt.loader.lazy.LazyLoader([str(tmp_path)], opts)
+    with pytest.raises(KeyError):
+        _ = loader["x509.expires"]
+
+    reason = loader.missing_modules.get("x509")
+    assert reason is not None
+    assert "Superseded, using x509_v2" in reason
+    assert "Could not load cryptography" in reason
+
+    msg = loader.missing_fun_string("x509.expires")
+    assert "Superseded, using x509_v2" in msg
+    assert "Could not load cryptography" in msg


### PR DESCRIPTION
### What does this PR do?
When two execution modules declare the same `__virtualname__` and each `__virtual__()` returns `False`, the loader now records every failure reason under that virtualname instead of only the first one seen.

### What issues does this PR fix or reference?
Fixes #68625

### Previous Behavior
A `salt-ssh` user trying to call `x509.expires` on a target without `cryptography` installed only saw:

```
'x509' __virtual__ returned False: Superseded, using x509_v2
```

The actual blocker (`x509_v2`'s `Could not load cryptography`) was masked because the loader stored only the first failure reason recorded under the shared `x509` virtualname.

### New Behavior
The user now sees both reasons:

```
'x509' __virtual__ returned False: Superseded, using x509_v2; Could not load cryptography
```

Internally:

- `_process_virtual()` now reports `False` results under the module's explicit `__virtualname__` when one is set, so the caller can detect collisions.
- `_load_module()` merges new failure reasons with the existing one under the shared virtualname (joined by `; `) instead of dropping all but the first.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
