### PR TITLE
Bump relenv to 0.22.14 (3008.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,8 +472,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -489,8 +489,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -506,8 +506,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -522,10 +522,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.14.5"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -543,7 +543,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -562,7 +562,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       workflow-slug: ci
       default-timeout: 180

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -466,8 +466,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -483,8 +483,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -504,8 +504,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -524,10 +524,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.14.5"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -545,7 +545,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -564,7 +564,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       workflow-slug: nightly
       default-timeout: 360

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -520,8 +520,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -537,8 +537,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -554,8 +554,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -570,10 +570,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.14.5"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -591,7 +591,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -610,7 +610,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       workflow-slug: scheduled
       default-timeout: 360

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -494,8 +494,8 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -512,8 +512,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -534,8 +534,8 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.11"
-      python-version: "3.14.5"
+      relenv-version: "0.22.14"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -554,10 +554,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.14.5"
+      python-version: "3.14.6"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -575,7 +575,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -594,7 +594,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.5
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.14.6
       skip-code-coverage: true
       workflow-slug: staging
       default-timeout: 180

--- a/changelog/69129.fixed.md
+++ b/changelog/69129.fixed.md
@@ -1,0 +1,4 @@
+* Relenv 0.22.14
+  - Update python 3.14 to 3.14.6
+  - Update sqlite to 3.53.2.0
+  - Update openssl to 3.5.7

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -3,8 +3,8 @@
 
 # Tool versions
 nox_version: "2022.8.7"
-python_version: "3.14.5"
-relenv_version: "0.22.11"
+python_version: "3.14.6"
+relenv_version: "0.22.14"
 release_branches:
   - "3006.x"
   - "3007.x"


### PR DESCRIPTION
## Summary
- Bumps relenv `0.22.11` → `0.22.14` on 3008.x.
- Bumps python `3.14.5` → `3.14.6` (matches relenv 0.22.14).
- 0.22.12: sqlite 3.53.2.0
- 0.22.13: openssl 3.5.7
- 0.22.14: python 3.13.14 / 3.14.6

## Test plan
- [ ] CI green on this PR
- [ ] Onedir builds succeed with relenv 0.22.14 / python 3.14.6