### PR TITLE
Fix cp.get_template on Jinja imports with context (#68572)

### DIFF
--- a/changelog/68572.fixed.md
+++ b/changelog/68572.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``cp.get_template`` raising ``AttributeError: 'NoneType' object has no attribute 'get'`` when the Jinja template uses ``{% from '...' import ... with context %}``. The cp module's loader-backed ``__opts__`` is now unwrapped to a plain dict before the SaltCacheLoader instantiates the file client and channel that fetch the imported template.

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -341,6 +341,14 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     :returns str: The string rendered by the template.
     """
     opts = context["opts"]
+    if isinstance(opts, NamedLoaderContext):
+        # Unwrap loader-backed opts so any file client and channel created
+        # downstream (e.g. by SaltCacheLoader) receive a plain dict. A
+        # NamedLoaderContext resolves through the loader contextvar, which
+        # is not propagated into the tornado IO loop the channel runs on,
+        # so leaving it wrapped causes ``opts.get(...)`` to raise
+        # AttributeError when the channel reads its own configuration.
+        opts = opts.value()
     saltenv = context["saltenv"]
     loader = None
     newline = False

--- a/tests/pytests/integration/modules/test_cp.py
+++ b/tests/pytests/integration/modules/test_cp.py
@@ -1,0 +1,50 @@
+"""
+Integration tests for the cp execution module.
+"""
+
+import pytest
+
+import salt.utils.files
+import salt.utils.stringutils
+
+
+@pytest.fixture
+def issue_68572_template_tree(base_env_state_tree_root_dir):
+    main = base_env_state_tree_root_dir / "issue-68572-main.j2"
+    mapfile = base_env_state_tree_root_dir / "issue-68572-map.jinja"
+    main.write_text(
+        "{%- from 'issue-68572-map.jinja' import defaults with context -%}\n"
+        "{{ defaults['foo'] }}\n"
+    )
+    mapfile.write_text("{% set defaults = {'foo': 'bar'} %}\n")
+    try:
+        yield "salt://issue-68572-main.j2"
+    finally:
+        main.unlink(missing_ok=True)
+        mapfile.unlink(missing_ok=True)
+
+
+def test_get_template_with_imported_context(
+    salt_call_cli, issue_68572_template_tree, tmp_path
+):
+    """
+    Regression test for #68572.
+
+    ``cp.get_template`` against a Jinja template that contains a
+    ``{% from '...' import ... with context %}`` statement must render
+    successfully. Prior to the fix the loader-backed dunders passed to the
+    template rendering machinery were left wrapped in
+    ``NamedLoaderContext``; the file client and channel constructed by
+    ``SaltCacheLoader`` for the imported template then ran on the tornado
+    IO loop where the loader context is not set, causing
+    ``NamedLoaderContext.value()`` to return ``None`` and the channel's
+    ``self.opts.get(...)`` call to raise
+    ``AttributeError: 'NoneType' object has no attribute 'get'``.
+    """
+    dest = tmp_path / "issue-68572.out"
+    ret = salt_call_cli.run("cp.get_template", issue_68572_template_tree, str(dest))
+    assert ret.returncode == 0, ret
+    assert ret.data, ret
+    with salt.utils.files.fopen(str(dest), "r") as fp_:
+        rendered = salt.utils.stringutils.to_unicode(fp_.read())
+    assert "bar" in rendered

--- a/tests/pytests/unit/utils/templates/test_jinja.py
+++ b/tests/pytests/unit/utils/templates/test_jinja.py
@@ -7,6 +7,7 @@ import re
 from collections import OrderedDict
 import pytest
 from salt.exceptions import SaltRenderError
+from salt.loader.context import LoaderContext
 from salt.utils.templates import render_jinja_tmpl
 
 from tests.support.mock import patch
@@ -101,3 +102,44 @@ def test_render_cve_2021_25283(render_context):
     render_context["var"] = "OK"
     with pytest.raises(SaltRenderError):
         res = render_jinja_tmpl(tmpl, render_context)
+
+
+def test_render_unwraps_named_loader_context_opts(render_context):
+    """
+    Regression test for #68572.
+
+    ``salt.modules.cp.get_template`` passes the cp module's loader-backed
+    ``__opts__`` (a ``NamedLoaderContext``) through to the Jinja renderer.
+    If ``render_jinja_tmpl`` leaves the wrapper in place, the
+    ``SaltCacheLoader`` it constructs will instantiate a downstream file
+    client / channel with the wrapper as its ``self.opts``. The channel
+    runs on the tornado IO loop, where the loader contextvar is not set,
+    so ``self.opts.get(...)`` raises ``AttributeError: 'NoneType' object
+    has no attribute 'get'``. ``render_jinja_tmpl`` must unwrap a
+    ``NamedLoaderContext`` to a plain dict before it reaches that path.
+    """
+    opts_dict = dict(render_context["opts"])
+    wrapped = LoaderContext().named_context("__opts__", default=opts_dict)
+    render_context["opts"] = wrapped
+    # If the wrapper survives into the renderer, the Jinja environment
+    # build-up (which calls ``opts.get(...)``) succeeds only because the
+    # default is non-None here; the substantive assertion is the dict-typed
+    # opts the SaltCacheLoader sees, captured below.
+    seen = {}
+    real_init = __import__(
+        "salt.utils.jinja", fromlist=["SaltCacheLoader"]
+    ).SaltCacheLoader.__init__
+
+    def capture_init(self, opts, *args, **kwargs):
+        seen["opts_type"] = type(opts)
+        return real_init(self, opts, *args, **kwargs)
+
+    from salt.utils.jinja import SaltCacheLoader
+
+    with patch.object(SaltCacheLoader, "__init__", capture_init):
+        # Use a saltenv so the SaltCacheLoader branch executes.
+        render_context["saltenv"] = "base"
+        # A trivial template avoids the file client running.
+        render_jinja_tmpl("OK", render_context)
+    # If the fix is in place the loader sees a plain dict.
+    assert seen["opts_type"] is dict, seen


### PR DESCRIPTION
### What does this PR do?

Fixes `cp.get_template` raising `AttributeError: 'NoneType' object has no attribute 'get'` when the rendered Jinja template uses `{% from '...' import ... with context %}`. The cp module's loader-backed `__opts__` is unwrapped to a plain dict at the top of `render_jinja_tmpl` so the downstream `SaltCacheLoader`, file client, and channel never have to resolve through the loader contextvar.

### What issues does this PR fix or reference?

Fixes #68572

### Previous Behavior

Rendering a template that imports another template with `with context` failed:

```
$ salt-call cp.get_template salt://templates/file.j2 ./file
[...]
AttributeError: 'NoneType' object has no attribute 'get'
```

The cp module's `__opts__` (a `NamedLoaderContext`) was passed through to the Jinja renderer untouched. When `SaltCacheLoader` instantiated a file client to fetch the imported template, the channel ran on the tornado IO loop where the loader contextvar is not set, so `NamedLoaderContext.value()` returned `None` and the channel's `self.opts.get("detect_mode")` call raised `AttributeError`.

### New Behavior

`cp.get_template` renders templates that use `{% from '...' import ... with context %}` without error.

### Merge requirements satisfied?

- [x] Docs (no user-facing config or API change; not required)
- [x] Changelog — `changelog/68572.fixed.md`
- [x] Tests written/updated — `tests/pytests/unit/utils/templates/test_jinja.py::test_render_unwraps_named_loader_context_opts` and `tests/pytests/integration/modules/test_cp.py::test_get_template_with_imported_context`.

### Commits signed with GPG?

No
