### PR TITLE
Fix postgres._find_pg_binary to prefer bins_dir over system PATH

### DIFF
--- a/changelog/53190.fixed.md
+++ b/changelog/53190.fixed.md
@@ -1,0 +1,1 @@
+Fixed `postgres._find_pg_binary` ignoring `postgres.bins_dir` when a `psql` binary is also present on the system PATH, ensuring the configured `bins_dir` is always preferred over the system PATH.

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -126,13 +126,10 @@ def __virtual__():
     Only load this module if the psql bin exist.
     initdb bin might also be used, but its presence will be detected on runtime.
     """
-    utils = ["psql"]
     if not HAS_CSV:
         return False
-    for util in utils:
-        if not salt.utils.path.which(util):
-            if not _find_pg_binary(util):
-                return (False, f"{util} was not found")
+    if not _find_pg_binary("psql"):
+        return (False, "psql was not found")
     return True
 
 
@@ -143,12 +140,11 @@ def _find_pg_binary(util):
     Helper function to locate various psql related binaries
     """
     pg_bin_dir = __salt__["config.option"]("postgres.bins_dir")
-    util_bin = salt.utils.path.which(util)
-    if not util_bin:
-        if pg_bin_dir:
-            return salt.utils.path.which(os.path.join(pg_bin_dir, util))
-    else:
-        return util_bin
+    if pg_bin_dir:
+        util_bin = salt.utils.path.which(os.path.join(pg_bin_dir, util))
+        if util_bin:
+            return util_bin
+    return salt.utils.path.which(util)
 
 
 def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -2532,6 +2532,92 @@ def test_tablespace_alter_new_name():
         )
 
 
+def test_find_pg_binary_bins_dir_preferred_over_path():
+    """
+    When postgres.bins_dir is configured, _find_pg_binary should return the
+    binary from bins_dir even when a psql binary is also present on the system
+    PATH (GitHub issue #53190).
+    """
+
+    def which_side_effect(path):
+        if path == "/usr/pgsql-15/bin/psql":
+            return "/usr/pgsql-15/bin/psql"
+        if path == "psql":
+            return "/usr/bin/psql"
+        return None
+
+    with patch.dict(
+        postgres.__salt__,
+        {"config.option": MagicMock(return_value="/usr/pgsql-15/bin")},
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/pgsql-15/bin/psql"
+
+
+def test_find_pg_binary_bins_dir_used_when_not_on_path():
+    """
+    When postgres.bins_dir is configured and psql is not on the system PATH,
+    _find_pg_binary should still find the binary via bins_dir.
+    """
+
+    def which_side_effect(path):
+        if path == "/usr/pgsql-15/bin/psql":
+            return "/usr/pgsql-15/bin/psql"
+        return None
+
+    with patch.dict(
+        postgres.__salt__,
+        {"config.option": MagicMock(return_value="/usr/pgsql-15/bin")},
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/pgsql-15/bin/psql"
+
+
+def test_find_pg_binary_falls_back_to_path_when_bins_dir_not_set():
+    """
+    When postgres.bins_dir is not configured, _find_pg_binary should fall
+    back to the system PATH (regression guard).
+    """
+    with patch.dict(
+        postgres.__salt__,
+        {"config.option": MagicMock(return_value=None)},
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/psql")):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/bin/psql"
+
+
+def test_find_pg_binary_falls_back_to_path_when_not_in_bins_dir():
+    """
+    When postgres.bins_dir is configured but the binary is not found there,
+    _find_pg_binary should fall back to the system PATH.
+    """
+
+    def which_side_effect(path):
+        if path == "psql":
+            return "/usr/bin/psql"
+        return None
+
+    with patch.dict(
+        postgres.__salt__,
+        {"config.option": MagicMock(return_value="/usr/pgsql-15/bin")},
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/bin/psql"
+
+
+def test_find_pg_binary_returns_none_when_not_found_anywhere():
+    """
+    When psql cannot be found in bins_dir or on the system PATH,
+    _find_pg_binary should return None so the caller can handle the error.
+    """
+    with patch.dict(
+        postgres.__salt__,
+        {"config.option": MagicMock(return_value="/usr/pgsql-15/bin")},
+    ), patch("salt.utils.path.which", MagicMock(return_value=None)):
+        result = postgres._find_pg_binary("psql")
+    assert result is None
+
+
 def test_tablespace_remove():
     with patch(
         "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})


### PR DESCRIPTION
### What does this PR do?
When postgres.bins_dir is configured, _find_pg_binary was ignoring it whenever psql happened to be present on the system PATH, always returning the system binary instead. This caused two failure modes: the wrong (old) psql version being used when upgrading PostgreSQL via PGDG repos alongside an OS-package install (GitHub #53190), and the postgres module failing to load entirely when psql was absent from PATH but bins_dir was only available via a pillar that failed to render.

Fix _find_pg_binary to check bins_dir first and fall back to PATH only if the binary is not found there. Simplify __virtual__ to delegate entirely to _find_pg_binary, removing the redundant salt.utils.path.which call that was bypassing the bins_dir logic. Add unit tests covering all lookup combinations.

### What issues does this PR fix or reference?
Fixes #53190 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
