### PR TITLE
Fix TypeError when beacons.list returns None in beacon state functions

### DIFF
--- a/changelog/66440.fixed.md
+++ b/changelog/66440.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``TypeError: argument of type 'NoneType' is not iterable`` in beacon state functions (``present``, ``absent``, ``enabled``, ``disabled``) when ``beacons.list`` returns ``None`` due to event-system failure. The return value is now defaulted to an empty dict before iteration.

--- a/salt/states/beacon.py
+++ b/salt/states/beacon.py
@@ -99,6 +99,8 @@ def present(name, save=False, **kwargs):
     ret = {"name": name, "result": True, "changes": {}, "comment": []}
 
     current_beacons = __salt__["beacons.list"](return_yaml=False, **kwargs)
+    if current_beacons is None:
+        current_beacons = {}
     beacon_data = [{k: v} for k, v in kwargs.items()]
 
     if name in current_beacons:
@@ -172,6 +174,8 @@ def absent(name, save=False, **kwargs):
     ret = {"name": name, "result": True, "changes": {}, "comment": []}
 
     current_beacons = __salt__["beacons.list"](return_yaml=False, **kwargs)
+    if current_beacons is None:
+        current_beacons = {}
     if name in current_beacons:
         if __opts__.get("test"):
             kwargs["test"] = True
@@ -219,6 +223,8 @@ def enabled(name, **kwargs):
     ret = {"name": name, "result": True, "changes": {}, "comment": []}
 
     current_beacons = __salt__["beacons.list"](return_yaml=False, **kwargs)
+    if current_beacons is None:
+        current_beacons = {}
     if name in current_beacons:
         if __opts__.get("test"):
             kwargs["test"] = True
@@ -259,6 +265,8 @@ def disabled(name, **kwargs):
     ret = {"name": name, "result": True, "changes": {}, "comment": []}
 
     current_beacons = __salt__["beacons.list"](return_yaml=False, **kwargs)
+    if current_beacons is None:
+        current_beacons = {}
     if name in current_beacons:
         if __opts__.get("test"):
             kwargs["test"] = True

--- a/tests/pytests/unit/states/test_beacon.py
+++ b/tests/pytests/unit/states/test_beacon.py
@@ -47,7 +47,9 @@ def test_present_none_beacons():
     """
     beacon_name = "test_beacon"
 
-    mock_mod = MagicMock(return_value={"name": beacon_name, "result": True, "changes": {}, "comment": []})
+    mock_mod = MagicMock(
+        return_value={"name": beacon_name, "result": True, "changes": {}, "comment": []}
+    )
     mock_lst = MagicMock(return_value=None)
     with patch.dict(
         beacon.__salt__,

--- a/tests/pytests/unit/states/test_beacon.py
+++ b/tests/pytests/unit/states/test_beacon.py
@@ -41,6 +41,27 @@ def test_present():
             assert beacon.present(beacon_name) == ret
 
 
+def test_present_none_beacons():
+    """
+    Test present when beacons.list returns None.
+    """
+    beacon_name = "test_beacon"
+
+    mock_mod = MagicMock(return_value={"name": beacon_name, "result": True, "changes": {}, "comment": []})
+    mock_lst = MagicMock(return_value=None)
+    with patch.dict(
+        beacon.__salt__,
+        {
+            "beacons.list": mock_lst,
+            "beacons.add": mock_mod,
+        },
+    ):
+        with patch.dict(beacon.__opts__, {"test": False}):
+            ret = beacon.present(beacon_name)
+            assert ret["result"] is True
+            assert ret["comment"] == f"Adding {beacon_name} to beacons"
+
+
 def test_absent():
     """
     Test to ensure a job is absent from the schedule.
@@ -61,3 +82,22 @@ def test_absent():
             comt = "ps not configured in beacons"
             ret.update({"comment": comt, "result": True})
             assert beacon.absent(beacon_name) == ret
+
+
+def test_absent_none_beacons():
+    """
+    Test absent when beacons.list returns None.
+    """
+    beacon_name = "test_beacon"
+
+    mock_lst = MagicMock(return_value=None)
+    with patch.dict(
+        beacon.__salt__,
+        {
+            "beacons.list": mock_lst,
+        },
+    ):
+        with patch.dict(beacon.__opts__, {"test": False}):
+            ret = beacon.absent(beacon_name)
+            assert ret["result"] is True
+            assert f"{beacon_name} not configured in beacons" in ret["comment"]


### PR DESCRIPTION
Fixes #66440.

### What changed
Fix TypeError when beacons.list returns None in beacon state functions

### Why
The issue reports that `beacon.present` crashes with TypeError: argument of type 'NoneType' is not iterable when `beacons.list` returns None, which can happen when the event system fails. The fix adds a None check on the return value of `beacons.list` in all four beacon state functions (`present`, `absent`, `enabled`, `disabled`) and defaults to an empty dict, which is safe to iterate over. This addresses the root cause without adding retry logic, which would be a larger feature change.

### Verification
- python ast parse passed

### Not run
- Repository runtime tests were not run outside the configured static/sandbox policy.

### Changed files
- `salt/states/beacon.py`
- `tests/pytests/unit/states/test_beacon.py`