### PR TITLE
[3006.x] Backport: Handle SaltDeserializationError in grains cache loading (#68678)

### DIFF
--- a/changelog/68678.fixed.md
+++ b/changelog/68678.fixed.md
@@ -1,0 +1,1 @@
+Handle `SaltDeserializationError` in grains cache loading so a corrupted cache file no longer propagates as CRITICAL during minion startup.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -26,7 +26,7 @@ import salt.utils.lazy
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import LoaderError
+from salt.exceptions import LoaderError, SaltDeserializationError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 
@@ -1067,7 +1067,7 @@ def _load_cached_grains(opts, cfn):
             return None
 
         return _format_cached_grains(cached_grains)
-    except OSError:
+    except (OSError, SaltDeserializationError):
         return None
 
 

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1694,6 +1694,30 @@ class LoaderLoadCachedGrainsTest(TestCase):
         osrelease_info = grains["osrelease_info"]
         assert isinstance(osrelease_info, tuple), osrelease_info
 
+    def test_deserialization_error_caught(self):
+        """
+        Test that _load_cached_grains catches SaltDeserializationError.
+
+        When msgpack encounters corrupted cache data, it raises
+        SaltDeserializationError. This should be caught and return None
+        so grains can be regenerated.
+        """
+        import time
+
+        import salt.exceptions
+
+        with patch("os.path.isfile", return_value=True), patch(
+            "os.path.getmtime", return_value=time.time()
+        ), patch("salt.utils.files.fopen"), patch(
+            "salt.payload.load",
+            side_effect=salt.exceptions.SaltDeserializationError(
+                "Could not deserialize msgpack message"
+            ),
+        ):
+            result = salt.loader._load_cached_grains(self.opts, "/fake/path")
+            # Should return None, not raise exception
+            self.assertIsNone(result)
+
 
 class LazyLoaderRefreshFileMappingTest(TestCase):
     """


### PR DESCRIPTION
### What does this PR do?
Backport of merged PR #68674 to `3006.x`. The fix in PR #68674 landed on `master`
and flowed forward to `3008.x` via merge-forward, but never reached `3006.x` or
`3007.x`, where the bug still reproduces (3007.x will be picked up by the
merge-forward from this PR).

Cherry-picks upstream commit `4158e1f061f` and ports the regression test added
in the same PR.

### What issues does this PR fix or reference?
Fixes #68678

### Previous Behavior
On 3006.x, `_load_cached_grains()` in `salt/loader/__init__.py` only catches
`OSError`. When a corrupted grains cache fails msgpack deserialization,
`salt.payload.load()` raises `SaltDeserializationError`, which propagates out
and gets logged as a CRITICAL by the minion connect loop, repeatedly.

### New Behavior
`SaltDeserializationError` is caught alongside `OSError`. A corrupted cache is
treated like a missing cache: return `None`, regenerate grains, and overwrite
the corrupted file. Recovery is automatic.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
