### PR TITLE
Fix lgpo.set state idempotency when element ids are used (#68489)

### DIFF
--- a/changelog/68489.fixed.md
+++ b/changelog/68489.fixed.md
@@ -1,0 +1,1 @@
+Fixed `lgpo.set` state reporting "Failed to set the following policies" on subsequent runs of policies with sub-elements (e.g. Storage Sense thresholds). The state compared a user-supplied dict keyed by element id with a current dict keyed by the ADML display name; both forms now normalize to the canonical element id before comparison so the state is idempotent.

--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -250,6 +250,31 @@ def _compare_policies(new_policy, current_policy):
             return False
 
 
+def _normalize_element_names(policy_dict, policy_elements):
+    """
+    Helper function that returns a copy of ``policy_dict`` with its keys
+    rewritten to the canonical ``element_id`` for each policy element. Both
+    the element id and the ADML display name are accepted aliases for the
+    same setting, but the LGPO module reads them back keyed by the display
+    name. Without normalization, comparisons between a user-supplied dict
+    (typically keyed by element id) and the current policy (keyed by display
+    name) always look different even when the settings match. See #68489.
+    """
+    if not isinstance(policy_dict, dict) or not policy_elements:
+        return policy_dict
+    alias_to_id = {}
+    for element in policy_elements:
+        element_id = element.get("element_id")
+        if not element_id:
+            continue
+        for alias in element.get("element_aliases", []):
+            alias_to_id[alias] = element_id
+    normalized = {}
+    for key, value in policy_dict.items():
+        normalized[alias_to_id.get(key, key)] = value
+    return normalized
+
+
 def _convert_to_unicode(data):
     """
     Helper function that makes sure all items in the dictionary are unicode for
@@ -508,6 +533,20 @@ def set_(
                         requested_policy_json
                     )
                     current_policy_check = salt.utils.json.loads(current_policy_json)
+
+                    # Element keys may be passed as either an element id or the
+                    # full ADML display name. Normalize both sides to the
+                    # canonical element id so the comparison is alias-aware
+                    # and idempotent on subsequent runs (#68489).
+                    policy_elements = p_data["policy_lookup"][p_name].get(
+                        "policy_elements"
+                    )
+                    requested_policy_check = _normalize_element_names(
+                        requested_policy_check, policy_elements
+                    )
+                    current_policy_check = _normalize_element_names(
+                        current_policy_check, policy_elements
+                    )
 
                     # Are the requested and current policies identical
                     policies_are_equal = _compare_policies(

--- a/tests/pytests/unit/states/test_win_lgpo.py
+++ b/tests/pytests/unit/states/test_win_lgpo.py
@@ -11,7 +11,7 @@ import salt.loader
 import salt.states.win_lgpo as win_lgpo
 import salt.utils.platform
 import salt.utils.stringutils
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 @pytest.fixture
@@ -334,3 +334,94 @@ def test_invalid_elements_true():
     assert "Invalid element squidward" in result["comment"]
     assert "Invalid element spongebob" in result["comment"]
     assert not expected["result"]
+
+
+def test__normalize_element_names_maps_aliases_to_element_id():
+    """
+    Element ids and ADML display names are interchangeable aliases. The
+    helper must rewrite both to the canonical ``element_id``.
+    """
+    policy_elements = [
+        {
+            "element_id": "StorageSenseCloudContentDehydrationThreshold",
+            "element_aliases": [
+                "StorageSenseCloudContentDehydrationThreshold",
+                (
+                    "Number of days since a cloud-backed file has been opened"
+                    " before Storage Sense will dehydrate it"
+                ),
+            ],
+        }
+    ]
+    # Element id key passes through unchanged.
+    assert win_lgpo._normalize_element_names(
+        {"StorageSenseCloudContentDehydrationThreshold": 7}, policy_elements
+    ) == {"StorageSenseCloudContentDehydrationThreshold": 7}
+    # Display name key is rewritten to the element id.
+    assert win_lgpo._normalize_element_names(
+        {
+            "Number of days since a cloud-backed file has been opened"
+            " before Storage Sense will dehydrate it": 7
+        },
+        policy_elements,
+    ) == {"StorageSenseCloudContentDehydrationThreshold": 7}
+    # Unknown key is left alone so the comparison still flags it.
+    assert win_lgpo._normalize_element_names({"Unknown": 1}, policy_elements) == {
+        "Unknown": 1
+    }
+    # Non-dict inputs are returned unchanged.
+    assert (
+        win_lgpo._normalize_element_names("Not Configured", policy_elements)
+        == "Not Configured"
+    )
+
+
+def test_set_idempotent_when_current_policy_keyed_by_display_name():
+    """
+    Regression test for #68489: ``lgpo.set`` succeeded on the first run but
+    failed on subsequent runs because the state compared a requested
+    dictionary keyed by element id with a current dictionary keyed by the
+    ADML display name. Even when ``lgpo.set`` reported success, the post-set
+    diff was empty and the state declared "Failed to set the following
+    policies".
+    """
+    policy_name = (
+        "System\\Storage Sense\\Configure Storage Sense Cloud Content"
+        " dehydration threshold"
+    )
+    element_id = "StorageSenseCloudContentDehydrationThreshold"
+    display_name = (
+        "Number of days since a cloud-backed file has been opened before"
+        " Storage Sense will dehydrate it"
+    )
+    computer_policy = {policy_name: {element_id: 7}}
+    lookup = {
+        "policy_found": True,
+        "policy_aliases": [policy_name],
+        "rights_assignment": False,
+        "policy_elements": [
+            {
+                "element_id": element_id,
+                "element_aliases": [element_id, display_name],
+            }
+        ],
+        "message": "",
+    }
+    # Current policy comes back keyed by the display name (what
+    # lgpo.get_policy returns when return_full_policy_names=True).
+    current_value = {display_name: 7}
+    salt_mock = {
+        "lgpo.get_policy_info": MagicMock(return_value=lookup),
+        "lgpo.get_policy": MagicMock(return_value=current_value),
+        "lgpo.set": MagicMock(return_value=True),
+        "lgpo.clear_policy_cache": MagicMock(return_value=None),
+    }
+    with patch.dict(win_lgpo.__salt__, salt_mock), patch.dict(
+        win_lgpo.__opts__, {"test": False}
+    ):
+        result = win_lgpo.set_(name="test_state", computer_policy=computer_policy)
+    # Already set means no changes, no failure, and lgpo.set is not invoked.
+    assert result["result"] is True, result
+    assert result["changes"] == {}
+    assert "Failed to set" not in result["comment"]
+    assert salt_mock["lgpo.set"].call_count == 0


### PR DESCRIPTION
### What does this PR do?
Makes the `lgpo.set` state idempotent when the requested policy uses ADMX
element ids for sub-element keys. Previously the state succeeded on the first
run and then reported "Failed to set the following policies" on every
subsequent run for any policy with sub-elements.

### What issues does this PR fix or reference?
Fixes #68489

### Previous Behavior
The state compared a requested dict keyed by ADMX element id with a current
dict (read back via `lgpo.get_policy`) keyed by the ADML display name. The
two keys differ, so the comparison declared a change. `lgpo.set` returned
True (no work to do), the post-set diff was empty, and the state returned
`result=False, comment="Failed to set the following policies: …"`.

### New Behavior
The comparison normalizes both the requested and current sub-element dicts
to the canonical ADMX `element_id` (using the `policy_elements`
metadata already retrieved via `lgpo.get_policy_info`) before
`_compare_policies` runs. Both alias forms now compare equal, so repeated
state runs are idempotent.

### Merge requirements satisfied?
- [x] Docs (no documented behavior changes)
- [x] Changelog (`changelog/68489.fixed.md`)
- [x] Tests written/updated (new unit + regression tests in
      `tests/pytests/unit/states/test_win_lgpo.py`)

### Commits signed with GPG?
No
