### PR TITLE
Fix state.event crash on binary event payloads (#68411)

### DIFF
--- a/changelog/68411.fixed.md
+++ b/changelog/68411.fixed.md
@@ -1,0 +1,4 @@
+Fixed `state.event` (and `salt-run state.event`) crashing with `UnicodeDecodeError`
+when an event payload contains raw binary bytes such as the DER-encoded certificate
+returned by `x509.sign_remote_certificate`. Undecodable bytes are now base64-encoded
+in the JSON output instead of aborting the runner.

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -10,6 +10,7 @@ highdata and won't hit the fileserver except for ``salt://`` links in the
 states themselves.
 """
 
+import base64
 import logging
 import os
 import shutil
@@ -2690,6 +2691,20 @@ def _disabled(funs):
     return ret
 
 
+def _json_safe(obj):
+    """
+    JSON ``default`` fallback for objects that ``json.dumps`` cannot natively
+    serialize. Event payloads may contain raw ``bytes`` (e.g. DER-encoded
+    certificates returned by ``x509.sign_remote_certificate``) that are not
+    valid UTF-8 and therefore cannot be decoded to ``str``; emit them as
+    base64-encoded ASCII so the stream stays valid JSON instead of aborting
+    the runner.
+    """
+    if isinstance(obj, (bytes, bytearray)):
+        return base64.b64encode(bytes(obj)).decode("ascii")
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
 def event(
     tagmatch="*", count=-1, quiet=False, sock_dir=None, pretty=False, node="minion"
 ):
@@ -2739,9 +2754,10 @@ def event(
                         "{}\t{}".format(
                             salt.utils.stringutils.to_str(ret["tag"]),
                             salt.utils.json.dumps(
-                                salt.utils.data.decode(ret["data"]),
+                                salt.utils.data.decode(ret["data"], keep=True),
                                 sort_keys=pretty,
                                 indent=None if not pretty else 4,
+                                default=_json_safe,
                             ),
                         )
                     )

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -341,3 +341,61 @@ def test_check_queue_detects_queued_file_as_conflict():
 
         # Should have dumped payload
         assert mock_dump.called
+
+
+def test_event_handles_binary_payload(tmp_path):
+    """
+    state.event must not abort with UnicodeDecodeError when an event payload
+    contains arbitrary binary bytes (e.g. the DER-encoded certificate returned
+    by x509.sign_remote_certificate).
+
+    Regression test for #68411.
+    """
+    import json as _json
+
+    # A snippet of real DER-encoded cert bytes that cannot be UTF-8 decoded.
+    binary_payload = b"0\x82\x04\x8c\x82\x18\xb0"
+    fake_event = {
+        "tag": "salt/job/20251020115221844441/ret/localhost",
+        "data": {
+            "fun": "x509.sign_remote_certificate",
+            "return": {
+                "data": {"signing_cert": binary_payload},
+                "errors": [],
+            },
+        },
+    }
+
+    captured = []
+
+    class _FakeEvent:
+        def __init__(self, *args, **kwargs):
+            self._delivered = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get_event(self, *args, **kwargs):
+            if self._delivered:
+                return None
+            self._delivered = True
+            return fake_event
+
+    def _capture(msg):
+        captured.append(msg)
+
+    with patch("salt.utils.event.get_event", _FakeEvent), patch(
+        "salt.utils.stringutils.print_cli", _capture
+    ), patch.dict(state.__opts__, {"sock_dir": str(tmp_path)}, create=True):
+        # count=1 so the loop exits after the single matched event.
+        state.event(tagmatch="*", count=1, quiet=False)
+
+    assert captured, "state.event did not emit the binary-payload event"
+    line = captured[0]
+    tag, _, body = line.partition("\t")
+    assert tag == fake_event["tag"]
+    parsed = _json.loads(body)
+    assert parsed["fun"] == "x509.sign_remote_certificate"


### PR DESCRIPTION
### What does this PR do?

Stops `salt-run state.event` (and any consumer of `salt.modules.state.event`) from
aborting with `UnicodeDecodeError` when an event payload contains arbitrary binary
bytes — most commonly the DER-encoded certificate that `x509.sign_remote_certificate`
returns through the event bus.

### What issues does this PR fix or reference?

Fixes #68411
Related: #68076 (closed by #68084, which only scrubbed the `tok` field)

### Previous Behavior

`salt.utils.data.decode(ret["data"])` walked every container and tried to UTF-8
decode every `bytes` value. On the first non-UTF-8 byte (e.g. `0x82` from a DER
cert) it raised `UnicodeDecodeError`, which propagated out of the runner and
terminated the event stream:

```
Exception occurred in runner state.event: Traceback (most recent call last):
  ...
  File ".../salt/modules/state.py", line 2594, in event
    salt.utils.data.decode(ret["data"]),
  ...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 1: invalid start byte
```

### New Behavior

The `decode` call now uses `keep=True`, so values that aren't valid UTF-8 pass
through unchanged. A `default=` callback on `salt.utils.json.dumps` base64-encodes
any `bytes` that reach the serializer so the JSON stays well-formed. The runner
keeps streaming events instead of crashing.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
