### PR TITLE
Fix proxmox driver raising IP error before VM is created (#68353)

### DIFF
--- a/changelog/68353.fixed.md
+++ b/changelog/68353.fixed.md
@@ -1,0 +1,1 @@
+Fixed the ``proxmox`` salt-cloud driver raising ``Could not determine an IP address to use`` before the VM was created and started. The IP address is now determined after the VM is running, and the running VM's address reported by Proxmox is used as a fallback when neither a static ``ip_address`` nor ``agent_get_ip`` is configured.

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -698,19 +698,6 @@ def create(vm_):
 
     agent_get_ip = vm_.get("agent_get_ip", False)
 
-    if agent_get_ip is False:
-        # Determine which IP to use in order of preference:
-        if "ip_address" in vm_:
-            ip_address = str(vm_["ip_address"])
-        elif "public_ips" in data:
-            ip_address = str(data["public_ips"][0])  # first IP
-        elif "private_ips" in data:
-            ip_address = str(data["private_ips"][0])  # first IP
-        else:
-            raise SaltCloudExecutionFailure("Could not determine an IP address to use")
-
-        log.debug("Using IP address %s", ip_address)
-
     # wait until the vm has been created so we can start it
     if not wait_for_created(data["upid"], timeout=300):
         return {"Error": f"Unable to create {name}, command timed out"}
@@ -741,6 +728,30 @@ def create(vm_):
                 pass
             finally:
                 raise SaltCloudSystemExit(str(exc))
+
+        log.debug("Using IP address %s", ip_address)
+    else:
+        # Determine which IP to use in order of preference, *after* the VM
+        # has been created and started. Doing the lookup before the VM is
+        # running gave the provider no chance to discover an IP that
+        # Proxmox itself reports for the running guest (see #68353).
+        ip_address = None
+        if "ip_address" in vm_:
+            ip_address = str(vm_["ip_address"])
+        else:
+            try:
+                node_info = list_nodes().get(name, {})
+            except Exception:  # pylint: disable=broad-except
+                node_info = {}
+            public_ips = node_info.get("public_ips") or []
+            private_ips = node_info.get("private_ips") or []
+            if public_ips:
+                ip_address = str(public_ips[0])
+            elif private_ips:
+                ip_address = str(private_ips[0])
+
+        if ip_address is None:
+            raise SaltCloudExecutionFailure("Could not determine an IP address to use")
 
         log.debug("Using IP address %s", ip_address)
 

--- a/tests/pytests/unit/cloud/clouds/test_proxmox.py
+++ b/tests/pytests/unit/cloud/clouds/test_proxmox.py
@@ -463,6 +463,80 @@ def test__authenticate_failure():
     return
 
 
+def test_create_waits_for_vm_before_determining_ip_68353():
+    """
+    Regression test for #68353.
+
+    When a VM profile does not set a top-level ``ip_address`` and does not
+    opt into ``agent_get_ip``, ``create`` must not raise
+    ``SaltCloudExecutionFailure("Could not determine an IP address to use")``
+    before the VM has been created and started. Proxmox can report the VM's
+    address once it is running, so the IP determination has to happen after
+    ``wait_for_state(..., "running")``.
+    """
+    next_vmid = 101
+    upid = "UPID:myhost:00123456:12345678:9ABCDEF0:qmclone:123:root@pam:"
+
+    def mock_query_response(conn_type, option, post_data=None):
+        if conn_type == "get" and option == "cluster/tasks":
+            return [{"upid": upid, "status": "OK"}]
+        if conn_type == "post":
+            return upid
+        return None
+
+    running_node = {
+        "vm4": {
+            "id": "101",
+            "image": "101",
+            "size": "10G",
+            "state": "running",
+            "private_ips": ["192.168.1.101"],
+            "public_ips": [],
+        }
+    }
+
+    mock_wait_for_state = MagicMock(return_value=True)
+    with patch(
+        "salt.cloud.clouds.proxmox._get_properties",
+        MagicMock(return_value=["vmid"]),
+    ), patch(
+        "salt.cloud.clouds.proxmox._get_next_vmid",
+        MagicMock(return_value=next_vmid),
+    ), patch(
+        "salt.cloud.clouds.proxmox.start", MagicMock(return_value=True)
+    ), patch(
+        "salt.cloud.clouds.proxmox.wait_for_state", mock_wait_for_state
+    ), patch(
+        "salt.cloud.clouds.proxmox.wait_for_created", MagicMock(return_value=True)
+    ), patch(
+        "salt.cloud.clouds.proxmox.list_nodes",
+        MagicMock(return_value=running_node),
+    ), patch(
+        "salt.cloud.clouds.proxmox.query", side_effect=mock_query_response
+    ):
+        vm_ = {
+            "profile": "my_proxmox",
+            "driver": "proxmox",
+            "technology": "qemu",
+            "name": "vm4",
+            "host": "myhost",
+            "clone": True,
+            "clone_from": 123,
+        }
+
+        # Must not raise "Could not determine an IP address to use" before
+        # the VM has been created and started. After the VM is running, the
+        # IP address reported by Proxmox should be used.
+        result = proxmox.create(vm_)
+
+        # The VM was actually started (we got to wait_for_state) - i.e.
+        # the IP determination ran *after* VM start, not before.
+        mock_wait_for_state.assert_called_with(next_vmid, "running")
+
+        # And the IP discovered from the running VM was recorded.
+        assert vm_.get("ssh_host") == "192.168.1.101"
+
+
 def test_creation_failure_logging(caplog):
     """
     Test detailed logging on HTTP errors during VM creation.


### PR DESCRIPTION
### What does this PR do?

The salt-cloud proxmox driver determined the deployment IP *before*
cloning/starting the VM and inspected the parsed UPID dict for
``public_ips``/``private_ips`` keys that ``_parse_proxmox_upid`` never
populates. When a profile did not set a top-level ``ip_address`` and did
not opt into ``agent_get_ip``, ``create()`` raised
``Could not determine an IP address to use`` before the VM was even cloned.

This PR runs the IP lookup after ``wait_for_state(vmid, "running")``,
drops the dead ``data["public_ips"|"private_ips"]`` branches, and falls
back to the address ``list_nodes()`` reports for the running guest.

### What issues does this PR fix or reference?

Fixes #68353

### Previous Behavior

```
[ERROR   ] Failed to deploy 'deploy-test-01.domain.local'. Error: Could not determine an IP address to use
  File ".../salt/cloud/clouds/proxmox.py", line 710, in create
    raise SaltCloudExecutionFailure("Could not determine an IP address to use")
salt.exceptions.SaltCloudExecutionFailure: Could not determine an IP address to use
```

The error fired before the VM was created or started, so even profiles
where Proxmox could have reported the IP after start were unusable
without manually setting ``agent_get_ip`` or a static ``ip_address``.

### New Behavior

``create()`` waits for the VM to be created and reach the ``running``
state, then determines the IP from (in order): the static
``ip_address`` on the profile; the address Proxmox reports via
``list_nodes()`` for the running guest; otherwise raises the same
``SaltCloudExecutionFailure`` so the existing error surface for genuinely
unreachable VMs is preserved. The ``agent_get_ip=True`` code path is
unchanged.

### Scope note

``salt/cloud/clouds/proxmox.py`` was purged from upstream into the
community extensions migration on 3008.x/master (commit
``dc526dc2b17``), so this fix only applies to ``3006.x`` and ``3007.x``
(via merge-forward). A follow-up against the saltext-proxmox extension
repository will be required to carry the fix forward.

### Merge requirements satisfied?

- [x] Docs (no doc change required — error path was an undocumented
      premature failure)
- [x] Changelog (``changelog/68353.fixed.md``)
- [x] Tests written/updated
      (``test_create_waits_for_vm_before_determining_ip_68353``)

### Commits signed with GPG?

Yes
