### PR TITLE
Fix Photon OS Arm64 FIPS nightlies: re-enable OpenSSL default provider

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -225,6 +225,12 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test \
             tdnf install -y openssl-fips-provider
+          # openssl-fips-provider <= 3.1.2-3.ph5 disables the OpenSSL default
+          # provider in /etc/ssl/distro.cnf, breaking TLS in curl/git/tdnf.
+          # Re-enable it to mirror the upstream fix in vmware/photon@4610f36756
+          # (openssl-fips-provider 3.1.2-4.ph5). Idempotent on fixed builds.
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i '/^#\.include \/etc\/ssl\/provider_default.cnf/s/^#//g' /etc/ssl/distro.cnf
 
       - name: "Show container inspect ${{ matrix.container }}"
         run: |
@@ -594,6 +600,12 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test \
             tdnf install -y openssl-fips-provider
+          # openssl-fips-provider <= 3.1.2-3.ph5 disables the OpenSSL default
+          # provider in /etc/ssl/distro.cnf, breaking TLS in curl/git/tdnf.
+          # Re-enable it to mirror the upstream fix in vmware/photon@4610f36756
+          # (openssl-fips-provider 3.1.2-4.ph5). Idempotent on fixed builds.
+          docker exec ${{ github.run_id }}_salt-test \
+            sed -i '/^#\.include \/etc\/ssl\/provider_default.cnf/s/^#//g' /etc/ssl/distro.cnf
 
       - name: "Show container inspect ${{ matrix.container }}"
         run: |

--- a/.github/workflows/test-packages-action.yml
+++ b/.github/workflows/test-packages-action.yml
@@ -167,6 +167,12 @@ jobs:
         run: |
           docker exec ${{ github.run_id }}_salt-test-pkg \
             tdnf install -y openssl-fips-provider
+          # openssl-fips-provider <= 3.1.2-3.ph5 disables the OpenSSL default
+          # provider in /etc/ssl/distro.cnf, breaking TLS in curl/git/tdnf.
+          # Re-enable it to mirror the upstream fix in vmware/photon@4610f36756
+          # (openssl-fips-provider 3.1.2-4.ph5). Idempotent on fixed builds.
+          docker exec ${{ github.run_id }}_salt-test-pkg \
+            sed -i '/^#\.include \/etc\/ssl\/provider_default.cnf/s/^#//g' /etc/ssl/distro.cnf
 
       - name: Decompress .nox Directory
         run: |

--- a/changelog/69448.fixed.md
+++ b/changelog/69448.fixed.md
@@ -1,0 +1,1 @@
+Fixed Photon OS Arm64 FIPS CI by re-enabling the OpenSSL default provider after installing openssl-fips-provider, working around the disabled-default-provider bug in `openssl-fips-provider <= 3.1.2-3.ph5` on the lagging Photon aarch64 mirror.


### PR DESCRIPTION
## Summary

- `openssl-fips-provider` builds `<= 3.1.2-3.ph5` disable the OpenSSL default provider in `/etc/ssl/distro.cnf` via the spec's `%post` script. The remaining `fips` + `base` providers don't export the decoders TLS clients need, so curl/git/tdnf inside Photon OS Arm64 FIPS containers fail handshakes with `error:03000072:digital envelope routines::decode error`.
- Photon already published the upstream fix in vmware/photon@4610f36756 (`openssl-fips-provider 3.1.2-4.ph5`), but the **aarch64** mirror on `packages.broadcom.com` still serves `3.1.2-2.ph5` because Photon's ARM build/publish lags x86.
- Result: every `Photon OS 5 Arm64` FIPS job in the 3008.x nightly has been failing since 2026-06-13 (run [27483489352](https://github.com/saltstack/salt/actions/runs/27483489352): 10 test jobs across `Test Package install/upgrade`, `Test Salt functional zeromq(fips) 1/3/4/5`, `integration tcp(fips) 2`, `integration zeromq(fips) 2`).

## Fix

Replicate the upstream `%post` repair in our CI: after `tdnf install -y openssl-fips-provider`, re-uncomment `.include /etc/ssl/provider_default.cnf` in `/etc/ssl/distro.cnf`. The edit is idempotent — it's a no-op once the corrected `3.1.2-4.ph5` aarch64 RPM lands on the mirror, so there's nothing to revert later.

Three call sites touched:
- `.github/workflows/test-action.yml` (test-salt path, both jobs)
- `.github/workflows/test-packages-action.yml` (test-packages path)

## Test plan

- [ ] `Test Salt / Photon OS 5 Arm64 functional zeromq(fips) 1/3/4/5` pass
- [ ] `Test Salt / Photon OS 5 Arm64 integration tcp(fips) 2` passes
- [ ] `Test Salt / Photon OS 5 Arm64 integration zeromq(fips) 2` passes
- [ ] `Test Package / Photon OS 5 Arm64 install` and `upgrade 3006.25 / 3007.14 / 3008.1` pass
- [ ] No regression on Photon OS 4 FIPS (which already had the fixed provider) or Photon OS 5 non-FIPS