### PR TITLE
Fix salt zsh completion

### DIFF
--- a/changelog/69419.fixed.md
+++ b/changelog/69419.fixed.md
@@ -1,0 +1,1 @@
+Fixed zsh completion by using the proper python3 instead of python2.

--- a/pkg/common/salt.zsh
+++ b/pkg/common/salt.zsh
@@ -271,7 +271,11 @@ _salt_comp(){
     fi
 
     if _cache_invalid salt/salt_dir || ! _retrieve_cache salt/salt_dir; then
-        salt_dir="${$(python2 -c 'import salt; print(salt.__file__);')%__init__*}"
+        python_path="$(dirname $(readlink -f $(which salt)))/bin/python3"
+        if [ ! -e "$python_path" ]; then
+            python_path="python3"
+        fi
+        salt_dir="${$(${python_path} -c 'import salt; print(salt.__file__);')%__init__*}"
         _store_cache salt/salt_dir salt_dir
     fi
 }


### PR DESCRIPTION
### What does this PR do?
This was still hard coded to python2 and didn't account for onedir. This will now attempt to find the onedir location of python3 based on the location of the salt command. If it fails it will attempt the system python3, this will handle cases where the python salt module is installed via pip.

### What issues does this PR fix or reference?
Fixes #69419

### Previous Behavior
zsh completion fails with (anon):7: command not found: python2

### New Behavior
zsh completion works without issue.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
