### PR TITLE
Fix prereq chain misfire when an intermediate state reports test changes (#68438)

### DIFF
--- a/changelog/68438.fixed.md
+++ b/changelog/68438.fixed.md
@@ -1,0 +1,1 @@
+Fixed a prereq chain bug where a state at the head of a chain (e.g. `state1 -prereq-> state2 -prereq-> state3`) would always run when an intermediate state in the chain always produced changes in test mode (e.g. `test.succeed_with_changes`, `module.run`), even though the tail state of the chain produced no changes.

--- a/salt/state.py
+++ b/salt/state.py
@@ -3315,10 +3315,30 @@ class State:
                         return running
             if low.get("__prereq__"):
                 status, reqs = self.check_requisite(low, running, chunks)
-                self.pre[tag] = self.call(low, chunks, running)
-                if not self.pre[tag]["changes"] and status == "change":
-                    self.pre[tag]["changes"] = {"watch": "watch"}
-                    self.pre[tag]["result"] = None
+                if status == "pre":
+                    # The prereq chain for this state reported no changes, so
+                    # this state should not run either. Mark it as having no
+                    # changes so a state prerequiring this one does not run.
+                    # Fixes #68438.
+                    start_time, duration = _calculate_fake_duration()
+                    pre_ret = {
+                        "changes": {},
+                        "result": True,
+                        "duration": duration,
+                        "start_time": start_time,
+                        "comment": "No changes detected",
+                        "__run_num__": self.__run_num,
+                        "__state_ran__": False,
+                    }
+                    for key in ("__sls__", "__id__", "name"):
+                        pre_ret[key] = low.get(key)
+                    self.pre[tag] = pre_ret
+                    self.__run_num += 1
+                else:
+                    self.pre[tag] = self.call(low, chunks, running)
+                    if not self.pre[tag]["changes"] and status == "change":
+                        self.pre[tag]["changes"] = {"watch": "watch"}
+                        self.pre[tag]["result"] = None
             else:
                 depth += 1
                 # even this depth is being generous. This shouldn't exceed 1 no

--- a/tests/pytests/functional/modules/state/requisites/test_prereq.py
+++ b/tests/pytests/functional/modules/state/requisites/test_prereq.py
@@ -730,3 +730,51 @@ def test_requisites_prereq_fail_in_prereq(state, state_tree):
             ret["test_|-State C_|-State C_|-nop"].full_return["comment"]
             == "State was not run because none of the onchanges reqs changed"
         )
+
+
+def test_requisites_prereq_chain_no_changes_at_tail_68438(state, state_tree):
+    """
+    Test that a prereq chain in which the tail state produces no changes
+    does not cause the head state to run, even when an intermediate state
+    in the chain always produces (test-mode) changes.
+
+    Regression test for #68438.
+
+    Chain:
+
+        state1  --prereq--> state2  --prereq--> state3
+
+    state3 produces no changes, so state2's prereq is satisfied with no
+    pending changes, so state1's prereq should also report no pending
+    changes and state1 should NOT run.
+    """
+    sls_contents = """
+    state1:
+      test.succeed_with_changes:
+        - prereq:
+          - test: state2
+
+    state2:
+      test.succeed_with_changes:
+        - prereq:
+          - test: state3
+
+    state3:
+      test.succeed_without_changes: []
+    """
+    with pytest.helpers.temp_file("requisite.sls", sls_contents, state_tree):
+        ret = state.sls("requisite")
+        state1_tag = "test_|-state1_|-state1_|-succeed_with_changes"
+        state2_tag = "test_|-state2_|-state2_|-succeed_with_changes"
+        state3_tag = "test_|-state3_|-state3_|-succeed_without_changes"
+
+        # state3 has no changes; state2's prereq on state3 is satisfied
+        # with no pending changes, so state2 should not run; therefore
+        # state1's prereq on state2 should also report no pending changes
+        # and state1 should not run.
+        assert ret[state1_tag].full_return["changes"] == {}
+        assert ret[state2_tag].full_return["changes"] == {}
+        assert ret[state3_tag].full_return["changes"] == {}
+        assert ret[state1_tag].result is True
+        assert ret[state2_tag].result is True
+        assert ret[state3_tag].result is True


### PR DESCRIPTION
### What does this PR do?

Fixes a prereq chain bug where a state at the head of a chain
(`state1 -prereq-> state2 -prereq-> state3`) would always run when an
intermediate state in the chain always produces changes in test mode
(e.g. `test.succeed_with_changes`, `module.run`), even though the tail
state of the chain produced no changes.

### What issues does this PR fix or reference?

Fixes #68438

### Previous Behavior

For the chain in the issue:

```sls
state1:
  test.succeed_with_changes:
  - prereq:
    - test: state2

state2:
  test.succeed_with_changes:
  - prereq:
    - test: state3

state3:
  test.succeed_without_changes: []
```

state1 produced changes even though state3 reported no changes.

### New Behavior

state1 reports no changes when the tail of the prereq chain reports no
changes, matching documented prereq semantics.

### Merge requirements satisfied?

- [x] Used a personal fork of the source repository to submit this PR
- [x] Tests written/updated
- [x] Changelog entry
- [x] Documentation updated

### Commits signed with GPG?

Yes
