### PR TITLE
Percent-encode userinfo in add_http_basic_auth (#55561)

### DIFF
--- a/changelog/55561.fixed.md
+++ b/changelog/55561.fixed.md
@@ -1,0 +1,1 @@
+Percent-encode the user and password when adding HTTP basic auth to a URL so reserved characters no longer corrupt the result

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -4,7 +4,7 @@ URL utils
 
 import re
 import sys
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import salt.utils.data
 import salt.utils.path
@@ -156,12 +156,16 @@ def add_http_basic_auth(url, user=None, password=None, https_only=False):
         urltuple = urlparse(url)
         if https_only and urltuple.scheme != "https":
             raise ValueError("Basic Auth only supported for HTTPS")
+        # Percent-encode the userinfo so reserved characters (e.g. "/", "@",
+        # ":") in the user or password do not corrupt the resulting URL.
         if password is None:
-            netloc = f"{user}@{urltuple.netloc}"
+            netloc = f"{quote(user, safe='')}@{urltuple.netloc}"
             urltuple = urltuple._replace(netloc=netloc)
             return urlunparse(urltuple)
         else:
-            netloc = f"{user}:{password}@{urltuple.netloc}"
+            netloc = (
+                f"{quote(user, safe='')}:{quote(password, safe='')}@{urltuple.netloc}"
+            )
             urltuple = urltuple._replace(netloc=netloc)
             return urlunparse(urltuple)
 

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote, urlparse
+
 import salt.utils.platform
 import salt.utils.url
 from tests.support.mock import MagicMock, patch
@@ -363,6 +365,28 @@ class UrlTestCase(TestCase):
             expected = expected.replace("http://", "https://", 1)
             result = salt.utils.url.add_http_basic_auth(**kwargs)
             self.assertEqual(result, expected)
+
+    def test_http_basic_auth_quotes_userinfo(self):
+        """
+        Reserved characters in the user or password must be percent-encoded so
+        they do not corrupt the resulting URL (see #55561).
+        """
+        result = salt.utils.url.add_http_basic_auth(
+            "https://example.com/repo.git",
+            user="some@User",
+            password="some+Generated/Password",
+        )
+        self.assertEqual(
+            result,
+            "https://some%40User:some%2BGenerated%2FPassword@example.com/repo.git",
+        )
+        # The encoded URL must round-trip back to the original credentials and
+        # leave the host/path intact.
+        parsed = urlparse(result)
+        self.assertEqual(parsed.hostname, "example.com")
+        self.assertEqual(parsed.path, "/repo.git")
+        self.assertEqual(unquote(parsed.username), "some@User")
+        self.assertEqual(unquote(parsed.password), "some+Generated/Password")
 
     def test_http_basic_auth_https_only(self):
         """


### PR DESCRIPTION
### What does this PR do?

`salt.utils.url.add_http_basic_auth` inserted the `user` and `password` into the URL netloc verbatim, without percent-encoding. When a credential contains a character that is reserved in the userinfo component (for example a generated password with `/`, `@` or `:`), the resulting URL gets mis-parsed.

For instance:

```python
>>> salt.utils.url.add_http_basic_auth(
...     "https://example.com/repo.git",
...     user="user", password="some+Generated/Password")
'https://user:some+Generated/Password@example.com/repo.git'
```

Re-parsing that string, the `/` ends the netloc, so the host becomes `user` and the path becomes `/Password@example.com/repo.git` — which is how the `Port number ended with 'N'` style failures in #55561 happen when cloning a git repo with such a password.

The fix percent-encodes the user and password with `quote(..., safe="")` so reserved characters survive a round-trip. Plain alphanumeric credentials are unchanged.

### What issues does this PR fix or reference?

Fixes #55561

### Previous Behavior

Reserved characters in the user/password corrupted the generated URL (wrong host/path on re-parse).

### New Behavior

User and password are percent-encoded, so the URL round-trips back to the original credentials with the host and path intact.

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

No
