### PR TITLE
Fix missing rich.markup.escape import in tools/ci.py

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -17,6 +17,7 @@ import time
 from typing import TYPE_CHECKING, Any, Literal
 
 from ptscripts import Context, command_group
+from rich.markup import escape
 
 import tools.utils
 import tools.utils.gh
@@ -796,7 +797,7 @@ def workflow_config(
     config["testrun"] = _define_testrun(ctx, changed_files, labels, full)
 
     ctx.info(f"{'==== testrun ====':^80s}")
-    ctx.info(escape(pprint.pformat(config['testrun'])))
+    ctx.info(escape(pprint.pformat(config["testrun"])))
     ctx.info(f"{'==== testrun ====':^80s}")
 
     jobs = {
@@ -828,7 +829,7 @@ def workflow_config(
         for platform in platforms
     }
     ctx.info(f"{'==== build matrix ====':^80s}")
-    ctx.info(escape(pprint.pformat(config['build-matrix'])))
+    ctx.info(escape(pprint.pformat(config["build-matrix"])))
     ctx.info(f"{'==== end build matrix ====':^80s}")
     config["artifact-matrix"] = []
     for platform in platforms:
@@ -836,7 +837,7 @@ def workflow_config(
             dict({"platform": platform}, **_) for _ in config["build-matrix"][platform]
         ]
     ctx.info(f"{'==== artifact matrix ====':^80s}")
-    ctx.info(escape(pprint.pformat(config['artifact-matrix'])))
+    ctx.info(escape(pprint.pformat(config["artifact-matrix"])))
     ctx.info(f"{'==== end artifact matrix ====':^80s}")
 
     # Get salt releases.


### PR DESCRIPTION
Commit `fffeee3f235` ("Run pre-commit twice in dependabot sync") added `escape(...)` calls at 9 locations in `tools/ci.py` but did not add the import. Since that change merged via `a58c4dcd602` on 2026-06-09, every push to `3006.x` and every PR targeting `3006.x` fails at *Prepare Workflow Run* with:

```
NameError: name 'escape' is not defined
```

Importing `escape` from `rich.markup` unblocks CI for every open 3006.x PR.

`3007.x` already has this exact import at `tools/ci.py:21`.

This same fix is also bundled inside #69403 as commit `4ca3e1bd7a7`, but #69403 has other in-progress changes including a regression in `salt/states/file.py::test_managed`. Landing the escape fix standalone here unblocks the CI fleet without waiting on #69403's other concerns.