### PR TITLE
Fix jobs.list_jobs search_metadata for CLI keyword metadata (#68481)

### DIFF
--- a/changelog/68481.fixed.md
+++ b/changelog/68481.fixed.md
@@ -1,0 +1,4 @@
+Fixed ``jobs.list_jobs search_metadata`` so it matches jobs whose metadata
+was passed as a CLI keyword argument (e.g. ``state.apply metadata={...}``)
+and is therefore carried inside the job's ``Arguments`` rather than at the
+top of the job payload.

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -558,10 +558,22 @@ def _format_job_instance(job):
 
     if "metadata" in job:
         ret["Metadata"] = job.get("metadata", {})
+    elif "kwargs" in job and "metadata" in job["kwargs"]:
+        ret["Metadata"] = job["kwargs"].get("metadata", {})
     else:
-        if "kwargs" in job:
-            if "metadata" in job["kwargs"]:
-                ret["Metadata"] = job["kwargs"].get("metadata", {})
+        # When ``metadata`` is passed as a keyword argument on the CLI
+        # (e.g. ``salt '*' state.apply foo metadata='{...}'``) it is
+        # carried inside ``arg`` as a ``__kwarg__: True`` dict rather
+        # than at the top of the job payload. Surface it as ``Metadata``
+        # so ``jobs.list_jobs search_metadata=...`` can match it.
+        for arg in job.get("arg", []) or []:
+            if (
+                isinstance(arg, dict)
+                and arg.get("__kwarg__") is True
+                and "metadata" in arg
+            ):
+                ret["Metadata"] = arg.get("metadata", {})
+                break
 
     if "Minions" in job:
         ret["Minions"] = job["Minions"]

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -85,10 +85,22 @@ def format_job_instance(job):
 
     if "metadata" in job:
         ret["Metadata"] = job.get("metadata", {})
+    elif "kwargs" in job and "metadata" in job["kwargs"]:
+        ret["Metadata"] = job["kwargs"].get("metadata", {})
     else:
-        if "kwargs" in job:
-            if "metadata" in job["kwargs"]:
-                ret["Metadata"] = job["kwargs"].get("metadata", {})
+        # When ``metadata`` is passed as a keyword argument on the CLI
+        # (e.g. ``salt '*' state.apply foo metadata='{...}'``) it is
+        # carried inside ``arg`` as a ``__kwarg__: True`` dict rather
+        # than at the top of the job payload. Surface it as ``Metadata``
+        # so ``jobs.list_jobs search_metadata=...`` can match it.
+        for arg in job.get("arg", []) or []:
+            if (
+                isinstance(arg, dict)
+                and arg.get("__kwarg__") is True
+                and "metadata" in arg
+            ):
+                ret["Metadata"] = arg.get("metadata", {})
+                break
     return ret
 
 

--- a/tests/pytests/unit/runners/test_jobs.py
+++ b/tests/pytests/unit/runners/test_jobs.py
@@ -6,6 +6,7 @@ import pytest
 
 import salt.minion
 import salt.runners.jobs as jobs
+import salt.utils.jid
 from tests.support.mock import patch
 
 
@@ -70,3 +71,87 @@ def test_list_jobs_with_search_target():
         assert jobs.list_jobs(search_target="node-1-2.com") == returns["node-1-2.com"]
 
         assert jobs.list_jobs(search_target="non-existant") == returns["non-existant"]
+
+
+def test_list_jobs_search_metadata_state_apply():
+    """
+    Ensure list_jobs search_metadata matches jobs whose metadata was
+    passed through the CLI as a keyword argument to state.apply (the
+    metadata then lives inside ``Arguments`` as a ``__kwarg__`` dict
+    rather than at the top of the job instance).
+
+    Regression test for #68481.
+    """
+    # Already-formatted job entries as returned by the
+    # ``local_cache.get_jids`` returner via ``format_jid_instance``. The
+    # cmd.run job exposes ``Metadata`` directly while the state.apply job
+    # carries its metadata inside ``Arguments`` because it was passed as
+    # a keyword argument from the command line (``__kwarg__: True``).
+    state_apply_job = salt.utils.jid.format_job_instance(
+        {
+            "fun": "state.apply",
+            "arg": [
+                "Sandbox.create_test_file",
+                {
+                    "__kwarg__": True,
+                    "metadata": {
+                        "task_id": "bb52013a",
+                        "source": "flask",
+                    },
+                },
+            ],
+            "tgt": ["salt-minion"],
+            "tgt_type": "list",
+            "user": "root",
+        }
+    )
+    cmd_run_job = salt.utils.jid.format_job_instance(
+        {
+            "fun": "cmd.run",
+            "arg": ["echo 'test'"],
+            "metadata": {"task_id": "0c47889f", "source": "Flask"},
+            "tgt": "salt-minion",
+            "tgt_type": "glob",
+            "user": "root",
+        }
+    )
+    other_job = salt.utils.jid.format_job_instance(
+        {
+            "fun": "state.apply",
+            "arg": [
+                "Sandbox.create_test_file",
+                {
+                    "__kwarg__": True,
+                    "metadata": {"task_id": "different"},
+                },
+            ],
+            "tgt": ["salt-minion"],
+            "tgt_type": "list",
+            "user": "root",
+        }
+    )
+    mock_jobs_cache = {
+        "20251121134552341171": state_apply_job,
+        "20251121100403664430": cmd_run_job,
+        "20251121134652341171": other_job,
+    }
+
+    def return_mock_jobs():
+        return mock_jobs_cache
+
+    class MockMasterMinion:
+
+        returners = {"local_cache.get_jids": return_mock_jobs}
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    with patch.object(salt.minion, "MasterMinion", MockMasterMinion):
+        result = jobs.list_jobs(search_metadata={"task_id": "bb52013a"})
+        assert "20251121134552341171" in result
+        assert "20251121100403664430" not in result
+        assert "20251121134652341171" not in result
+
+        result = jobs.list_jobs(search_metadata={"task_id": "0c47889f"})
+        assert "20251121100403664430" in result
+        assert "20251121134552341171" not in result


### PR DESCRIPTION
### What does this PR do?

`jobs.list_jobs search_metadata=...` now matches jobs whose metadata was
passed on the CLI as a keyword argument (e.g.
`salt '*' state.apply foo metadata='{...}'`). Previously only jobs whose
payload carried a top-level `metadata` key (or `kwargs['metadata']`) were
matched, so state.apply jobs — where the CLI parker parks metadata
inside `arg` as a `__kwarg__: True` dict — were silently skipped.

### What issues does this PR fix or reference?

Fixes #68481

### Previous Behavior

```
$ salt-run jobs.list_jobs search_metadata='{"task_id":"bb52013a"}'
{}
```

…even though the same `task_id` was clearly present in the full
`jobs.list_jobs` output, nested inside `Arguments` for a state.apply job.

### New Behavior

The same command now returns the matching state.apply job.

### Merge requirements satisfied?

- [x] Used `pre-commit` to check my changes
- [x] Updated changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
