### PR TITLE
Fix minion connect loop aborting on TypeError after request timeout (#68506)

### DIFF
--- a/changelog/68506.fixed.md
+++ b/changelog/68506.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``TypeError: 'NoneType' object is not iterable`` raised from ``AsyncReqMessageClient._send_recv`` when a per-message timeout completes the future before the send/receive coroutine catches a transient transport exception, which aborted the minion's connect loop and prevented it from connecting to the master.

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -817,7 +817,8 @@ class AsyncReqMessageClient:
                     log.trace("Loop closed while sending.")
                     # The ioloop was closed before polling finished.
                     send_recv_running = False
-                    future.set_exception(exc)
+                    if not future.done():
+                        future.set_exception(exc)
                     break
                 except zmq.ZMQError as exc:
                     if exc.errno in [
@@ -827,16 +828,19 @@ class AsyncReqMessageClient:
                     ]:
                         log.trace("Send socket closed while sending.")
                         send_recv_running = False
-                        future.set_exception(exc)
+                        if not future.done():
+                            future.set_exception(exc)
                     elif exc.errno == zmq.EFSM:
                         log.error("Socket was found in invalid state.")
                         send_recv_running = False
-                        future.set_exception(exc)
+                        if not future.done():
+                            future.set_exception(exc)
                     else:
                         log.error(
                             "Unhandled Zeromq error durring send/receive: %s", exc
                         )
-                        future.set_exception(exc)
+                        if not future.done():
+                            future.set_exception(exc)
 
                 if future.done():
                     exc = future.exception()
@@ -875,7 +879,8 @@ class AsyncReqMessageClient:
                     except zmq.ZMQError as exc:
                         log.trace("Receive socket closed while polling.")
                         send_recv_running = False
-                        future.set_exception(exc)
+                        if not future.done():
+                            future.set_exception(exc)
 
                     if ready:
                         try:
@@ -884,11 +889,13 @@ class AsyncReqMessageClient:
                         except zmq.eventloop.future.CancelledError as exc:
                             log.trace("Loop closed while receiving.")
                             send_recv_running = False
-                            future.set_exception(exc)
+                            if not future.done():
+                                future.set_exception(exc)
                         except zmq.ZMQError as exc:
                             log.trace("Receive socket closed while receiving.")
                             send_recv_running = False
-                            future.set_exception(exc)
+                            if not future.done():
+                                future.set_exception(exc)
                         break
                     elif future.done():
                         break
@@ -911,7 +918,8 @@ class AsyncReqMessageClient:
                     send_recv_running = False
                 elif received:
                     data = salt.payload.loads(recv)
-                    future.set_result(data)
+                    if not future.done():
+                        future.set_result(data)
         finally:
             if (
                 self._send_recv_exit_future is not None

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1830,6 +1830,39 @@ async def test_client_send_recv_on_cancelled_error(minion_opts):
         client.close()
 
 
+async def test_client_send_recv_no_double_set_exception_after_timeout(minion_opts):
+    """
+    Regression test for #68506.
+
+    When ``_timeout_message`` has already marked the per-message future done
+    (callbacks consumed, ``_callbacks`` set to ``None`` by tornado's
+    ``Future._set_done``), a subsequent ``socket.send`` failure inside
+    ``_send_recv`` must not call ``future.set_exception`` again. Doing so
+    triggers ``TypeError: 'NoneType' object is not iterable`` from tornado's
+    ``Future._set_done`` and aborts the minion connect loop.
+    """
+    client = salt.transport.zeromq.AsyncReqMessageClient(
+        minion_opts, "tcp://127.0.0.1:4506"
+    )
+
+    future = salt.ext.tornado.concurrent.Future()
+    # Simulate _timeout_message having fired first: future is now done and
+    # tornado has cleared its callback list to None.
+    future.set_exception(salt.exceptions.SaltReqTimeoutError("Message timed out"))
+    assert future.done()
+
+    try:
+        client.socket = AsyncMock()
+        client.socket.send.side_effect = zmq.ZMQError(zmq.ETERM)
+        client._queue.put_nowait((future, {"meh": "bah"}))
+        # Before the fix this raises TypeError from tornado's _set_done.
+        await client._send_recv(client.socket)
+        # The timeout exception must be preserved, not overwritten.
+        assert isinstance(future.exception(), salt.exceptions.SaltReqTimeoutError)
+    finally:
+        client.close()
+
+
 def test_async_req_message_client_close_never_connected(minion_opts):
     """
     close() must not hang when connect() was never called (#68637).


### PR DESCRIPTION
### What does this PR do?

Adds the missing ``if not future.done():`` guards to every ``set_exception`` / ``set_result`` call in ``AsyncReqMessageClient._send_recv`` so a transient transport error after the per-message timeout has already completed the future no longer raises ``TypeError: 'NoneType' object is not iterable`` from tornado, which was aborting the minion's connect loop.

### What issues does this PR fix or reference?

Fixes #68506

### Previous Behavior

When ``_timeout_message`` completed the future first and a send/receive ZMQError (or CancelledError) fired immediately after, ``future.set_exception(exc)`` reached tornado's ``Future._set_done`` a second time. That iterates ``self._callbacks`` after it has been cleared to ``None``, raising ``TypeError: 'NoneType' object is not iterable``. The exception propagated out of the coroutine and the minion logged "unable to successfully connect to a Salt Master" without retrying — most visible on Windows minions reaching a master over a higher-latency WAN link.

### New Behavior

Each ``set_exception`` / ``set_result`` is guarded with ``if not future.done():``, matching the pattern already used in the same file's companion ``send`` path (added in #66006) and the rewritten 3008.x / master coroutine. The timeout exception is preserved and the connect loop proceeds with its normal reconnect/retry flow.

### Merge requirements satisfied?
- [x] Docs (no documented behavior changed)
- [x] Changelog (`changelog/68506.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/transport/test_zeromq.py::test_client_send_recv_no_double_set_exception_after_timeout`)

### Commits signed with GPG?
No
