### PR TITLE
fix: percent-encode userinfo in add_http_basic_auth

### DIFF
--- a/changelog/55561.fixed.md
+++ b/changelog/55561.fixed.md
@@ -1,0 +1,1 @@
+Percent-encode user and password in `salt.utils.url.add_http_basic_auth` so reserved characters like `+`, `/`, `@`, `:` in credentials no longer corrupt the URL netloc.

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -4,7 +4,7 @@ URL utils
 
 import re
 import sys
-from urllib.parse import urlparse, urlunparse, urlunsplit
+from urllib.parse import quote, urlparse, urlunparse, urlunsplit
 
 import salt.utils.data
 import salt.utils.path
@@ -154,12 +154,14 @@ def add_http_basic_auth(url, user=None, password=None, https_only=False):
         urltuple = urlparse(url)
         if https_only and urltuple.scheme != "https":
             raise ValueError("Basic Auth only supported for HTTPS")
+        # RFC 3986 §3.2.1: userinfo percent-encodes special characters
+        safe = ""
         if password is None:
-            netloc = f"{user}@{urltuple.netloc}"
+            netloc = f"{quote(user, safe=safe)}@{urltuple.netloc}"
             urltuple = urltuple._replace(netloc=netloc)
             return urlunparse(urltuple)
         else:
-            netloc = f"{user}:{password}@{urltuple.netloc}"
+            netloc = f"{quote(user, safe=safe)}:{quote(password, safe=safe)}@{urltuple.netloc}"
             urltuple = urltuple._replace(netloc=netloc)
             return urlunparse(urltuple)
 

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -384,8 +384,14 @@ class UrlTestCase(TestCase):
         """
         # ((user, password), expected) tuples
         test_inputs = (
-            (("user+name", "p@ss:word"), "https://user%2Bname:p%40ss%3Aword@example.com"),
-            (("user/name", "some+Generated/Password"), "https://user%2Fname:some%2BGenerated%2FPassword@example.com"),
+            (
+                ("user+name", "p@ss:word"),
+                "https://user%2Bname:p%40ss%3Aword@example.com",
+            ),
+            (
+                ("user/name", "some+Generated/Password"),
+                "https://user%2Fname:some%2BGenerated%2FPassword@example.com",
+            ),
             (("user name", "pass word"), "https://user%20name:pass%20word@example.com"),
         )
         for (user, password), expected in test_inputs:

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -377,6 +377,25 @@ class UrlTestCase(TestCase):
         }
         self.assertRaises(ValueError, salt.utils.url.add_http_basic_auth, **kwargs)
 
+    def test_http_basic_auth_special_chars(self):
+        """
+        Tests that special characters in user/password are percent-encoded
+        per RFC 3986 §3.2.1
+        """
+        # ((user, password), expected) tuples
+        test_inputs = (
+            (("user+name", "p@ss:word"), "https://user%2Bname:p%40ss%3Aword@example.com"),
+            (("user/name", "some+Generated/Password"), "https://user%2Fname:some%2BGenerated%2FPassword@example.com"),
+            (("user name", "pass word"), "https://user%20name:pass%20word@example.com"),
+        )
+        for (user, password), expected in test_inputs:
+            result = salt.utils.url.add_http_basic_auth(
+                url="https://example.com",
+                user=user,
+                password=password,
+            )
+            self.assertEqual(result, expected)
+
     def test_redact_http_basic_auth(self):
         sensitive_outputs = (
             "https://deadbeaf@example.com",


### PR DESCRIPTION
## What does this PR do?

Fixes `add_http_basic_auth` to percent-encode user and password fields per RFC 3986 §3.2.1.

### Problem

Passwords containing special characters (`+`, `/`, `@`, `:`, etc.) were inserted verbatim into the URL userinfo component. This caused URL parsing errors like `Port number ended with 'N'` when the password contained these characters.

### Solution

Uses `urllib.parse.quote()` on both user and password fields before constructing the netloc. Alphanumeric characters and `-`, `_`, `.`, `~` are left unencoded (safe by default in `quote()`).

### Example

```python
# Before: broken
add_http_basic_auth(url, user='someUser', password='some+Generated/Password')
# => 'https://someUser:some+Generated/Password@example.com'  # '+' and '/' break URL parsing

# After: correct
add_http_basic_auth(url, user='someUser', password='some+Generated/Password')
# => 'https://someUser:some%2BGenerated%2FPassword@example.com'
```

Fixes #55561