### PR TITLE
timeout from _send_req_async

### DIFF
--- a/changelog/69415.fixed.md
+++ b/changelog/69415.fixed.md
@@ -1,0 +1,8 @@
+Fixed minion worker threads hanging or crashing when returning job results
+to the master. The main process now fires an error event back to the worker
+when ``req_channel.send()`` times out, so workers wake up immediately rather
+than waiting out their full timeout. Replaced the bare ``TimeoutError`` raised
+in ``_send_req_sync`` with ``SaltReqTimeoutError`` so ``_return_pub``'s existing
+handler catches it correctly. The worker's wait timeout is now derived from
+``return_retry_timer_max * return_retry_tries`` to ensure it always outlasts
+the main process's retry budget.

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1338,7 +1338,6 @@ def test_return_pub_handles_send_req_timeout(minion_opts):
     that _return_pub's except clause fires correctly.
     """
     io_loop = tornado.ioloop.IOLoop()
-    io_loop.make_current()
     minion = salt.minion.Minion(minion_opts, io_loop=io_loop)
     try:
         minion.proc_dir = salt.minion.get_proc_dir(minion_opts["cachedir"])


### PR DESCRIPTION
The timeout from _send_req_async could end up being shorter than actual timeout in handle_event. Make this whole thing more deterministic by signaling an actual timeout by passing it back in the return to _send_req_async.
