### PR TITLE
Add missing rich.markup.escape import in tools/ci.py

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any, Literal
 
 from ptscripts import Context, command_group
+from rich.markup import escape
 
 import tools.utils
 import tools.utils.gh
@@ -722,7 +723,7 @@ def workflow_config(
     slugs: str | list[str] = []
 
     ctx.info(f"{'==== environment ====':^80s}")
-    ctx.info(f"{pprint.pformat(dict(os.environ))}")
+    ctx.info(escape(pprint.pformat(dict(os.environ))))
     ctx.info(f"{'==== end environment ====':^80s}")
     ctx.info(f"Github event path is {gh_event_path}")
 
@@ -772,11 +773,11 @@ def workflow_config(
     )
 
     ctx.info(f"{'==== requested slugs ====':^80s}")
-    ctx.info(f"{pprint.pformat(requested_slugs)}")
+    ctx.info(escape(pprint.pformat(requested_slugs)))
     ctx.info(f"{'==== end requested slugs ====':^80s}")
 
     ctx.info(f"{'==== labels ====':^80s}")
-    ctx.info(f"{pprint.pformat(labels)}")
+    ctx.info(escape(pprint.pformat(labels)))
     ctx.info(f"{'==== end labels ====':^80s}")
 
     config["skip_code_coverage"] = True
@@ -790,13 +791,13 @@ def workflow_config(
         ctx.info("Skipping code coverage.")
 
     ctx.info(f"{'==== github event ====':^80s}")
-    ctx.info(f"{pprint.pformat(gh_event)}")
+    ctx.info(escape(pprint.pformat(gh_event)))
     ctx.info(f"{'==== end github event ====':^80s}")
 
     config["testrun"] = _define_testrun(ctx, changed_files, labels, full)
 
     ctx.info(f"{'==== testrun ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['testrun'])}")
+    ctx.info(escape(pprint.pformat(config["testrun"])))
     ctx.info(f"{'==== testrun ====':^80s}")
 
     jobs = {
@@ -828,7 +829,7 @@ def workflow_config(
         for platform in platforms
     }
     ctx.info(f"{'==== build matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['build-matrix'])}")
+    ctx.info(escape(pprint.pformat(config["build-matrix"])))
     ctx.info(f"{'==== end build matrix ====':^80s}")
     config["artifact-matrix"] = []
     for platform in platforms:
@@ -836,7 +837,7 @@ def workflow_config(
             dict({"platform": platform}, **_) for _ in config["build-matrix"][platform]
         ]
     ctx.info(f"{'==== artifact matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['artifact-matrix'])}")
+    ctx.info(escape(pprint.pformat(config["artifact-matrix"])))
     ctx.info(f"{'==== end artifact matrix ====':^80s}")
 
     # Get salt releases.
@@ -922,7 +923,7 @@ def workflow_config(
                     if _.slug in requested_slugs
                 ]
     ctx.info(f"{'==== pkg test matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(pkg_test_matrix)}")
+    ctx.info(escape(pprint.pformat(pkg_test_matrix)))
     ctx.info(f"{'==== end pkg test matrix ====':^80s}")
 
     # We need to be careful about how many chunks we make. We are limitied to
@@ -1038,7 +1039,7 @@ def workflow_config(
             )
 
     ctx.info(f"{'==== test matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(test_matrix)}")
+    ctx.info(escape(pprint.pformat(test_matrix)))
     ctx.info(f"{'==== end test matrix ====':^80s}")
     config["pkg-test-matrix"] = pkg_test_matrix
     config["test-matrix"] = test_matrix


### PR DESCRIPTION
The dependabot-group PRs (#69391, #69392, #69393, #69394) each carry a "Fix rich MarkupError when rendering dependabot PR body" commit that calls `escape()` in `workflow_config` without importing it, so Prepare Workflow Run fails with `NameError: name 'escape' is not defined` and blocks every downstream job.

Landing the proper fix (with `from rich.markup import escape`) on the base branches so a `@dependabot rebase` on each of those PRs picks up a working `tools/ci.py`.

Mirrors the earlier fix in a1f56cacf94 ("Fix markup parsing error in tools/ci.py").