### PR TITLE
Add missing rich.markup.escape import in tools/ci.py

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
 from ptscripts import Context, command_group
+from rich.markup import escape
 
 import tools.utils
 import tools.utils.gh
@@ -780,7 +781,7 @@ def workflow_config(
     slugs: str | list[str] = []
 
     ctx.info(f"{'==== environment ====':^80s}")
-    ctx.info(f"{pprint.pformat(dict(os.environ))}")
+    ctx.info(escape(pprint.pformat(dict(os.environ))))
     ctx.info(f"{'==== end environment ====':^80s}")
     ctx.info(f"Github event path is {gh_event_path}")
 
@@ -830,11 +831,11 @@ def workflow_config(
     )
 
     ctx.info(f"{'==== requested slugs ====':^80s}")
-    ctx.info(f"{pprint.pformat(requested_slugs)}")
+    ctx.info(escape(pprint.pformat(requested_slugs)))
     ctx.info(f"{'==== end requested slugs ====':^80s}")
 
     ctx.info(f"{'==== labels ====':^80s}")
-    ctx.info(f"{pprint.pformat(labels)}")
+    ctx.info(escape(pprint.pformat(labels)))
     ctx.info(f"{'==== end labels ====':^80s}")
 
     config["skip_code_coverage"] = True
@@ -848,7 +849,7 @@ def workflow_config(
         ctx.info("Skipping code coverage.")
 
     ctx.info(f"{'==== github event ====':^80s}")
-    ctx.info(f"{pprint.pformat(gh_event)}")
+    ctx.info(escape(pprint.pformat(gh_event)))
     ctx.info(f"{'==== end github event ====':^80s}")
 
     config["testrun"] = _define_testrun(ctx, changed_files, labels, full)


### PR DESCRIPTION
The dependabot-group PR #69391 carries a 'Fix rich MarkupError when rendering dependabot PR body' commit that calls `escape()` in `workflow_config` without importing it, so Prepare Workflow Run fails with `NameError: name 'escape' is not defined` and blocks every downstream job.

Landing the proper fix (with `from rich.markup import escape`) on master so a `@dependabot rebase` on #69391 picks up a working `tools/ci.py`.

Mirrors the matching fix in #69395 on 3006.x.