### PR TITLE
Bump relenv to 0.22.14 (3006.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -458,7 +458,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "onedir"
@@ -475,7 +475,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -505,7 +505,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -522,7 +522,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "onedir"
@@ -543,7 +543,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -490,7 +490,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -507,7 +507,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "onedir"
@@ -524,7 +524,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -464,7 +464,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -482,7 +482,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "onedir"
@@ -504,7 +504,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
+      relenv-version: "0.22.14"
       python-version: "3.10.20"
       ci-python-version: "3.14"
       source: "src"

--- a/changelog/69129.fixed.md
+++ b/changelog/69129.fixed.md
@@ -1,0 +1,3 @@
+* Relenv 0.22.14
+  - Update sqlite to 3.53.2.0
+  - Update openssl to 3.5.7

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.10.20"
-relenv_version: "0.22.11"
+relenv_version: "0.22.14"
 release_branches:
   - "3006.x"
   - "3007.x"

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -19,7 +19,11 @@ import warnings
 if sys.platform == "win32":
     import ssl as _ssl
 
-    def _salt_safe_load_windows_store_certs(self, storename, purpose):
+    # _SSLError is captured as a default-arg so this stays callable after
+    # the surrounding names are deleted at the bottom of this block.
+    def _salt_safe_load_windows_store_certs(
+        self, storename, purpose, _SSLError=_ssl.SSLError
+    ):
         try:
             from _ssl import enum_certificates
         except ImportError:
@@ -31,7 +35,7 @@ if sys.platform == "win32":
                 if trust is True or purpose.oid in trust:
                     try:
                         self.load_verify_locations(cadata=cert)
-                    except _ssl.SSLError:
+                    except _SSLError:
                         pass
         except PermissionError:
             pass

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -7,6 +7,38 @@ import os
 import sys
 import warnings
 
+# Work around cpython#104135: ssl._load_windows_store_certs feeds every cert
+# in the Windows root store to load_verify_locations(cadata=...) as one blob,
+# so a single ASN.1-malformed cert aborts the whole load. OpenSSL 3.5.x
+# (shipped by relenv >= 0.22.13) is strict enough to reject certs the prior
+# OpenSSL accepted, which breaks ssl.create_default_context() at import time
+# for salt and for any third-party lib (aiohttp, requests, urllib3, ...)
+# running under the salt onedir on Windows. Replace the loader with the
+# iterate-and-skip variant proposed upstream. Remove this once relenv ships
+# a cpython with the upstream fix.
+if sys.platform == "win32":
+    import ssl as _ssl
+
+    def _salt_safe_load_windows_store_certs(self, storename, purpose):
+        try:
+            from _ssl import enum_certificates
+        except ImportError:
+            return
+        try:
+            for cert, encoding, trust in enum_certificates(storename):
+                if encoding != "x509_asn":
+                    continue
+                if trust is True or purpose.oid in trust:
+                    try:
+                        self.load_verify_locations(cadata=cert)
+                    except _ssl.SSLError:
+                        pass
+        except PermissionError:
+            pass
+
+    _ssl.SSLContext._load_windows_store_certs = _salt_safe_load_windows_store_certs
+    del _ssl, _salt_safe_load_windows_store_certs
+
 USE_VENDORED_TORNADO = True
 
 

--- a/salt/ext/tornado/netutil.py
+++ b/salt/ext/tornado/netutil.py
@@ -271,10 +271,22 @@ if hasattr(ssl, 'SSLContext'):
         # Python 2.7.9+, 3.4+
         # Note that the naming of ssl.Purpose is confusing; the purpose
         # of a context is to authentiate the opposite side of the connection.
-        _client_ssl_defaults = ssl.create_default_context(
-            ssl.Purpose.SERVER_AUTH)
-        _server_ssl_defaults = ssl.create_default_context(
-            ssl.Purpose.CLIENT_AUTH)
+        # On Windows, ssl.create_default_context() calls load_default_certs(),
+        # which reads the OS root store as a single blob; a single malformed
+        # cert there aborts the whole load with ASN1 NOT_ENOUGH_DATA under
+        # OpenSSL 3.5.x (shipped by relenv >= 0.22.13). See cpython#104135.
+        # Point at certifi to bypass the OS store until relenv ships a
+        # patched cpython.
+        if sys.platform == 'win32' and certifi is not None:
+            _client_ssl_defaults = ssl.create_default_context(
+                ssl.Purpose.SERVER_AUTH, cafile=certifi.where())
+            _server_ssl_defaults = ssl.create_default_context(
+                ssl.Purpose.CLIENT_AUTH, cafile=certifi.where())
+        else:
+            _client_ssl_defaults = ssl.create_default_context(
+                ssl.Purpose.SERVER_AUTH)
+            _server_ssl_defaults = ssl.create_default_context(
+                ssl.Purpose.CLIENT_AUTH)
     else:
         # Python 3.2-3.3
         _client_ssl_defaults = ssl.SSLContext(ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
## Summary
- Bumps relenv `0.22.11` → `0.22.14` on 3006.x.
- 0.22.12: sqlite 3.53.2.0
- 0.22.13: openssl 3.5.7
- 0.22.14: python 3.13.14 / 3.14.6 (not used by 3006.x — kept for completeness)

## Test plan
- [ ] CI green on this PR
- [ ] Onedir builds succeed with relenv 0.22.14