### PR TITLE
Regenerate py3.14 pkg lockfiles for dependabot all-pip-updates #69394

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,72 +1,72 @@
 # Dependencies are listed alphabetically by package name.
 # Multiple entries for the same package (with different version constraints) are grouped together.
 
-aiohttp>=3.13.3
+aiohttp>=3.13.5
 apache-libcloud>=3.8.0
 cffi>=2.0.0
 # cheroot 8.5.2 fails to build with modern setuptools due to setuptools_scm_git_archive dependency
-cheroot>=10.0.1
-cherrypy>=18.6.1
+cheroot>=11.1.2
+cherrypy>=18.10.0
 # We need contextvars for salt-ssh
 contextvars; python_version < '3.7'
-croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
-cryptography>=46.0.7
-distro>=1.0.1
-frozenlist>=1.3.0; python_version < '3.11'
+croniter!=0.3.22,>=6.2.2; sys_platform != 'win32'
+cryptography>=48.0.0
+distro>=1.9.0
+frozenlist>=1.8.0; python_version < '3.11'
 frozenlist>=1.5.0; python_version >= '3.11'
 gitpython>=3.1.50
-idna>=2.8
+idna>=3.18
 immutables>=0.21; python_version < '3.7'
 importlib-metadata>=3.3.0; python_version < '3.11'
 importlib-metadata>=8.7.0; python_version >= '3.11'
-jaraco.functools>=4.1.0
-jaraco.context>=6.1.0
-jaraco.text>=4.0.0
-Jinja2>=3.1.5
+jaraco.functools>=4.4.0
+jaraco.context>=6.1.1
+jaraco.text>=4.2.0
+Jinja2>=3.1.6
 jmespath>=1.1.0
 looseversion
-lxml>=6.1.0; sys_platform == 'win32'
-MarkupSafe>=3.0.0
-more-itertools>=9.1.0
-msgpack>=1.0.0 ; python_version < '3.13'
+lxml>=6.1.1; sys_platform == 'win32'
+MarkupSafe>=3.0.3
+more-itertools>=10.8.0
+msgpack>=1.1.2 ; python_version < '3.13'
 msgpack>=1.1.0 ; python_version >= '3.13'
-opentelemetry-api>=1.30.0
-opentelemetry-sdk>=1.30.0
-opentelemetry-exporter-otlp-proto-http>=1.30.0
-opentelemetry-exporter-prometheus>=0.51b0
-xxhash>=3.0.0
+opentelemetry-api>=1.41.1
+opentelemetry-sdk>=1.41.1
+opentelemetry-exporter-otlp-proto-http>=1.41.1
+opentelemetry-exporter-prometheus>=0.62b1
+xxhash>=3.7.0
 # Packaging 24.1 imports annotations from __future__ which breaks salt ssh
 # tests on target hosts with older python versions.
-packaging>=21.3; python_version < '3.11'
+packaging>=26.2; python_version < '3.11'
 packaging==24.0; python_version >= '3.11'
 psutil<6.0.0; python_version <= '3.9'
 psutil>=5.0.0; python_version >= '3.10'
 pyasn1>=0.6.3
-pycparser>=2.21
+pycparser>=2.23
 pymssql>=2.2.1; sys_platform == 'win32' and python_version < '3.11'
 pymssql==2.3.11; sys_platform == 'win32' and python_version >= '3.11'
-pyopenssl>=26.0.0
-python-dateutil>=2.8.1
-python-gnupg>=0.4.7
+pyopenssl>=26.2.0
+python-dateutil>=2.9.0.post0
+python-gnupg>=0.5.6
 pythonnet>=3.0.1; sys_platform == 'win32' and python_version < '3.11'
 pythonnet>=3.0.4; sys_platform == 'win32' and python_version >= '3.11' and python_version < '3.13'
 pythonnet>=3.1.0rc0; sys_platform == 'win32' and python_version >= '3.13'
-pywin32>=305; sys_platform == 'win32'
-pycryptodomex>=3.9.8
+pywin32>=312; sys_platform == 'win32'
+pycryptodomex>=3.23.0
 PyYAML
-requests>=2.25.1; python_version < '3.10'
+requests>=2.32.5; python_version < '3.10'
 requests<2.32.0 ; python_version >= '3.10' and python_version < '3.11'
 requests>=2.32.5 ; python_version >= '3.11'
 rpm-vercmp; sys_platform == 'linux'
-setproctitle>=1.2.3
-timelib>=0.2.5; python_version < '3.11'
+setproctitle>=1.3.7
+timelib>=0.3.0; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-tornado>=6.5.5
+tornado>=6.5.6
 truststore>=0.10.0; python_version >= "3.10"
-urllib3>=1.26.20,<2.0.0; python_version < '3.10'
+urllib3>=2.6.3,<3.0.0; python_version < '3.10'
 urllib3>=2.7.0; python_version >= '3.10'
 virtualenv
 vultr>=1.0.1
 wmi>=1.5.1; sys_platform == 'win32'
-xmltodict>=0.13.0; sys_platform == 'win32'
-zipp>=3.19.1
+xmltodict>=1.0.4; sys_platform == 'win32'
+zipp>=3.23.1

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,2 @@
 twine
-build>=0.7.0
+build>=1.4.4

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,7 +1,7 @@
 # IMPORTANT: The versions here must be compatible with the environment where
 # uv-pre-commit hooks run. We do not pin setuptools in .pre-commit-config.yaml
 # to allow uv to resolve a version that satisfies these constraints.
-wheel >= 0.46.3
+wheel >= 0.47.0
 # Floor at the CVE fix: 78.1.1 patches GHSA-5rjg-fvgr-3xxf
 # (PYSEC-2025-49) -- path traversal in setuptools.PackageIndex.download.
 # A higher floor (e.g. 80.x) makes the PEP 517 build-env install fail
@@ -10,5 +10,5 @@ wheel >= 0.46.3
 # bootstraps build envs with), e.g. yarl on Python 3.14 where no cp314
 # wheel is available under salt's ``--no-binary=:all:`` policy.
 setuptools >= 78.1.1
-pip == 25.2
+pip == 26.0.1
 markdown-it-py < 3.0.0; python_version == "3.9"

--- a/requirements/crypto.txt
+++ b/requirements/crypto.txt
@@ -1,2 +1,2 @@
 
-pycryptodomex>=3.9.8
+pycryptodomex>=3.23.0

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,12 +1,12 @@
-mock >= 3.0.0
+mock >= 5.2.0
 # PyTest
 docker >= 7.1.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'
-pytest >= 7.2.0
-pytest-salt-factories >= 1.0.3
-pytest-helpers-namespace >= 2019.1.8
+pytest >= 8.4.2
+pytest-salt-factories >= 1.0.5
+pytest-helpers-namespace >= 2021.12.29
 pytest-subtests
-pytest-timeout >= 2.3.1
+pytest-timeout >= 2.4.0
 pytest-httpserver
 pytest-custom-exit-code >= 0.3
 flaky

--- a/requirements/static/ci/changelog.txt
+++ b/requirements/static/ci/changelog.txt
@@ -1,3 +1,3 @@
-towncrier==24.8.0
+towncrier==25.8.0
 looseversion
 packaging

--- a/requirements/static/ci/cloud.txt
+++ b/requirements/static/ci/cloud.txt
@@ -1,5 +1,5 @@
 # Cloud tests requirements
-apache-libcloud>=3.8.0
+apache-libcloud>=3.9.1
 netaddr
 profitbricks
 pypsexec

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -3,69 +3,69 @@
 # to a particular platform, please add it to the corresponding `<platform>.in` file in this directory.
 
 # aiohttp is a dependency of etcd3-py
-aiohttp>=3.10.2
-apache-libcloud>=3.8.0; sys_platform != 'win32'
+aiohttp>=3.14.1
+apache-libcloud>=3.9.1; sys_platform != 'win32'
 # bcrypt is an extra requirement for passlib, and we shouldn't use extras, like, passlib[bcrypt]
 # since that will break using the compiled static requirements files as contraints file
 bcrypt
-boto3>=1.30.0
-boto>=2.47.0
-botocore>=1.30.0
-cryptography>=46.0.5
-cffi>=1.14.6
-cherrypy>=17.4.1
+boto3>=1.43.24
+boto>=2.49.0
+botocore>=1.43.24
+cryptography>=48.0.0
+cffi>=2.0.0
+cherrypy>=18.10.0
 clustershell
 dnspython
 etcd3-py==0.1.6
 filelock>=3.19.1 ; python_version < '3.10'
-filelock>=3.20.3 ; python_version >= '3.10'
-gitpython>=3.1.37
+filelock>=3.29.1 ; python_version >= '3.10'
+gitpython>=3.1.50
 google-auth==2.35.0; python_version == '3.9'
 jmespath>=1.1.0
 jsonschema
 junos-eznc; sys_platform != 'win32'
-ncclient>=0.6.16; sys_platform != 'win32'
+ncclient>=0.7.1; sys_platform != 'win32'
 junit-xml>=1.9
 jxmlease; sys_platform != 'win32'
 # salt.modules.junos imports this; junos-eznc no longer declares it on PyPI
 yamlordereddictloader; sys_platform != 'win32'
 kazoo; sys_platform != 'win32' and sys_platform != 'darwin'
-keyring==5.7.1
+keyring==25.7.0
 pyasn1-modules==0.4.0; python_version == '3.9'
-kubernetes>=24.0.0
-libnacl>=1.7.1; sys_platform != 'win32' and sys_platform != 'darwin'
-moto>=5.0.0
+kubernetes>=36.0.2
+libnacl>=2.1.0; sys_platform != 'win32' and sys_platform != 'darwin'
+moto>=5.2.2
 # Napalm pulls in pyeapi which does not work on Py3.10
 napalm; sys_platform != 'win32' and python_version < '3.10'
-paramiko>=2.10.1; sys_platform != 'win32' and sys_platform != 'darwin'
+paramiko>=5.0.0; sys_platform != 'win32' and sys_platform != 'darwin'
 passlib>=1.7.4
 pycryptodomex
-pynacl>=1.5.0
+pynacl>=1.6.2
 pyinotify>=0.9.6; sys_platform != 'win32' and sys_platform != 'darwin' and platform_system != "openbsd"
-python-etcd>0.4.2
+python-etcd>=0.4.5
 pyvmomi
 rfc3339-validator>=0.1.4
 rfc3987
-sqlparse>=0.5.4
+sqlparse>=0.5.5
 strict_rfc3339>=0.7
 toml
 vcert; sys_platform != 'win32' and python_version < '3.13.0'
-virtualenv>=20.3.0
-watchdog>=0.9.0
-xmldiff>=2.4
+virtualenv>=21.4.2
+watchdog>=6.0.0
+xmldiff>=2.7.0
 # werkzeug is a dependency of moto
-werkzeug>=3.0.6
+werkzeug>=3.1.8
 textfsm
 toml
-vcert~=0.9.0; sys_platform != 'win32'
+vcert~=0.18.1; sys_platform != 'win32'
 virtualenv>=20.36.1
-watchdog>=0.9.0
-websocket-client>=1.3.3
+watchdog>=6.0.0
+websocket-client>=1.9.0
 # werkzeug is a dependency of moto
 werkzeug>=3.1.6
-xmldiff>=2.4
+xmldiff>=2.7.0
 # Available template libraries that can be used
-genshi>=0.7.3
-cheetah3>=3.2.2
+genshi>=0.7.11
+cheetah3>=3.2.6.post1
 mako
 wempy

--- a/requirements/static/ci/darwin.txt
+++ b/requirements/static/ci/darwin.txt
@@ -1,7 +1,7 @@
-pygit2>=1.14.0
+pygit2>=1.19.2
 yamllint
-mercurial>=7.1.2
+mercurial>=7.2.2
 hglib
 # Pin versions to match 3007.x
-apache-libcloud>=3.8.0
-gitpython>=3.1.46
+apache-libcloud>=3.9.1
+gitpython>=3.1.50

--- a/requirements/static/ci/docs.txt
+++ b/requirements/static/ci/docs.txt
@@ -1,7 +1,7 @@
 sphinx>=3.5.1; python_version < '3.9'
-sphinx>=6.1.0; python_version >= '3.9'
+sphinx>=9.1.0; python_version >= '3.9'
 myst-docutils[linkify]
-sphinxcontrib-httpdomain>=1.8.0
+sphinxcontrib-httpdomain>=2.0.0
 sphinxcontrib-spelling
 cherrypy
 jinja2

--- a/requirements/static/ci/freebsd.txt
+++ b/requirements/static/ci/freebsd.txt
@@ -1,5 +1,5 @@
 # FreeBSD static CI requirements
 
 yamllint
-mercurial>=7.1.2
+mercurial>=7.2.2
 hglib

--- a/requirements/static/ci/lint.txt
+++ b/requirements/static/ci/lint.txt
@@ -2,6 +2,6 @@
 
 docker >= 7.1.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'
-pylint~=3.1.0
-SaltPyLint>=2024.2.2
+pylint~=4.0.5
+SaltPyLint>=2024.2.5
 toml

--- a/requirements/static/ci/linux.txt
+++ b/requirements/static/ci/linux.txt
@@ -1,16 +1,16 @@
 # Linux static CI requirements
 pyiface
-pygit2>=1.14.0
-pymysql>=1.1.1
+pygit2>=1.19.2
+pymysql>=1.2.0
 ansible>=10.7.0; python_version >= '3.10' and python_version < '3.11'
 ansible>=12.3.0; python_version >= '3.11' and python_version < '3.12'
-ansible>=13.4.0; python_version >= '3.12'
+ansible>=14.0.0; python_version >= '3.12'
 ansible>=7.0.0; python_version >= '3.9' and python_version < '3.10'
 ansible>=4.4.0,<5.0.1; python_version < '3.9'
-twilio>=9.10.3
-python-telegram-bot>=13.7
+twilio>=9.10.9
+python-telegram-bot>=22.7
 yamllint
-mercurial>=7.1.2
+mercurial>=7.2.2
 hglib
 redis
 python-consul

--- a/requirements/static/ci/py3.14/changelog.lock
+++ b/requirements/static/ci/py3.14/changelog.lock
@@ -18,5 +18,5 @@ packaging==24.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/changelog.txt
-towncrier==24.8.0
+towncrier==25.8.0
     # via -r requirements/static/ci/changelog.txt

--- a/requirements/static/ci/tools.txt
+++ b/requirements/static/ci/tools.txt
@@ -1,5 +1,5 @@
 attrs
-python-tools-scripts >= 0.20.0
+python-tools-scripts >= 0.20.5
 boto3
 pyyaml
 jinja2

--- a/requirements/static/ci/windows.txt
+++ b/requirements/static/ci/windows.txt
@@ -1,6 +1,6 @@
 dmidecode
 patch
-pygit2>=1.14.0
+pygit2>=1.19.2
 sed
-pywinrm>=0.4.1
+pywinrm>=0.5.0
 yamllint

--- a/requirements/static/pkg/freebsd.txt
+++ b/requirements/static/pkg/freebsd.txt
@@ -1,16 +1,16 @@
 # This file only exists to trigger the right static compiled requirements destination
 # Any non hard dependencies of Salt for FreeBSD can go here
 # If they are freebsd specific, place "; sys_platform == 'freebsd'" in front of the requirement.
-cherrypy>=18.7.0
-cryptography>=41.0.3
-pycparser>=2.21; python_version >= '3.9'
-pyopenssl>=25.0.0
-python-dateutil>=2.8.0
-python-gnupg>=0.4.4
-setproctitle>=1.2.3
+cherrypy>=18.10.0
+cryptography>=48.0.0
+pycparser>=3.0; python_version >= '3.9'
+pyopenssl>=26.2.0
+python-dateutil>=2.9.0.post0
+python-gnupg>=0.5.6
+setproctitle>=1.3.7
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-distro>=1.3.0
-importlib-metadata>=8.7.0
+distro>=1.9.0
+importlib-metadata>=9.0.0
 # cheroot 8.5.2 fails to build with modern setuptools due to setuptools_scm_git_archive dependency
-cheroot>=10.0.1
+cheroot>=11.1.2

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -2,17 +2,17 @@
 # Don't add any requirements here, add them in requirements/base.txt
 # If they are linux specific, place "; sys_platform == 'linux'" in front of the requirement.
 # Any non hard dependencies of Salt for linux can go here
-cherrypy>=18.7.0
+cherrypy>=18.10.0
 # cheroot 8.5.2 fails to build with modern setuptools due to setuptools_scm_git_archive dependency
-cheroot>=10.0.1
-pycparser>=2.21; python_version >= '3.9'
-pyopenssl>=25.0.0
-python-dateutil>=2.8.0
-python-gnupg>=0.4.4
+cheroot>=11.1.2
+pycparser>=3.0; python_version >= '3.9'
+pyopenssl>=26.2.0
+python-dateutil>=2.9.0.post0
+python-gnupg>=0.5.6
 rpm-vercmp
-setproctitle>=1.2.3
+setproctitle>=1.3.7
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
-importlib-metadata>=8.7.0
-cryptography>=42.0.0
-more-itertools>=9.1.0
+importlib-metadata>=9.0.0
+cryptography>=48.0.0
+more-itertools>=11.1.0

--- a/requirements/static/pkg/py3.14/darwin.lock
+++ b/requirements/static/pkg/py3.14/darwin.lock
@@ -6,12 +6,12 @@ aiohttp==3.13.5
     # via -r requirements/base.txt
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via typer
 apache-libcloud==3.9.0
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-autocommand==2.2.2
-    # via jaraco-text
 certifi==2026.1.4
     # via requests
 cffi==2.0.0
@@ -26,9 +26,9 @@ cheroot==11.1.2
     #   cherrypy
 cherrypy==18.10.0
     # via -r requirements/base.txt
-croniter==6.0.0
+croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -49,7 +49,7 @@ gitpython==3.1.50
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
@@ -58,7 +58,7 @@ importlib-metadata==8.7.1
     # via -r requirements/base.txt
 jaraco-collections==5.2.1
     # via cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
@@ -68,7 +68,7 @@ jaraco-functools==4.4.0
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -78,10 +78,14 @@ jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
+markdown-it-py==4.2.0
+    # via rich
 markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 more-itertools==10.8.0
     # via
     #   -r requirements/base.txt
@@ -147,7 +151,9 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==26.0.0
+pygments==2.20.0
+    # via rich
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -156,8 +162,6 @@ python-dateutil==2.9.0.post0
     #   tempora
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pytz==2025.2
-    # via croniter
 pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
@@ -168,12 +172,16 @@ requests==2.33.1
     #   apache-libcloud
     #   opentelemetry-exporter-otlp-proto-http
     #   vultr
+rich==15.0.0
+    # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
 setuptools==82.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via python-dateutil
 smmap==5.0.2
@@ -184,10 +192,14 @@ timelib==0.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/darwin.txt
-tornado==6.5.5
+tornado==6.5.6
     # via -r requirements/base.txt
 truststore==0.10.4
     # via -r requirements/base.txt
+typer==0.26.7
+    # via typer-slim
+typer-slim==0.24.0
+    # via jaraco-text
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api
@@ -208,7 +220,7 @@ yarl==1.22.0
     # via aiohttp
 zc-lockfile==4.0
     # via cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata

--- a/requirements/static/pkg/py3.14/darwin.txt
+++ b/requirements/static/pkg/py3.14/darwin.txt
@@ -1,4 +1,4 @@
 # Python 3.13 specific package constraints
 # This file is used when compiling requirements for Python 3.13
 
-cherrypy>=18.7.0
+cherrypy>=18.10.0

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -6,12 +6,12 @@ aiohttp==3.13.5
     # via -r requirements/base.txt
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via typer
 apache-libcloud==3.9.0
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-autocommand==2.2.2
-    # via jaraco-text
 certifi==2026.1.4
     # via requests
 cffi==2.0.0
@@ -33,9 +33,11 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/freebsd.txt
 clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
-croniter==6.0.0 ; sys_platform != 'win32'
+colorama==0.4.6 ; sys_platform == 'win32'
+    # via typer
+croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -59,18 +61,18 @@ gitpython==3.1.50
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
 jaraco-collections==5.2.1
     # via cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
@@ -80,7 +82,7 @@ jaraco-functools==4.4.0
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -90,12 +92,18 @@ jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
-lxml==6.1.0 ; sys_platform == 'win32'
+lxml==6.1.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt
+markdown-it-py==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   rich
 markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 more-itertools==10.8.0
     # via
     #   -r requirements/base.txt
@@ -162,9 +170,11 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
+pygments==2.20.0
+    # via rich
 pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.0.0
+pyopenssl==26.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -180,9 +190,7 @@ python-gnupg==0.5.6
     #   -r requirements/static/pkg/freebsd.txt
 pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pytz==2025.2 ; sys_platform != 'win32'
-    # via croniter
-pywin32==311 ; sys_platform == 'win32'
+pywin32==312 ; sys_platform == 'win32'
     # via
     #   -r requirements/base.txt
     #   wmi
@@ -196,6 +204,8 @@ requests==2.33.1
     #   apache-libcloud
     #   opentelemetry-exporter-otlp-proto-http
     #   vultr
+rich==15.0.0
+    # via typer
 rpm-vercmp==0.1.2 ; sys_platform == 'linux'
     # via -r requirements/base.txt
 setproctitle==1.3.7
@@ -206,6 +216,8 @@ setuptools==82.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via python-dateutil
 smmap==5.0.2
@@ -216,10 +228,14 @@ timelib==0.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-tornado==6.5.5
+tornado==6.5.6
     # via -r requirements/base.txt
 truststore==0.10.4
     # via -r requirements/base.txt
+typer==0.26.7
+    # via typer-slim
+typer-slim==0.24.0
+    # via jaraco-text
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api
@@ -244,7 +260,7 @@ yarl==1.22.0
     # via aiohttp
 zc-lockfile==4.0
     # via cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata

--- a/requirements/static/pkg/py3.14/freebsd.txt
+++ b/requirements/static/pkg/py3.14/freebsd.txt
@@ -1,4 +1,4 @@
 # Python 3.13 specific package constraints
 # This file is used when compiling requirements for Python 3.13
 
-cherrypy>=18.7.0
+cherrypy>=18.10.0

--- a/requirements/static/pkg/py3.14/linux.lock
+++ b/requirements/static/pkg/py3.14/linux.lock
@@ -6,12 +6,12 @@ aiohttp==3.13.5
     # via -r requirements/base.txt
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via typer
 apache-libcloud==3.9.0
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-autocommand==2.2.2
-    # via jaraco-text
 certifi==2026.1.4
     # via requests
 cffi==2.0.0
@@ -29,9 +29,9 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-croniter==6.0.0
+croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -53,18 +53,18 @@ gitpython==3.1.50
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
     #   yarl
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
 jaraco-collections==5.2.1
     # via cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
@@ -74,7 +74,7 @@ jaraco-functools==4.4.0
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -84,11 +84,15 @@ jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
+markdown-it-py==4.2.0
+    # via rich
 markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
-more-itertools==10.8.0
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -155,7 +159,9 @@ pycryptodomex==3.23.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/crypto.txt
-pyopenssl==26.0.0
+pygments==2.20.0
+    # via rich
+pyopenssl==26.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -169,8 +175,6 @@ python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-pytz==2025.2
-    # via croniter
 pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
@@ -181,6 +185,8 @@ requests==2.33.1
     #   apache-libcloud
     #   opentelemetry-exporter-otlp-proto-http
     #   vultr
+rich==15.0.0
+    # via typer
 rpm-vercmp==0.1.2
     # via
     #   -r requirements/base.txt
@@ -193,6 +199,8 @@ setuptools==82.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via python-dateutil
 smmap==5.0.2
@@ -203,10 +211,14 @@ timelib==0.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-tornado==6.5.5
+tornado==6.5.6
     # via -r requirements/base.txt
 truststore==0.10.4
     # via -r requirements/base.txt
+typer==0.26.7
+    # via typer-slim
+typer-slim==0.24.0
+    # via jaraco-text
 typing-extensions==4.15.0
     # via
     #   opentelemetry-api
@@ -227,7 +239,7 @@ yarl==1.22.0
     # via aiohttp
 zc-lockfile==4.0
     # via cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata

--- a/requirements/static/pkg/py3.14/linux.txt
+++ b/requirements/static/pkg/py3.14/linux.txt
@@ -1,4 +1,4 @@
 # Python 3.13 specific package constraints
 # This file is used when compiling requirements for Python 3.13
 
-cherrypy>=18.7.0
+cherrypy>=18.10.0

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -33,7 +33,7 @@ clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
-cryptography==46.0.7
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -56,7 +56,7 @@ gitpython==3.1.50
     # via -r requirements/base.txt
 googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
-idna==3.11
+idna==3.18
     # via
     #   -r requirements/base.txt
     #   requests
@@ -65,7 +65,7 @@ importlib-metadata==8.7.1
     # via -r requirements/base.txt
 jaraco-collections==5.2.1
     # via cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
@@ -85,7 +85,7 @@ jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
-lxml==6.1.0
+lxml==6.1.1
     # via -r requirements/base.txt
 markdown-it-py==4.0.0
     # via rich
@@ -166,7 +166,7 @@ pygments==2.19.2
     # via rich
 pymssql==2.3.11
     # via -r requirements/base.txt
-pyopenssl==26.0.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -178,7 +178,7 @@ python-gnupg==0.5.6
     # via -r requirements/base.txt
 pythonnet==3.1.0
     # via -r requirements/base.txt
-pywin32==311
+pywin32==312
     # via
     #   -r requirements/base.txt
     #   wmi
@@ -212,7 +212,7 @@ timelib==0.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/windows.txt
-tornado==6.5.5
+tornado==6.5.6
     # via -r requirements/base.txt
 truststore==0.10.4
     # via -r requirements/base.txt
@@ -244,7 +244,7 @@ yarl==1.23.0
     # via aiohttp
 zc-lockfile==4.0
     # via cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata

--- a/requirements/static/pkg/py3.14/windows.txt
+++ b/requirements/static/pkg/py3.14/windows.txt
@@ -1,4 +1,4 @@
 # Python 3.13 specific package constraints
 # This file is used when compiling requirements for Python 3.13
 
-cherrypy>=18.7.0
+cherrypy>=18.10.0

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/pkg/py3.8/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-aiohttp==3.9.5
+aiohttp==3.14.1
     # via -r requirements/base.txt
-aiosignal==1.3.1
+aiosignal==1.4.0
     # via aiohttp
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via aiohttp
 autocommand==2.2.2
     # via jaraco.text
@@ -20,62 +20,62 @@ certifi==2023.07.22 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.4.7
     # via requests
-cheroot==10.0.0
+cheroot==11.1.2
     # via cherrypy
-cherrypy==18.8.0
+cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==2.0.5 ; sys_platform != "win32"
+croniter==6.2.2 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5 ; python_version < "3.13"
     # via
     #   -r requirements/base.txt
     #   pyopenssl
-distro==1.8.0
+distro==1.9.0
     # via -r requirements/base.txt
-frozenlist==1.4.1
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.7
+idna==3.18
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.21
     # via contextvars
-importlib-metadata==6.6.0
+importlib-metadata==9.0.0
     # via -r requirements/base.txt
-importlib-resources==5.12.0
+importlib-resources==7.1.0
     # via jaraco.text
-inflect==7.0.0
+inflect==7.5.0
     # via jaraco.text
-jaraco.collections==4.1.0
+jaraco.collections==5.2.1
     # via cherrypy
-jaraco.context==4.3.0
+jaraco.context==6.1.2
     # via jaraco.text
-jaraco.functools==3.7.0
+jaraco.functools==4.5.0
     # via
     #   cheroot
     #   jaraco.text
     #   tempora
-jaraco.text==3.11.1
+jaraco.text==4.2.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.6
     # via -r requirements/base.txt
-jmespath==1.0.1
+jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
-markupsafe==2.1.3
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
-more-itertools==9.1.0
+more-itertools==11.1.0
     # via
     #   cheroot
     #   cherrypy
@@ -83,65 +83,65 @@ more-itertools==9.1.0
     #   jaraco.text
 msgpack==1.0.7 ; python_version < "3.13"
     # via -r requirements/base.txt
-multidict==6.1.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-packaging==23.1
+packaging==26.2
     # via -r requirements/base.txt
-portend==3.1.0
+portend==3.2.1
     # via cherrypy
 psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
-pycparser==2.21
+pycparser==3.0
     # via cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.23.0
     # via -r requirements/crypto.txt
-pydantic-core==2.16.3
+pydantic-core==2.47.0
     # via pydantic
-pydantic==2.6.4
+pydantic==2.13.4
     # via inflect
-pyopenssl==24.0.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
-python-gnupg==0.5.2
+python-gnupg==0.5.6
     # via -r requirements/base.txt
-pytz==2024.1
+pytz==2026.2
     # via
     #   croniter
     #   tempora
-pyyaml==6.0.1
+pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==25.1.2 ; python_version < "3.13"
     # via -r requirements/zeromq.txt
 requests==2.31.0 ; python_version < "3.10"
     # via -r requirements/base.txt
-setproctitle==1.3.2
+setproctitle==1.3.7
     # via -r requirements/base.txt
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-tempora==5.3.0
+tempora==5.9.0
     # via portend
 timelib==0.3.0
     # via -r requirements/base.txt
-tornado==6.3.3
+tornado==6.5.6
     # via -r requirements/base.txt
-typing-extensions==4.8.0
+typing-extensions==4.15.0
     # via
     #   annotated-types
     #   inflect
     #   pydantic
     #   pydantic-core
-urllib3==1.26.18
+urllib3==2.7.0
     # via requests
-yarl==1.9.4
+yarl==1.24.2
     # via aiohttp
-zc.lockfile==3.0.post1
+zc.lockfile==4.0
     # via cherrypy
-zipp==3.16.2
+zipp==4.1.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/pkg/py3.8/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-aiohttp==3.9.5
+aiohttp==3.14.1
     # via -r requirements/base.txt
-aiosignal==1.3.1
+aiosignal==1.4.0
     # via aiohttp
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via aiohttp
 autocommand==2.2.2
     # via jaraco.text
@@ -20,62 +20,62 @@ certifi==2023.07.22 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.4.7
     # via requests
-cheroot==10.0.0
+cheroot==11.1.2
     # via cherrypy
-cherrypy==18.8.0
+cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==2.0.5 ; sys_platform != "win32"
+croniter==6.2.2 ; sys_platform != "win32"
     # via -r requirements/base.txt
 cryptography==42.0.5 ; python_version < "3.13"
     # via
     #   -r requirements/base.txt
     #   pyopenssl
-distro==1.8.0
+distro==1.9.0
     # via -r requirements/base.txt
-frozenlist==1.4.1
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.7
+idna==3.18
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.21
     # via contextvars
-importlib-metadata==6.6.0
+importlib-metadata==9.0.0
     # via -r requirements/base.txt
-importlib-resources==5.12.0
+importlib-resources==7.1.0
     # via jaraco.text
-inflect==7.0.0
+inflect==7.5.0
     # via jaraco.text
-jaraco.collections==4.1.0
+jaraco.collections==5.2.1
     # via cherrypy
-jaraco.context==4.3.0
+jaraco.context==6.1.2
     # via jaraco.text
-jaraco.functools==3.7.0
+jaraco.functools==4.5.0
     # via
     #   cheroot
     #   jaraco.text
     #   tempora
-jaraco.text==3.11.1
+jaraco.text==4.2.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.6
     # via -r requirements/base.txt
-jmespath==1.0.1
+jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
-markupsafe==2.1.3
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
-more-itertools==9.1.0
+more-itertools==11.1.0
     # via
     #   cheroot
     #   cherrypy
@@ -83,37 +83,37 @@ more-itertools==9.1.0
     #   jaraco.text
 msgpack==1.0.7 ; python_version < "3.13"
     # via -r requirements/base.txt
-multidict==6.1.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-packaging==23.1
+packaging==26.2
     # via -r requirements/base.txt
-portend==3.1.0
+portend==3.2.1
     # via cherrypy
 psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
-pycparser==2.21
+pycparser==3.0
     # via cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.23.0
     # via -r requirements/crypto.txt
-pydantic-core==2.16.3
+pydantic-core==2.47.0
     # via pydantic
-pydantic==2.6.4
+pydantic==2.13.4
     # via inflect
-pyopenssl==24.0.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
-python-gnupg==0.5.2
+python-gnupg==0.5.6
     # via -r requirements/base.txt
-pytz==2024.1
+pytz==2026.2
     # via
     #   croniter
     #   tempora
-pyyaml==6.0.1
+pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==25.1.2 ; python_version < "3.13"
     # via -r requirements/zeromq.txt
@@ -121,29 +121,29 @@ requests==2.31.0 ; python_version < "3.10"
     # via -r requirements/base.txt
 rpm-vercmp==0.1.2 ; sys_platform == "linux"
     # via -r requirements/base.txt
-setproctitle==1.3.2
+setproctitle==1.3.7
     # via -r requirements/base.txt
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-tempora==5.3.0
+tempora==5.9.0
     # via portend
 timelib==0.3.0
     # via -r requirements/base.txt
-tornado==6.3.3
+tornado==6.5.6
     # via -r requirements/base.txt
-typing-extensions==4.8.0
+typing-extensions==4.15.0
     # via
     #   annotated-types
     #   inflect
     #   pydantic
     #   pydantic-core
-urllib3==1.26.18
+urllib3==2.7.0
     # via requests
-yarl==1.9.4
+yarl==1.24.2
     # via aiohttp
-zc.lockfile==3.0.post1
+zc.lockfile==4.0
     # via cherrypy
-zipp==3.16.2
+zipp==4.1.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements/static/pkg/py3.8/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-aiohttp==3.9.5
+aiohttp==3.14.1
     # via -r requirements/base.txt
-aiosignal==1.3.1
+aiosignal==1.4.0
     # via aiohttp
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via aiohttp
 autocommand==2.2.2
     # via jaraco.text
@@ -20,17 +20,17 @@ certifi==2023.07.22 ; python_version < "3.10"
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   clr-loader
     #   cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.4.7
     # via requests
-cheroot==10.0.0
+cheroot==11.1.2
     # via cherrypy
-cherrypy==18.8.0
+cherrypy==18.10.0
     # via -r requirements/base.txt
-clr-loader==0.2.6
+clr-loader==0.3.1
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
@@ -38,52 +38,52 @@ cryptography==42.0.5 ; python_version < "3.13"
     # via
     #   -r requirements/base.txt
     #   pyopenssl
-distro==1.8.0
+distro==1.9.0
     # via -r requirements/base.txt
-frozenlist==1.4.1
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-gitdb==4.0.10
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43 ; sys_platform == "win32"
+gitpython==3.1.50 ; sys_platform == "win32"
     # via -r requirements/base.txt
-idna==3.7
+idna==3.18
     # via
     #   requests
     #   yarl
-immutables==0.15
+immutables==0.21
     # via contextvars
-importlib-metadata==6.6.0
+importlib-metadata==9.0.0
     # via -r requirements/base.txt
-importlib-resources==5.12.0
+importlib-resources==7.1.0
     # via jaraco.text
-inflect==7.0.0
+inflect==7.5.0
     # via jaraco.text
-jaraco.collections==4.1.0
+jaraco.collections==5.2.1
     # via cherrypy
-jaraco.context==4.3.0
+jaraco.context==6.1.2
     # via jaraco.text
-jaraco.functools==3.7.0
+jaraco.functools==4.5.0
     # via
     #   cheroot
     #   jaraco.text
     #   tempora
-jaraco.text==3.11.1
+jaraco.text==4.2.0
     # via jaraco.collections
-jinja2==3.1.4
+jinja2==3.1.6
     # via -r requirements/base.txt
-jmespath==1.0.1
+jmespath==1.1.0
     # via -r requirements/base.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
-lxml==4.9.2 ; sys_platform == "win32"
+lxml==6.1.1 ; sys_platform == "win32"
     # via -r requirements/base.txt
-markupsafe==2.1.3
+markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
     #   jinja2
-more-itertools==9.1.0
+more-itertools==11.1.0
     # via
     #   cheroot
     #   cherrypy
@@ -91,78 +91,78 @@ more-itertools==9.1.0
     #   jaraco.text
 msgpack==1.0.7 ; python_version < "3.13"
     # via -r requirements/base.txt
-multidict==6.1.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-packaging==23.1
+packaging==26.2
     # via -r requirements/base.txt
-portend==3.1.0
+portend==3.2.1
     # via cherrypy
 psutil==5.9.6 ; python_version <= "3.9"
     # via -r requirements/base.txt
-pycparser==2.21
+pycparser==3.0
     # via cffi
-pycryptodomex==3.19.1
+pycryptodomex==3.23.0
     # via -r requirements/crypto.txt
-pydantic-core==2.16.3
+pydantic-core==2.47.0
     # via pydantic
-pydantic==2.6.4
+pydantic==2.13.4
     # via inflect
-pymssql==2.3.1 ; sys_platform == "win32"
+pymssql==2.3.13 ; sys_platform == "win32"
     # via -r requirements/base.txt
-pymysql==1.1.0 ; sys_platform == "win32"
+pymysql==1.2.0 ; sys_platform == "win32"
     # via -r requirements/base.txt
-pyopenssl==24.0.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via -r requirements/base.txt
-python-gnupg==0.5.2
+python-gnupg==0.5.6
     # via -r requirements/base.txt
 pythonnet==3.0.4 ; sys_platform == "win32" and python_version < "3.13"
     # via -r requirements/base.txt
-pytz==2024.1
+pytz==2026.2
     # via tempora
-pywin32==306 ; sys_platform == "win32"
+pywin32==312 ; sys_platform == "win32"
     # via
     #   -r requirements/base.txt
     #   cherrypy
     #   wmi
-pyyaml==6.0.1
+pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==25.1.2 ; python_version < "3.13"
     # via -r requirements/zeromq.txt
 requests==2.31.0 ; python_version < "3.10"
     # via -r requirements/base.txt
-setproctitle==1.3.2
+setproctitle==1.3.7
     # via -r requirements/base.txt
-six==1.15.0
+six==1.17.0
     # via python-dateutil
-smmap==5.0.1
+smmap==5.0.3
     # via gitdb
-tempora==5.3.0
+tempora==5.9.0
     # via portend
 timelib==0.3.0
     # via -r requirements/base.txt
-tornado==6.3.3
+tornado==6.5.6
     # via -r requirements/base.txt
-typing-extensions==4.8.0
+typing-extensions==4.15.0
     # via
     #   annotated-types
     #   inflect
     #   pydantic
     #   pydantic-core
-urllib3==1.26.18
+urllib3==2.7.0
     # via requests
 wmi==1.5.1 ; sys_platform == "win32"
     # via -r requirements/base.txt
-xmltodict==0.13.0 ; sys_platform == "win32"
+xmltodict==1.0.4 ; sys_platform == "win32"
     # via -r requirements/base.txt
-yarl==1.9.4
+yarl==1.24.2
     # via aiohttp
-zc.lockfile==3.0.post1
+zc.lockfile==4.0
     # via cherrypy
-zipp==3.16.2
+zipp==4.1.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,2 +1,2 @@
-pyzmq>=25.1.2 ; python_version < '3.13'
+pyzmq>=27.1.0 ; python_version < '3.13'
 pyzmq>=26.2.0 ; python_version >= '3.13'

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
+from rich.markup import escape
 from ptscripts import Context, command_group
 
 import tools.utils
@@ -780,7 +781,7 @@ def workflow_config(
     slugs: str | list[str] = []
 
     ctx.info(f"{'==== environment ====':^80s}")
-    ctx.info(f"{pprint.pformat(dict(os.environ))}")
+    ctx.info(escape(pprint.pformat(dict(os.environ))))
     ctx.info(f"{'==== end environment ====':^80s}")
     ctx.info(f"Github event path is {gh_event_path}")
 
@@ -830,11 +831,11 @@ def workflow_config(
     )
 
     ctx.info(f"{'==== requested slugs ====':^80s}")
-    ctx.info(f"{pprint.pformat(requested_slugs)}")
+    ctx.info(escape(pprint.pformat(requested_slugs)))
     ctx.info(f"{'==== end requested slugs ====':^80s}")
 
     ctx.info(f"{'==== labels ====':^80s}")
-    ctx.info(f"{pprint.pformat(labels)}")
+    ctx.info(escape(pprint.pformat(labels)))
     ctx.info(f"{'==== end labels ====':^80s}")
 
     config["skip_code_coverage"] = True
@@ -848,13 +849,13 @@ def workflow_config(
         ctx.info("Skipping code coverage.")
 
     ctx.info(f"{'==== github event ====':^80s}")
-    ctx.info(f"{pprint.pformat(gh_event)}")
+    ctx.info(escape(pprint.pformat(gh_event)))
     ctx.info(f"{'==== end github event ====':^80s}")
 
     config["testrun"] = _define_testrun(ctx, changed_files, labels, full)
 
     ctx.info(f"{'==== testrun ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['testrun'])}")
+    ctx.info(escape(pprint.pformat(config['testrun'])))
     ctx.info(f"{'==== testrun ====':^80s}")
 
     jobs = {
@@ -886,7 +887,7 @@ def workflow_config(
         for platform in platforms
     }
     ctx.info(f"{'==== build matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['build-matrix'])}")
+    ctx.info(escape(pprint.pformat(config['build-matrix'])))
     ctx.info(f"{'==== end build matrix ====':^80s}")
     config["artifact-matrix"] = []
     for platform in platforms:
@@ -894,7 +895,7 @@ def workflow_config(
             dict({"platform": platform}, **_) for _ in config["build-matrix"][platform]
         ]
     ctx.info(f"{'==== artifact matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(config['artifact-matrix'])}")
+    ctx.info(escape(pprint.pformat(config['artifact-matrix'])))
     ctx.info(f"{'==== end artifact matrix ====':^80s}")
 
     # Get salt releases.
@@ -988,7 +989,7 @@ def workflow_config(
                     if _.slug in requested_slugs and "photon" not in _.slug
                 ]
     ctx.info(f"{'==== pkg test matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(pkg_test_matrix)}")
+    ctx.info(escape(pprint.pformat(pkg_test_matrix)))
     ctx.info(f"{'==== end pkg test matrix ====':^80s}")
 
     # We need to be careful about how many chunks we make. We are limitied to
@@ -1113,7 +1114,7 @@ def workflow_config(
             )
 
     ctx.info(f"{'==== test matrix ====':^80s}")
-    ctx.info(f"{pprint.pformat(test_matrix)}")
+    ctx.info(escape(pprint.pformat(test_matrix)))
     ctx.info(f"{'==== end test matrix ====':^80s}")
     config["pkg-test-matrix"] = pkg_test_matrix
     config["test-matrix"] = test_matrix


### PR DESCRIPTION
## What

Sibling fix PR for #69394 (dependabot all-pip-updates rollup on 3008.x).

Contains:

- Dependabot's bump commit (so the floors are present).
- The 3008.x rich.markup.escape import fix (already in #69398 — included here so this branch resolves on its own).
- Regenerated py3.14 pkg lockfiles (linux/freebsd/darwin/windows) and py3.14/changelog ci lock, so the new floors are reflected in the constraint chain.

## Why

Dependabot bumped the floor in requirements/base.txt and the pkg .txt
files for croniter, cryptography, idna, importlib-metadata,
jaraco-context, jaraco-text, pyopenssl, tornado, yarl, zipp (etc.) but
only regenerated the py3.8 lockfiles. The py3.14 pkg lockfiles still
pinned the pre-bump versions, so several jobs hit ResolutionImpossible:

- ``Documentation / Build (html)`` / ``(man)``
- ``Build Source Tarball``
- ``Build Salt Onedir / macOS (arm64)``

all do ``pip install -r requirements/base.txt --constraint
requirements/static/pkg/py3.14/<platform>.lock`` and the constraint
chain conflicts (e.g. ``croniter>=6.2.2`` from base.txt vs
``croniter==6.0.0`` constraint from the un-regenerated lock).

## Out of scope

Two upstream-floor problems in dependabot's rollup that are NOT fixed
here:

1. ``cryptography>=48.0.0`` in base.txt — cryptography 48 dropped
   py3.9 support. 3008.x still ships py3.9 lockfile sets. ``uv pip
   compile`` fails for every py3.9 target. Either gate
   ``cryptography>=48.0.0 ; python_version >= '3.10'`` or narrow the
   dependabot scope on 3008.x.
2. ``virtualenv>=21.4.2`` in ``requirements/static/ci/common.txt`` —
   virtualenv 21.4.2 is satisfiable by uv but is not selected by the
   pkg-lock resolver under pre-commit's invocation (pkg lock pins
   ``virtualenv==20.36.1``), so every CI-stage lock fails with
   ``virtualenv>=21.4.2 vs virtualenv==20.36.1``. Either revert the
   floor bump or pin the pkg-stage resolution explicitly.
3. ``pip == 26.0.1`` in ``requirements/constraints.txt`` —
   ``tools/pkg/build.py`` hard-codes ``pip==25.2`` for the urllib3
   CVE-patcher (relenv ships pip 25.2 pre-installed). Needs relenv
   coordination.

## Test plan

- [ ] CI green on this PR for ``Documentation / Build``,
      ``Build Source Tarball``, and ``Build Salt Onedir / macOS (arm64)``.
- [ ] Pre-commit still red for the three upstream issues above —
      expected and called out.