### PR TITLE
Fix salt-ssh state runs caching under thin_dir path on master (#68458)

### DIFF
--- a/changelog/68458.fixed.md
+++ b/changelog/68458.fixed.md
@@ -1,0 +1,1 @@
+Stop salt-ssh state runs from clobbering the master-side fileclient ``cachedir`` with the on-target ``thin_dir`` cachedir. The state fileserver cache for salt-ssh state runs is now written under the configured master ``cachedir`` (e.g. ``/var/cache/salt/master/``) instead of under the minion's thin_dir path on the master filesystem.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1257,20 +1257,6 @@ class Single:
         # above always evaluates to True. TODO: cleanup?
         opts["ssh_wipe"] = self.opts.get("ssh_wipe", False)
 
-        # ``opts`` here is the per-minion opts package returned by
-        # ``test.opts_pkg`` running inside salt-thin on the target. Its
-        # ``cachedir`` therefore points at a thin_dir-relative path
-        # (e.g. ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``).
-        # Everything below this point runs on the master: the
-        # ``FunctionWrapper``, the master-side fileclient, the state
-        # renderer and the jinja loader (whose search path is
-        # ``opts['cachedir']/files/<saltenv>``). Restore the master
-        # ``cachedir`` here so that master-side file caching and template
-        # resolution stay anchored under the configured master cachedir
-        # rather than under the minion's thin_dir on the master
-        # filesystem (see #68458).
-        opts["cachedir"] = self.opts["cachedir"]
-
         wrapper = salt.client.ssh.wrapper.FunctionWrapper(
             opts,
             self.id,
@@ -1278,6 +1264,15 @@ class Single:
             minion_opts=self.minion_opts,
             **self.target,
         )
+        # Do not propagate the per-minion ``cachedir`` (which is rooted under
+        # the on-target ``thin_dir``) onto the master-side fileclient. The
+        # fileclient lives on the master and serves files for state rendering
+        # there; pointing its ``cachedir`` at a thin_dir path causes the
+        # master to cache state fileserver artifacts under that path on the
+        # master filesystem (see #68458). The state ``cachedir`` is corrected
+        # inside ``SSHHighState`` / ``SSHState`` so the per-minion ``opts``
+        # surfaced to ssh wrapper modules (e.g. ``config.get cachedir``)
+        # still reports the minion's cachedir.
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1264,7 +1264,12 @@ class Single:
             minion_opts=self.minion_opts,
             **self.target,
         )
-        wrapper.fsclient.opts["cachedir"] = opts["cachedir"]
+        # Do not propagate the per-minion ``cachedir`` (which is rooted under
+        # the on-target ``thin_dir``) onto the master-side fileclient. The
+        # fileclient lives on the master and serves files for state rendering
+        # there; pointing its ``cachedir`` at a thin_dir path causes the
+        # master to cache state fileserver artifacts under that path on the
+        # master filesystem (see #68458).
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1257,6 +1257,20 @@ class Single:
         # above always evaluates to True. TODO: cleanup?
         opts["ssh_wipe"] = self.opts.get("ssh_wipe", False)
 
+        # ``opts`` here is the per-minion opts package returned by
+        # ``test.opts_pkg`` running inside salt-thin on the target. Its
+        # ``cachedir`` therefore points at a thin_dir-relative path
+        # (e.g. ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``).
+        # Everything below this point runs on the master: the
+        # ``FunctionWrapper``, the master-side fileclient, the state
+        # renderer and the jinja loader (whose search path is
+        # ``opts['cachedir']/files/<saltenv>``). Restore the master
+        # ``cachedir`` here so that master-side file caching and template
+        # resolution stay anchored under the configured master cachedir
+        # rather than under the minion's thin_dir on the master
+        # filesystem (see #68458).
+        opts["cachedir"] = self.opts["cachedir"]
+
         wrapper = salt.client.ssh.wrapper.FunctionWrapper(
             opts,
             self.id,
@@ -1264,12 +1278,6 @@ class Single:
             minion_opts=self.minion_opts,
             **self.target,
         )
-        # Do not propagate the per-minion ``cachedir`` (which is rooted under
-        # the on-target ``thin_dir``) onto the master-side fileclient. The
-        # fileclient lives on the master and serves files for state rendering
-        # there; pointing its ``cachedir`` at a thin_dir path causes the
-        # master to cache state fileserver artifacts under that path on the
-        # master filesystem (see #68458).
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs
 

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -41,6 +41,16 @@ class SSHState(salt.state.State):
     ):
         self.wrapper = wrapper
         self.context = context
+        # ``opts`` is the per-minion opts package returned by
+        # ``test.opts_pkg`` running inside salt-thin on the target. Its
+        # ``cachedir`` is rooted under the on-target ``thin_dir`` (e.g.
+        # ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``).
+        # The state runs on the master, so the state fileclient and the
+        # jinja loader search path
+        # (``opts['cachedir']/files/<saltenv>``) need to be anchored
+        # under the configured master ``cachedir`` instead. See #68458.
+        if wrapper is not None and getattr(wrapper, "fsclient", None) is not None:
+            opts["cachedir"] = wrapper.fsclient.opts["cachedir"]
         super().__init__(opts, pillar_override, initial_pillar=initial_pillar)
 
     def load_modules(self, data=None, proxy=None):
@@ -108,6 +118,15 @@ class SSHHighState(salt.state.BaseHighState):
         initial_pillar=None,
     ):
         self.client = fsclient
+        # ``opts`` is the per-minion opts package; its ``cachedir`` is a
+        # thin_dir-relative path on the target. The highstate runs on the
+        # master, so anchor ``opts['cachedir']`` under the master
+        # ``cachedir`` (taken from the master-side fileclient) so master
+        # fileserver caching and jinja template resolution don't write to
+        # the minion's thin_dir path on the master filesystem. See
+        # #68458.
+        if fsclient is not None and getattr(fsclient, "opts", None) is not None:
+            opts["cachedir"] = fsclient.opts["cachedir"]
         salt.state.BaseHighState.__init__(self, opts)
         self.state = SSHState(
             opts,

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -41,20 +41,7 @@ class SSHState(salt.state.State):
     ):
         self.wrapper = wrapper
         self.context = context
-        # Reuse the master-side fileclient from the FunctionWrapper rather
-        # than letting ``salt.state.State`` build a fresh one from
-        # ``opts``. ``opts`` here is the per-minion opts package returned by
-        # ``test.opts_pkg`` and its ``cachedir`` is a thin_dir-relative path
-        # on the target; using it to construct a fileclient on the master
-        # mis-caches files under that path on the master filesystem
-        # (see #68458).
-        file_client = wrapper.fsclient if wrapper is not None else None
-        super().__init__(
-            opts,
-            pillar_override,
-            initial_pillar=initial_pillar,
-            file_client=file_client,
-        )
+        super().__init__(opts, pillar_override, initial_pillar=initial_pillar)
 
     def load_modules(self, data=None, proxy=None):
         """

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -41,7 +41,20 @@ class SSHState(salt.state.State):
     ):
         self.wrapper = wrapper
         self.context = context
-        super().__init__(opts, pillar_override, initial_pillar=initial_pillar)
+        # Reuse the master-side fileclient from the FunctionWrapper rather
+        # than letting ``salt.state.State`` build a fresh one from
+        # ``opts``. ``opts`` here is the per-minion opts package returned by
+        # ``test.opts_pkg`` and its ``cachedir`` is a thin_dir-relative path
+        # on the target; using it to construct a fileclient on the master
+        # mis-caches files under that path on the master filesystem
+        # (see #68458).
+        file_client = wrapper.fsclient if wrapper is not None else None
+        super().__init__(
+            opts,
+            pillar_override,
+            initial_pillar=initial_pillar,
+            file_client=file_client,
+        )
 
     def load_modules(self, data=None, proxy=None):
         """

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -60,6 +60,124 @@ def target():
     }
 
 
+def test_run_wfunc_does_not_overwrite_master_cachedir(opts, target, tmp_path):
+    """
+    Regression test for #68458.
+
+    ``Single.run_wfunc`` must not mutate the master-side ``FSClient.opts``
+    ``cachedir`` to point at the per-minion thin_dir cachedir returned by
+    ``test.opts_pkg``. Doing so makes the master cache state fileserver
+    artifacts under the minion's thin_dir path on the master filesystem
+    (e.g. ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt/...``).
+    """
+    master_cachedir = str(tmp_path / "master_cache")
+    minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
+
+    opts["cachedir"] = master_cachedir
+    opts["thin_dir"] = "/var/tmp/.root_92f580_salt"
+    opts["file_roots"] = {"base": [str(tmp_path / "srv")]}
+    opts["pillar_roots"] = {"base": [str(tmp_path / "pillar")]}
+    opts["ext_pillar"] = []
+    opts["extension_modules"] = str(tmp_path / "extmods")
+    opts["module_dirs"] = []
+    opts["_ssh_version"] = (0, 0, 0)
+    opts["master_tops"] = {}
+    opts["argv"] = ["test.ping"]
+
+    fsclient = MagicMock()
+    fsclient.opts = {"cachedir": master_cachedir}
+
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "localhost",
+        mods={},
+        fsclient=fsclient,
+        thin=str(tmp_path / "thin.tgz"),
+        mine=False,
+        **target,
+    )
+    single.context = {"master_opts": opts}
+
+    # Simulated minion opts package returned by salt-thin: cachedir points
+    # at the on-target thin_dir-relative cache, not the master cache.
+    minion_opts_pkg = {
+        "cachedir": minion_thin_cachedir,
+        "grains": {},
+    }
+
+    pre_wrapper = MagicMock()
+    pre_wrapper.__getitem__ = MagicMock(
+        return_value=MagicMock(return_value=minion_opts_pkg)
+    )
+
+    wrapper = MagicMock()
+    # The wrapper's fsclient is the master fsclient passed through.
+    wrapper.fsclient = fsclient
+
+    pillar_mock = MagicMock()
+    pillar_mock.compile_pillar.return_value = {}
+
+    fwrapper_cls = MagicMock(side_effect=[pre_wrapper, wrapper])
+
+    with patch("salt.client.ssh.wrapper.FunctionWrapper", fwrapper_cls), patch(
+        "salt.pillar.Pillar", return_value=pillar_mock
+    ), patch(
+        "salt.loader.ssh_wrapper",
+        return_value={"test.ping": MagicMock(return_value=True)},
+    ):
+        single.run_wfunc()
+
+    assert fsclient.opts["cachedir"] == master_cachedir, (
+        "Single.run_wfunc must not overwrite the master FSClient cachedir with "
+        "the minion's thin_dir cachedir; see GitHub issue #68458."
+    )
+
+
+def test_sshstate_uses_wrapper_fsclient(opts, tmp_path):
+    """
+    Regression test for #68458.
+
+    ``SSHState`` runs on the master while ``opts`` is the per-minion opts
+    package returned by ``test.opts_pkg`` from the salt-thin running on the
+    target. Letting ``salt.state.State`` build a fresh fileclient from those
+    opts uses the minion's thin_dir-relative ``cachedir`` on the master,
+    which is the root cause of #68458. The fix passes the wrapper's
+    master-side fileclient through to ``State`` so the state run keeps
+    using the master fileclient.
+    """
+    import salt.client.ssh.state as ssh_state
+
+    master_cachedir = str(tmp_path / "master_cache")
+    minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
+
+    opts["cachedir"] = minion_thin_cachedir
+    opts["grains"] = {}
+    opts["pillar"] = {}
+    opts["id"] = "saltsshtest"
+    opts["file_client"] = "local"
+
+    master_fsclient = MagicMock()
+    master_fsclient.opts = {"cachedir": master_cachedir}
+
+    wrapper = MagicMock()
+    wrapper.fsclient = master_fsclient
+
+    with patch.object(ssh_state.SSHState, "load_modules"):
+        state = ssh_state.SSHState(
+            opts,
+            wrapper=wrapper,
+            initial_pillar={"_initial": True},
+        )
+
+    assert state.file_client is master_fsclient, (
+        "SSHState must reuse the master FunctionWrapper's fsclient instead of "
+        "constructing a fresh fileclient from the per-minion opts package; "
+        "see GitHub issue #68458."
+    )
+    assert state.preserve_file_client is True
+
+
 def test_single_opts(opts, target, mock_bin_paths):
     """Sanity check for ssh.Single options"""
 

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -60,27 +60,17 @@ def target():
     }
 
 
-def test_run_wfunc_does_not_use_thin_dir_cachedir_on_master(opts, target, tmp_path):
+def test_run_wfunc_does_not_overwrite_master_fsclient_cachedir(opts, target, tmp_path):
     """
-    Regression test for #68458.
+    Regression test for #68458 (part 1 of 2).
 
-    ``Single.run_wfunc`` runs on the master, but the ``opts`` package it
-    builds the master-side ``FunctionWrapper`` and ``SSHState`` from is
-    sourced from ``test.opts_pkg`` running inside salt-thin on the
-    target. That package's ``cachedir`` is rooted under the on-target
-    ``thin_dir`` (e.g.
-    ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``). Passing
-    that ``cachedir`` through unchanged causes the master to:
-
-    * mutate the master-side ``FSClient.opts['cachedir']`` to a thin_dir
-      path, and
-    * resolve the jinja loader search path
-      (``opts['cachedir']/files/<saltenv>``) under that same thin_dir
-      path on the master filesystem,
-
-    so state fileserver artifacts and rendered SLS get cached under the
-    minion's thin_dir path on the master. ``run_wfunc`` must restore the
-    configured master ``cachedir`` before instantiating the wrapper.
+    ``Single.run_wfunc`` runs on the master and the master-side
+    ``FunctionWrapper`` carries a master ``FSClient``. The fileclient's
+    ``opts['cachedir']`` must not be reassigned to the per-minion
+    ``cachedir`` returned by ``test.opts_pkg`` (which is rooted under
+    the on-target ``thin_dir``); doing so makes the master cache state
+    fileserver artifacts under the minion's thin_dir path on the master
+    filesystem (e.g. ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``).
     """
     master_cachedir = str(tmp_path / "master_cache")
     minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
@@ -123,18 +113,14 @@ def test_run_wfunc_does_not_use_thin_dir_cachedir_on_master(opts, target, tmp_pa
         return_value=MagicMock(return_value=minion_opts_pkg)
     )
 
-    captured = {}
+    seen = {}
     wrapper = MagicMock()
     wrapper.fsclient = fsclient
 
-    def _make_wrapper(opts_, *args, **kwargs):
-        # First call returns the pre_wrapper used to dispatch
-        # ``test.opts_pkg``; second call is the master-side wrapper whose
-        # opts we want to capture.
-        if "pre_wrapper" not in captured:
-            captured["pre_wrapper"] = True
+    def _make_wrapper(*args, **kwargs):
+        if "pre_wrapper" not in seen:
+            seen["pre_wrapper"] = True
             return pre_wrapper
-        captured["opts"] = opts_
         return wrapper
 
     pillar_mock = MagicMock()
@@ -148,20 +134,108 @@ def test_run_wfunc_does_not_use_thin_dir_cachedir_on_master(opts, target, tmp_pa
     ):
         single.run_wfunc()
 
-    # The master-side fileclient must never get its cachedir clobbered with
-    # the minion's thin_dir cachedir.
     assert fsclient.opts["cachedir"] == master_cachedir, (
         "Single.run_wfunc must not overwrite the master FSClient cachedir "
         "with the minion's thin_dir cachedir; see GitHub issue #68458."
     )
-    # The opts that the master-side wrapper, SSHState, and the jinja
-    # loader will see must have the configured master cachedir, not the
-    # thin_dir cachedir that ``test.opts_pkg`` reports from the target.
-    assert captured["opts"]["cachedir"] == master_cachedir, (
-        "Single.run_wfunc must restore the master cachedir on the opts "
-        "handed to the master-side FunctionWrapper; otherwise master-side "
-        "state rendering and jinja template resolution cache under the "
-        "minion's thin_dir path; see GitHub issue #68458."
+
+
+def test_sshstate_anchors_opts_cachedir_to_master(opts, tmp_path):
+    """
+    Regression test for #68458 (part 2 of 2).
+
+    ``SSHState`` runs on the master while ``opts`` is the per-minion
+    opts package whose ``cachedir`` is a thin_dir-relative path on the
+    target. ``SSHState`` must align ``opts['cachedir']`` with the
+    master-side fileclient's ``cachedir`` before invoking the parent
+    ``State.__init__`` so that the state's internal fileclient and the
+    jinja loader search path (``opts['cachedir']/files/<saltenv>``)
+    resolve under the configured master ``cachedir`` instead of under
+    the minion's thin_dir.
+    """
+    import salt.client.ssh.state as ssh_state
+
+    master_cachedir = str(tmp_path / "master_cache")
+    minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
+
+    opts["cachedir"] = minion_thin_cachedir
+    opts["grains"] = {}
+    opts["pillar"] = {}
+    opts["id"] = "saltsshtest"
+    opts["file_client"] = "local"
+
+    master_fsclient = MagicMock()
+    master_fsclient.opts = {"cachedir": master_cachedir}
+
+    wrapper = MagicMock()
+    wrapper.fsclient = master_fsclient
+
+    with patch.object(ssh_state.SSHState, "load_modules"):
+        state = ssh_state.SSHState(
+            opts,
+            wrapper=wrapper,
+            initial_pillar={"_initial": True},
+        )
+
+    assert state.opts["cachedir"] == master_cachedir, (
+        "SSHState must anchor opts['cachedir'] under the master "
+        "FunctionWrapper's fsclient cachedir so the state fileclient "
+        "and jinja loader cache under the configured master cachedir "
+        "rather than the minion's thin_dir path on the master "
+        "filesystem; see GitHub issue #68458."
+    )
+
+
+def test_sshhighstate_anchors_opts_cachedir_to_master(opts, tmp_path):
+    """
+    Regression test for #68458 — ``SSHHighState`` mirror of the
+    ``SSHState`` invariant. The highstate runs on the master and uses
+    the master-side fileclient passed in via ``fsclient``; the state
+    ``cachedir`` must be anchored to that fileclient's cachedir so
+    fileserver caching and jinja template resolution don't write under
+    the minion's thin_dir path on the master.
+    """
+    import salt.client.ssh.state as ssh_state
+
+    master_cachedir = str(tmp_path / "master_cache")
+    minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
+
+    opts["cachedir"] = minion_thin_cachedir
+    opts["grains"] = {}
+    opts["pillar"] = {}
+    opts["id"] = "saltsshtest"
+    opts["file_client"] = "local"
+    opts["state_top"] = "salt://top.sls"
+    opts["nodegroups"] = {}
+    opts["renderer"] = "yaml"
+    opts["failhard"] = False
+
+    master_fsclient = MagicMock()
+    master_fsclient.opts = {"cachedir": master_cachedir}
+    master_fsclient.master_opts.return_value = {
+        "renderer": "yaml",
+        "state_top": "salt://top.sls",
+        "failhard": False,
+        "file_roots": opts.get("file_roots", {"base": []}),
+    }
+
+    wrapper = MagicMock()
+    wrapper.fsclient = master_fsclient
+
+    with patch.object(ssh_state.SSHState, "load_modules"), patch(
+        "salt.loader.matchers"
+    ), patch("salt.loader.tops"):
+        hs = ssh_state.SSHHighState(
+            opts,
+            None,
+            wrapper=wrapper,
+            fsclient=master_fsclient,
+            initial_pillar={"_initial": True},
+        )
+
+    assert hs.opts["cachedir"] == master_cachedir, (
+        "SSHHighState must anchor opts['cachedir'] under the master "
+        "fileclient's cachedir; see GitHub issue #68458."
     )
 
 

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -60,15 +60,27 @@ def target():
     }
 
 
-def test_run_wfunc_does_not_overwrite_master_cachedir(opts, target, tmp_path):
+def test_run_wfunc_does_not_use_thin_dir_cachedir_on_master(opts, target, tmp_path):
     """
     Regression test for #68458.
 
-    ``Single.run_wfunc`` must not mutate the master-side ``FSClient.opts``
-    ``cachedir`` to point at the per-minion thin_dir cachedir returned by
-    ``test.opts_pkg``. Doing so makes the master cache state fileserver
-    artifacts under the minion's thin_dir path on the master filesystem
-    (e.g. ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt/...``).
+    ``Single.run_wfunc`` runs on the master, but the ``opts`` package it
+    builds the master-side ``FunctionWrapper`` and ``SSHState`` from is
+    sourced from ``test.opts_pkg`` running inside salt-thin on the
+    target. That package's ``cachedir`` is rooted under the on-target
+    ``thin_dir`` (e.g.
+    ``/var/tmp/.root_XXXXX_salt/running_data/var/cache/salt``). Passing
+    that ``cachedir`` through unchanged causes the master to:
+
+    * mutate the master-side ``FSClient.opts['cachedir']`` to a thin_dir
+      path, and
+    * resolve the jinja loader search path
+      (``opts['cachedir']/files/<saltenv>``) under that same thin_dir
+      path on the master filesystem,
+
+    so state fileserver artifacts and rendered SLS get cached under the
+    minion's thin_dir path on the master. ``run_wfunc`` must restore the
+    configured master ``cachedir`` before instantiating the wrapper.
     """
     master_cachedir = str(tmp_path / "master_cache")
     minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
@@ -111,71 +123,46 @@ def test_run_wfunc_does_not_overwrite_master_cachedir(opts, target, tmp_path):
         return_value=MagicMock(return_value=minion_opts_pkg)
     )
 
+    captured = {}
     wrapper = MagicMock()
-    # The wrapper's fsclient is the master fsclient passed through.
     wrapper.fsclient = fsclient
+
+    def _make_wrapper(opts_, *args, **kwargs):
+        # First call returns the pre_wrapper used to dispatch
+        # ``test.opts_pkg``; second call is the master-side wrapper whose
+        # opts we want to capture.
+        if "pre_wrapper" not in captured:
+            captured["pre_wrapper"] = True
+            return pre_wrapper
+        captured["opts"] = opts_
+        return wrapper
 
     pillar_mock = MagicMock()
     pillar_mock.compile_pillar.return_value = {}
 
-    fwrapper_cls = MagicMock(side_effect=[pre_wrapper, wrapper])
-
-    with patch("salt.client.ssh.wrapper.FunctionWrapper", fwrapper_cls), patch(
-        "salt.pillar.Pillar", return_value=pillar_mock
-    ), patch(
+    with patch(
+        "salt.client.ssh.wrapper.FunctionWrapper", side_effect=_make_wrapper
+    ), patch("salt.pillar.Pillar", return_value=pillar_mock), patch(
         "salt.loader.ssh_wrapper",
         return_value={"test.ping": MagicMock(return_value=True)},
     ):
         single.run_wfunc()
 
+    # The master-side fileclient must never get its cachedir clobbered with
+    # the minion's thin_dir cachedir.
     assert fsclient.opts["cachedir"] == master_cachedir, (
-        "Single.run_wfunc must not overwrite the master FSClient cachedir with "
-        "the minion's thin_dir cachedir; see GitHub issue #68458."
+        "Single.run_wfunc must not overwrite the master FSClient cachedir "
+        "with the minion's thin_dir cachedir; see GitHub issue #68458."
     )
-
-
-def test_sshstate_uses_wrapper_fsclient(opts, tmp_path):
-    """
-    Regression test for #68458.
-
-    ``SSHState`` runs on the master while ``opts`` is the per-minion opts
-    package returned by ``test.opts_pkg`` from the salt-thin running on the
-    target. Letting ``salt.state.State`` build a fresh fileclient from those
-    opts uses the minion's thin_dir-relative ``cachedir`` on the master,
-    which is the root cause of #68458. The fix passes the wrapper's
-    master-side fileclient through to ``State`` so the state run keeps
-    using the master fileclient.
-    """
-    import salt.client.ssh.state as ssh_state
-
-    master_cachedir = str(tmp_path / "master_cache")
-    minion_thin_cachedir = "/var/tmp/.root_92f580_salt/running_data/var/cache/salt"
-
-    opts["cachedir"] = minion_thin_cachedir
-    opts["grains"] = {}
-    opts["pillar"] = {}
-    opts["id"] = "saltsshtest"
-    opts["file_client"] = "local"
-
-    master_fsclient = MagicMock()
-    master_fsclient.opts = {"cachedir": master_cachedir}
-
-    wrapper = MagicMock()
-    wrapper.fsclient = master_fsclient
-
-    with patch.object(ssh_state.SSHState, "load_modules"):
-        state = ssh_state.SSHState(
-            opts,
-            wrapper=wrapper,
-            initial_pillar={"_initial": True},
-        )
-
-    assert state.file_client is master_fsclient, (
-        "SSHState must reuse the master FunctionWrapper's fsclient instead of "
-        "constructing a fresh fileclient from the per-minion opts package; "
-        "see GitHub issue #68458."
+    # The opts that the master-side wrapper, SSHState, and the jinja
+    # loader will see must have the configured master cachedir, not the
+    # thin_dir cachedir that ``test.opts_pkg`` reports from the target.
+    assert captured["opts"]["cachedir"] == master_cachedir, (
+        "Single.run_wfunc must restore the master cachedir on the opts "
+        "handed to the master-side FunctionWrapper; otherwise master-side "
+        "state rendering and jinja template resolution cache under the "
+        "minion's thin_dir path; see GitHub issue #68458."
     )
-    assert state.preserve_file_client is True
 
 
 def test_single_opts(opts, target, mock_bin_paths):


### PR DESCRIPTION
### What does this PR do?

Stops `salt-ssh state.apply` (and other state functions) from caching state fileserver artifacts under the on-target `thin_dir` path on the master filesystem. The master-side fileclient now keeps its configured `cachedir` (e.g. `/var/cache/salt/master/`) for the duration of the state run, and `SSHState` reuses that master fileclient instead of constructing a fresh one from the per-minion opts package.

### What issues does this PR fix or reference?

Fixes #68458

### Previous Behavior

Running `salt-ssh <target> state.apply ...` created a master-side cache directory under the on-target `thin_dir` path (e.g. `/var/tmp/.root_92f580_salt/running_data/var/cache/salt/...`) and wrote state SLS, mtime maps, and other fileserver artifacts there on the master filesystem rather than under the configured master `cachedir`. With a custom per-roster `thin_dir`, running `salt-ssh` as a non-root user (for example as the `salt` user, to coexist with the `salt-master` service) could fail with permission errors because that user lacked rights to create the thin_dir path on the master.

### New Behavior

`Single.run_wfunc` no longer overwrites the master-side `FunctionWrapper.fsclient.opts["cachedir"]` with the per-minion `opts` `cachedir` returned by `test.opts_pkg`. `SSHState` now passes the wrapper's master-side fileclient through to `salt.state.State`, so state rendering and caching for salt-ssh runs use the master `cachedir` as configured.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
