### PR TITLE
Fix user.setpassword reporting success on missing user (#68428)

### DIFF
--- a/changelog/68428.fixed.md
+++ b/changelog/68428.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``user.setpassword`` on Windows reporting success (``retcode: 0``) when the target user does not exist. The execution module now returns ``False`` and logs an error in that case, so callers and the ``user.present`` state correctly detect the failure instead of swallowing the Win32 "user name could not be found" message as a successful return.

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -532,7 +532,15 @@ def setpassword(name, password):
 
         salt '*' user.setpassword jsnuffy sup3rs3cr3t
     """
-    return update(name=name, password=password)
+    # update() returns the Win32 error string on failure (e.g. when the user
+    # does not exist), which is truthy and would otherwise be misreported as
+    # success by callers that check the return value as a boolean. Verify the
+    # user exists first so we can return a proper ``False`` and surface a
+    # clear log message.
+    if not info(name):
+        log.error("User '%s' does not exist", name)
+        return False
+    return update(name=name, password=password) is True
 
 
 def addgroup(name, group):

--- a/tests/pytests/unit/modules/test_win_useradd.py
+++ b/tests/pytests/unit/modules/test_win_useradd.py
@@ -9,8 +9,17 @@ from tests.support.mock import MagicMock, patch
 
 try:
     import pywintypes
+    import win32net
 
     WINAPI = True
+
+    class _WinNetError(win32net.error):
+        """Subclass that lets us instantiate a win32net.error in tests."""
+
+        winerror = 2221  # NERR_UserNotFound
+        funcname = "NetUserGetInfo"
+        strerror = "The user name could not be found."
+
 except ImportError:
     WINAPI = False
 
@@ -83,3 +92,34 @@ def test_info_error(account, caplog):
         account.username = f"{domain}\\{account.username}"
         win_useradd.info(account.username)
     assert f"DC not found. Using username: {account.username}" in caplog.text
+
+
+@pytest.mark.skipif(not WINAPI, reason="pywin32 not available")
+def test_setpassword_user_not_found(caplog):
+    """
+    Regression test for #68428.
+
+    ``user.setpassword`` must return ``False`` (not the Win32 error string)
+    when the target user does not exist, so the CLI and the ``user.present``
+    state correctly report failure instead of a bogus success.
+    """
+    missing_user = random_string("missing-account-", uppercase=False)
+
+    # Force info() to behave as it does when the user doesn't exist: the
+    # NetUserGetInfo lookup raises win32net.error and info() returns an empty
+    # dict. We patch the underlying win32net call so the production code path
+    # in both info() and update() is exercised.
+    with caplog.at_level(logging.ERROR), patch(
+        "win32net.NetUserGetInfo",
+        MagicMock(
+            side_effect=_WinNetError(
+                2221, "NetUserGetInfo", "The user name could not be found."
+            )
+        ),
+    ):
+        result = win_useradd.setpassword(missing_user, "P@ssw0rd")
+
+    assert (
+        result is False
+    ), f"setpassword on a missing user must return False, got {result!r}"
+    assert f"User '{missing_user}' does not exist" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Fixes `user.setpassword` on Windows silently returning a success result when the target user does not exist. The execution module now returns `False` with a clear error log instead of forwarding the raw Win32 "user name could not be found" message as a truthy return value.

### What issues does this PR fix or reference?

Fixes #68428

### Previous Behavior

```
salt 'win-minion' user.setpassword nonexistent some_password
win-minion:
    The user name could not be found.
```
The JSON return shows `"retcode": 0, "success": true`, so the failure is invisible to orchestrators. The same masking happens inside the `user.present` state, whose `if not __salt__["user.setpassword"](...)` check treats the truthy error string as success.

### New Behavior

`user.setpassword` probes the user with `info()` before delegating to `update()`. If the user does not exist it logs `User '<name>' does not exist` and returns `False`. The CLI now reports the call as a failure and `user.present` correctly detects the failure.

### Merge requirements satisfied?

- [x] Docs (no documented behavior change; module docstring already says `bool`)
- [x] Changelog (`changelog/68428.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/modules/test_win_useradd.py::test_setpassword_user_not_found`)

### Commits signed with GPG?

Yes
