### PR TITLE
Keep ASCII-armored .asc keys armored in aptpkg (#68464)

### DIFF
--- a/changelog/68464.fixed.md
+++ b/changelog/68464.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``pkg.add_repo_key`` and ``pkgrepo.managed`` so APT keyring files that target an ``.asc`` destination keep their ASCII armor instead of being dearmored, matching the apt-secure(8) convention and allowing armored keyfiles that bundle multiple keys to be installed even when the ``gpg`` binary is not available on the minion.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2291,14 +2291,28 @@ def get_repo_keys(aptkey=True, keydir=None):
     return ret
 
 
-def _decrypt_key(key):
+def _decrypt_key(key, keyfile=None):
     """
     Check if the key needs to be decrypted. If it needs
     to be decrypt it, do so with the gpg binary.
+
+    When the destination ``keyfile`` uses the ``.asc`` extension, the key is
+    intentionally left ASCII-armored: per the apt-secure(8) spec, ``.asc``
+    keyrings are accepted by apt without dearmoring. This also lets keyfiles
+    that bundle more than one armored key (which ``gpg --dearmor`` cannot
+    losslessly round-trip in all configurations) pass through unchanged and
+    avoids requiring ``gpg`` on the minion just to copy the file.
     """
     try:
         with salt.utils.files.fopen(key, "r") as fp:
             if fp.read().strip("-").startswith("BEGIN PGP"):
+                if keyfile and str(keyfile).endswith(".asc"):
+                    log.debug(
+                        "Destination keyfile %s uses .asc extension; "
+                        "leaving key ASCII-armored.",
+                        keyfile,
+                    )
+                    return key
                 if not salt.utils.path.which("gpg"):
                     log.error(
                         "Detected an ASCII armored key %s and the gpg binary is not available. Not decrypting the key.",
@@ -2395,7 +2409,11 @@ def add_repo_key(
             return False
 
         if not aptkey:
-            key = _decrypt_key(cached_source_path)
+            # Decide the destination filename up front so _decrypt_key can
+            # honor the apt-secure(8) convention that .asc keyrings are kept
+            # ASCII-armored rather than dearmored.
+            dest_keyfile = keyfile or pathlib.Path(cached_source_path).name
+            key = _decrypt_key(cached_source_path, keyfile=dest_keyfile)
             if not key:
                 return False
             key = pathlib.Path(str(key))

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -367,6 +367,90 @@ def test_add_repo_key_keyserver_keyid_not_sepcified(
         assert err_msg in err.value.message
 
 
+def test_add_repo_key_ascii_armored_asc_keeps_armor_68464(tmp_path):
+    """
+    Regression test for #68464.
+
+    When ``add_repo_key`` is called with ``aptkey=False`` and the cached
+    source file is an ASCII-armored key whose destination keyfile uses the
+    ``.asc`` extension (as ``signed-by=/etc/apt/keyrings/foo.asc`` does),
+    the key must be copied verbatim. ``gpg --dearmor`` must NOT be invoked,
+    and the absence of the ``gpg`` binary must not cause the call to fail
+    -- per the apt-secure spec, ``.asc`` files are accepted ASCII-armored.
+    """
+    keydir = tmp_path / "keyrings"
+    keydir.mkdir()
+    cached = tmp_path / "cached-unified-streaming.asc"
+    armored_payload = (
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+        "\n"
+        "mDMEY1m4AhYJKwYBBAHaRw8BAQdAabcdefg=\n"
+        "-----END PGP PUBLIC KEY BLOCK-----\n"
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+        "\n"
+        "mDMEY1m4AhYJKwYBBAHaRw8BAQdAxyz1234=\n"
+        "-----END PGP PUBLIC KEY BLOCK-----\n"
+    )
+    cached.write_text(armored_payload)
+
+    cmd_run_all = MagicMock(return_value={"retcode": 0, "stdout": "OK"})
+    with patch.dict(
+        aptpkg.__salt__,
+        {
+            "cp.cache_file": MagicMock(return_value=str(cached)),
+            "cmd.run_all": cmd_run_all,
+        },
+    ), patch("salt.modules.aptpkg.get_repo_keys", MagicMock(return_value={})), patch(
+        "salt.utils.path.which",
+        # apt-key absent (forces aptkey=False branch); gpg also absent
+        # to mimic the reporter's onedir minion where gpg is not bundled.
+        MagicMock(return_value=None),
+    ):
+        ret = aptpkg.add_repo_key(
+            path="salt://files/etc/apt/keyrings/unified-streaming.asc",
+            aptkey=False,
+            keydir=keydir,
+        )
+
+    assert ret is True
+    # gpg --dearmor must never have been invoked.
+    for call_args in cmd_run_all.call_args_list:
+        cmd = call_args.args[0] if call_args.args else call_args.kwargs.get("cmd", [])
+        assert "--dearmor" not in cmd, f"gpg --dearmor was called: {cmd}"
+    # The destination file must exist with the original armored bytes intact.
+    dest = keydir / "cached-unified-streaming.asc"
+    assert dest.is_file()
+    assert dest.read_text() == armored_payload
+
+
+def test_decrypt_key_skips_dearmor_for_asc_destination_68464(tmp_path):
+    """
+    Regression test for #68464.
+
+    ``_decrypt_key`` is the inner helper that decides whether to dearmor.
+    When invoked with an ASCII-armored key whose destination extension is
+    ``.asc``, it must return the input path unchanged (no dearmor) instead
+    of failing because the gpg binary is unavailable.
+    """
+    armored = tmp_path / "unified-streaming.asc"
+    armored.write_text(
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+        "\n"
+        "mDMEY1m4AhYJKwYBBAHaRw8BAQdAabcdefg=\n"
+        "-----END PGP PUBLIC KEY BLOCK-----\n"
+    )
+    cmd_run_all = MagicMock(return_value={"retcode": 0, "stdout": ""})
+    with patch.dict(aptpkg.__salt__, {"cmd.run_all": cmd_run_all}), patch(
+        "salt.utils.path.which", MagicMock(return_value=None)
+    ):
+        # New signature: pass the destination keyfile name so the helper
+        # can decide based on its extension.
+        result = aptpkg._decrypt_key(str(armored), keyfile="unified-streaming.asc")
+    assert result == str(armored)
+    # gpg must not have been invoked.
+    assert not cmd_run_all.called
+
+
 def test_get_repo_keys(repo_keys_var):
     """
     Test - List known repo key details.


### PR DESCRIPTION
### What does this PR do?

Stops `pkg.add_repo_key` (and therefore `pkgrepo.managed` when
`aptkey: false`) from running `gpg --dearmor` on an ASCII-armored key
file when the destination keyring is `.asc`. Per `apt-secure(8)`, apt
accepts ASCII-armored keyrings as long as the filename ends in `.asc`;
binary keyrings use `.gpg`. Salt now respects that convention.

### What issues does this PR fix or reference?

Fixes #68464

### Previous Behavior

With:

```yaml
unified-streaming-repo:
  pkgrepo.managed:
    - name: "deb [signed-by=/etc/apt/keyrings/unified-streaming.asc] ..."
    - aptkey: false
    - key_url: salt://files/etc/apt/keyrings/unified-streaming.asc
```

the minion would log:

> Detected an ASCII armored key ... and the gpg binary is not available.
> Not decrypting the key.
> Failed to configure repo ...: Error: Could not add key: ...

and the repo would not be installed. Even when `gpg` was available, the
dearmor step silently lost data for keyfiles that bundle more than one
armored key (the upstream Unified Streaming key is one such file).

### New Behavior

When the destination keyfile ends in `.asc`, `_decrypt_key` returns the
cached path unchanged and `add_repo_key` copies it verbatim. No `gpg`
required, no data loss for multi-key armored files. Behavior for `.gpg`
destinations is unchanged.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
