### PR TITLE
Fix task.edit_task rejecting restart_count=999 on Windows (#68419)

### DIFF
--- a/changelog/68419.fixed.md
+++ b/changelog/68419.fixed.md
@@ -1,0 +1,1 @@
+Fixed `task.edit_task` on Windows rejecting `restart_count=999` even though the documented and error-message-stated maximum is 999. The validation now accepts the full 1..999 range.

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -1206,7 +1206,7 @@ def edit_task(
                     return 'Invalid value for "restart_every"'
         if task_definition.Settings.RestartInterval:
             if restart_count is not None:
-                if restart_count in range(1, 999):
+                if restart_count in range(1, 1000):
                     task_definition.Settings.RestartCount = restart_count
                 else:
                     return '"restart_count" must be a value between 1 and 999'

--- a/tests/pytests/unit/modules/test_win_task_edit.py
+++ b/tests/pytests/unit/modules/test_win_task_edit.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for the win_task execution module's edit_task validation logic.
+
+These tests mock the win32com Task Definition object so the validation
+logic in :func:`salt.modules.win_task.edit_task` can be exercised on any
+platform.
+"""
+
+import pytest
+
+import salt.modules.win_task as win_task
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def task_definition():
+    """
+    A MagicMock standing in for a win32com Task Definition object.
+
+    ``Settings.RestartInterval`` is set to a truthy value so the
+    ``restart_count`` validation branch in ``edit_task`` is reached.
+    """
+    definition = MagicMock()
+    definition.Settings.RestartInterval = "PT1H"
+    definition.Settings.RunOnlyIfIdle = False
+    definition.Settings.RunOnlyIfNetworkAvailable = False
+    return definition
+
+
+@pytest.mark.parametrize("restart_count", [1, 500, 998, 999])
+def test_edit_task_restart_count_accepts_valid_range(task_definition, restart_count):
+    """
+    ``edit_task`` must accept restart_count values 1 through 999 inclusive
+    when restart_every is set.
+
+    Regression test for https://github.com/saltstack/salt/issues/68419 —
+    the validation used ``range(1, 999)`` which excluded 999 even though
+    the error message claims ``"must be a value between 1 and 999"``.
+    """
+    with patch.object(win_task.salt.utils.winapi, "Com", MagicMock()):
+        result = win_task.edit_task(
+            name="dummy",
+            restart_every="1 hour",
+            restart_count=restart_count,
+            task_definition=task_definition,
+        )
+
+    # The validation error string must not be returned for valid values.
+    assert result != '"restart_count" must be a value between 1 and 999'
+    # And RestartCount must have been assigned to the mock.
+    assert task_definition.Settings.RestartCount == restart_count
+
+
+@pytest.mark.parametrize("restart_count", [0, 1000, -1])
+def test_edit_task_restart_count_rejects_invalid(task_definition, restart_count):
+    """
+    ``edit_task`` must reject restart_count values outside 1..999.
+    """
+    with patch.object(win_task.salt.utils.winapi, "Com", MagicMock()):
+        result = win_task.edit_task(
+            name="dummy",
+            restart_every="1 hour",
+            restart_count=restart_count,
+            task_definition=task_definition,
+        )
+
+    assert result == '"restart_count" must be a value between 1 and 999'


### PR DESCRIPTION
### What does this PR do?
Fixes the Windows Task Scheduler `task.edit_task` execution module so that `restart_count=999` is accepted. The validation used `range(1, 999)` which excludes 999, even though both the docs and the validation error message say the range is 1..999 inclusive.

### What issues does this PR fix or reference?
Fixes #68419

### Previous Behavior
Calling `task.edit_task(..., restart_every="1 hour", restart_count=999)` returned `"restart_count" must be a value between 1 and 999`, contradicting the stated valid range.

### New Behavior
`restart_count=999` is accepted. Values 1..999 inclusive are valid; 0, 1000, and negatives still return the validation error.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
