### PR TITLE
Fix LocalClient.cmd_subset crashing on failed minion probing (#68103)

### DIFF
--- a/changelog/68103.fixed.md
+++ b/changelog/68103.fixed.md
@@ -1,0 +1,1 @@
+Fixed `LocalClient.cmd_subset` raising `TypeError: argument of type 'bool' is not iterable` when one or more targeted minions failed to respond to the `sys.list_functions` probe. Failed minions are now skipped during subset selection.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -536,7 +536,13 @@ class LocalClient:
         random.shuffle(minions)
         f_tgt = []
         for minion in minions:
-            if fun in minion_ret[minion]:
+            # Minions that failed to respond to ``sys.list_functions`` are
+            # represented as ``False`` (see the failed-minion handling in
+            # ``cmd``). Skip them rather than letting ``in`` raise.
+            functions = minion_ret[minion]
+            if not isinstance(functions, (list, tuple, set, dict)):
+                continue
+            if fun in functions:
                 f_tgt.append(minion)
             if len(f_tgt) >= subset:
                 break

--- a/tests/pytests/unit/test_client.py
+++ b/tests/pytests/unit/test_client.py
@@ -177,6 +177,46 @@ def test_cmd_subset(salt_master_factory):
                 )
 
 
+def test_cmd_subset_skips_failed_minions_68103(salt_master_factory):
+    """
+    Regression test for #68103.
+
+    When ``LocalClient.cmd`` cannot reach a minion it returns ``False`` for
+    that minion's entry in the result dict. ``cmd_subset`` previously did
+    ``if fun in minion_ret[minion]`` without checking the value type and
+    raised ``TypeError: argument of type 'bool' is not iterable``. The
+    failed minion(s) should simply be skipped.
+    """
+    salt_local_client = salt.client.get_local_client(mopts=salt_master_factory.config)
+
+    # ``cmd_subset`` calls ``random.shuffle`` on the minion list before
+    # iterating it. Replace shuffle with a no-op so the iteration order is
+    # deterministic and the failed minion is encountered first.
+    with patch("salt.client.random.shuffle", lambda x: None), patch(
+        "salt.client.LocalClient.cmd",
+        return_value={
+            # A minion that did not respond to ``sys.list_functions`` shows
+            # up in the return as ``False`` (see LocalClient.cmd's failed
+            # minion handling).
+            "minion1": False,
+            "minion2": ["first.func", "second.func"],
+        },
+    ):
+        with patch("salt.client.LocalClient.cmd_cli") as cmd_cli_mock:
+            # Should not raise TypeError; failed minion must be skipped.
+            salt_local_client.cmd_subset("*", "first.func", subset=1, cli=True)
+            cmd_cli_mock.assert_called_with(
+                ["minion2"],
+                "first.func",
+                (),
+                progress=False,
+                kwarg=None,
+                tgt_type="list",
+                full_return=False,
+                ret="",
+            )
+
+
 @pytest.mark.skip_on_windows(reason="Not supported on Windows")
 def test_pub(salt_master_factory):
     """


### PR DESCRIPTION
### What does this PR do?

Stops `LocalClient.cmd_subset` from raising `TypeError: argument of type 'bool' is not iterable` when one or more targeted minions fail the `sys.list_functions` probe. Failed minions surface as `False` in the probe result and are now skipped during subset selection.

### What issues does this PR fix or reference?

Fixes #68103

### Previous Behavior

`cmd_subset` iterates the result of a `sys.list_functions` probe with `if fun in minion_ret[minion]`. When a minion failed to respond, `LocalClient.cmd` records its entry as `False`, so the membership test raised `TypeError: argument of type 'bool' is not iterable` and aborted the call:

```
File "salt/client/__init__.py", line 539, in cmd_subset
    if fun in minion_ret[minion]:
TypeError: argument of type 'bool' is not iterable
```

### New Behavior

Failed minions (non-container probe responses) are skipped during the subset loop. `cmd_subset` returns the subset of responsive minions and never raises on this code path.

### Merge requirements satisfied?
- [x] Used a Salt Project PR template
- [x] Tests written/updated
- [x] Changelog entry
- [x] Documentation updated (no user-facing docs change required)

### Commits signed with GPG?

Yes
