### PR TITLE
Fire minion_data_cache_events on resource registration (#69451)

### DIFF
--- a/changelog/69451.fixed.md
+++ b/changelog/69451.fixed.md
@@ -1,0 +1,1 @@
+Fixed `AESFuncs._register_resources` to fire a `minion_data_cache_events` notification on the master event bus when resource grains are written to the cache, mirroring the existing notification fired by `_pillar` for ordinary minion grains.

--- a/salt/master.py
+++ b/salt/master.py
@@ -2503,6 +2503,14 @@ class AESFuncs(TransportMethods):
                     load["id"],
                     exc,
                 )
+            # Mirror the notification ``_pillar`` fires when ordinary minion
+            # grains are refreshed in the cache, so consumers subscribed to
+            # ``salt/minion/*/refresh/*`` see resource-grain refreshes too.
+            if self.opts.get("minion_data_cache_events") is True:
+                self.event.fire_event(
+                    {"Resource cache refresh": load["id"]},
+                    tagify(load["id"], "refresh", "resource"),
+                )
         return True
 
     def _file_recv(self, load):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1704,6 +1704,73 @@ def test_register_resources_resource_grains_visible_across_aes_funcs_instances(
         salt.utils.resource_registry.reset_registry()
 
 
+def test_register_resources_fires_minion_data_cache_event(master_opts, tmp_path):
+    """
+    When ``minion_data_cache: True`` and ``minion_data_cache_events: True``,
+    ``_register_resources`` must fire a cache-refresh event on the master
+    event bus that mirrors the notification ``_pillar`` fires for ordinary
+    minion grains. Without this signal, downstream consumers subscribed to
+    cache-refresh events miss every resource registration.
+
+    Regression for #69451.
+    """
+    import salt.utils.resource_registry
+
+    aes_funcs, opts = _make_aes_funcs_for_resource_grains(master_opts, tmp_path)
+    opts["minion_data_cache_events"] = True
+    aes_funcs.opts["minion_data_cache_events"] = True
+    aes_funcs.event = MagicMock()
+    try:
+        load = {
+            "id": "minion-2",
+            "resources": {"dummy": ["m2-d1"]},
+            "resource_grains": {"dummy:m2-d1": {"k": "v1"}},
+        }
+        with patch("salt.utils.minions.update_resource_index", return_value=(1, 0)):
+            aes_funcs._register_resources(load)
+        # ``_pillar`` fires ``minion/refresh/<id>`` for grain refreshes (see
+        # the analogous ``tagify(load["id"], "refresh", "minion")`` call);
+        # the resource registration path mirrors that with ``resource`` as
+        # the namespace, yielding ``resource/refresh/<id>``.
+        aes_funcs.event.fire_event.assert_called_once_with(
+            {"Resource cache refresh": "minion-2"},
+            "resource/refresh/minion-2",
+        )
+    finally:
+        aes_funcs.destroy()
+        salt.utils.resource_registry.reset_registry()
+
+
+def test_register_resources_does_not_fire_event_when_events_disabled(
+    master_opts, tmp_path
+):
+    """
+    With ``minion_data_cache: True`` but ``minion_data_cache_events: False``,
+    ``_register_resources`` must not fire a cache-refresh event. Symmetric
+    to ``_pillar``'s behaviour.
+
+    Regression for #69451.
+    """
+    import salt.utils.resource_registry
+
+    aes_funcs, opts = _make_aes_funcs_for_resource_grains(master_opts, tmp_path)
+    opts["minion_data_cache_events"] = False
+    aes_funcs.opts["minion_data_cache_events"] = False
+    aes_funcs.event = MagicMock()
+    try:
+        load = {
+            "id": "minion-2",
+            "resources": {"dummy": ["m2-d1"]},
+            "resource_grains": {"dummy:m2-d1": {"k": "v1"}},
+        }
+        with patch("salt.utils.minions.update_resource_index", return_value=(1, 0)):
+            aes_funcs._register_resources(load)
+        aes_funcs.event.fire_event.assert_not_called()
+    finally:
+        aes_funcs.destroy()
+        salt.utils.resource_registry.reset_registry()
+
+
 async def test_collect__auth_to_master_stats():
     """
     Check if master stats is collecting _auth calls while not calling neither _handle_aes nor _handle_clear


### PR DESCRIPTION
### What does this PR do?

`AESFuncs._register_resources` now fires a `minion_data_cache_events`
notification on the master event bus when resource grains are written to the
`resource_grains` cache bank, mirroring the notification `AESFuncs._pillar`
already fires when ordinary minion grains are cached. Consumers subscribed to
cache-refresh events see resource registrations on equal footing with grain
refreshes.

### What issues does this PR fix or reference?

Fixes #69451

### Previous Behavior

When a minion sent a `cmd: _register_resources` payload to a master with
`minion_data_cache: True` and `minion_data_cache_events: True`, the master
wrote the resource grains into the `resource_grains` cache bank but fired no
event on the bus. External cache managers, SSE/RaaS master modules, and any
other consumer that watched `salt/minion/*/refresh/*` saw nothing and only
picked up the change on direct poll.

### New Behavior

When `minion_data_cache` and `minion_data_cache_events` are both enabled,
`_register_resources` now fires an event with tag `resource/refresh/<minion_id>`
and payload `{"Resource cache refresh": "<minion_id>"}`, symmetric to
`_pillar`'s existing `minion/refresh/<minion_id>` notification.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change; the event tag is internal contract)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
