### PR TITLE
Allow user.present test mode with not-yet-existing groups (#68110)

### DIFF
--- a/changelog/68110.fixed.md
+++ b/changelog/68110.fixed.md
@@ -1,0 +1,1 @@
+Fixed `user.present` to not fail with `result: False` in test mode when a referenced group does not yet exist; the state now reports the pending changes so users can preview states that depend on groups created by a `group.present` requisite in the same run.

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -597,14 +597,25 @@ def present(
             ret["result"] = False
             return ret
 
+    missing_groups = []
     if groups:
         missing_groups = [x for x in groups if not __salt__["group.info"](x)]
         if missing_groups:
-            ret["comment"] = "The following group(s) are not present: {}".format(
-                ",".join(missing_groups)
-            )
-            ret["result"] = False
-            return ret
+            if __opts__.get("test"):
+                # In test mode, a missing group is not necessarily an error:
+                # a `group.present` requisite may create it during the real
+                # run. Note the missing groups in the result, drop them from
+                # the membership check below (they cannot be diffed against
+                # the user's current groups since they do not yet exist),
+                # and let the rest of the function report whatever else
+                # would change. Issue #68110.
+                groups = [x for x in groups if x not in missing_groups]
+            else:
+                ret["comment"] = "The following group(s) are not present: {}".format(
+                    ",".join(missing_groups)
+                )
+                ret["result"] = False
+                return ret
 
     if optional_groups:
         present_optgroups = [x for x in optional_groups if __salt__["group.info"](x)]
@@ -686,6 +697,10 @@ def present(
                 elif key == "group" and not remove_groups:
                     key = "ensure groups"
                 ret["comment"] += f"{key}: {val}\n"
+            if missing_groups:
+                ret["comment"] += "groups (pending creation): {}\n".format(
+                    ",".join(missing_groups)
+                )
             return ret
         # The user is present
         if "shadow.info" in __salt__:
@@ -870,6 +885,10 @@ def present(
         if __opts__["test"]:
             ret["result"] = None
             ret["comment"] = f"User {name} set to be added"
+            if missing_groups:
+                ret["comment"] += " (pending groups: {})".format(
+                    ",".join(missing_groups)
+                )
             return ret
         if groups and present_optgroups:
             groups.extend(present_optgroups)

--- a/tests/pytests/unit/states/test_user.py
+++ b/tests/pytests/unit/states/test_user.py
@@ -462,6 +462,66 @@ def test_present_password_unlock():
             unlock_account.assert_not_called()
 
 
+def test_present_test_mode_missing_group_new_user():
+    """
+    Regression test for #68110: user.present should not fail in test mode
+    when a referenced group does not yet exist (e.g. it will be created by
+    a group.present requisite during the actual run). When the user also
+    does not yet exist, the state should report it would be added and that
+    the missing groups are pending.
+    """
+    mock_false = MagicMock(return_value=False)
+    mock_empty_list = MagicMock(return_value=[])
+    with patch.dict(user.__grains__, {"kernel": "Linux"}), patch.dict(
+        user.__salt__,
+        {
+            "group.info": mock_false,
+            "user.info": mock_empty_list,
+            "user.chkey": mock_empty_list,
+            "user.add": mock_false,
+        },
+    ), patch.dict(user.__opts__, {"test": True}):
+        ret = user.present("foo", groups=["foo"])
+        assert ret["result"] is None, ret
+        assert "set to be added" in ret["comment"], ret
+        assert "foo" in ret["comment"], ret
+
+
+def test_present_test_mode_missing_group_existing_user():
+    """
+    Regression test for #68110: when the user already exists, a missing
+    required group should not cause a hard failure in test mode. The
+    pending group(s) should appear in the test-mode comment.
+    """
+    mock_info = MagicMock(
+        return_value={
+            "uid": 5000,
+            "gid": 5000,
+            "groups": ["bar"],
+            "home": "/home/baz",
+            "fullname": "Baz",
+        }
+    )
+    # group.info: "foo" missing, "bar" exists.
+    group_info = MagicMock(
+        side_effect=lambda name: False if name == "foo" else {"gid": 5000}
+    )
+    dunder_salt = {
+        "group.info": group_info,
+        "user.info": mock_info,
+        "file.group_to_gid": MagicMock(return_value=5000),
+        "file.gid_to_group": MagicMock(return_value="bar"),
+    }
+    with patch.dict(user.__grains__, {"kernel": "Linux"}), patch.dict(
+        user.__salt__, dunder_salt
+    ), patch.dict(user.__opts__, {"test": True}):
+        ret = user.present("baz", groups=["foo", "bar"])
+        assert ret["result"] is not False, ret
+        assert "not present" not in ret["comment"], ret
+        # Pending group should be reported somewhere in the comment.
+        assert "foo" in ret["comment"], ret
+
+
 @pytest.mark.parametrize(
     "current,wanted,remove,return_value,expected",
     [


### PR DESCRIPTION
### What does this PR do?

`user.present` previously failed immediately with `result: False` and
"The following group(s) are not present: ..." whenever it was given a
`groups:` list that referenced a group not yet on the minion. That
happened even under `state.apply test=True`, which made it impossible to
preview states where the missing group is created by a `group.present`
requisite in the same run.

This PR gates the hard failure on `not __opts__["test"]`. In test mode,
missing groups are dropped from the membership comparison (they cannot
be diffed against the user's current groups since they do not exist
yet) and added to the test-mode comment as pending so the operator can
still see what would change.

### What issues does this PR fix or reference?

Fixes #68110

### Previous Behavior

```
foo:
  group.present: []
  user.present:
    - groups:
      - foo
    - require:
      - group: foo
```

`salt '*' state.apply test=True` returned `result: False` on the
`user.present` state with comment "The following group(s) are not
present: foo", even though the group would have been created during a
real run.

### New Behavior

In test mode, the missing group is reported as pending; the state's
`result` is `None` (changes would be made) instead of `False` (hard
error). Behavior in non-test mode is unchanged — a truly missing
required group is still a failure.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
