### PR TITLE
Fix pkg.installed verification on x86_64 hosts using x86_64_v2 packages (#68540)

### DIFF
--- a/changelog/68540.fixed.md
+++ b/changelog/68540.fixed.md
@@ -1,0 +1,1 @@
+Fixed `pkg.installed` verification on x86_64 hosts that mix `x86_64` and `x86_64_v2` packages (e.g. AlmaLinux 10.1). `salt.utils.pkg.rpm.resolve_name` and `salt.modules.yumpkg.normalize_name` now treat `x86_64_v2` as compatible with `x86_64` instead of appending the arch suffix, so installed packages match the names Salt records.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -448,10 +448,12 @@ def normalize_name(name):
             return name
     except ValueError:
         return name
-    if arch in (__grains__["osarch"], "noarch") or salt.utils.pkg.rpm.check_32(
-        arch, osarch=__grains__["osarch"]
+    stripped_name = name[: -(len(arch) + 1)]
+    if (
+        salt.utils.pkg.rpm.resolve_name(stripped_name, arch, __grains__["osarch"])
+        == stripped_name
     ):
-        return name[: -(len(arch) + 1)]
+        return stripped_name
     return name
 
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -14,7 +14,8 @@ import salt.utils.stringutils
 log = logging.getLogger(__name__)
 
 # These arches compiled from the rpmUtils.arch python module source
-ARCHES_64 = ("x86_64", "athlon", "amd64", "ia32e", "ia64", "geode")
+ARCHES_X86_64 = ("x86_64", "x86_64_v2")
+ARCHES_64 = ARCHES_X86_64 + ("athlon", "amd64", "ia32e", "ia64", "geode")
 ARCHES_32 = ("i386", "i486", "i586", "i686")
 ARCHES_PPC = ("ppc", "ppc64", "ppc64le", "ppc64iseries", "ppc64pseries")
 ARCHES_S390 = ("s390", "s390x")
@@ -105,7 +106,11 @@ def resolve_name(name, arch, osarch=None):
     if osarch is None:
         osarch = get_osarch()
 
-    if not check_32(arch, osarch) and arch not in (osarch, "noarch"):
+    if (
+        not check_32(arch, osarch)
+        and arch not in (osarch, "noarch")
+        and not (arch in ARCHES_X86_64 and osarch in ARCHES_X86_64)
+    ):
         name += f".{arch}"
     return name
 

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2586,6 +2586,38 @@ def test_normalize_name_noarch():
     assert yumpkg.normalize_name("zsh.noarch") == "zsh"
 
 
+def test_normalize_name_with_arch_x86_64_v2():
+    """
+    Regression test for #68540: ``salt.modules.yumpkg.normalize_name`` should
+    recognize ``x86_64_v2`` as a valid package architecture and strip it from
+    the name when running on an ``x86_64`` host, while leaving foreign arches
+    intact.
+    """
+    with patch.dict(yumpkg.__grains__, {"osarch": "x86_64"}):
+        assert yumpkg.normalize_name("chrony.x86_64_v2") == "chrony"
+        assert yumpkg.normalize_name("chrony.x86_64") == "chrony"
+        assert yumpkg.normalize_name("rootfiles.noarch") == "rootfiles"
+    with patch.dict(yumpkg.__grains__, {"osarch": "aarch64"}):
+        assert yumpkg.normalize_name("chrony.x86_64_v2") == "chrony.x86_64_v2"
+
+
+def test_resolve_name_with_arch_x86_64_v2():
+    """
+    Regression test for #68540: ``salt.utils.pkg.rpm.resolve_name`` should
+    treat ``x86_64_v2`` as compatible with ``x86_64`` so the arch suffix is
+    not appended on matching hosts.
+    """
+    import salt.utils.pkg.rpm
+
+    assert salt.utils.pkg.rpm.resolve_name("chrony", "x86_64_v2", "x86_64") == "chrony"
+    assert salt.utils.pkg.rpm.resolve_name("chrony", "x86_64", "x86_64_v2") == "chrony"
+    assert salt.utils.pkg.rpm.resolve_name("chrony", "x86_64", "x86_64") == "chrony"
+    assert (
+        salt.utils.pkg.rpm.resolve_name("chrony", "x86_64_v2", "aarch64")
+        == "chrony.x86_64_v2"
+    )
+
+
 def test_latest_version_no_names():
     assert yumpkg.latest_version() == ""
 


### PR DESCRIPTION
### What does this PR do?
Teaches `salt.utils.pkg.rpm.resolve_name` and `salt.modules.yumpkg.normalize_name` to treat `x86_64` and `x86_64_v2` as a compatible pair so package names round-trip correctly on hosts that mix the two arches (e.g. AlmaLinux 10.1's AppStream).

### What issues does this PR fix or reference?
Fixes #68540

This is a backport of the fix already shipped on `3008.x`/`master` (commits `047150b5aec` and `bf3c5cef6d5` by @vzhestkov).

### Previous Behavior
On an `x86_64` host that received `x86_64_v2`-tagged packages, `pkg.installed` could install the package but failed to verify it, because Salt rewrote the package name with a `.x86_64_v2` suffix that did not match the literal package name reported by `rpm -q`.

### New Behavior
`x86_64` and `x86_64_v2` are recognised as a mutually compatible arch pair: `resolve_name` no longer appends the suffix when one side is `x86_64` and the other is `x86_64_v2`, and `normalize_name` strips the suffix accordingly. Foreign arches (e.g. `x86_64_v2` on an `aarch64` host) keep the suffix as before.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change; docstring of `normalize_name` is unaffected)
- [x] Changelog (`changelog/68540.fixed.md`)
- [x] Tests written/updated (regression tests in `tests/pytests/unit/modules/test_yumpkg.py`)

### Commits signed with GPG?
Yes
