### PR TITLE
Fix docker_network.present recreating networks on Docker 29+ (#68518)

### DIFF
--- a/changelog/68518.fixed.md
+++ b/changelog/68518.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``docker_network.present`` recreating networks on every run against Docker 29+. Docker 29 added an empty ``IPRange`` field to every IPAM Config entry; ``docker.compare_networks`` now drops empty/None placeholder values before comparing pools, and the state's default-pool short-circuit treats the empty field as absent.

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1336,8 +1336,21 @@ def compare_networks(first, second, ignore="Name,Id,Created,Containers"):
                     def kvsort(x):
                         return (list(x.keys()), list(x.values()))
 
-                    config1 = sorted(val1["Config"], key=kvsort)
-                    config2 = sorted(val2.get("Config", []), key=kvsort)
+                    def strip_empty(pool):
+                        # Newer Docker engines (29.x) emit empty-string
+                        # placeholder fields (e.g. ``IPRange: ""``) in IPAM
+                        # Config entries that older engines and Salt-built
+                        # desired configs omit. Treat empty/None values as
+                        # absent so the comparison stays semantic.
+                        return {k: v for k, v in pool.items() if v not in ("", None)}
+
+                    config1 = sorted(
+                        [strip_empty(p) for p in val1["Config"]], key=kvsort
+                    )
+                    config2 = sorted(
+                        [strip_empty(p) for p in val2.get("Config", [])],
+                        key=kvsort,
+                    )
                     if config1 != config2:
                         ret.setdefault("IPAM", {})["Config"] = {
                             "old": config1,

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -689,7 +689,12 @@ def present(
             desired_pool_count = len(temp_net_info["IPAM"]["Config"])
 
             def is_default_pool(x):
-                return True if sorted(x) == ["Gateway", "Subnet"] else False
+                # Docker 29+ emits an empty ``IPRange`` field on every IPAM
+                # Config entry; drop empty/None values so the default-pool
+                # short-circuit still matches networks created without an
+                # explicit IPAM configuration. See #68518.
+                keys = sorted(k for k, v in x.items() if v not in ("", None))
+                return keys == ["Gateway", "Subnet"]
 
             if (
                 desired_pool_count == 0

--- a/tests/pytests/unit/modules/dockermod/test_module.py
+++ b/tests/pytests/unit/modules/dockermod/test_module.py
@@ -450,6 +450,53 @@ def test_inspect_network():
 
 
 @docker_older_than_1_5_0_skip_marker
+def test_compare_networks_ipam_config_empty_iprange():
+    """
+    Docker 29 added an empty-string ``IPRange`` to every IPAM Config entry.
+    Older Salt-built desired configs don't carry that key, so a strict dict
+    comparison reports a spurious diff and ``docker_network.present`` would
+    recreate the network on every run.
+
+    Regression test for #68518.
+    """
+    existing = {
+        "Name": "inf-network",
+        "Driver": "bridge",
+        "IPAM": {
+            "Driver": "default",
+            "Options": None,
+            "Config": [
+                {
+                    "Subnet": "172.18.0.0/16",
+                    "IPRange": "",
+                    "Gateway": "172.18.0.1",
+                }
+            ],
+        },
+        "Options": {},
+    }
+    desired = {
+        "Name": "inf-network",
+        "Driver": "bridge",
+        "IPAM": {
+            "Driver": "default",
+            "Options": {},
+            "Config": [
+                {
+                    "Subnet": "172.18.0.0/16",
+                    "Gateway": "172.18.0.1",
+                }
+            ],
+        },
+        "Options": {},
+    }
+    assert docker_mod.compare_networks(existing, desired) == {}
+    # Symmetric: a real subnet change still has to be reported.
+    desired["IPAM"]["Config"][0]["Subnet"] = "172.19.0.0/16"
+    assert "IPAM" in docker_mod.compare_networks(existing, desired)
+
+
+@docker_older_than_1_5_0_skip_marker
 def test_connect_container_to_network():
     """
     test connect_container_to_network


### PR DESCRIPTION
### What does this PR do?

Stops `docker_network.present` from reporting a spurious change (and recreating the network) on every state run against Docker 29+.

### What issues does this PR fix or reference?

Fixes #68518

### Previous Behavior

After upgrading from Docker 28 to Docker 29, every `docker_network.present` state run reported `Network would be recreated with new config` and produced a no-op IPAM diff. Docker 29 added an empty-string `IPRange` field to every IPAM `Config` entry returned by `docker inspect`; Salt's `docker.compare_networks` did a strict dict-equality check, so the engine's `{Subnet, IPRange:"", Gateway}` never matched the Salt-built desired `{Subnet, Gateway}`. The state's default-pool short-circuit (`is_default_pool`) keyed off `sorted(x) == ["Gateway", "Subnet"]` and likewise stopped matching once Docker emitted the new field.

### New Behavior

`docker.compare_networks` strips empty-string/None placeholder values from each IPAM `Config` entry before sorting and comparing pools. `docker_network.present::is_default_pool` applies the same normalisation. A real configuration change is still reported.

### Note

`salt/states/docker_network.py` and `salt/modules/dockermod.py` were removed from upstream Salt starting in 3008.x and migrated to the `saltext-docker` extension. This PR targets the oldest still-supported branch carrying the bug (`3006.x`); merge-forward propagates the fix to `3007.x`. A separate PR will be needed against `saltstack/saltext-docker` to cover 3008.x+/master.

### Merge requirements satisfied?

- [x] Docs (no documented behavior change; existing comments updated inline)
- [x] Changelog (`changelog/68518.fixed.md`)
- [x] Tests written/updated (`test_compare_networks_ipam_config_empty_iprange`)

### Commits signed with GPG?

Yes
