### PR TITLE
Fix minion stuck on "Invalid master key" after restart (#68493)

### DIFF
--- a/changelog/68493.fixed.md
+++ b/changelog/68493.fixed.md
@@ -1,0 +1,1 @@
+Fixed minion rejecting the master with "Invalid master key" after restart when the cached `minion_master.pub` differs from the master's payload pub_key only in trailing whitespace. `AsyncAuth.verify_master` now normalizes both sides through `clean_key` before comparing and caches the normalized form on first contact.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1326,11 +1326,18 @@ class AsyncAuth:
         """
         m_pub_fn = os.path.join(self.opts["pki_dir"], self.mpub)
         m_pub_exists = os.path.isfile(m_pub_fn)
+        # Compare the master's pub_key against the cached copy using the same
+        # normalization on both sides. Older masters (pre-clean_key) send the
+        # raw file content with a trailing newline; without this normalization
+        # the comparison spuriously fails and the minion is stuck rejecting
+        # the master with "Invalid master key" until minion_master.pub is
+        # manually deleted. See issue #68493.
+        payload_pub_key = clean_key(payload["pub_key"])
         if m_pub_exists and master_pub and not self.opts["open_mode"]:
             with salt.utils.files.fopen(m_pub_fn) as fp_:
                 local_master_pub = clean_key(fp_.read())
 
-            if payload["pub_key"] != local_master_pub:
+            if payload_pub_key != local_master_pub:
                 if not self.check_auth_deps(payload):
                     return ""
 
@@ -1380,9 +1387,11 @@ class AsyncAuth:
             else:
                 if not m_pub_exists:
                     # the minion has not received any masters pubkey yet, write
-                    # the newly received pubkey to minion_master.pub
+                    # the newly received pubkey to minion_master.pub. Store
+                    # the clean_key'd form so that subsequent restarts compare
+                    # like-for-like (see issue #68493).
                     with salt.utils.files.fopen(m_pub_fn, "wb+") as fp_:
-                        fp_.write(salt.utils.stringutils.to_bytes(payload["pub_key"]))
+                        fp_.write(salt.utils.stringutils.to_bytes(payload_pub_key))
                 return self.extract_aes(payload, master_pub=False)
 
     def _finger_fail(self, finger, master_key):

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -243,3 +243,110 @@ def test_async_auth_cache_token(minion_root, io_loop):
         auth.gen_token("salt")
         auth.gen_token("salt")
         moc.assert_called_once()
+
+
+def test_verify_master_accepts_cached_key_with_whitespace_drift(
+    minion_root, io_loop, key_data
+):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/68493
+
+    A master that does not ``clean_key()`` its outgoing ``pub_key`` (e.g. an
+    older 3006.0 master) sends a payload whose ``pub_key`` carries a trailing
+    newline. ``verify_master`` writes that raw payload to ``minion_master.pub``
+    on first contact, but on every subsequent restart it reads the cached file
+    through ``clean_key()`` (which strips trailing whitespace) and then
+    compares the normalized cache against the raw payload. The two strings
+    only differ in trailing whitespace, but the comparison fails and the
+    minion rejects the master with "Invalid master key" forever (until the
+    cache file is deleted).
+
+    The fix normalizes both sides of the comparison through ``clean_key()``.
+    """
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+        "open_mode": False,
+        "verify_master_pubkey_sign": False,
+        "always_verify_signature": False,
+    }
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    raw_pub_key = "\n".join(key_data) + "\n"
+    cached_pub_key = crypt.clean_key(raw_pub_key)
+    assert raw_pub_key != cached_pub_key, "fixture must exercise the drift"
+
+    # Simulate the on-disk cache that the minion would build up after talking
+    # to a master whose outgoing pub_key has been normalized by clean_key().
+    m_pub_fn = pki_dir / auth.mpub
+    m_pub_fn.write_text(cached_pub_key)
+
+    payload = {
+        "enc": "pub",
+        "pub_key": raw_pub_key,
+        "aes": "ignored-by-extract-aes-mock",
+    }
+
+    with patch.object(auth, "extract_aes", return_value="aes-key") as extract:
+        result = auth.verify_master(payload)
+
+    assert result == "aes-key"
+    extract.assert_called_once()
+
+
+def test_verify_master_caches_clean_key_on_first_contact(
+    minion_root, io_loop, key_data
+):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/68493
+
+    When ``verify_master`` accepts a master's pub_key for the first time it
+    must cache the ``clean_key()``-normalized form to ``minion_master.pub``.
+    Caching the raw payload causes the next call (which reads through
+    ``clean_key()``) to compare a normalized cache against a raw payload and
+    spuriously reject the master.
+    """
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 60,
+        "acceptance_wait_time_max": 60,
+        "open_mode": False,
+        "verify_master_pubkey_sign": False,
+        "always_verify_signature": False,
+    }
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    raw_pub_key = "\n".join(key_data) + "\n"
+    cached_pub_key = crypt.clean_key(raw_pub_key)
+
+    m_pub_fn = pki_dir / auth.mpub
+    assert not m_pub_fn.exists()
+
+    payload = {
+        "enc": "pub",
+        "pub_key": raw_pub_key,
+        "aes": "ignored-by-extract-aes-mock",
+    }
+
+    with patch.object(auth, "extract_aes", return_value="aes-key"):
+        # First contact: master_pub=False because the minion hadn't seen a
+        # pubkey yet when it sent the auth request.
+        result = auth.verify_master(payload, master_pub=False)
+
+    assert result == "aes-key"
+    assert m_pub_fn.read_text() == cached_pub_key


### PR DESCRIPTION
### What does this PR do?
Stops the minion from rejecting the master with `Invalid master key` on every
restart when the cached `minion_master.pub` differs from the master's payload
`pub_key` only in trailing whitespace.

### What issues does this PR fix or reference?
Fixes #68493

### Previous Behavior
After a minion restart in a multi-master setup against an older master (e.g.
3006.0, whose `get_pub_str` does not pass the pub_key through `clean_key()`),
the minion logged:

```
ERROR Error while bringing up minion for multi-master. Is master at <host> responding?
  The error message was Unable to sign_in to master: Invalid master key
salt.exceptions.SaltClientError: Invalid master key
```

The only workaround was to stop the service, `rm /etc/salt/pki/minion/minion_master.pub`,
and start it again.

Root cause: `AsyncAuth.verify_master` reads the cached `minion_master.pub`
through `clean_key()` (which strips trailing whitespace and normalizes line
endings) but compared it directly against `payload["pub_key"]`, and wrote the
raw payload to disk on first contact. When the master end did not normalize
its outgoing pub_key, the on-disk cache ended up with a trailing newline
while the normalized read did not — so every subsequent restart hit the
mismatch branch.

### New Behavior
`AsyncAuth.verify_master` normalizes `payload["pub_key"]` through `clean_key()`
once and uses that value for both the comparison against the cached file and
the first-contact write of the cache file. The on-disk cache and the payload
are now normalized identically, and the minion reconnects cleanly after a
restart.

### Merge requirements satisfied?
- [x] Docs (no doc-visible behavior change)
- [x] Changelog (`changelog/68493.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/test_crypt.py`:
  `test_verify_master_accepts_cached_key_with_whitespace_drift`,
  `test_verify_master_caches_clean_key_on_first_contact`)

### Commits signed with GPG?
Yes
