### PR TITLE
docs: fix Docker Salt Extension link

### DIFF
--- a/doc/topics/releases/3007.0.md
+++ b/doc/topics/releases/3007.0.md
@@ -96,7 +96,7 @@ This is auto generated
 
 - Deprecate all Proxmox cloud modules [#64224](https://github.com/saltstack/salt/issues/64224)
 - Deprecate all the Vault modules in favor of the Vault Salt Extension https://github.com/salt-extensions/saltext-vault. The Vault modules will be removed in Salt core in 3009.0. [#64893](https://github.com/saltstack/salt/issues/64893)
-- Deprecate all the Docker modules in favor of the Docker Salt Extension https://github.com/saltstack/saltext-docker. The Docker modules will be removed in Salt core in 3009.0. [#64894](https://github.com/saltstack/salt/issues/64894)
+- Deprecate all the Docker modules in favor of the Docker Salt Extension https://github.com/salt-extensions/saltext-dockermod. The Docker modules will be removed in Salt core in 3009.0. [#64894](https://github.com/saltstack/salt/issues/64894)
 - Deprecate all the Zabbix modules in favor of the Zabbix Salt Extension https://github.com/salt-extensions/saltext-zabbix. The Zabbix modules will be removed in Salt core in 3009.0. [#64896](https://github.com/saltstack/salt/issues/64896)
 - Deprecate all the Apache modules in favor of the Apache Salt Extension https://github.com/salt-extensions/saltext-apache. The Apache modules will be removed in Salt core in 3009.0. [#64909](https://github.com/saltstack/salt/issues/64909)
 - Deprecation warning for Salt's backport of ``OrderedDict`` class which will be removed in 3009 [#65542](https://github.com/saltstack/salt/issues/65542)


### PR DESCRIPTION
### What does this PR do?

Updates the Docker Salt Extension link in the 3007.0 release notes from the non-existent `saltstack/saltext-docker` repository to the current `salt-extensions/saltext-dockermod` repository referenced by maintainers in the issue discussion.

Fixes #65814

### What issues does this PR fix or reference?

Fixes: #65814

### Previous Behavior

The release notes pointed to `https://github.com/saltstack/saltext-docker`, which returns 404.

### New Behavior

The release notes point to `https://github.com/salt-extensions/saltext-dockermod`, which resolves successfully.

### Merge requirements satisfied?

- [x] Docs-only change
- [x] `git diff --check`
