### PR TITLE
Fix salt://-URL truncation on Python 3.13+ (#68421)

### DIFF
--- a/changelog/68421.fixed.md
+++ b/changelog/68421.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt.utils.url.create`` so ``salt://`` URLs built from relative paths round-trip correctly on Python 3.13+, where ``urllib.parse.urlunparse`` no longer emits a ``file:///`` prefix for relative paths. salt-ssh ``file.managed`` ``source: salt://...`` references now resolve as expected on newer-Python targets (e.g. Debian trixie).

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -4,7 +4,7 @@ URL utils
 
 import re
 import sys
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse, urlunsplit
 
 import salt.utils.data
 import salt.utils.path
@@ -46,8 +46,7 @@ def create(path, saltenv=None):
     path = salt.utils.data.decode(path)
 
     query = f"saltenv={saltenv}" if saltenv else ""
-    url = salt.utils.data.decode(urlunparse(("file", "", path, "", query, "")))
-    return "salt://{}".format(url[len("file:///") :])
+    return f'salt://{salt.utils.data.decode(urlunsplit(("", "", path, query, "")))}'
 
 
 def is_escaped(url):

--- a/tests/pytests/unit/utils/test_url_create.py
+++ b/tests/pytests/unit/utils/test_url_create.py
@@ -1,0 +1,77 @@
+"""
+Regression tests for salt.utils.url.create and Python 3.13+ compatibility.
+
+Python 3.13 changed urllib.parse.urlunparse so that a relative path with the
+``file`` scheme is rendered as ``file:path`` instead of the historical
+``file:///path``. The legacy salt.utils.url.create implementation stripped a
+literal ``file:///`` prefix; under the new behavior it silently chops the first
+characters of the path, corrupting every ``salt://`` URL that salt-ssh builds
+for state/file references.
+
+See issue #68421 (duplicate of #66898).
+"""
+
+from urllib.parse import urlunparse as real_urlunparse
+
+import pytest
+
+import salt.utils.url
+
+
+def _py313_urlunparse(components):
+    """
+    Emulate the Python 3.13+ urllib.parse.urlunparse behavior for relative
+    paths with the ``file`` scheme.
+    """
+    scheme, netloc, path, params, query, fragment = components
+    if scheme == "file" and not netloc and not path.startswith("/"):
+        result = f"file:{path}"
+        if params:
+            result = f"{result};{params}"
+        if query:
+            result = f"{result}?{query}"
+        if fragment:
+            result = f"{result}#{fragment}"
+        return result
+    return real_urlunparse(components)
+
+
+@pytest.fixture
+def py313_urlunparse(monkeypatch):
+    """
+    Force ``salt.utils.url`` to see the Python 3.13+ behavior of
+    ``urlunparse`` regardless of the interpreter running the test suite.
+    """
+    monkeypatch.setattr(salt.utils.url, "urlunparse", _py313_urlunparse)
+
+
+def test_create_relative_path_python_3_13(py313_urlunparse):
+    """
+    ``salt.utils.url.create`` must round-trip a relative path under the
+    Python 3.13+ ``urlunparse`` behavior. Regression test for #68421.
+    """
+    assert salt.utils.url.create("top.sls") == "salt://top.sls"
+
+
+def test_create_relative_path_with_saltenv_python_3_13(py313_urlunparse):
+    """
+    ``salt.utils.url.create`` must keep the path intact when a saltenv is
+    supplied under the Python 3.13+ ``urlunparse`` behavior. Regression test
+    for #68421.
+    """
+    assert (
+        salt.utils.url.create("test7.txt.jinja", "base")
+        == "salt://test7.txt.jinja?saltenv=base"
+    )
+
+
+def test_create_nested_relative_path_python_3_13(py313_urlunparse):
+    """
+    Nested relative paths (the common salt-ssh ``file.managed`` source case)
+    must survive the Python 3.13+ urlunparse change. Regression test for
+    #68421.
+    """
+    assert (
+        salt.utils.url.create("services/openssh/files/sshd_config.jj")
+        == "salt://services/openssh/files/sshd_config.jj"
+    )


### PR DESCRIPTION
### What does this PR do?
Fixes `salt.utils.url.create` so `salt://` URLs built from relative paths round-trip correctly on Python 3.13+. The old code stripped a literal `file:///` prefix from `urlunparse` output; Python 3.13 changed `urlunparse` to emit `file:path` for relative paths (cpython#85110), so the strip silently chopped the first characters of every path -- breaking top-file discovery and salt-ssh `file.managed` `source: salt://...` resolution on Debian trixie and other Python 3.13+ targets.

### What issues does this PR fix or reference?
Fixes #68421

(Same root cause as #66898; the master/3008.x/3007.x trees already carry the fix via 4cdd334e2f6c and 3346ef7f07e. This backports it to 3006.x.)

### Previous Behavior
`salt-ssh state.apply ...` against a Python 3.13+ target failed with
`Source file salt://<name> not found in saltenv 'base'` even though the
file existed on the master. Internally `salt.utils.url.create("top.sls")`
returned `salt://.sls`.

### New Behavior
`salt.utils.url.create("top.sls")` returns `salt://top.sls` regardless
of the interpreter. salt-ssh resolves `source: salt://...` correctly on
Debian trixie / Python 3.13+ targets.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
