### PR TITLE
Fix missing dns_plugin_propagate_seconds arg in acme state/module

### DIFF
--- a/changelog/63700.fixed.md
+++ b/changelog/63700.fixed.md
@@ -1,0 +1,1 @@
+Fix missing `dns_plugin_propagate_seconds` arg in acme state/module so DNS propagation timeout is actually forwarded to certbot.

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -132,6 +132,7 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    dns_plugin_propagate_seconds=10,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -216,6 +217,9 @@ def cert(
         if dns_plugin == "cloudflare":
             cmd.append("--dns-cloudflare")
             cmd.append(f"--dns-cloudflare-credentials {dns_plugin_credentials}")
+            cmd.append(
+                f"--dns-cloudflare-propagation-seconds {dns_plugin_propagate_seconds}"
+            )
         else:
             return {
                 "result": False,

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -61,6 +61,7 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    dns_plugin_propagate_seconds=10,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -91,6 +92,7 @@ def cert(
     :param https_01_address: The address the server listens to during http-01 challenge.
     :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare')
     :param dns_plugin_credentials: Path to the credentials file if required by the specified DNS plugin
+    :param dns_plugin_propagate_seconds: Number of seconds to wait for DNS propagation before asking ACME servers to verify the DNS record. (default 10)
     """
 
     if certname is None:
@@ -138,6 +140,7 @@ def cert(
                 http_01_address=http_01_address,
                 dns_plugin=dns_plugin,
                 dns_plugin_credentials=dns_plugin_credentials,
+                dns_plugin_propagate_seconds=dns_plugin_propagate_seconds,
             )
             ret["result"] = res["result"]
             ret["comment"].append(res["comment"])

--- a/tests/pytests/unit/modules/test_acme.py
+++ b/tests/pytests/unit/modules/test_acme.py
@@ -337,3 +337,32 @@ def test_cert():
     ):
         assert acme.cert("test") == result_renew
         assert acme.cert("testing.example.com", certname="test") == result_renew
+
+
+def test_cert_forwards_dns_plugin_propagate_seconds():
+    """
+    Ensure dns_plugin_propagate_seconds is forwarded to certbot as
+    --dns-cloudflare-propagation-seconds (regression test for #63700).
+    """
+    cmd_result = {"stdout": "", "stderr": "", "retcode": 0}
+    run_all_mock = MagicMock(return_value=cmd_result)
+    with patch("salt.modules.acme.LEA", "certbot"), patch.dict(
+        acme.__salt__,
+        {  # pylint: disable=no-member
+            "cmd.run_all": run_all_mock,
+            "file.file_exists": MagicMock(return_value=False),
+            "tls.cert_info": MagicMock(return_value={"not_after": 0}),
+            "file.check_perms": MagicMock(
+                side_effect=lambda a, x, b, c, d, follow_symlinks: (None, None)
+            ),
+        },
+    ):
+        acme.cert(
+            "test",
+            dns_plugin="cloudflare",
+            dns_plugin_credentials="/etc/letsencrypt/cloudflare.ini",
+            dns_plugin_propagate_seconds=42,
+        )
+
+    invoked_cmd = run_all_mock.call_args[0][0]
+    assert "--dns-cloudflare-propagation-seconds 42" in invoked_cmd


### PR DESCRIPTION
Forward `dns_plugin_propagate_seconds` from `acme.cert` state to `acme.cert` module, and pass it as `--dns-cloudflare-propagation-seconds` to certbot. Before this change, supplying `dns_plugin_propagate_seconds` to `acme.cert` raised `TypeError: 'dns_plugin_propagate_seconds' is an invalid keyword argument for 'acme.cert'`.

Adopted from #64441 (rittycat's fork was deleted; rebased onto 3006.x where `acme` still ships — module was purged from master/3008.x via dc526dc2b17).

Co-authored-by: rittycat <rittycat@users.noreply.github.com>

Fixes #63700
