### PR TITLE
Fix changelog template splitting multi-line entries into duplicate bullets (#69454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ Versions are `MAJOR.PATCH`.
 
 ### Changed
 
-- Changed `salt.returners.redis_return` to enumerate the Redis keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-- with `SCAN` instead of the blocking `KEYS pattern` command in both [#69037](https://github.com/saltstack/salt/issues/69037)
-- `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-- synchronously and stalls the Redis server for the duration; on a [#69037](https://github.com/saltstack/salt/issues/69037)
-- master with hundreds of thousands of jobs this can block all clients [#69037](https://github.com/saltstack/salt/issues/69037)
-- of that Redis instance for seconds. `SCAN` is incremental and [#69037](https://github.com/saltstack/salt/issues/69037)
-- non-blocking. Order of returned keys is no longer guaranteed (the [#69037](https://github.com/saltstack/salt/issues/69037)
-- returner does not rely on order); operators with custom scripts that [#69037](https://github.com/saltstack/salt/issues/69037)
-- read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
+- Changed `salt.returners.redis_return` to enumerate the Redis keyspace
+  with `SCAN` instead of the blocking `KEYS pattern` command in both
+  `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace
+  synchronously and stalls the Redis server for the duration; on a
+  master with hundreds of thousands of jobs this can block all clients
+  of that Redis instance for seconds. `SCAN` is incremental and
+  non-blocking. Order of returned keys is no longer guaranteed (the
+  returner does not rely on order); operators with custom scripts that
+  read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
 
 
 ### Fixed
@@ -30,64 +30,64 @@ Versions are `MAJOR.PATCH`.
 - Improved documentation for the `runas` and `password` parameters in `cmd.run`, `cmd.script`, and all `salt.modules.cmdmod` execution functions on Windows. The docs now accurately describe when a password is required: only when the salt-minion is **not** running as SYSTEM or as an elevated Administrator. Removed the inaccurate claim that the target user account must be in the Administrators group. Also changed `cmd.script` to log a warning instead of hard-failing when `runas` is used without a password on Windows, since a password is not always required. [#57951](https://github.com/saltstack/salt/issues/57951)
 - Fixed `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` errors in the VMware cloud driver by reconnecting when a cached vCenter service instance is found to be stale or corrupted (for example when inherited across a fork by salt-cloud's parallel provider queries). [#61983](https://github.com/saltstack/salt/issues/61983)
 - Fixed event signature verification failing under ``minion_sign_messages``. The minion was signing the return load before ``salt.channel.client.AsyncReqChannel._package_load`` attached transport metadata (``nonce``, ``ts``, ``tok``, ``id``), so the bytes the master re-serialized to verify did not match what was signed and every signed return was dropped. Signing is now performed inside ``_package_load`` after the metadata is attached, against the same bytes the master verifies. [#68181](https://github.com/saltstack/salt/issues/68181)
-- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that [#69031](https://github.com/saltstack/salt/issues/69031)
-- together prevented it from being usable. `start()` no longer raises [#69031](https://github.com/saltstack/salt/issues/69031)
-- `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3 [#69031](https://github.com/saltstack/salt/issues/69031)
-- (the dict.values() result is now wrapped in `list(...)`). `Listener` and [#69031](https://github.com/saltstack/salt/issues/69031)
-- `start()` now accept an optional `password` argument and forward it to [#69031](https://github.com/saltstack/salt/issues/69031)
-- the redis client, allowing the engine to authenticate against a Sentinel [#69031](https://github.com/saltstack/salt/issues/69031)
-- that requires AUTH; the default of `None` keeps existing configurations [#69031](https://github.com/saltstack/salt/issues/69031)
-- working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
-- Fixed `salt.returners.redis_return` silently ignoring the documented [#69032](https://github.com/saltstack/salt/issues/69032)
-- `redis.password` configuration option. The returner now reads [#69032](https://github.com/saltstack/salt/issues/69032)
-- `redis.password` from config (in both regular and proxy modes) and [#69032](https://github.com/saltstack/salt/issues/69032)
-- forwards it to both the single-server `redis.StrictRedis` and the [#69032](https://github.com/saltstack/salt/issues/69032)
-- `StrictRedisCluster` constructors. Operators with auth-protected Redis [#69032](https://github.com/saltstack/salt/issues/69032)
-- no longer lose every job return to a hidden `NOAUTH Authentication [#69032](https://github.com/saltstack/salt/issues/69032)
-- required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
-- Fixed three closely-related bugs in `salt.cache.redis_cache` that [#69033](https://github.com/saltstack/salt/issues/69033)
-- together broke hierarchical-bank semantics: [#69033](https://github.com/saltstack/salt/issues/69033)
-- `_build_bank_hier` now registers each child bank name in both the [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's `$BANK_` set (consumed by `flush()` tree traversal) and the [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove` [#69033](https://github.com/saltstack/salt/issues/69033)
-- now decodes the bytes returned by `smembers` and skips the `"."` [#69033](https://github.com/saltstack/salt/issues/69033)
-- placeholder, so recursive `flush()` of a parent bank actually descends [#69033](https://github.com/saltstack/salt/issues/69033)
-- into sub-banks instead of corrupting the path; and `flush(bank)` of a [#69033](https://github.com/saltstack/salt/issues/69033)
-- sub-bank now removes the flushed bank's own reference from its [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's index sets so `list_(parent)` no longer reports it as [#69033](https://github.com/saltstack/salt/issues/69033)
-- present. Together these fixes restore `cache.list("minions")`, [#69033](https://github.com/saltstack/salt/issues/69033)
-- `salt-run manage.present` and `salt-run manage.up` for masters [#69033](https://github.com/saltstack/salt/issues/69033)
-- configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
-- Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-- token. The cluster client was created with `decode_responses=True`, [#69035](https://github.com/saltstack/salt/issues/69035)
-- which caused `redis_client.get()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-- `salt.payload.loads` (msgpack rejects `str`); it also caused [#69035](https://github.com/saltstack/salt/issues/69035)
-- `redis_client.keys()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-- `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both [#69035](https://github.com/saltstack/salt/issues/69035)
-- errors were swallowed by broad `except Exception` handlers, so eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-- appeared to silently reject every token. `decode_responses=True` is [#69035](https://github.com/saltstack/salt/issues/69035)
-- removed; values now round-trip as bytes through msgpack as the rest [#69035](https://github.com/saltstack/salt/issues/69035)
-- of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
-- Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid [#69038](https://github.com/saltstack/salt/issues/69038)
-- pointer keys indefinitely. The pointer was written with `pipeline.set` [#69038](https://github.com/saltstack/salt/issues/69038)
-- and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck [#69038](https://github.com/saltstack/salt/issues/69038)
-- in Redis forever -- O(minions × distinct funcs) keys accumulating over [#69038](https://github.com/saltstack/salt/issues/69038)
-- the lifetime of the master. The pointer now expires on the same TTL [#69038](https://github.com/saltstack/salt/issues/69038)
-- as the rest of the returner data (`keep_jobs_seconds`). Operators with [#69038](https://github.com/saltstack/salt/issues/69038)
-- external scripts reading these keys directly may observe them [#69038](https://github.com/saltstack/salt/issues/69038)
-- expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
-- Fixed `salt.returners.redis_return.get_fun` always returning an [#69039](https://github.com/saltstack/salt/issues/69039)
-- empty dict. The function read return data from a `<minion>:<jid>` [#69039](https://github.com/saltstack/salt/issues/69039)
-- key that no other code in the module ever wrote -- a leftover from [#69039](https://github.com/saltstack/salt/issues/69039)
-- an older storage schema. It now reads from the canonical [#69039](https://github.com/saltstack/salt/issues/69039)
-- `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the [#69039](https://github.com/saltstack/salt/issues/69039)
-- storage layout that `returner` actually produces and the read [#69039](https://github.com/saltstack/salt/issues/69039)
-- pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
+- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that
+  together prevented it from being usable. `start()` no longer raises
+  `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3
+  (the dict.values() result is now wrapped in `list(...)`). `Listener` and
+  `start()` now accept an optional `password` argument and forward it to
+  the redis client, allowing the engine to authenticate against a Sentinel
+  that requires AUTH; the default of `None` keeps existing configurations
+  working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
+- Fixed `salt.returners.redis_return` silently ignoring the documented
+  `redis.password` configuration option. The returner now reads
+  `redis.password` from config (in both regular and proxy modes) and
+  forwards it to both the single-server `redis.StrictRedis` and the
+  `StrictRedisCluster` constructors. Operators with auth-protected Redis
+  no longer lose every job return to a hidden `NOAUTH Authentication
+  required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
+- Fixed three closely-related bugs in `salt.cache.redis_cache` that
+  together broke hierarchical-bank semantics:
+  `_build_bank_hier` now registers each child bank name in both the
+  parent's `$BANK_` set (consumed by `flush()` tree traversal) and the
+  parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove`
+  now decodes the bytes returned by `smembers` and skips the `"."`
+  placeholder, so recursive `flush()` of a parent bank actually descends
+  into sub-banks instead of corrupting the path; and `flush(bank)` of a
+  sub-bank now removes the flushed bank's own reference from its
+  parent's index sets so `list_(parent)` no longer reports it as
+  present. Together these fixes restore `cache.list("minions")`,
+  `salt-run manage.present` and `salt-run manage.up` for masters
+  configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
+- Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth
+  token. The cluster client was created with `decode_responses=True`,
+  which caused `redis_client.get()` to return `str` and broke
+  `salt.payload.loads` (msgpack rejects `str`); it also caused
+  `redis_client.keys()` to return `str` and broke
+  `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both
+  errors were swallowed by broad `except Exception` handlers, so eauth
+  appeared to silently reject every token. `decode_responses=True` is
+  removed; values now round-trip as bytes through msgpack as the rest
+  of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
+- Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid
+  pointer keys indefinitely. The pointer was written with `pipeline.set`
+  and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck
+  in Redis forever -- O(minions × distinct funcs) keys accumulating over
+  the lifetime of the master. The pointer now expires on the same TTL
+  as the rest of the returner data (`keep_jobs_seconds`). Operators with
+  external scripts reading these keys directly may observe them
+  expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
+- Fixed `salt.returners.redis_return.get_fun` always returning an
+  empty dict. The function read return data from a `<minion>:<jid>`
+  key that no other code in the module ever wrote -- a leftover from
+  an older storage schema. It now reads from the canonical
+  `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the
+  storage layout that `returner` actually produces and the read
+  pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
 - ``cmd.run`` and friends no longer include the ``env`` and ``stdin`` arguments in the ``CommandExecutionError`` raised when the underlying subprocess fails to start (typically ``ENOENT`` / binary not found). Both fields routinely carry credentials passed in by the caller (``env={"DB_PASSWORD": "..."}``, password piped via ``stdin``), and the error message ends up in master/minion logs and in event-bus return data visible to the API caller. [#69075](https://github.com/saltstack/salt/issues/69075)
-- * Relenv 0.22.14 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.6 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.2.0 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.14
+  - Update python 3.14 to 3.14.6
+  - Update sqlite to 3.53.2.0
+  - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix pillar masking leaking ``**********`` into rendered pillar and state values. ``MaskedDict`` / ``MaskedList`` ``__repr__`` / ``__str__`` now consult the ``salt.utils.secret.mask_pillar`` ContextVar, so ``{{ pillar['list_or_dict_value'] }}`` interpolations on the minion return plain values inside a render bracket. Hoist the ``mask_pillar=False`` bracket from ``render_pillar`` to ``compile_pillar`` so ``ext_pillar`` handlers and the rest of the master-side pillar build also run unmasked. [#69160](https://github.com/saltstack/salt/issues/69160)
 - Fixed Windows MSI self-upgrade via ``pkg.install`` failing with error 1603. The old product's ``DeleteConfig_DECAC`` custom action was unconditionally deleting ``ROOTDIR\var`` during ``RemoveExistingProducts``, destroying the MSI that ``pkg.install`` had cached to ``ROOTDIR\var\cache`` before launching the upgrade. Users who had ``REMOVE_CONFIG=1`` persisted in the registry (from checking "On uninstall" at install time) hit a worse variant where the entire ``ROOTDIR`` was deleted. The fix checks ``UPGRADINGPRODUCTCODE`` — set by Windows Installer whenever an uninstall is triggered by a major upgrade — and skips all ``ROOTDIR`` deletion during upgrades, matching the behaviour of the NSIS installer which has always preserved ``ROOTDIR`` during upgrades. [#69219](https://github.com/saltstack/salt/issues/69219)
 - Fixed `TypeError: string indices must be integers` in the minion when the master returns a bare string error response (e.g. `"bad load"`, `"Some exception handling minion payload"`) for a pillar request. The minion now raises a clean `AuthenticationError` instead of crashing, allowing the caller to retry or fail gracefully. [#69228](https://github.com/saltstack/salt/issues/69228)
@@ -101,11 +101,11 @@ Versions are `MAJOR.PATCH`.
 
 ### Added
 
-- Added ``dsc_resource`` execution module and state module for invoking individual [#43718](https://github.com/saltstack/salt/issues/43718)
-- PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling [#43718](https://github.com/saltstack/salt/issues/43718)
-- a MOF file or involving the Local Configuration Manager. The [#43718](https://github.com/saltstack/salt/issues/43718)
-- ``dsc_resource.managed`` state provides idiomatic Salt state management for any [#43718](https://github.com/saltstack/salt/issues/43718)
-- installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
+- Added ``dsc_resource`` execution module and state module for invoking individual
+  PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling
+  a MOF file or involving the Local Configuration Manager. The
+  ``dsc_resource.managed`` state provides idiomatic Salt state management for any
+  installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
 - fix etcdv3 module authentification when using etcd3-py lib [#69202](https://github.com/saltstack/salt/issues/69202)
 
 ## 3008.0 (2026-05-27)
@@ -136,13 +136,13 @@ Versions are `MAJOR.PATCH`.
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -190,22 +190,22 @@ Versions are `MAJOR.PATCH`.
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
-- Fixed a regression where setting ``ipv6: true`` in the minion configuration [#66603](https://github.com/saltstack/salt/issues/66603)
-- caused the minion to fail to start on Windows. Three IPC socket paths in the [#66603](https://github.com/saltstack/salt/issues/66603)
-- TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6 [#66603](https://github.com/saltstack/salt/issues/66603)
-- setting: the IPC publish server/client addresses in ``salt.transport.base``, [#66603](https://github.com/saltstack/salt/issues/66603)
-- the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client [#66603](https://github.com/saltstack/salt/issues/66603)
-- socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback [#66603](https://github.com/saltstack/salt/issues/66603)
-- address (or vice-versa) is rejected by the OS. All three paths now use [#66603](https://github.com/saltstack/salt/issues/66603)
-- ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1`` [#66603](https://github.com/saltstack/salt/issues/66603)
-- with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed a regression where setting ``ipv6: true`` in the minion configuration
+  caused the minion to fail to start on Windows. Three IPC socket paths in the
+  TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6
+  setting: the IPC publish server/client addresses in ``salt.transport.base``,
+  the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client
+  socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback
+  address (or vice-versa) is rejected by the OS. All three paths now use
+  ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1``
+  with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -234,38 +234,38 @@ Versions are `MAJOR.PATCH`.
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -273,46 +273,46 @@ Versions are `MAJOR.PATCH`.
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - debpkg include 0/1 as valid options when parsing bool values in deb822 [#68996](https://github.com/saltstack/salt/issues/68996)
 - Drain cancelled tasks on PublishClient close so the TCP transport no longer prints `[ERROR ] Task was destroyed but it is pending!` at the end of every salt command. [#68998](https://github.com/saltstack/salt/issues/68998)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - ``LoadAuth.get_tok`` now distinguishes between corrupt token blobs (removed from the store) and transient backend errors such as Redis connection drops or NFS hangs (token kept, request treated as not-authenticated). Previously a single backend hiccup could log every authenticated user out by deleting valid tokens. [#69073](https://github.com/saltstack/salt/issues/69073)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
 - Fixed ``lgpo_reg.value_absent`` failing when the Registry.pol entry was already absent but the registry value still existed. ``lgpo_reg.delete_value`` was returning early before reaching the registry cleanup code, causing the state to see no changes and report failure. The registry value is now removed regardless of whether the pol entry was present. [#69203](https://github.com/saltstack/salt/issues/69203)
 - Fixed `!!binary` YAML tag failing with "Incorrect padding" when base64 padding characters are omitted. Salt's YAML loader now tolerates unpadded base64 values, restoring behavior that worked on Salt 3006 (Python 3.10). [#69207](https://github.com/saltstack/salt/issues/69207)
-- Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar [#69218](https://github.com/saltstack/salt/issues/69218)
-- lists or dicts. Pillar containers are wrapped in ``MaskedDict`` / [#69218](https://github.com/saltstack/salt/issues/69218)
-- ``MaskedList`` for repr redaction; representers are now registered so the [#69218](https://github.com/saltstack/salt/issues/69218)
-- YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
+- Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar
+  lists or dicts. Pillar containers are wrapped in ``MaskedDict`` /
+  ``MaskedList`` for repr redaction; representers are now registered so the
+  YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
 
 
 ### Added
 
 - Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-- validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-- ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-- `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-- creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-- the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-- to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-- differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-- platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+  validates a Windows user's password via ``LogonUser`` with
+  ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+  `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+  creating an interactive session. If the check causes an account lockout,
+  the account is automatically unlocked. Updated ``user.present`` on Windows
+  to use ``shadow.verify_password`` so the password is only changed when it
+  differs from the current value, matching the idempotent behaviour on other
+  platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Add 'show_changes' arg for file.append and file.prepend states to hide output [#59329](https://github.com/saltstack/salt/issues/59329)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -342,73 +342,73 @@ Versions are `MAJOR.PATCH`.
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added OpenTelemetry distributed-tracing support across all Salt [#68999](https://github.com/saltstack/salt/issues/68999)
-- inter-process hops (network and IPC).  When `tracing.enabled` is true in the [#68999](https://github.com/saltstack/salt/issues/68999)
-- master/minion config, salt emits W3C-TraceContext-propagated spans via an [#68999](https://github.com/saltstack/salt/issues/68999)
-- OTLP exporter, covering the CLI, channel layer, master workers, minion [#68999](https://github.com/saltstack/salt/issues/68999)
-- command execution, event bus, reactor, syndic forwarding, salt-ssh, and [#68999](https://github.com/saltstack/salt/issues/68999)
-- salt-api.  Trace context travels inside the AES-encrypted Salt envelope so [#68999](https://github.com/saltstack/salt/issues/68999)
-- it remains opaque on the wire.  Tracing is opt-in and a complete no-op when [#68999](https://github.com/saltstack/salt/issues/68999)
-- disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added OpenTelemetry distributed-tracing support across all Salt
+  inter-process hops (network and IPC).  When `tracing.enabled` is true in the
+  master/minion config, salt emits W3C-TraceContext-propagated spans via an
+  OTLP exporter, covering the CLI, channel layer, master workers, minion
+  command execution, event bus, reactor, syndic forwarding, salt-ssh, and
+  salt-api.  Trace context travels inside the AES-encrypted Salt envelope so
+  it remains opaque on the wire.  Tracing is opt-in and a complete no-op when
+  disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 - Migrate Salt documentation to the PyData Sphinx theme. This update modernizes the documentation UI, improves navigation with a persistent sidebar tree, and fixes issues with embedded video playback. [#69185](https://github.com/saltstack/salt/issues/69185)
-- Added OpenTelemetry metrics support alongside the existing tracing [#69200](https://github.com/saltstack/salt/issues/69200)
-- integration.  When ``metrics.enabled`` is true in the master/minion [#69200](https://github.com/saltstack/salt/issues/69200)
-- config, salt daemons emit counters (``salt.jobs.published``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.returners.calls``), histograms (``salt.job.duration``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.minion.exec.duration``), and observable gauges [#69200](https://github.com/saltstack/salt/issues/69200)
-- (``salt.master.connected_minions.count``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via [#69200](https://github.com/saltstack/salt/issues/69200)
-- OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a [#69200](https://github.com/saltstack/salt/issues/69200)
-- complete no-op when disabled.  See ``doc/topics/metrics/index.rst`` [#69200](https://github.com/saltstack/salt/issues/69200)
-- for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
-- Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was [#69201](https://github.com/saltstack/salt/issues/69201)
-- removed when community extensions were purged. The module is reinstated as a [#69201](https://github.com/saltstack/salt/issues/69201)
-- core ext_pillar so existing PillarStack-based pillar trees continue to work on [#69201](https://github.com/saltstack/salt/issues/69201)
-- 3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
+- Added OpenTelemetry metrics support alongside the existing tracing
+  integration.  When ``metrics.enabled`` is true in the master/minion
+  config, salt daemons emit counters (``salt.jobs.published``,
+  ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``,
+  ``salt.returners.calls``), histograms (``salt.job.duration``,
+  ``salt.minion.exec.duration``), and observable gauges
+  (``salt.master.connected_minions.count``,
+  ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via
+  OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a
+  complete no-op when disabled.  See ``doc/topics/metrics/index.rst``
+  for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
+- Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was
+  removed when community extensions were purged. The module is reinstated as a
+  core ext_pillar so existing PillarStack-based pillar trees continue to work on
+  3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
 - Added ``lgpo_reg.get_rsop_value`` to query the Resultant Set of Policy (RSoP) for a registry key/value and detect whether it is managed by a Domain Group Policy Object. The ``lgpo_reg`` module functions ``set_value``, ``disable_value``, and ``delete_value`` now log a warning when a Domain GPO is detected for the target value. The ``lgpo_reg`` state functions ``value_present``, ``value_disabled``, and ``value_absent`` append the same warning to the state comment so it is visible in state output. [#69205](https://github.com/saltstack/salt/issues/69205)
 
 ## 3008.0rc4 (2026-05-15)
@@ -439,13 +439,13 @@ Versions are `MAJOR.PATCH`.
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -488,13 +488,13 @@ Versions are `MAJOR.PATCH`.
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -521,86 +521,86 @@ Versions are `MAJOR.PATCH`.
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
 
 
 ### Added
 
 - Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-- validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-- ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-- `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-- creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-- the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-- to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-- differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-- platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+  validates a Windows user's password via ``LogonUser`` with
+  ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+  `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+  creating an interactive session. If the check causes an account lockout,
+  the account is automatically unlocked. Updated ``user.present`` on Windows
+  to use ``shadow.verify_password`` so the password is only changed when it
+  differs from the current value, matching the idempotent behaviour on other
+  platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -629,48 +629,48 @@ Versions are `MAJOR.PATCH`.
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -702,13 +702,13 @@ Versions are `MAJOR.PATCH`.
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -751,13 +751,13 @@ Versions are `MAJOR.PATCH`.
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -784,66 +784,66 @@ Versions are `MAJOR.PATCH`.
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 
 
 ### Added
@@ -852,8 +852,8 @@ Versions are `MAJOR.PATCH`.
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -882,48 +882,48 @@ Versions are `MAJOR.PATCH`.
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -955,13 +955,13 @@ Versions are `MAJOR.PATCH`.
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1004,13 +1004,13 @@ Versions are `MAJOR.PATCH`.
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1037,60 +1037,60 @@ Versions are `MAJOR.PATCH`.
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Fixed on the ``3008.x`` release line: Salt NetAPI rest_tornado header parsing without ``cgi.parse_header`` (removed in Python 3.13). Integration ``salt_minion`` / ``salt_sub_minion`` fixtures now call ``saltutil.sync_all`` with ``saltenv=base`` to avoid long master round-trips from top-file environment discovery during Windows CI. Salt factories use a 120 second daemon start timeout when ``ONEDIR_TESTRUN`` is set so Windows onedir runs match CI and avoid flaky minion start event waits. [#69014](https://github.com/saltstack/salt/issues/69014)
 
 
@@ -1100,8 +1100,8 @@ Versions are `MAJOR.PATCH`.
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1130,47 +1130,47 @@ Versions are `MAJOR.PATCH`.
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- The minion public-key index (``salt.cache.mmap_key`` / [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate [#68936](https://github.com/saltstack/salt/issues/68936)
-- existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  The minion public-key index (``salt.cache.mmap_key`` /
+  ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir``
+  scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate
+  existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 
 
 ## 3008.0rc1 (2026-04-23)
@@ -1200,13 +1200,13 @@ Versions are `MAJOR.PATCH`.
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1251,13 +1251,13 @@ Versions are `MAJOR.PATCH`.
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1285,46 +1285,46 @@ Versions are `MAJOR.PATCH`.
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
-- Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when [#68763](https://github.com/saltstack/salt/issues/68763)
-- Homebrew returns `null` values for cask metadata: [#68763](https://github.com/saltstack/salt/issues/68763)
--  [#68763](https://github.com/saltstack/salt/issues/68763)
-- - When the installed version of a cask is `null` (e.g. Homebrew cannot [#68763](https://github.com/saltstack/salt/issues/68763)
-- determine the installed version), it is now reported as `"unknown"` [#68763](https://github.com/saltstack/salt/issues/68763)
-- instead of raising an error. [#68763](https://github.com/saltstack/salt/issues/68763)
-- - When `full_token` is `null`, it is now filtered out so that `None` [#68763](https://github.com/saltstack/salt/issues/68763)
-- is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when
+  Homebrew returns `null` values for cask metadata:
+
+  - When the installed version of a cask is `null` (e.g. Homebrew cannot
+  determine the installed version), it is now reported as `"unknown"`
+  instead of raising an error.
+  - When `full_token` is `null`, it is now filtered out so that `None`
+  is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -1332,10 +1332,10 @@ Versions are `MAJOR.PATCH`.
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 
 
 ### Added
@@ -1344,8 +1344,8 @@ Versions are `MAJOR.PATCH`.
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1374,25 +1374,25 @@ Versions are `MAJOR.PATCH`.
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)

--- a/changelog/.template.jinja
+++ b/changelog/.template.jinja
@@ -4,14 +4,7 @@
 ### {{ definitions[category]['name'] }}
 
 {% for text, values in sections[""][category].items() %}
-{% set lines = text.split('\n') %}
-{% for line in lines %}
-{% if line.startswith('- ') %}
-{{ line | trim }} {{ values|join(', ') }}
-{% else %}
-- {{ line | trim }} {{ values|join(', ') }}
-{% endif %}
-{% endfor %}
+- {{ text | indent(2) }} {{ values|join(', ') }}
 {% endfor %}
 
 {% endfor %}

--- a/changelog/69454.fixed.md
+++ b/changelog/69454.fixed.md
@@ -1,0 +1,1 @@
+Fixed the towncrier changelog template splitting every multi-line fragment into separate top-level bullets with a duplicate `[#NNNN]` link on each. Multi-line fragments now render as a single bullet with continuation lines indented under it, and the issue link is appended exactly once.

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -3,15 +3,15 @@ salt (3008.1) stable; urgency=medium
 
   # Changed
 
-  * Changed `salt.returners.redis_return` to enumerate the Redis keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-  * with `SCAN` instead of the blocking `KEYS pattern` command in both [#69037](https://github.com/saltstack/salt/issues/69037)
-  * `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-  * synchronously and stalls the Redis server for the duration; on a [#69037](https://github.com/saltstack/salt/issues/69037)
-  * master with hundreds of thousands of jobs this can block all clients [#69037](https://github.com/saltstack/salt/issues/69037)
-  * of that Redis instance for seconds. `SCAN` is incremental and [#69037](https://github.com/saltstack/salt/issues/69037)
-  * non-blocking. Order of returned keys is no longer guaranteed (the [#69037](https://github.com/saltstack/salt/issues/69037)
-  * returner does not rely on order); operators with custom scripts that [#69037](https://github.com/saltstack/salt/issues/69037)
-  * read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
+  * Changed `salt.returners.redis_return` to enumerate the Redis keyspace
+    with `SCAN` instead of the blocking `KEYS pattern` command in both
+    `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace
+    synchronously and stalls the Redis server for the duration; on a
+    master with hundreds of thousands of jobs this can block all clients
+    of that Redis instance for seconds. `SCAN` is incremental and
+    non-blocking. Order of returned keys is no longer guaranteed (the
+    returner does not rely on order); operators with custom scripts that
+    read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
 
   # Fixed
 
@@ -20,64 +20,64 @@ salt (3008.1) stable; urgency=medium
   * Improved documentation for the `runas` and `password` parameters in `cmd.run`, `cmd.script`, and all `salt.modules.cmdmod` execution functions on Windows. The docs now accurately describe when a password is required: only when the salt-minion is **not** running as SYSTEM or as an elevated Administrator. Removed the inaccurate claim that the target user account must be in the Administrators group. Also changed `cmd.script` to log a warning instead of hard-failing when `runas` is used without a password on Windows, since a password is not always required. [#57951](https://github.com/saltstack/salt/issues/57951)
   * Fixed `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` errors in the VMware cloud driver by reconnecting when a cached vCenter service instance is found to be stale or corrupted (for example when inherited across a fork by salt-cloud's parallel provider queries). [#61983](https://github.com/saltstack/salt/issues/61983)
   * Fixed event signature verification failing under ``minion_sign_messages``. The minion was signing the return load before ``salt.channel.client.AsyncReqChannel._package_load`` attached transport metadata (``nonce``, ``ts``, ``tok``, ``id``), so the bytes the master re-serialized to verify did not match what was signed and every signed return was dropped. Signing is now performed inside ``_package_load`` after the metadata is attached, against the same bytes the master verifies. [#68181](https://github.com/saltstack/salt/issues/68181)
-  * Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that [#69031](https://github.com/saltstack/salt/issues/69031)
-  * together prevented it from being usable. `start()` no longer raises [#69031](https://github.com/saltstack/salt/issues/69031)
-  * `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3 [#69031](https://github.com/saltstack/salt/issues/69031)
-  * (the dict.values() result is now wrapped in `list(...)`). `Listener` and [#69031](https://github.com/saltstack/salt/issues/69031)
-  * `start()` now accept an optional `password` argument and forward it to [#69031](https://github.com/saltstack/salt/issues/69031)
-  * the redis client, allowing the engine to authenticate against a Sentinel [#69031](https://github.com/saltstack/salt/issues/69031)
-  * that requires AUTH; the default of `None` keeps existing configurations [#69031](https://github.com/saltstack/salt/issues/69031)
-  * working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
-  * Fixed `salt.returners.redis_return` silently ignoring the documented [#69032](https://github.com/saltstack/salt/issues/69032)
-  * `redis.password` configuration option. The returner now reads [#69032](https://github.com/saltstack/salt/issues/69032)
-  * `redis.password` from config (in both regular and proxy modes) and [#69032](https://github.com/saltstack/salt/issues/69032)
-  * forwards it to both the single-server `redis.StrictRedis` and the [#69032](https://github.com/saltstack/salt/issues/69032)
-  * `StrictRedisCluster` constructors. Operators with auth-protected Redis [#69032](https://github.com/saltstack/salt/issues/69032)
-  * no longer lose every job return to a hidden `NOAUTH Authentication [#69032](https://github.com/saltstack/salt/issues/69032)
-  * required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
-  * Fixed three closely-related bugs in `salt.cache.redis_cache` that [#69033](https://github.com/saltstack/salt/issues/69033)
-  * together broke hierarchical-bank semantics: [#69033](https://github.com/saltstack/salt/issues/69033)
-  * `_build_bank_hier` now registers each child bank name in both the [#69033](https://github.com/saltstack/salt/issues/69033)
-  * parent's `$BANK_` set (consumed by `flush()` tree traversal) and the [#69033](https://github.com/saltstack/salt/issues/69033)
-  * parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove` [#69033](https://github.com/saltstack/salt/issues/69033)
-  * now decodes the bytes returned by `smembers` and skips the `"."` [#69033](https://github.com/saltstack/salt/issues/69033)
-  * placeholder, so recursive `flush()` of a parent bank actually descends [#69033](https://github.com/saltstack/salt/issues/69033)
-  * into sub-banks instead of corrupting the path; and `flush(bank)` of a [#69033](https://github.com/saltstack/salt/issues/69033)
-  * sub-bank now removes the flushed bank's own reference from its [#69033](https://github.com/saltstack/salt/issues/69033)
-  * parent's index sets so `list_(parent)` no longer reports it as [#69033](https://github.com/saltstack/salt/issues/69033)
-  * present. Together these fixes restore `cache.list("minions")`, [#69033](https://github.com/saltstack/salt/issues/69033)
-  * `salt-run manage.present` and `salt-run manage.up` for masters [#69033](https://github.com/saltstack/salt/issues/69033)
-  * configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
-  * Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-  * token. The cluster client was created with `decode_responses=True`, [#69035](https://github.com/saltstack/salt/issues/69035)
-  * which caused `redis_client.get()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-  * `salt.payload.loads` (msgpack rejects `str`); it also caused [#69035](https://github.com/saltstack/salt/issues/69035)
-  * `redis_client.keys()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-  * `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both [#69035](https://github.com/saltstack/salt/issues/69035)
-  * errors were swallowed by broad `except Exception` handlers, so eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-  * appeared to silently reject every token. `decode_responses=True` is [#69035](https://github.com/saltstack/salt/issues/69035)
-  * removed; values now round-trip as bytes through msgpack as the rest [#69035](https://github.com/saltstack/salt/issues/69035)
-  * of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
-  * Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid [#69038](https://github.com/saltstack/salt/issues/69038)
-  * pointer keys indefinitely. The pointer was written with `pipeline.set` [#69038](https://github.com/saltstack/salt/issues/69038)
-  * and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck [#69038](https://github.com/saltstack/salt/issues/69038)
-  * in Redis forever -- O(minions × distinct funcs) keys accumulating over [#69038](https://github.com/saltstack/salt/issues/69038)
-  * the lifetime of the master. The pointer now expires on the same TTL [#69038](https://github.com/saltstack/salt/issues/69038)
-  * as the rest of the returner data (`keep_jobs_seconds`). Operators with [#69038](https://github.com/saltstack/salt/issues/69038)
-  * external scripts reading these keys directly may observe them [#69038](https://github.com/saltstack/salt/issues/69038)
-  * expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
-  * Fixed `salt.returners.redis_return.get_fun` always returning an [#69039](https://github.com/saltstack/salt/issues/69039)
-  * empty dict. The function read return data from a `<minion>:<jid>` [#69039](https://github.com/saltstack/salt/issues/69039)
-  * key that no other code in the module ever wrote -- a leftover from [#69039](https://github.com/saltstack/salt/issues/69039)
-  * an older storage schema. It now reads from the canonical [#69039](https://github.com/saltstack/salt/issues/69039)
-  * `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the [#69039](https://github.com/saltstack/salt/issues/69039)
-  * storage layout that `returner` actually produces and the read [#69039](https://github.com/saltstack/salt/issues/69039)
-  * pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
+  * Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that
+    together prevented it from being usable. `start()` no longer raises
+    `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3
+    (the dict.values() result is now wrapped in `list(...)`). `Listener` and
+    `start()` now accept an optional `password` argument and forward it to
+    the redis client, allowing the engine to authenticate against a Sentinel
+    that requires AUTH; the default of `None` keeps existing configurations
+    working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
+  * Fixed `salt.returners.redis_return` silently ignoring the documented
+    `redis.password` configuration option. The returner now reads
+    `redis.password` from config (in both regular and proxy modes) and
+    forwards it to both the single-server `redis.StrictRedis` and the
+    `StrictRedisCluster` constructors. Operators with auth-protected Redis
+    no longer lose every job return to a hidden `NOAUTH Authentication
+    required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
+  * Fixed three closely-related bugs in `salt.cache.redis_cache` that
+    together broke hierarchical-bank semantics:
+    `_build_bank_hier` now registers each child bank name in both the
+    parent's `$BANK_` set (consumed by `flush()` tree traversal) and the
+    parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove`
+    now decodes the bytes returned by `smembers` and skips the `"."`
+    placeholder, so recursive `flush()` of a parent bank actually descends
+    into sub-banks instead of corrupting the path; and `flush(bank)` of a
+    sub-bank now removes the flushed bank's own reference from its
+    parent's index sets so `list_(parent)` no longer reports it as
+    present. Together these fixes restore `cache.list("minions")`,
+    `salt-run manage.present` and `salt-run manage.up` for masters
+    configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
+  * Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth
+    token. The cluster client was created with `decode_responses=True`,
+    which caused `redis_client.get()` to return `str` and broke
+    `salt.payload.loads` (msgpack rejects `str`); it also caused
+    `redis_client.keys()` to return `str` and broke
+    `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both
+    errors were swallowed by broad `except Exception` handlers, so eauth
+    appeared to silently reject every token. `decode_responses=True` is
+    removed; values now round-trip as bytes through msgpack as the rest
+    of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
+  * Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid
+    pointer keys indefinitely. The pointer was written with `pipeline.set`
+    and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck
+    in Redis forever -- O(minions × distinct funcs) keys accumulating over
+    the lifetime of the master. The pointer now expires on the same TTL
+    as the rest of the returner data (`keep_jobs_seconds`). Operators with
+    external scripts reading these keys directly may observe them
+    expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
+  * Fixed `salt.returners.redis_return.get_fun` always returning an
+    empty dict. The function read return data from a `<minion>:<jid>`
+    key that no other code in the module ever wrote -- a leftover from
+    an older storage schema. It now reads from the canonical
+    `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the
+    storage layout that `returner` actually produces and the read
+    pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
   * ``cmd.run`` and friends no longer include the ``env`` and ``stdin`` arguments in the ``CommandExecutionError`` raised when the underlying subprocess fails to start (typically ``ENOENT`` / binary not found). Both fields routinely carry credentials passed in by the caller (``env={"DB_PASSWORD": "..."}``, password piped via ``stdin``), and the error message ends up in master/minion logs and in event-bus return data visible to the API caller. [#69075](https://github.com/saltstack/salt/issues/69075)
-  * * Relenv 0.22.14 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update python 3.14 to 3.14.6 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update sqlite to 3.53.2.0 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
+  * * Relenv 0.22.14
+    - Update python 3.14 to 3.14.6
+    - Update sqlite to 3.53.2.0
+    - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
   * Fix pillar masking leaking ``**********`` into rendered pillar and state values. ``MaskedDict`` / ``MaskedList`` ``__repr__`` / ``__str__`` now consult the ``salt.utils.secret.mask_pillar`` ContextVar, so ``{{ pillar['list_or_dict_value'] }}`` interpolations on the minion return plain values inside a render bracket. Hoist the ``mask_pillar=False`` bracket from ``render_pillar`` to ``compile_pillar`` so ``ext_pillar`` handlers and the rest of the master-side pillar build also run unmasked. [#69160](https://github.com/saltstack/salt/issues/69160)
   * Fixed Windows MSI self-upgrade via ``pkg.install`` failing with error 1603. The old product's ``DeleteConfig_DECAC`` custom action was unconditionally deleting ``ROOTDIR\var`` during ``RemoveExistingProducts``, destroying the MSI that ``pkg.install`` had cached to ``ROOTDIR\var\cache`` before launching the upgrade. Users who had ``REMOVE_CONFIG=1`` persisted in the registry (from checking "On uninstall" at install time) hit a worse variant where the entire ``ROOTDIR`` was deleted. The fix checks ``UPGRADINGPRODUCTCODE`` — set by Windows Installer whenever an uninstall is triggered by a major upgrade — and skips all ``ROOTDIR`` deletion during upgrades, matching the behaviour of the NSIS installer which has always preserved ``ROOTDIR`` during upgrades. [#69219](https://github.com/saltstack/salt/issues/69219)
   * Fixed `TypeError: string indices must be integers` in the minion when the master returns a bare string error response (e.g. `"bad load"`, `"Some exception handling minion payload"`) for a pillar request. The minion now raises a clean `AuthenticationError` instead of crashing, allowing the caller to retry or fail gracefully. [#69228](https://github.com/saltstack/salt/issues/69228)
@@ -90,11 +90,11 @@ salt (3008.1) stable; urgency=medium
 
   # Added
 
-  * Added ``dsc_resource`` execution module and state module for invoking individual [#43718](https://github.com/saltstack/salt/issues/43718)
-  * PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling [#43718](https://github.com/saltstack/salt/issues/43718)
-  * a MOF file or involving the Local Configuration Manager. The [#43718](https://github.com/saltstack/salt/issues/43718)
-  * ``dsc_resource.managed`` state provides idiomatic Salt state management for any [#43718](https://github.com/saltstack/salt/issues/43718)
-  * installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
+  * Added ``dsc_resource`` execution module and state module for invoking individual
+    PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling
+    a MOF file or involving the Local Configuration Manager. The
+    ``dsc_resource.managed`` state provides idiomatic Salt state management for any
+    installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
   * fix etcdv3 module authentification when using etcd3-py lib [#69202](https://github.com/saltstack/salt/issues/69202)
 
 
@@ -126,13 +126,13 @@ salt (3008.0) stable; urgency=medium
   * Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
   * Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
   * Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-  * Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-  * [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-  * Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+  * Do not use `ssl.PROTOCOL_TLS` which has been
+    [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+    Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
   * Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-  * PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-  * fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-  * salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+  * PillarCache: reimplement using salt.cache
+    fix minion data cache organization/move pillar and grains to dedicated cache banks
+    salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
   * Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
   * Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
   * Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -179,22 +179,22 @@ salt (3008.0) stable; urgency=medium
   * Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
   * Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
   * Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-  * Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-  * (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-  * grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-  * Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-  * leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-  * runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-  * beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
-  * Fixed a regression where setting ``ipv6: true`` in the minion configuration [#66603](https://github.com/saltstack/salt/issues/66603)
-  * caused the minion to fail to start on Windows. Three IPC socket paths in the [#66603](https://github.com/saltstack/salt/issues/66603)
-  * TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6 [#66603](https://github.com/saltstack/salt/issues/66603)
-  * setting: the IPC publish server/client addresses in ``salt.transport.base``, [#66603](https://github.com/saltstack/salt/issues/66603)
-  * the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client [#66603](https://github.com/saltstack/salt/issues/66603)
-  * socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback [#66603](https://github.com/saltstack/salt/issues/66603)
-  * address (or vice-versa) is rejected by the OS. All three paths now use [#66603](https://github.com/saltstack/salt/issues/66603)
-  * ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1`` [#66603](https://github.com/saltstack/salt/issues/66603)
-  * with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
+  * Fixed an issue where conflicting top level keys in the static grains file
+    (usually `/etc/salt/grains`) would break all grains states, and prevent static
+    grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+  * Fixed beacon delete not calling the beacon's close function, causing resource
+    leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+    runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+    beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+  * Fixed a regression where setting ``ipv6: true`` in the minion configuration
+    caused the minion to fail to start on Windows. Three IPC socket paths in the
+    TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6
+    setting: the IPC publish server/client addresses in ``salt.transport.base``,
+    the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client
+    socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback
+    address (or vice-versa) is rejected by the OS. All three paths now use
+    ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1``
+    with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
   * Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
   * Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
   * Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -223,38 +223,38 @@ salt (3008.0) stable; urgency=medium
   * Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
   * Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
   * Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-  * Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
-  *  [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
-  *  [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-  * migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-  * states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
-  *  [#68574](https://github.com/saltstack/salt/issues/68574)
-  * Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-  * community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-  * had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+  * Add `blockdev` state module back in to core
+
+    Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+  * Adds `mdadm` and `lvm` grains modules back in to core.
+
+    Restores the modules that had been removed as part of the community module
+    migration. They are core bits of functionality and the associated execution and
+    states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+  * Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+    Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+    Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+    Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+    Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+    Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+    Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+    Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+    Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+    Improved reliability of `state.running` integration test for `salt-ssh`.
+    Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+    Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+  * Adds `alias` state module back in to core.
+
+    Restores the module that had been removed as part of the
+    community module migration. The associated execution module
+    had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
   * Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-  * Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-  * making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-  * This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-  * `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-  * cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+  * Improved the rejected authentication warning message to include the minion ID,
+    making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+  * This PR fixes a bug where corrupted grains cache files cause unhandled
+    `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+    The fix adds proper exception handling to gracefully recover from corrupted
+    cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
   * Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
   * Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
   * Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -262,45 +262,45 @@ salt (3008.0) stable; urgency=medium
   * Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
   * Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
   * Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-  * Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+  * Remove deprecations.
+    - salt/auth/pki.py (removed)
+    - salt/features.py (removed)
+    - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
   * debpkg include 0/1 as valid options when parsing bool values in deb822 [#68996](https://github.com/saltstack/salt/issues/68996)
   * Drain cancelled tasks on PublishClient close so the TCP transport no longer prints `[ERROR ] Task was destroyed but it is pending!` at the end of every salt command. [#68998](https://github.com/saltstack/salt/issues/68998)
   * Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
   * ``LoadAuth.get_tok`` now distinguishes between corrupt token blobs (removed from the store) and transient backend errors such as Redis connection drops or NFS hangs (token kept, request treated as not-authenticated). Previously a single backend hiccup could log every authenticated user out by deleting valid tokens. [#69073](https://github.com/saltstack/salt/issues/69073)
   * Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-  * * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+  * * Relenv 0.22.11
+    - Update python 3.14 to 3.14.5
+    - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+    - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
   * Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
   * Fixed ``lgpo_reg.value_absent`` failing when the Registry.pol entry was already absent but the registry value still existed. ``lgpo_reg.delete_value`` was returning early before reaching the registry cleanup code, causing the state to see no changes and report failure. The registry value is now removed regardless of whether the pol entry was present. [#69203](https://github.com/saltstack/salt/issues/69203)
   * Fixed `!!binary` YAML tag failing with "Incorrect padding" when base64 padding characters are omitted. Salt's YAML loader now tolerates unpadded base64 values, restoring behavior that worked on Salt 3006 (Python 3.10). [#69207](https://github.com/saltstack/salt/issues/69207)
-  * Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar [#69218](https://github.com/saltstack/salt/issues/69218)
-  * lists or dicts. Pillar containers are wrapped in ``MaskedDict`` / [#69218](https://github.com/saltstack/salt/issues/69218)
-  * ``MaskedList`` for repr redaction; representers are now registered so the [#69218](https://github.com/saltstack/salt/issues/69218)
-  * YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
+  * Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar
+    lists or dicts. Pillar containers are wrapped in ``MaskedDict`` /
+    ``MaskedList`` for repr redaction; representers are now registered so the
+    YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
 
   # Added
 
   * Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-  * Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-  * validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-  * ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-  * `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-  * creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-  * the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-  * to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-  * differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-  * platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+  * Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+    validates a Windows user's password via ``LogonUser`` with
+    ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+    `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+    creating an interactive session. If the check causes an account lockout,
+    the account is automatically unlocked. Updated ``user.present`` on Windows
+    to use ``shadow.verify_password`` so the password is only changed when it
+    differs from the current value, matching the idempotent behaviour on other
+    platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
   * Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
   * Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
   * Add 'show_changes' arg for file.append and file.prepend states to hide output [#59329](https://github.com/saltstack/salt/issues/59329)
   * Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-  * the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+    the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
   * Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
   * Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
   * Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -330,73 +330,73 @@ salt (3008.0) stable; urgency=medium
   * Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
   * Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
   * Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-  * refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-  * optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-  * refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+  * refactored server-side PKI to support cache interface
+    optimization: check_compound_minions: defer _pki_minions fetch
+    refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
   * Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
   * Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
   * Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-  * Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
-  *  [#68410](https://github.com/saltstack/salt/issues/68410)
-  * Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+  * Added booleans argument to selinux.booleans
+    Added mod_aggregate to selinux to combine boolean
+    Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+  * Add support for minion_id in log formats
+
+    Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
   * Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-  * Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-  * and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-  * slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-  * `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-  * Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-  * configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+  * Added tunable worker pools: partition the master's MWorkers into named pools
+    and route specific commands (for example `_auth`) to dedicated pools so a
+    slow workload cannot starve time-critical traffic. Controlled by the new
+    `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+    Worker Pools" topic guide for details. Existing `worker_threads`
+    configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
   * Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
   * utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
   * Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
   * Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
   * Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-  * an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-  * safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-  * scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-  * a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-  * batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-  * Added OpenTelemetry distributed-tracing support across all Salt [#68999](https://github.com/saltstack/salt/issues/68999)
-  * inter-process hops (network and IPC).  When `tracing.enabled` is true in the [#68999](https://github.com/saltstack/salt/issues/68999)
-  * master/minion config, salt emits W3C-TraceContext-propagated spans via an [#68999](https://github.com/saltstack/salt/issues/68999)
-  * OTLP exporter, covering the CLI, channel layer, master workers, minion [#68999](https://github.com/saltstack/salt/issues/68999)
-  * command execution, event bus, reactor, syndic forwarding, salt-ssh, and [#68999](https://github.com/saltstack/salt/issues/68999)
-  * salt-api.  Trace context travels inside the AES-encrypted Salt envelope so [#68999](https://github.com/saltstack/salt/issues/68999)
-  * it remains opaque on the wire.  Tracing is opt-in and a complete no-op when [#68999](https://github.com/saltstack/salt/issues/68999)
-  * disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
-  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-  * targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-  * moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-  * mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-  * arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-  * the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+    an O(1) hash-table store with a segmented heap, durable and multi-process
+    safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+    A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+    scans for the master's minion-key store; select it with
+    ``keys.cache_driver: mmap_key``. Migrate existing data with
+    ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+  * Batch mode now uses a single JID for the entire batch run instead of generating
+    a separate JID per batch iteration. This enables unified job tracking via
+    ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+    batch slices. The job cache merges minion lists from each iteration so that
+    ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+  * Added OpenTelemetry distributed-tracing support across all Salt
+    inter-process hops (network and IPC).  When `tracing.enabled` is true in the
+    master/minion config, salt emits W3C-TraceContext-propagated spans via an
+    OTLP exporter, covering the CLI, channel layer, master workers, minion
+    command execution, event bus, reactor, syndic forwarding, salt-ssh, and
+    salt-api.  Trace context travels inside the AES-encrypted Salt envelope so
+    it remains opaque on the wire.  Tracing is opt-in and a complete no-op when
+    disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
+  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+    targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+    moment they accept the published job, before the function runs. The payload
+    mirrors the master's ``salt/job/<jid>/new`` event minus the function
+    arguments, letting orchestrators confirm reachability without waiting for
+    the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
   * Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
   * Migrate Salt documentation to the PyData Sphinx theme. This update modernizes the documentation UI, improves navigation with a persistent sidebar tree, and fixes issues with embedded video playback. [#69185](https://github.com/saltstack/salt/issues/69185)
-  * Added OpenTelemetry metrics support alongside the existing tracing [#69200](https://github.com/saltstack/salt/issues/69200)
-  * integration.  When ``metrics.enabled`` is true in the master/minion [#69200](https://github.com/saltstack/salt/issues/69200)
-  * config, salt daemons emit counters (``salt.jobs.published``, [#69200](https://github.com/saltstack/salt/issues/69200)
-  * ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``, [#69200](https://github.com/saltstack/salt/issues/69200)
-  * ``salt.returners.calls``), histograms (``salt.job.duration``, [#69200](https://github.com/saltstack/salt/issues/69200)
-  * ``salt.minion.exec.duration``), and observable gauges [#69200](https://github.com/saltstack/salt/issues/69200)
-  * (``salt.master.connected_minions.count``, [#69200](https://github.com/saltstack/salt/issues/69200)
-  * ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via [#69200](https://github.com/saltstack/salt/issues/69200)
-  * OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a [#69200](https://github.com/saltstack/salt/issues/69200)
-  * complete no-op when disabled.  See ``doc/topics/metrics/index.rst`` [#69200](https://github.com/saltstack/salt/issues/69200)
-  * for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
-  * Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was [#69201](https://github.com/saltstack/salt/issues/69201)
-  * removed when community extensions were purged. The module is reinstated as a [#69201](https://github.com/saltstack/salt/issues/69201)
-  * core ext_pillar so existing PillarStack-based pillar trees continue to work on [#69201](https://github.com/saltstack/salt/issues/69201)
-  * 3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
+  * Added OpenTelemetry metrics support alongside the existing tracing
+    integration.  When ``metrics.enabled`` is true in the master/minion
+    config, salt daemons emit counters (``salt.jobs.published``,
+    ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``,
+    ``salt.returners.calls``), histograms (``salt.job.duration``,
+    ``salt.minion.exec.duration``), and observable gauges
+    (``salt.master.connected_minions.count``,
+    ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via
+    OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a
+    complete no-op when disabled.  See ``doc/topics/metrics/index.rst``
+    for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
+  * Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was
+    removed when community extensions were purged. The module is reinstated as a
+    core ext_pillar so existing PillarStack-based pillar trees continue to work on
+    3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
   * Added ``lgpo_reg.get_rsop_value`` to query the Resultant Set of Policy (RSoP) for a registry key/value and detect whether it is managed by a Domain Group Policy Object. The ``lgpo_reg`` module functions ``set_value``, ``disable_value``, and ``delete_value`` now log a warning when a Domain GPO is detected for the target value. The ``lgpo_reg`` state functions ``value_present``, ``value_disabled``, and ``value_absent`` append the same warning to the state comment so it is visible in state output. [#69205](https://github.com/saltstack/salt/issues/69205)
 
 
@@ -428,13 +428,13 @@ salt (3008.0~rc4) stable; urgency=medium
   * Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
   * Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
   * Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-  * Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-  * [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-  * Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+  * Do not use `ssl.PROTOCOL_TLS` which has been
+    [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+    Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
   * Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-  * PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-  * fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-  * salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+  * PillarCache: reimplement using salt.cache
+    fix minion data cache organization/move pillar and grains to dedicated cache banks
+    salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
   * Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
   * Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
   * Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -476,13 +476,13 @@ salt (3008.0~rc4) stable; urgency=medium
   * Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
   * Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
   * Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-  * Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-  * (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-  * grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-  * Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-  * leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-  * runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-  * beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+  * Fixed an issue where conflicting top level keys in the static grains file
+    (usually `/etc/salt/grains`) would break all grains states, and prevent static
+    grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+  * Fixed beacon delete not calling the beacon's close function, causing resource
+    leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+    runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+    beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
   * Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
   * Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
   * Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -509,85 +509,85 @@ salt (3008.0~rc4) stable; urgency=medium
   * Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
   * Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
   * Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-  * Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-  * '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-  * newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-  * execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+  * Fixed multiline powershell -Command { } blocks failing with "Missing closing
+    '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+    newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+    execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
   * Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-  * Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
-  *  [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
-  *  [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-  * migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-  * states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
-  *  [#68574](https://github.com/saltstack/salt/issues/68574)
-  * Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-  * community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-  * had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+  * Add `blockdev` state module back in to core
+
+    Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+  * Adds `mdadm` and `lvm` grains modules back in to core.
+
+    Restores the modules that had been removed as part of the community module
+    migration. They are core bits of functionality and the associated execution and
+    states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+  * Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+    Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+    Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+    Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+    Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+    Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+    Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+    Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+    Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+    Improved reliability of `state.running` integration test for `salt-ssh`.
+    Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+    Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+  * Adds `alias` state module back in to core.
+
+    Restores the module that had been removed as part of the
+    community module migration. The associated execution module
+    had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
   * Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-  * Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-  * making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-  * This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-  * `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-  * cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+  * Improved the rejected authentication warning message to include the minion ID,
+    making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+  * This PR fixes a bug where corrupted grains cache files cause unhandled
+    `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+    The fix adds proper exception handling to gracefully recover from corrupted
+    cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
   * Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
   * Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
   * Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
   * Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
   * Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
   * Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-  * Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-  * mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-  * to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-  * when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+  * Fixed a regression in win_pkg where msiexec install flags containing
+    Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+    mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+    Restored the pre-regression behaviour where ``shlex_split`` is not applied
+    to command strings on Windows, preserving Windows-style argument quoting
+    when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
   * Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-  * Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+  * Remove deprecations.
+    - salt/auth/pki.py (removed)
+    - salt/features.py (removed)
+    - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
   * Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
   * Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-  * * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+  * * Relenv 0.22.11
+    - Update python 3.14 to 3.14.5
+    - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+    - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
   * Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
 
   # Added
 
   * Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-  * Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-  * validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-  * ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-  * `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-  * creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-  * the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-  * to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-  * differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-  * platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+  * Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+    validates a Windows user's password via ``LogonUser`` with
+    ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+    `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+    creating an interactive session. If the check causes an account lockout,
+    the account is automatically unlocked. Updated ``user.present`` on Windows
+    to use ``shadow.verify_password`` so the password is only changed when it
+    differs from the current value, matching the idempotent behaviour on other
+    platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
   * Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
   * Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
   * Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-  * the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+    the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
   * Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
   * Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
   * Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -616,48 +616,48 @@ salt (3008.0~rc4) stable; urgency=medium
   * Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
   * Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
   * Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-  * refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-  * optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-  * refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+  * refactored server-side PKI to support cache interface
+    optimization: check_compound_minions: defer _pki_minions fetch
+    refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
   * Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
   * Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
   * Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-  * Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
-  *  [#68410](https://github.com/saltstack/salt/issues/68410)
-  * Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+  * Added booleans argument to selinux.booleans
+    Added mod_aggregate to selinux to combine boolean
+    Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+  * Add support for minion_id in log formats
+
+    Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
   * Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-  * Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-  * and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-  * slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-  * `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-  * Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-  * configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+  * Added tunable worker pools: partition the master's MWorkers into named pools
+    and route specific commands (for example `_auth`) to dedicated pools so a
+    slow workload cannot starve time-critical traffic. Controlled by the new
+    `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+    Worker Pools" topic guide for details. Existing `worker_threads`
+    configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
   * Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
   * utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
   * Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
   * Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
   * Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-  * an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-  * safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-  * scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-  * a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-  * batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-  * targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-  * moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-  * mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-  * arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-  * the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+    an O(1) hash-table store with a segmented heap, durable and multi-process
+    safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+    A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+    scans for the master's minion-key store; select it with
+    ``keys.cache_driver: mmap_key``. Migrate existing data with
+    ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+  * Batch mode now uses a single JID for the entire batch run instead of generating
+    a separate JID per batch iteration. This enables unified job tracking via
+    ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+    batch slices. The job cache merges minion lists from each iteration so that
+    ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+    targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+    moment they accept the published job, before the function runs. The payload
+    mirrors the master's ``salt/job/<jid>/new`` event minus the function
+    arguments, letting orchestrators confirm reachability without waiting for
+    the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
   * Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -689,13 +689,13 @@ salt (3008.0~rc3) stable; urgency=medium
   * Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
   * Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
   * Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-  * Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-  * [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-  * Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+  * Do not use `ssl.PROTOCOL_TLS` which has been
+    [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+    Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
   * Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-  * PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-  * fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-  * salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+  * PillarCache: reimplement using salt.cache
+    fix minion data cache organization/move pillar and grains to dedicated cache banks
+    salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
   * Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
   * Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
   * Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -737,13 +737,13 @@ salt (3008.0~rc3) stable; urgency=medium
   * Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
   * Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
   * Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-  * Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-  * (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-  * grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-  * Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-  * leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-  * runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-  * beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+  * Fixed an issue where conflicting top level keys in the static grains file
+    (usually `/etc/salt/grains`) would break all grains states, and prevent static
+    grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+  * Fixed beacon delete not calling the beacon's close function, causing resource
+    leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+    runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+    beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
   * Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
   * Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
   * Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -770,66 +770,66 @@ salt (3008.0~rc3) stable; urgency=medium
   * Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
   * Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
   * Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-  * Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-  * '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-  * newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-  * execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+  * Fixed multiline powershell -Command { } blocks failing with "Missing closing
+    '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+    newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+    execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
   * Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-  * Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
-  *  [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
-  *  [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-  * migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-  * states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
-  *  [#68574](https://github.com/saltstack/salt/issues/68574)
-  * Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-  * community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-  * had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+  * Add `blockdev` state module back in to core
+
+    Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+  * Adds `mdadm` and `lvm` grains modules back in to core.
+
+    Restores the modules that had been removed as part of the community module
+    migration. They are core bits of functionality and the associated execution and
+    states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+  * Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+    Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+    Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+    Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+    Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+    Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+    Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+    Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+    Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+    Improved reliability of `state.running` integration test for `salt-ssh`.
+    Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+    Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+  * Adds `alias` state module back in to core.
+
+    Restores the module that had been removed as part of the
+    community module migration. The associated execution module
+    had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
   * Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-  * Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-  * making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-  * This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-  * `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-  * cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+  * Improved the rejected authentication warning message to include the minion ID,
+    making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+  * This PR fixes a bug where corrupted grains cache files cause unhandled
+    `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+    The fix adds proper exception handling to gracefully recover from corrupted
+    cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
   * Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
   * Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
   * Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
   * Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
   * Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
   * Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-  * Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-  * mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-  * to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-  * when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+  * Fixed a regression in win_pkg where msiexec install flags containing
+    Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+    mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+    Restored the pre-regression behaviour where ``shlex_split`` is not applied
+    to command strings on Windows, preserving Windows-style argument quoting
+    when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
   * Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-  * Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+  * Remove deprecations.
+    - salt/auth/pki.py (removed)
+    - salt/features.py (removed)
+    - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
   * Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
   * Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-  * * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-  * - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+  * * Relenv 0.22.11
+    - Update python 3.14 to 3.14.5
+    - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+    - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 
   # Added
 
@@ -837,8 +837,8 @@ salt (3008.0~rc3) stable; urgency=medium
   * Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
   * Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
   * Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-  * the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+    the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
   * Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
   * Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
   * Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -867,48 +867,48 @@ salt (3008.0~rc3) stable; urgency=medium
   * Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
   * Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
   * Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-  * refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-  * optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-  * refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+  * refactored server-side PKI to support cache interface
+    optimization: check_compound_minions: defer _pki_minions fetch
+    refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
   * Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
   * Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
   * Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-  * Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
-  *  [#68410](https://github.com/saltstack/salt/issues/68410)
-  * Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+  * Added booleans argument to selinux.booleans
+    Added mod_aggregate to selinux to combine boolean
+    Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+  * Add support for minion_id in log formats
+
+    Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
   * Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-  * Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-  * and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-  * slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-  * `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-  * Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-  * configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+  * Added tunable worker pools: partition the master's MWorkers into named pools
+    and route specific commands (for example `_auth`) to dedicated pools so a
+    slow workload cannot starve time-critical traffic. Controlled by the new
+    `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+    Worker Pools" topic guide for details. Existing `worker_threads`
+    configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
   * Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
   * utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
   * Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
   * Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
   * Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-  * an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-  * safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-  * scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-  * a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-  * batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-  * targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-  * moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-  * mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-  * arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-  * the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+    an O(1) hash-table store with a segmented heap, durable and multi-process
+    safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+    A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+    scans for the master's minion-key store; select it with
+    ``keys.cache_driver: mmap_key``. Migrate existing data with
+    ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+  * Batch mode now uses a single JID for the entire batch run instead of generating
+    a separate JID per batch iteration. This enables unified job tracking via
+    ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+    batch slices. The job cache merges minion lists from each iteration so that
+    ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+    targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+    moment they accept the published job, before the function runs. The payload
+    mirrors the master's ``salt/job/<jid>/new`` event minus the function
+    arguments, letting orchestrators confirm reachability without waiting for
+    the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
   * Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -940,13 +940,13 @@ salt (3008.0~rc2) stable; urgency=medium
   * Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
   * Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
   * Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-  * Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-  * [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-  * Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+  * Do not use `ssl.PROTOCOL_TLS` which has been
+    [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+    Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
   * Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-  * PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-  * fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-  * salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+  * PillarCache: reimplement using salt.cache
+    fix minion data cache organization/move pillar and grains to dedicated cache banks
+    salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
   * Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
   * Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
   * Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -988,13 +988,13 @@ salt (3008.0~rc2) stable; urgency=medium
   * Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
   * Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
   * Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-  * Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-  * (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-  * grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-  * Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-  * leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-  * runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-  * beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+  * Fixed an issue where conflicting top level keys in the static grains file
+    (usually `/etc/salt/grains`) would break all grains states, and prevent static
+    grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+  * Fixed beacon delete not calling the beacon's close function, causing resource
+    leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+    runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+    beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
   * Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
   * Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
   * Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1021,60 +1021,60 @@ salt (3008.0~rc2) stable; urgency=medium
   * Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
   * Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
   * Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-  * Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-  * '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-  * newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-  * execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+  * Fixed multiline powershell -Command { } blocks failing with "Missing closing
+    '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+    newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+    execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
   * Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-  * Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
-  *  [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
-  *  [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-  * migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-  * states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
-  *  [#68574](https://github.com/saltstack/salt/issues/68574)
-  * Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-  * community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-  * had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+  * Add `blockdev` state module back in to core
+
+    Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+  * Adds `mdadm` and `lvm` grains modules back in to core.
+
+    Restores the modules that had been removed as part of the community module
+    migration. They are core bits of functionality and the associated execution and
+    states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+  * Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+    Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+    Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+    Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+    Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+    Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+    Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+    Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+    Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+    Improved reliability of `state.running` integration test for `salt-ssh`.
+    Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+    Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+  * Adds `alias` state module back in to core.
+
+    Restores the module that had been removed as part of the
+    community module migration. The associated execution module
+    had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
   * Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-  * Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-  * making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-  * This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-  * `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-  * cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+  * Improved the rejected authentication warning message to include the minion ID,
+    making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+  * This PR fixes a bug where corrupted grains cache files cause unhandled
+    `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+    The fix adds proper exception handling to gracefully recover from corrupted
+    cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
   * Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
   * Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
   * Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
   * Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
   * Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
   * Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-  * Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-  * mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-  * Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-  * to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-  * when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+  * Fixed a regression in win_pkg where msiexec install flags containing
+    Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+    mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+    Restored the pre-regression behaviour where ``shlex_split`` is not applied
+    to command strings on Windows, preserving Windows-style argument quoting
+    when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
   * Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-  * Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+  * Remove deprecations.
+    - salt/auth/pki.py (removed)
+    - salt/features.py (removed)
+    - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
   * Fixed on the ``3008.x`` release line: Salt NetAPI rest_tornado header parsing without ``cgi.parse_header`` (removed in Python 3.13). Integration ``salt_minion`` / ``salt_sub_minion`` fixtures now call ``saltutil.sync_all`` with ``saltenv=base`` to avoid long master round-trips from top-file environment discovery during Windows CI. Salt factories use a 120 second daemon start timeout when ``ONEDIR_TESTRUN`` is set so Windows onedir runs match CI and avoid flaky minion start event waits. [#69014](https://github.com/saltstack/salt/issues/69014)
 
   # Added
@@ -1083,8 +1083,8 @@ salt (3008.0~rc2) stable; urgency=medium
   * Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
   * Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
   * Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-  * the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+    the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
   * Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
   * Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
   * Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1113,47 +1113,47 @@ salt (3008.0~rc2) stable; urgency=medium
   * Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
   * Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
   * Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-  * refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-  * optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-  * refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+  * refactored server-side PKI to support cache interface
+    optimization: check_compound_minions: defer _pki_minions fetch
+    refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
   * Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
   * Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
   * Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-  * Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
-  *  [#68410](https://github.com/saltstack/salt/issues/68410)
-  * Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+  * Added booleans argument to selinux.booleans
+    Added mod_aggregate to selinux to combine boolean
+    Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+  * Add support for minion_id in log formats
+
+    Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
   * Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-  * Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-  * and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-  * slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-  * `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-  * Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-  * configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+  * Added tunable worker pools: partition the master's MWorkers into named pools
+    and route specific commands (for example `_auth`) to dedicated pools so a
+    slow workload cannot starve time-critical traffic. Controlled by the new
+    `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+    Worker Pools" topic guide for details. Existing `worker_threads`
+    configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
   * Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
   * utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
   * Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
   * Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
-  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-  * an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-  * safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * The minion public-key index (``salt.cache.mmap_key`` / [#68936](https://github.com/saltstack/salt/issues/68936)
-  * ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-  * scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate [#68936](https://github.com/saltstack/salt/issues/68936)
-  * existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-  * Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-  * a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-  * batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-  * ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-  * targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-  * moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-  * mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-  * arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-  * the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+  * Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+    an O(1) hash-table store with a segmented heap, durable and multi-process
+    safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+    The minion public-key index (``salt.cache.mmap_key`` /
+    ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir``
+    scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate
+    existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+  * Batch mode now uses a single JID for the entire batch run instead of generating
+    a separate JID per batch iteration. This enables unified job tracking via
+    ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+    batch slices. The job cache merges minion lists from each iteration so that
+    ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+  * Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+    targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+    moment they accept the published job, before the function runs. The payload
+    mirrors the master's ``salt/job/<jid>/new`` event minus the function
+    arguments, letting orchestrators confirm reachability without waiting for
+    the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 
 
  -- Salt Project Packaging <saltproject-packaging@vmware.com>  Wed, 06 May 2026 17:42:55 +0000
@@ -1183,13 +1183,13 @@ salt (3008.0~rc1) stable; urgency=medium
   * Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
   * Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
   * Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-  * Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-  * [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-  * Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+  * Do not use `ssl.PROTOCOL_TLS` which has been
+    [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+    Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
   * Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-  * PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-  * fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-  * salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+  * PillarCache: reimplement using salt.cache
+    fix minion data cache organization/move pillar and grains to dedicated cache banks
+    salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
   * Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
   * Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
   * Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1231,13 +1231,13 @@ salt (3008.0~rc1) stable; urgency=medium
   * Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
   * Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
   * Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-  * Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-  * (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-  * grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-  * Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-  * leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-  * runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-  * beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+  * Fixed an issue where conflicting top level keys in the static grains file
+    (usually `/etc/salt/grains`) would break all grains states, and prevent static
+    grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+  * Fixed beacon delete not calling the beacon's close function, causing resource
+    leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+    runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+    beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
   * Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
   * Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
   * Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1265,46 +1265,46 @@ salt (3008.0~rc1) stable; urgency=medium
   * Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
   * Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
   * Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-  * Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
-  *  [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-  * Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
-  *  [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-  * migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-  * states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-  * Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-  * Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
-  *  [#68574](https://github.com/saltstack/salt/issues/68574)
-  * Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-  * community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-  * had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+  * Add `blockdev` state module back in to core
+
+    Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+  * Adds `mdadm` and `lvm` grains modules back in to core.
+
+    Restores the modules that had been removed as part of the community module
+    migration. They are core bits of functionality and the associated execution and
+    states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+  * Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+    Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+    Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+    Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+    Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+    Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+    Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+    Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+    Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+    Improved reliability of `state.running` integration test for `salt-ssh`.
+    Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+    Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+  * Adds `alias` state module back in to core.
+
+    Restores the module that had been removed as part of the
+    community module migration. The associated execution module
+    had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
   * Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-  * Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-  * making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-  * This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-  * `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-  * cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
-  * Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when [#68763](https://github.com/saltstack/salt/issues/68763)
-  * Homebrew returns `null` values for cask metadata: [#68763](https://github.com/saltstack/salt/issues/68763)
-  *  [#68763](https://github.com/saltstack/salt/issues/68763)
-  * - When the installed version of a cask is `null` (e.g. Homebrew cannot [#68763](https://github.com/saltstack/salt/issues/68763)
-  * determine the installed version), it is now reported as `"unknown"` [#68763](https://github.com/saltstack/salt/issues/68763)
-  * instead of raising an error. [#68763](https://github.com/saltstack/salt/issues/68763)
-  * - When `full_token` is `null`, it is now filtered out so that `None` [#68763](https://github.com/saltstack/salt/issues/68763)
-  * is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
+  * Improved the rejected authentication warning message to include the minion ID,
+    making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+  * This PR fixes a bug where corrupted grains cache files cause unhandled
+    `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+    The fix adds proper exception handling to gracefully recover from corrupted
+    cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+  * Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when
+    Homebrew returns `null` values for cask metadata:
+
+    - When the installed version of a cask is `null` (e.g. Homebrew cannot
+    determine the installed version), it is now reported as `"unknown"`
+    instead of raising an error.
+    - When `full_token` is `null`, it is now filtered out so that `None`
+    is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
   * Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
   * Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
   * Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -1312,10 +1312,10 @@ salt (3008.0~rc1) stable; urgency=medium
   * Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
   * Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
   * Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-  * Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-  * - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+  * Remove deprecations.
+    - salt/auth/pki.py (removed)
+    - salt/features.py (removed)
+    - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 
   # Added
 
@@ -1323,8 +1323,8 @@ salt (3008.0~rc1) stable; urgency=medium
   * Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
   * Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
   * Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-  * the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+  * Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+    the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
   * Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
   * Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
   * Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1353,25 +1353,25 @@ salt (3008.0~rc1) stable; urgency=medium
   * Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
   * Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
   * Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-  * refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-  * optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-  * refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+  * refactored server-side PKI to support cache interface
+    optimization: check_compound_minions: defer _pki_minions fetch
+    refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
   * Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
   * Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
   * Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-  * Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-  * Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
-  *  [#68410](https://github.com/saltstack/salt/issues/68410)
-  * Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+  * Added booleans argument to selinux.booleans
+    Added mod_aggregate to selinux to combine boolean
+    Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+  * Add support for minion_id in log formats
+
+    Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
   * Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-  * Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-  * and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-  * slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-  * `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-  * Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-  * configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+  * Added tunable worker pools: partition the master's MWorkers into named pools
+    and route specific commands (for example `_auth`) to dedicated pools so a
+    slow workload cannot starve time-critical traffic. Controlled by the new
+    `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+    Worker Pools" topic guide for details. Existing `worker_threads`
+    configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
   * Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
   * utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
   * Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -948,15 +948,15 @@ fi
 
 # Changed
 
-- Changed `salt.returners.redis_return` to enumerate the Redis keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-- with `SCAN` instead of the blocking `KEYS pattern` command in both [#69037](https://github.com/saltstack/salt/issues/69037)
-- `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace [#69037](https://github.com/saltstack/salt/issues/69037)
-- synchronously and stalls the Redis server for the duration; on a [#69037](https://github.com/saltstack/salt/issues/69037)
-- master with hundreds of thousands of jobs this can block all clients [#69037](https://github.com/saltstack/salt/issues/69037)
-- of that Redis instance for seconds. `SCAN` is incremental and [#69037](https://github.com/saltstack/salt/issues/69037)
-- non-blocking. Order of returned keys is no longer guaranteed (the [#69037](https://github.com/saltstack/salt/issues/69037)
-- returner does not rely on order); operators with custom scripts that [#69037](https://github.com/saltstack/salt/issues/69037)
-- read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
+- Changed `salt.returners.redis_return` to enumerate the Redis keyspace
+  with `SCAN` instead of the blocking `KEYS pattern` command in both
+  `get_jids` and `clean_old_jobs`. `KEYS` walks the entire keyspace
+  synchronously and stalls the Redis server for the duration; on a
+  master with hundreds of thousands of jobs this can block all clients
+  of that Redis instance for seconds. `SCAN` is incremental and
+  non-blocking. Order of returned keys is no longer guaranteed (the
+  returner does not rely on order); operators with custom scripts that
+  read `ret:*` or `load:*` directly may see them in a different order. [#69037](https://github.com/saltstack/salt/issues/69037)
 
 # Fixed
 
@@ -965,64 +965,64 @@ fi
 - Improved documentation for the `runas` and `password` parameters in `cmd.run`, `cmd.script`, and all `salt.modules.cmdmod` execution functions on Windows. The docs now accurately describe when a password is required: only when the salt-minion is **not** running as SYSTEM or as an elevated Administrator. Removed the inaccurate claim that the target user account must be in the Administrators group. Also changed `cmd.script` to log a warning instead of hard-failing when `runas` is used without a password on Windows, since a password is not always required. [#57951](https://github.com/saltstack/salt/issues/57951)
 - Fixed `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` errors in the VMware cloud driver by reconnecting when a cached vCenter service instance is found to be stale or corrupted (for example when inherited across a fork by salt-cloud's parallel provider queries). [#61983](https://github.com/saltstack/salt/issues/61983)
 - Fixed event signature verification failing under ``minion_sign_messages``. The minion was signing the return load before ``salt.channel.client.AsyncReqChannel._package_load`` attached transport metadata (``nonce``, ``ts``, ``tok``, ``id``), so the bytes the master re-serialized to verify did not match what was signed and every signed return was dropped. Signing is now performed inside ``_package_load`` after the metadata is attached, against the same bytes the master verifies. [#68181](https://github.com/saltstack/salt/issues/68181)
-- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that [#69031](https://github.com/saltstack/salt/issues/69031)
-- together prevented it from being usable. `start()` no longer raises [#69031](https://github.com/saltstack/salt/issues/69031)
-- `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3 [#69031](https://github.com/saltstack/salt/issues/69031)
-- (the dict.values() result is now wrapped in `list(...)`). `Listener` and [#69031](https://github.com/saltstack/salt/issues/69031)
-- `start()` now accept an optional `password` argument and forward it to [#69031](https://github.com/saltstack/salt/issues/69031)
-- the redis client, allowing the engine to authenticate against a Sentinel [#69031](https://github.com/saltstack/salt/issues/69031)
-- that requires AUTH; the default of `None` keeps existing configurations [#69031](https://github.com/saltstack/salt/issues/69031)
-- working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
-- Fixed `salt.returners.redis_return` silently ignoring the documented [#69032](https://github.com/saltstack/salt/issues/69032)
-- `redis.password` configuration option. The returner now reads [#69032](https://github.com/saltstack/salt/issues/69032)
-- `redis.password` from config (in both regular and proxy modes) and [#69032](https://github.com/saltstack/salt/issues/69032)
-- forwards it to both the single-server `redis.StrictRedis` and the [#69032](https://github.com/saltstack/salt/issues/69032)
-- `StrictRedisCluster` constructors. Operators with auth-protected Redis [#69032](https://github.com/saltstack/salt/issues/69032)
-- no longer lose every job return to a hidden `NOAUTH Authentication [#69032](https://github.com/saltstack/salt/issues/69032)
-- required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
-- Fixed three closely-related bugs in `salt.cache.redis_cache` that [#69033](https://github.com/saltstack/salt/issues/69033)
-- together broke hierarchical-bank semantics: [#69033](https://github.com/saltstack/salt/issues/69033)
-- `_build_bank_hier` now registers each child bank name in both the [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's `$BANK_` set (consumed by `flush()` tree traversal) and the [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove` [#69033](https://github.com/saltstack/salt/issues/69033)
-- now decodes the bytes returned by `smembers` and skips the `"."` [#69033](https://github.com/saltstack/salt/issues/69033)
-- placeholder, so recursive `flush()` of a parent bank actually descends [#69033](https://github.com/saltstack/salt/issues/69033)
-- into sub-banks instead of corrupting the path; and `flush(bank)` of a [#69033](https://github.com/saltstack/salt/issues/69033)
-- sub-bank now removes the flushed bank's own reference from its [#69033](https://github.com/saltstack/salt/issues/69033)
-- parent's index sets so `list_(parent)` no longer reports it as [#69033](https://github.com/saltstack/salt/issues/69033)
-- present. Together these fixes restore `cache.list("minions")`, [#69033](https://github.com/saltstack/salt/issues/69033)
-- `salt-run manage.present` and `salt-run manage.up` for masters [#69033](https://github.com/saltstack/salt/issues/69033)
-- configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
-- Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-- token. The cluster client was created with `decode_responses=True`, [#69035](https://github.com/saltstack/salt/issues/69035)
-- which caused `redis_client.get()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-- `salt.payload.loads` (msgpack rejects `str`); it also caused [#69035](https://github.com/saltstack/salt/issues/69035)
-- `redis_client.keys()` to return `str` and broke [#69035](https://github.com/saltstack/salt/issues/69035)
-- `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both [#69035](https://github.com/saltstack/salt/issues/69035)
-- errors were swallowed by broad `except Exception` handlers, so eauth [#69035](https://github.com/saltstack/salt/issues/69035)
-- appeared to silently reject every token. `decode_responses=True` is [#69035](https://github.com/saltstack/salt/issues/69035)
-- removed; values now round-trip as bytes through msgpack as the rest [#69035](https://github.com/saltstack/salt/issues/69035)
-- of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
-- Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid [#69038](https://github.com/saltstack/salt/issues/69038)
-- pointer keys indefinitely. The pointer was written with `pipeline.set` [#69038](https://github.com/saltstack/salt/issues/69038)
-- and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck [#69038](https://github.com/saltstack/salt/issues/69038)
-- in Redis forever -- O(minions × distinct funcs) keys accumulating over [#69038](https://github.com/saltstack/salt/issues/69038)
-- the lifetime of the master. The pointer now expires on the same TTL [#69038](https://github.com/saltstack/salt/issues/69038)
-- as the rest of the returner data (`keep_jobs_seconds`). Operators with [#69038](https://github.com/saltstack/salt/issues/69038)
-- external scripts reading these keys directly may observe them [#69038](https://github.com/saltstack/salt/issues/69038)
-- expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
-- Fixed `salt.returners.redis_return.get_fun` always returning an [#69039](https://github.com/saltstack/salt/issues/69039)
-- empty dict. The function read return data from a `<minion>:<jid>` [#69039](https://github.com/saltstack/salt/issues/69039)
-- key that no other code in the module ever wrote -- a leftover from [#69039](https://github.com/saltstack/salt/issues/69039)
-- an older storage schema. It now reads from the canonical [#69039](https://github.com/saltstack/salt/issues/69039)
-- `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the [#69039](https://github.com/saltstack/salt/issues/69039)
-- storage layout that `returner` actually produces and the read [#69039](https://github.com/saltstack/salt/issues/69039)
-- pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
+- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that
+  together prevented it from being usable. `start()` no longer raises
+  `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3
+  (the dict.values() result is now wrapped in `list(...)`). `Listener` and
+  `start()` now accept an optional `password` argument and forward it to
+  the redis client, allowing the engine to authenticate against a Sentinel
+  that requires AUTH; the default of `None` keeps existing configurations
+  working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
+- Fixed `salt.returners.redis_return` silently ignoring the documented
+  `redis.password` configuration option. The returner now reads
+  `redis.password` from config (in both regular and proxy modes) and
+  forwards it to both the single-server `redis.StrictRedis` and the
+  `StrictRedisCluster` constructors. Operators with auth-protected Redis
+  no longer lose every job return to a hidden `NOAUTH Authentication
+  required` failure; deployments without a password are unaffected. [#69032](https://github.com/saltstack/salt/issues/69032)
+- Fixed three closely-related bugs in `salt.cache.redis_cache` that
+  together broke hierarchical-bank semantics:
+  `_build_bank_hier` now registers each child bank name in both the
+  parent's `$BANK_` set (consumed by `flush()` tree traversal) and the
+  parent's `$BANKEYS_` set (consumed by `list_()`); `_get_banks_to_remove`
+  now decodes the bytes returned by `smembers` and skips the `"."`
+  placeholder, so recursive `flush()` of a parent bank actually descends
+  into sub-banks instead of corrupting the path; and `flush(bank)` of a
+  sub-bank now removes the flushed bank's own reference from its
+  parent's index sets so `list_(parent)` no longer reports it as
+  present. Together these fixes restore `cache.list("minions")`,
+  `salt-run manage.present` and `salt-run manage.up` for masters
+  configured with `cache: redis`. [#69033](https://github.com/saltstack/salt/issues/69033)
+- Fixed `salt.tokens.rediscluster` being unable to retrieve any eauth
+  token. The cluster client was created with `decode_responses=True`,
+  which caused `redis_client.get()` to return `str` and broke
+  `salt.payload.loads` (msgpack rejects `str`); it also caused
+  `redis_client.keys()` to return `str` and broke
+  `[k.decode("utf8") for k in ...]` (`str` has no `.decode`). Both
+  errors were swallowed by broad `except Exception` handlers, so eauth
+  appeared to silently reject every token. `decode_responses=True` is
+  removed; values now round-trip as bytes through msgpack as the rest
+  of the module already expected. [#69035](https://github.com/saltstack/salt/issues/69035)
+- Fixed `salt.returners.redis_return` leaking `<minion>:<fun>` last-jid
+  pointer keys indefinitely. The pointer was written with `pipeline.set`
+  and no `ex=` TTL, so any (minion, fun) pair that stopped running stuck
+  in Redis forever -- O(minions × distinct funcs) keys accumulating over
+  the lifetime of the master. The pointer now expires on the same TTL
+  as the rest of the returner data (`keep_jobs_seconds`). Operators with
+  external scripts reading these keys directly may observe them
+  expiring; the documentation never promised they would not. [#69038](https://github.com/saltstack/salt/issues/69038)
+- Fixed `salt.returners.redis_return.get_fun` always returning an
+  empty dict. The function read return data from a `<minion>:<jid>`
+  key that no other code in the module ever wrote -- a leftover from
+  an older storage schema. It now reads from the canonical
+  `ret:<jid>` hash via `HGET ret:<jid> <minion>`, matching the
+  storage layout that `returner` actually produces and the read
+  pattern that `get_jid` already uses. [#69039](https://github.com/saltstack/salt/issues/69039)
 - ``cmd.run`` and friends no longer include the ``env`` and ``stdin`` arguments in the ``CommandExecutionError`` raised when the underlying subprocess fails to start (typically ``ENOENT`` / binary not found). Both fields routinely carry credentials passed in by the caller (``env={"DB_PASSWORD": "..."}``, password piped via ``stdin``), and the error message ends up in master/minion logs and in event-bus return data visible to the API caller. [#69075](https://github.com/saltstack/salt/issues/69075)
-- * Relenv 0.22.14 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.6 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.2.0 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.14
+  - Update python 3.14 to 3.14.6
+  - Update sqlite to 3.53.2.0
+  - Update openssl to 3.5.7 [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix pillar masking leaking ``**********`` into rendered pillar and state values. ``MaskedDict`` / ``MaskedList`` ``__repr__`` / ``__str__`` now consult the ``salt.utils.secret.mask_pillar`` ContextVar, so ``{{ pillar['list_or_dict_value'] }}`` interpolations on the minion return plain values inside a render bracket. Hoist the ``mask_pillar=False`` bracket from ``render_pillar`` to ``compile_pillar`` so ``ext_pillar`` handlers and the rest of the master-side pillar build also run unmasked. [#69160](https://github.com/saltstack/salt/issues/69160)
 - Fixed Windows MSI self-upgrade via ``pkg.install`` failing with error 1603. The old product's ``DeleteConfig_DECAC`` custom action was unconditionally deleting ``ROOTDIR\var`` during ``RemoveExistingProducts``, destroying the MSI that ``pkg.install`` had cached to ``ROOTDIR\var\cache`` before launching the upgrade. Users who had ``REMOVE_CONFIG=1`` persisted in the registry (from checking "On uninstall" at install time) hit a worse variant where the entire ``ROOTDIR`` was deleted. The fix checks ``UPGRADINGPRODUCTCODE`` — set by Windows Installer whenever an uninstall is triggered by a major upgrade — and skips all ``ROOTDIR`` deletion during upgrades, matching the behaviour of the NSIS installer which has always preserved ``ROOTDIR`` during upgrades. [#69219](https://github.com/saltstack/salt/issues/69219)
 - Fixed `TypeError: string indices must be integers` in the minion when the master returns a bare string error response (e.g. `"bad load"`, `"Some exception handling minion payload"`) for a pillar request. The minion now raises a clean `AuthenticationError` instead of crashing, allowing the caller to retry or fail gracefully. [#69228](https://github.com/saltstack/salt/issues/69228)
@@ -1035,11 +1035,11 @@ fi
 
 # Added
 
-- Added ``dsc_resource`` execution module and state module for invoking individual [#43718](https://github.com/saltstack/salt/issues/43718)
-- PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling [#43718](https://github.com/saltstack/salt/issues/43718)
-- a MOF file or involving the Local Configuration Manager. The [#43718](https://github.com/saltstack/salt/issues/43718)
-- ``dsc_resource.managed`` state provides idiomatic Salt state management for any [#43718](https://github.com/saltstack/salt/issues/43718)
-- installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
+- Added ``dsc_resource`` execution module and state module for invoking individual
+  PowerShell DSC resources directly via ``Invoke-DscResource``, without compiling
+  a MOF file or involving the Local Configuration Manager. The
+  ``dsc_resource.managed`` state provides idiomatic Salt state management for any
+  installed DSC resource module. [#43718](https://github.com/saltstack/salt/issues/43718)
 - fix etcdv3 module authentification when using etcd3-py lib [#69202](https://github.com/saltstack/salt/issues/69202)
 
 
@@ -1068,13 +1068,13 @@ fi
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1121,22 +1121,22 @@ fi
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
-- Fixed a regression where setting ``ipv6: true`` in the minion configuration [#66603](https://github.com/saltstack/salt/issues/66603)
-- caused the minion to fail to start on Windows. Three IPC socket paths in the [#66603](https://github.com/saltstack/salt/issues/66603)
-- TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6 [#66603](https://github.com/saltstack/salt/issues/66603)
-- setting: the IPC publish server/client addresses in ``salt.transport.base``, [#66603](https://github.com/saltstack/salt/issues/66603)
-- the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client [#66603](https://github.com/saltstack/salt/issues/66603)
-- socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback [#66603](https://github.com/saltstack/salt/issues/66603)
-- address (or vice-versa) is rejected by the OS. All three paths now use [#66603](https://github.com/saltstack/salt/issues/66603)
-- ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1`` [#66603](https://github.com/saltstack/salt/issues/66603)
-- with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed a regression where setting ``ipv6: true`` in the minion configuration
+  caused the minion to fail to start on Windows. Three IPC socket paths in the
+  TCP transport hardcoded ``AF_INET`` or ``127.0.0.1`` regardless of the IPv6
+  setting: the IPC publish server/client addresses in ``salt.transport.base``,
+  the ``TCPPuller`` server socket, and the ``_TCPPubServerPublisher`` client
+  socket. On Windows, mixing an ``AF_INET6`` socket with the IPv4 loopback
+  address (or vice-versa) is rejected by the OS. All three paths now use
+  ``::1`` with ``AF_INET6`` when ``ipv6: true`` is set, and ``127.0.0.1``
+  with ``AF_INET`` otherwise. [#66603](https://github.com/saltstack/salt/issues/66603)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1165,38 +1165,38 @@ fi
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -1204,45 +1204,45 @@ fi
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - debpkg include 0/1 as valid options when parsing bool values in deb822 [#68996](https://github.com/saltstack/salt/issues/68996)
 - Drain cancelled tasks on PublishClient close so the TCP transport no longer prints `[ERROR ] Task was destroyed but it is pending!` at the end of every salt command. [#68998](https://github.com/saltstack/salt/issues/68998)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - ``LoadAuth.get_tok`` now distinguishes between corrupt token blobs (removed from the store) and transient backend errors such as Redis connection drops or NFS hangs (token kept, request treated as not-authenticated). Previously a single backend hiccup could log every authenticated user out by deleting valid tokens. [#69073](https://github.com/saltstack/salt/issues/69073)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
 - Fixed ``lgpo_reg.value_absent`` failing when the Registry.pol entry was already absent but the registry value still existed. ``lgpo_reg.delete_value`` was returning early before reaching the registry cleanup code, causing the state to see no changes and report failure. The registry value is now removed regardless of whether the pol entry was present. [#69203](https://github.com/saltstack/salt/issues/69203)
 - Fixed `!!binary` YAML tag failing with "Incorrect padding" when base64 padding characters are omitted. Salt's YAML loader now tolerates unpadded base64 values, restoring behavior that worked on Salt 3006 (Python 3.10). [#69207](https://github.com/saltstack/salt/issues/69207)
-- Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar [#69218](https://github.com/saltstack/salt/issues/69218)
-- lists or dicts. Pillar containers are wrapped in ``MaskedDict`` / [#69218](https://github.com/saltstack/salt/issues/69218)
-- ``MaskedList`` for repr redaction; representers are now registered so the [#69218](https://github.com/saltstack/salt/issues/69218)
-- YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
+- Fixed the ``yaml`` Jinja filter returning ``NULL`` when applied to Pillar
+  lists or dicts. Pillar containers are wrapped in ``MaskedDict`` /
+  ``MaskedList`` for repr redaction; representers are now registered so the
+  YAML dumper serializes them as their underlying list / dict. [#69218](https://github.com/saltstack/salt/issues/69218)
 
 # Added
 
 - Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-- validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-- ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-- `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-- creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-- the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-- to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-- differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-- platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+  validates a Windows user's password via ``LogonUser`` with
+  ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+  `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+  creating an interactive session. If the check causes an account lockout,
+  the account is automatically unlocked. Updated ``user.present`` on Windows
+  to use ``shadow.verify_password`` so the password is only changed when it
+  differs from the current value, matching the idempotent behaviour on other
+  platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Add 'show_changes' arg for file.append and file.prepend states to hide output [#59329](https://github.com/saltstack/salt/issues/59329)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1272,73 +1272,73 @@ fi
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added OpenTelemetry distributed-tracing support across all Salt [#68999](https://github.com/saltstack/salt/issues/68999)
-- inter-process hops (network and IPC).  When `tracing.enabled` is true in the [#68999](https://github.com/saltstack/salt/issues/68999)
-- master/minion config, salt emits W3C-TraceContext-propagated spans via an [#68999](https://github.com/saltstack/salt/issues/68999)
-- OTLP exporter, covering the CLI, channel layer, master workers, minion [#68999](https://github.com/saltstack/salt/issues/68999)
-- command execution, event bus, reactor, syndic forwarding, salt-ssh, and [#68999](https://github.com/saltstack/salt/issues/68999)
-- salt-api.  Trace context travels inside the AES-encrypted Salt envelope so [#68999](https://github.com/saltstack/salt/issues/68999)
-- it remains opaque on the wire.  Tracing is opt-in and a complete no-op when [#68999](https://github.com/saltstack/salt/issues/68999)
-- disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added OpenTelemetry distributed-tracing support across all Salt
+  inter-process hops (network and IPC).  When `tracing.enabled` is true in the
+  master/minion config, salt emits W3C-TraceContext-propagated spans via an
+  OTLP exporter, covering the CLI, channel layer, master workers, minion
+  command execution, event bus, reactor, syndic forwarding, salt-ssh, and
+  salt-api.  Trace context travels inside the AES-encrypted Salt envelope so
+  it remains opaque on the wire.  Tracing is opt-in and a complete no-op when
+  disabled. [#68999](https://github.com/saltstack/salt/issues/68999)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 - Migrate Salt documentation to the PyData Sphinx theme. This update modernizes the documentation UI, improves navigation with a persistent sidebar tree, and fixes issues with embedded video playback. [#69185](https://github.com/saltstack/salt/issues/69185)
-- Added OpenTelemetry metrics support alongside the existing tracing [#69200](https://github.com/saltstack/salt/issues/69200)
-- integration.  When ``metrics.enabled`` is true in the master/minion [#69200](https://github.com/saltstack/salt/issues/69200)
-- config, salt daemons emit counters (``salt.jobs.published``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.returners.calls``), histograms (``salt.job.duration``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.minion.exec.duration``), and observable gauges [#69200](https://github.com/saltstack/salt/issues/69200)
-- (``salt.master.connected_minions.count``, [#69200](https://github.com/saltstack/salt/issues/69200)
-- ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via [#69200](https://github.com/saltstack/salt/issues/69200)
-- OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a [#69200](https://github.com/saltstack/salt/issues/69200)
-- complete no-op when disabled.  See ``doc/topics/metrics/index.rst`` [#69200](https://github.com/saltstack/salt/issues/69200)
-- for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
-- Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was [#69201](https://github.com/saltstack/salt/issues/69201)
-- removed when community extensions were purged. The module is reinstated as a [#69201](https://github.com/saltstack/salt/issues/69201)
-- core ext_pillar so existing PillarStack-based pillar trees continue to work on [#69201](https://github.com/saltstack/salt/issues/69201)
-- 3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
+- Added OpenTelemetry metrics support alongside the existing tracing
+  integration.  When ``metrics.enabled`` is true in the master/minion
+  config, salt daemons emit counters (``salt.jobs.published``,
+  ``salt.jobs.completed``, ``salt.auth.attempts``, ``salt.events.fired``,
+  ``salt.returners.calls``), histograms (``salt.job.duration``,
+  ``salt.minion.exec.duration``), and observable gauges
+  (``salt.master.connected_minions.count``,
+  ``salt.master.workers.queue.depth``, ``salt.process.open_fds``) via
+  OTLP push or a Prometheus pull endpoint.  Metrics are opt-in and a
+  complete no-op when disabled.  See ``doc/topics/metrics/index.rst``
+  for the full configuration surface and instrument inventory. [#69200](https://github.com/saltstack/salt/issues/69200)
+- Restore the ``pillarstack`` ext_pillar module (``salt.pillar.stack``) that was
+  removed when community extensions were purged. The module is reinstated as a
+  core ext_pillar so existing PillarStack-based pillar trees continue to work on
+  3008.x. [#69201](https://github.com/saltstack/salt/issues/69201)
 - Added ``lgpo_reg.get_rsop_value`` to query the Resultant Set of Policy (RSoP) for a registry key/value and detect whether it is managed by a Domain Group Policy Object. The ``lgpo_reg`` module functions ``set_value``, ``disable_value``, and ``delete_value`` now log a warning when a Domain GPO is detected for the target value. The ``lgpo_reg`` state functions ``value_present``, ``value_disabled``, and ``value_absent`` append the same warning to the state comment so it is visible in state output. [#69205](https://github.com/saltstack/salt/issues/69205)
 
 
@@ -1367,13 +1367,13 @@ fi
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1415,13 +1415,13 @@ fi
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1448,85 +1448,85 @@ fi
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 - Fix master crash when `presence_events: True` is set on Python 3.14 by skipping the shared `secrets` dict during `iter_transport_opts` deepcopy. [#69146](https://github.com/saltstack/salt/issues/69146)
 
 # Added
 
 - Added proxy option to `gitfs`, `git_pillar` and `winrepo` for specifying a proxy server used to connect to git repositories [#30990](https://github.com/saltstack/salt/issues/30990)
-- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which [#41347](https://github.com/saltstack/salt/issues/41347)
-- validates a Windows user's password via ``LogonUser`` with [#41347](https://github.com/saltstack/salt/issues/41347)
-- ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per [#41347](https://github.com/saltstack/salt/issues/41347)
-- `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without [#41347](https://github.com/saltstack/salt/issues/41347)
-- creating an interactive session. If the check causes an account lockout, [#41347](https://github.com/saltstack/salt/issues/41347)
-- the account is automatically unlocked. Updated ``user.present`` on Windows [#41347](https://github.com/saltstack/salt/issues/41347)
-- to use ``shadow.verify_password`` so the password is only changed when it [#41347](https://github.com/saltstack/salt/issues/41347)
-- differs from the current value, matching the idempotent behaviour on other [#41347](https://github.com/saltstack/salt/issues/41347)
-- platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
+- Added ``shadow.verify_password`` to ``salt.modules.win_shadow``, which
+  validates a Windows user's password via ``LogonUser`` with
+  ``LOGON32_LOGON_NETWORK`` (Microsoft's recommended approach per
+  `KB180548 <https://support.microsoft.com/en-us/help/180548>`_) without
+  creating an interactive session. If the check causes an account lockout,
+  the account is automatically unlocked. Updated ``user.present`` on Windows
+  to use ``shadow.verify_password`` so the password is only changed when it
+  differs from the current value, matching the idempotent behaviour on other
+  platforms. [#41347](https://github.com/saltstack/salt/issues/41347)
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1555,48 +1555,48 @@ fi
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -1625,13 +1625,13 @@ fi
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1673,13 +1673,13 @@ fi
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1706,66 +1706,66 @@ fi
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Upgrade packaged python to 3.14 [#69014](https://github.com/saltstack/salt/issues/69014)
 - Fix pip install -e salt [#69101](https://github.com/saltstack/salt/issues/69101)
-- * Relenv 0.22.11 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update python 3.14 to 3.14.5 [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update sqlite to 3.53.1.0 (CVE-2025-70873) [#69129](https://github.com/saltstack/salt/issues/69129)
-- - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
+- * Relenv 0.22.11
+  - Update python 3.14 to 3.14.5
+  - Update sqlite to 3.53.1.0 (CVE-2025-70873)
+  - Update expat to 2.8.1 (CVE-2026-41080 and CVE-2026-45186) [#69129](https://github.com/saltstack/salt/issues/69129)
 
 # Added
 
@@ -1773,8 +1773,8 @@ fi
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -1803,48 +1803,48 @@ fi
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
 - Pillar data is now wrapped in SafeDict/SafeList with Pydantic SecretStr/SecretBytes for safer logging and output; optional state `no_log` and automatic redaction of pillar literals in state returns and minion job logs. [#68907](https://github.com/saltstack/salt/issues/68907)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for the master's minion-key store; select it with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``keys.cache_driver: mmap_key``. Migrate existing data with [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  A specialised variant (``salt.cache.mmap_key``) replaces linear ``pki_dir``
+  scans for the master's minion-key store; select it with
+  ``keys.cache_driver: mmap_key``. Migrate existing data with
+  ``salt-run cache.migrate`` and ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 - Added `state.graph` and `state.graph_highstate` execution modules and runners to generate a DOT representation of the state dependency graph. [#69091](https://github.com/saltstack/salt/issues/69091)
 
 
@@ -1873,13 +1873,13 @@ fi
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -1921,13 +1921,13 @@ fi
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -1954,60 +1954,60 @@ fi
 - Fix tests failing on AlmaLinux 10 and other clones [#68246](https://github.com/saltstack/salt/issues/68246)
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
-- Fixed multiline powershell -Command { } blocks failing with "Missing closing [#68397](https://github.com/saltstack/salt/issues/68397)
-- '}'" when used in a cmd.run state on Windows. Salt now collapses embedded [#68397](https://github.com/saltstack/salt/issues/68397)
-- newlines and re-encodes the script block as -EncodedCommand, ensuring correct [#68397](https://github.com/saltstack/salt/issues/68397)
-- execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
+- Fixed multiline powershell -Command { } blocks failing with "Missing closing
+  '}'" when used in a cmd.run state on Windows. Salt now collapses embedded
+  newlines and re-encodes the script block as -EncodedCommand, ensuring correct
+  execution and suppressing CLIXML noise from stderr. [#68397](https://github.com/saltstack/salt/issues/68397)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
 - Fixed source package builds (DEB/RPM) failing with ``LookupError: hatchling is already being built`` by adding ``hatchling`` to the ``--only-binary`` allow-list so pip uses its universal wheel instead of attempting a circular source build. [#68858](https://github.com/saltstack/salt/issues/68858)
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
-- Fixed a regression in win_pkg where msiexec install flags containing [#68950](https://github.com/saltstack/salt/issues/68950)
-- Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were [#68950](https://github.com/saltstack/salt/issues/68950)
-- mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang. [#68950](https://github.com/saltstack/salt/issues/68950)
-- Restored the pre-regression behaviour where ``shlex_split`` is not applied [#68950](https://github.com/saltstack/salt/issues/68950)
-- to command strings on Windows, preserving Windows-style argument quoting [#68950](https://github.com/saltstack/salt/issues/68950)
-- when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
+- Fixed a regression in win_pkg where msiexec install flags containing
+  Windows-style quoting (e.g. ``MYPROPERTY="C:\some file.txt"``) were
+  mangled into ``"MYPROPERTY=C:\some file.txt"`` causing msiexec to hang.
+  Restored the pre-regression behaviour where ``shlex_split`` is not applied
+  to command strings on Windows, preserving Windows-style argument quoting
+  when the command is passed directly to ``CreateProcess``. [#68950](https://github.com/saltstack/salt/issues/68950)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 - Fixed on the ``3008.x`` release line: Salt NetAPI rest_tornado header parsing without ``cgi.parse_header`` (removed in Python 3.13). Integration ``salt_minion`` / ``salt_sub_minion`` fixtures now call ``saltutil.sync_all`` with ``saltenv=base`` to avoid long master round-trips from top-file environment discovery during Windows CI. Salt factories use a 120 second daemon start timeout when ``ONEDIR_TESTRUN`` is set so Windows onedir runs match CI and avoid flaky minion start event waits. [#69014](https://github.com/saltstack/salt/issues/69014)
 
 # Added
@@ -2016,8 +2016,8 @@ fi
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -2046,47 +2046,47 @@ fi
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)
 - Added a centralized, declarative system for managing Salt's optional dependencies and their version-specific requirements in ``salt/utils/versions.py``. [#68894](https://github.com/saltstack/salt/issues/68894)
-- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``): [#68936](https://github.com/saltstack/salt/issues/68936)
-- an O(1) hash-table store with a segmented heap, durable and multi-process [#68936](https://github.com/saltstack/salt/issues/68936)
-- safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting. [#68936](https://github.com/saltstack/salt/issues/68936)
-- The minion public-key index (``salt.cache.mmap_key`` / [#68936](https://github.com/saltstack/salt/issues/68936)
-- ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir`` [#68936](https://github.com/saltstack/salt/issues/68936)
-- scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate [#68936](https://github.com/saltstack/salt/issues/68936)
-- existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
-- Batch mode now uses a single JID for the entire batch run instead of generating [#68941](https://github.com/saltstack/salt/issues/68941)
-- a separate JID per batch iteration. This enables unified job tracking via [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all [#68941](https://github.com/saltstack/salt/issues/68941)
-- batch slices. The job cache merges minion lists from each iteration so that [#68941](https://github.com/saltstack/salt/issues/68941)
-- ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
-- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks [#69019](https://github.com/saltstack/salt/issues/69019)
-- targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the [#69019](https://github.com/saltstack/salt/issues/69019)
-- moment they accept the published job, before the function runs. The payload [#69019](https://github.com/saltstack/salt/issues/69019)
-- mirrors the master's ``salt/job/<jid>/new`` event minus the function [#69019](https://github.com/saltstack/salt/issues/69019)
-- arguments, letting orchestrators confirm reachability without waiting for [#69019](https://github.com/saltstack/salt/issues/69019)
-- the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
+- Added a fast memory-mapped cache backend (``salt.cache.mmap_cache``):
+  an O(1) hash-table store with a segmented heap, durable and multi-process
+  safe, usable as a drop-in for ``localfs`` via the ``cache`` master setting.
+  The minion public-key index (``salt.cache.mmap_key`` /
+  ``salt.utils.pki.PkiIndex``) is built on it; it replaces linear ``pki_dir``
+  scans for large fleets and is opt-in via ``pki_index_enabled``. Migrate
+  existing keys with ``salt-run pki.migrate_to_mmap``. [#68936](https://github.com/saltstack/salt/issues/68936)
+- Batch mode now uses a single JID for the entire batch run instead of generating
+  a separate JID per batch iteration. This enables unified job tracking via
+  ``salt-run jobs.lookup_jid`` and consistent ``--show-jid`` output across all
+  batch slices. The job cache merges minion lists from each iteration so that
+  ``get_load`` returns the complete set of targeted minions. [#68941](https://github.com/saltstack/salt/issues/68941)
+- Added a per-job ``start_event`` opt-in (CLI flag ``--start-event``) that asks
+  targeted minions to fire a ``salt/job/<jid>/start/<minion_id>`` event the
+  moment they accept the published job, before the function runs. The payload
+  mirrors the master's ``salt/job/<jid>/new`` event minus the function
+  arguments, letting orchestrators confirm reachability without waiting for
+  the full return. [#69019](https://github.com/saltstack/salt/issues/69019)
 
 
 * Thu Apr 23 2026 Salt Project Packaging <saltproject-packaging@vmware.com> - 3008.0~rc1
@@ -2113,13 +2113,13 @@ fi
 - Included Salt extensions in Salt-SSH thin archive [#66559](https://github.com/saltstack/salt/issues/66559)
 - Add support for additional options in several mac_brew_pkg methods [#66611](https://github.com/saltstack/salt/issues/66611)
 - Make test_pip and test_fileserver tests compatible with venv execution [#66703](https://github.com/saltstack/salt/issues/66703)
-- Do not use `ssl.PROTOCOL_TLS` which has been [#66767](https://github.com/saltstack/salt/issues/66767)
-- [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in [#66767](https://github.com/saltstack/salt/issues/66767)
-- Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
+- Do not use `ssl.PROTOCOL_TLS` which has been
+  [deprecated](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) in
+  Python 3.10 will be removed in the future. [#66767](https://github.com/saltstack/salt/issues/66767)
 - Remove warning when running `slsutil.renderer` on non-SLS files [#67067](https://github.com/saltstack/salt/issues/67067)
-- PillarCache: reimplement using salt.cache [#68030](https://github.com/saltstack/salt/issues/68030)
-- fix minion data cache organization/move pillar and grains to dedicated cache banks [#68030](https://github.com/saltstack/salt/issues/68030)
-- salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
+- PillarCache: reimplement using salt.cache
+  fix minion data cache organization/move pillar and grains to dedicated cache banks
+  salt.cache: allow cache.store() to set expires per key [#68030](https://github.com/saltstack/salt/issues/68030)
 - Provide token storage using the salt.cache interface [#68039](https://github.com/saltstack/salt/issues/68039)
 - Update packaged python from 3.10 to 3.11 [#68148](https://github.com/saltstack/salt/issues/68148)
 - Added ceph to the specialFSes to match on name for set_fstab [#68207](https://github.com/saltstack/salt/issues/68207)
@@ -2161,13 +2161,13 @@ fi
 - Make win_timezone recognize Qyzylorda timezone [#66176](https://github.com/saltstack/salt/issues/66176)
 - Remove firing useless events with JID as a tag [#66279](https://github.com/saltstack/salt/issues/66279)
 - Made gpg modules create GNUPGHOME if it does not exist [#66312](https://github.com/saltstack/salt/issues/66312)
-- Fixed an issue where conflicting top level keys in the static grains file [#66445](https://github.com/saltstack/salt/issues/66445)
-- (usually `/etc/salt/grains`) would break all grains states, and prevent static [#66445](https://github.com/saltstack/salt/issues/66445)
-- grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
-- Fixed beacon delete not calling the beacon's close function, causing resource [#66449](https://github.com/saltstack/salt/issues/66449)
-- leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at [#66449](https://github.com/saltstack/salt/issues/66449)
-- runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during [#66449](https://github.com/saltstack/salt/issues/66449)
-- beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
+- Fixed an issue where conflicting top level keys in the static grains file
+  (usually `/etc/salt/grains`) would break all grains states, and prevent static
+  grains from being loaded. [#66445](https://github.com/saltstack/salt/issues/66445)
+- Fixed beacon delete not calling the beacon's close function, causing resource
+  leaks (e.g. inotify file descriptors) and CPU spin after deleting beacons at
+  runtime via ``beacons.delete``. Also fixed inotify file descriptor leak during
+  beacon refresh when the Beacon instance is replaced. [#66449](https://github.com/saltstack/salt/issues/66449)
 - Make "status.diskusage" more robust and prevent crashes when stats cannot be obtained [#66646](https://github.com/saltstack/salt/issues/66646)
 - Use `--cachedir` parameter for setting `extension_modules` with salt-call. [#66742](https://github.com/saltstack/salt/issues/66742)
 - Don't schedule `__master_alive` jobs if `master_alive_interval` is not specified [#66757](https://github.com/saltstack/salt/issues/66757)
@@ -2195,46 +2195,46 @@ fi
 - Speedup wheel key.finger call by removing redundant processing calls. [#68251](https://github.com/saltstack/salt/issues/68251)
 - Fixed cp.cache_file when using Tornado > 6.4 [#68328](https://github.com/saltstack/salt/issues/68328)
 - Stop mutating locals, which is unsupported in Py >=3.13 [#68445](https://github.com/saltstack/salt/issues/68445)
-- Add `blockdev` state module back in to core [#68465](https://github.com/saltstack/salt/issues/68465)
--  [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
-- Adds `mdadm` and `lvm` grains modules back in to core. [#68470](https://github.com/saltstack/salt/issues/68470)
--  [#68470](https://github.com/saltstack/salt/issues/68470)
-- Restores the modules that had been removed as part of the community module [#68470](https://github.com/saltstack/salt/issues/68470)
-- migration. They are core bits of functionality and the associated execution and [#68470](https://github.com/saltstack/salt/issues/68470)
-- states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
-- Fixed grains.list_present state to correctly handle multiple calls within the same state run. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved `network.traceroute` parsing to be more robust across different traceroute versions. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added retry logic to `saltutil.wheel` integration test to improve reliability in CI. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved architecture detection in `salt-ssh` to better support ARM64 platforms. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed `win_useradd.get_user_sid` to correctly handle non-string input. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Improved reliability of `state.running` integration test for `salt-ssh`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
-- Adds `alias` state module back in to core. [#68574](https://github.com/saltstack/salt/issues/68574)
--  [#68574](https://github.com/saltstack/salt/issues/68574)
-- Restores the module that had been removed as part of the [#68574](https://github.com/saltstack/salt/issues/68574)
-- community module migration. The associated execution module [#68574](https://github.com/saltstack/salt/issues/68574)
-- had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
+- Add `blockdev` state module back in to core
+
+  Adds the `blockdev` state module back into the core Salt repo as it is critical functionality that shouldn't have been pulled out in the module migration [#68465](https://github.com/saltstack/salt/issues/68465)
+- Adds `mdadm` and `lvm` grains modules back in to core.
+
+  Restores the modules that had been removed as part of the community module
+  migration. They are core bits of functionality and the associated execution and
+  states modules had not been removed. [#68470](https://github.com/saltstack/salt/issues/68470)
+- Fixed grains.list_present state to correctly handle multiple calls within the same state run.
+  Fixed `salt.utils.platform` to properly handle `__salt_system_encoding__` when synced as an extension module.
+  Improved `network.traceroute` parsing to be more robust across different traceroute versions.
+  Added retry logic to `saltutil.wheel` integration test to improve reliability in CI.
+  Improved architecture detection in `salt-ssh` to better support ARM64 platforms.
+  Fixed `salt-ssh` extension module syncing to avoid accidentally bundling core Salt modules and to correctly load wrapper modules.
+  Ensured `salt-ssh` relenv tests skip gracefully if the relenv tarball is unavailable in the test environment.
+  Fixed `mine.get` runner to correctly handle master's ID when ACLs are enabled.
+  Fixed `win_useradd.get_user_sid` to correctly handle non-string input.
+  Improved reliability of `state.running` integration test for `salt-ssh`.
+  Fixed high CPU usage in minion asynchronous authentication loop when masters are unreachable.
+  Added support for running Salt tools using `python -m tools`. [#68520](https://github.com/saltstack/salt/issues/68520)
+- Adds `alias` state module back in to core.
+
+  Restores the module that had been removed as part of the
+  community module migration. The associated execution module
+  had not been migrated. [#68574](https://github.com/saltstack/salt/issues/68574)
 - Fixed mongodb tops module authentication to be compatible with pymongo v4+ by passing credentials directly to MongoClient instead of using the deprecated authenticate() method [#68659](https://github.com/saltstack/salt/issues/68659)
-- Improved the rejected authentication warning message to include the minion ID, [#68671](https://github.com/saltstack/salt/issues/68671)
-- making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
-- This PR fixes a bug where corrupted grains cache files cause unhandled [#68678](https://github.com/saltstack/salt/issues/68678)
-- `SaltDeserializationError` exceptions, resulting in CRITICAL errors. [#68678](https://github.com/saltstack/salt/issues/68678)
-- The fix adds proper exception handling to gracefully recover from corrupted [#68678](https://github.com/saltstack/salt/issues/68678)
-- cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
-- Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when [#68763](https://github.com/saltstack/salt/issues/68763)
-- Homebrew returns `null` values for cask metadata: [#68763](https://github.com/saltstack/salt/issues/68763)
--  [#68763](https://github.com/saltstack/salt/issues/68763)
-- - When the installed version of a cask is `null` (e.g. Homebrew cannot [#68763](https://github.com/saltstack/salt/issues/68763)
-- determine the installed version), it is now reported as `"unknown"` [#68763](https://github.com/saltstack/salt/issues/68763)
-- instead of raising an error. [#68763](https://github.com/saltstack/salt/issues/68763)
-- - When `full_token` is `null`, it is now filtered out so that `None` [#68763](https://github.com/saltstack/salt/issues/68763)
-- is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
+- Improved the rejected authentication warning message to include the minion ID,
+  making it easier for administrators to identify which minions need upgrading. [#68671](https://github.com/saltstack/salt/issues/68671)
+- This PR fixes a bug where corrupted grains cache files cause unhandled
+  `SaltDeserializationError` exceptions, resulting in CRITICAL errors.
+  The fix adds proper exception handling to gracefully recover from corrupted
+  cache by regenerating grains. [#68678](https://github.com/saltstack/salt/issues/68678)
+- Fix `mac_brew_pkg.list_pkgs` crashing or producing incorrect results when
+  Homebrew returns `null` values for cask metadata:
+
+  - When the installed version of a cask is `null` (e.g. Homebrew cannot
+  determine the installed version), it is now reported as `"unknown"`
+  instead of raising an error.
+  - When `full_token` is `null`, it is now filtered out so that `None`
+  is never used as a package name key in the returned dictionary. [#68763](https://github.com/saltstack/salt/issues/68763)
 - Fix ansible.playbooks extra_vars quoting to prevent passing broken variables to ansible-playbook. [#68787](https://github.com/saltstack/salt/issues/68787)
 - Make `x86_64_v2` to be handled properly with `salt.modules.yumpkg` module as a possible package architecture. [#68789](https://github.com/saltstack/salt/issues/68789)
 - Make `salt-ssh` work without issues using `domain\user` notation for remote user with SSH. [#68790](https://github.com/saltstack/salt/issues/68790)
@@ -2242,10 +2242,10 @@ fi
 - Use a 30 second ``salt`` CLI timeout in the reauth scenario tests so Windows CI does not time out on ``test.ping`` after master/minion restart (default was often 5s). [#68924](https://github.com/saltstack/salt/issues/68924)
 - Fix logging in potentially dead process in reap_stray_processes fixture [#68927](https://github.com/saltstack/salt/issues/68927)
 - Fix dynamic version discovery on a new release branch before the first ``v<major>*`` tag exists: ``git describe`` still anchored on the previous line (e.g. ``v3007.13``) is lifted to the unreleased codename baseline (e.g. ``3008.0``) while keeping the commit offset and SHA. [#68964](https://github.com/saltstack/salt/issues/68964)
-- Remove deprecations. [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/auth/pki.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/features.py (removed) [#68985](https://github.com/saltstack/salt/issues/68985)
-- - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
+- Remove deprecations.
+  - salt/auth/pki.py (removed)
+  - salt/features.py (removed)
+  - salt/modules/nxos.py (modified) [#68985](https://github.com/saltstack/salt/issues/68985)
 
 # Added
 
@@ -2253,8 +2253,8 @@ fi
 - Added support for limiting the number of parallel states executing at the same time via `state_max_parallel` [#49301](https://github.com/saltstack/salt/issues/49301)
 - Added metalink to mod_repo in yumpkg and documented in pkgrepo state [#58931](https://github.com/saltstack/salt/issues/58931)
 - Added ssl and verify_ssl arguments to mongodb module and states. [#59927](https://github.com/saltstack/salt/issues/59927)
-- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to [#61318](https://github.com/saltstack/salt/issues/61318)
-- the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
+- Added two new options, ``win_delay_start`` and ``win_install_dir``, to pass to
+  the Windows installer in salt-cloud [#61318](https://github.com/saltstack/salt/issues/61318)
 - Add context aware change handling for file state module [#63328](https://github.com/saltstack/salt/issues/63328)
 - Added the ability to access already compiled pillar data during the pillar rendering process via the `__pillar__` global in templates and matchers. [#64043](https://github.com/saltstack/salt/issues/64043)
 - Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times [#64486](https://github.com/saltstack/salt/issues/64486)
@@ -2283,25 +2283,25 @@ fi
 - Add `_auth` calls to the master stats [#67746](https://github.com/saltstack/salt/issues/67746)
 - Added possibility to load data from multiple inventories with `ansible.targets`. [#67776](https://github.com/saltstack/salt/issues/67776)
 - Detect openEuler as RedHat family OS. [#67796](https://github.com/saltstack/salt/issues/67796)
-- refactored server-side PKI to support cache interface [#67799](https://github.com/saltstack/salt/issues/67799)
-- optimization: check_compound_minions: defer _pki_minions fetch [#67799](https://github.com/saltstack/salt/issues/67799)
-- refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
+- refactored server-side PKI to support cache interface
+  optimization: check_compound_minions: defer _pki_minions fetch
+  refactor: push salt.utils.minions bits into salt.key / optimize matching [#67799](https://github.com/saltstack/salt/issues/67799)
 - Add deb822 apt source format support to aptpkg module [#67956](https://github.com/saltstack/salt/issues/67956)
 - Add subsystem filter to "udev.exportdb" execution module function [#68047](https://github.com/saltstack/salt/issues/68047)
 - Implement SL Micro 6.2 detection to fill the grains with proper values. [#68247](https://github.com/saltstack/salt/issues/68247)
-- Added booleans argument to selinux.booleans [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added mod_aggregate to selinux to combine boolean [#68323](https://github.com/saltstack/salt/issues/68323)
-- Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
-- Add support for minion_id in log formats [#68410](https://github.com/saltstack/salt/issues/68410)
--  [#68410](https://github.com/saltstack/salt/issues/68410)
-- Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
+- Added booleans argument to selinux.booleans
+  Added mod_aggregate to selinux to combine boolean
+  Added some type hints to selinux module and made some minor changes to improve readability and performance slightly [#68323](https://github.com/saltstack/salt/issues/68323)
+- Add support for minion_id in log formats
+
+  Adds support for including `%(minion_id)s` in log formats. Where id is available log messages on the master will have that data added to allow easier correlation of messages to minions. [#68410](https://github.com/saltstack/salt/issues/68410)
 - Added feature parity for relenv and thin dir with salt-ssh. All salt-ssh tests pass with both thin dir and relenv. [#68531](https://github.com/saltstack/salt/issues/68531)
-- Added tunable worker pools: partition the master's MWorkers into named pools [#68532](https://github.com/saltstack/salt/issues/68532)
-- and route specific commands (for example `_auth`) to dedicated pools so a [#68532](https://github.com/saltstack/salt/issues/68532)
-- slow workload cannot starve time-critical traffic. Controlled by the new [#68532](https://github.com/saltstack/salt/issues/68532)
-- `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable [#68532](https://github.com/saltstack/salt/issues/68532)
-- Worker Pools" topic guide for details. Existing `worker_threads` [#68532](https://github.com/saltstack/salt/issues/68532)
-- configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
+- Added tunable worker pools: partition the master's MWorkers into named pools
+  and route specific commands (for example `_auth`) to dedicated pools so a
+  slow workload cannot starve time-critical traffic. Controlled by the new
+  `worker_pools` and `worker_pools_enabled` master settings; see the "Tunable
+  Worker Pools" topic guide for details. Existing `worker_threads`
+  configurations remain fully backward compatible. [#68532](https://github.com/saltstack/salt/issues/68532)
 - Added TLS encryption optimization via disable_aes_with_tls config option that eliminates redundant AES encryption when TLS with mutual authentication is active, improving performance while maintaining security through certificate identity verification. [#68536](https://github.com/saltstack/salt/issues/68536)
 - utils.dictdiffer: support diffing of dicts in lists [#68726](https://github.com/saltstack/salt/issues/68726)
 - Add support for nix package manager. [#68752](https://github.com/saltstack/salt/issues/68752)

--- a/tests/pytests/unit/changelog/test_template.py
+++ b/tests/pytests/unit/changelog/test_template.py
@@ -1,0 +1,165 @@
+"""
+Tests for the towncrier changelog template at ``changelog/.template.jinja``.
+
+These tests guard against the regression reported in saltstack/salt#69454,
+where the template split every multi-line fragment into a separate top-level
+bullet and appended the issue link to each one.
+"""
+
+import pathlib
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+TEMPLATE_PATH = REPO_ROOT / "changelog" / ".template.jinja"
+
+ISSUE_LINK = "[#69031](https://github.com/saltstack/salt/issues/69031)"
+
+DEFINITIONS = {
+    "fixed": {"name": "Fixed", "showcontent": True},
+    "added": {"name": "Added", "showcontent": True},
+}
+
+
+def _render(text, category="fixed", link=ISSUE_LINK):
+    template_src = TEMPLATE_PATH.read_text()
+    template = jinja2.Template(template_src)
+    sections = {"": {category: {text: [link]}}}
+    return template.render(sections=sections, definitions=DEFINITIONS)
+
+
+def test_single_line_fragment_renders_as_one_bullet():
+    """A one-line fragment renders as exactly one bullet with the link appended once."""
+    rendered = _render("Fixed a simple bug.")
+    bullets = [line for line in rendered.splitlines() if line.lstrip().startswith("- ")]
+    assert len(bullets) == 1
+    assert rendered.count(ISSUE_LINK) == 1
+    assert "- Fixed a simple bug." in rendered
+
+
+def test_multi_line_fragment_renders_as_one_bullet():
+    """
+    A multi-line wrapped fragment must produce a single top-level bullet whose
+    continuation lines are indented under it, and the issue link must appear
+    exactly once -- at the end of the bullet.
+
+    Regression test for saltstack/salt#69454.
+    """
+    text = (
+        "Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that\n"
+        "together prevented it from being usable. `start()` no longer raises\n"
+        "`AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3\n"
+        "(the dict.values() result is now wrapped in `list(...)`). `Listener` and\n"
+        "`start()` now accept an optional `password` argument and forward it to\n"
+        "the redis client, allowing the engine to authenticate against a Sentinel\n"
+        "that requires AUTH; the default of `None` keeps existing configurations\n"
+        "working unchanged."
+    )
+    rendered = _render(text)
+
+    # Exactly one top-level bullet for the whole fragment.
+    top_level_bullets = [
+        line for line in rendered.splitlines() if line.startswith("- ")
+    ]
+    assert len(top_level_bullets) == 1, (
+        "Multi-line fragment must collapse into a single top-level bullet; "
+        f"got {len(top_level_bullets)} bullets in:\n{rendered}"
+    )
+
+    # The issue link must appear exactly once.
+    assert (
+        rendered.count(ISSUE_LINK) == 1
+    ), f"Issue link should appear exactly once; rendered output:\n{rendered}"
+
+    # The first line of the fragment is the bullet's first line.
+    assert (
+        "- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that"
+        in rendered
+    )
+
+    # Continuation lines from the fragment are preserved (with indentation),
+    # not split onto separate bullets.
+    assert "together prevented it from being usable." in rendered
+    assert "working unchanged." in rendered
+
+    # The link is appended after the last line of the fragment.
+    assert f"working unchanged. {ISSUE_LINK}" in rendered
+
+
+def test_multi_line_fragment_continuation_is_indented():
+    """
+    Continuation lines under a bullet must be indented so Markdown treats them
+    as part of the same list item rather than as a new paragraph.
+    """
+    text = "First line of the entry.\nSecond line of the entry."
+    rendered = _render(text)
+
+    lines = rendered.splitlines()
+    # Find the bullet line.
+    bullet_idx = next(
+        i for i, line in enumerate(lines) if line.startswith("- First line")
+    )
+    # The next non-empty line should be the indented continuation.
+    continuation = next(line for line in lines[bullet_idx + 1 :] if line.strip())
+    assert continuation.startswith("  "), (
+        f"Continuation line should be indented with at least two spaces; got: "
+        f"{continuation!r}"
+    )
+    assert "Second line of the entry." in continuation
+
+
+def test_multiple_fragments_each_get_their_own_bullet():
+    """Two independent fragments produce two bullets, each with their own link."""
+    template_src = TEMPLATE_PATH.read_text()
+    template = jinja2.Template(template_src)
+    link_a = "[#1](https://github.com/saltstack/salt/issues/1)"
+    link_b = "[#2](https://github.com/saltstack/salt/issues/2)"
+    sections = {
+        "": {
+            "fixed": {
+                "Fixed bug A.": [link_a],
+                "Fixed multi-line bug B that\nwraps across two lines.": [link_b],
+            }
+        }
+    }
+    rendered = template.render(sections=sections, definitions=DEFINITIONS)
+    top_level_bullets = [
+        line for line in rendered.splitlines() if line.startswith("- ")
+    ]
+    assert len(top_level_bullets) == 2
+    assert rendered.count(link_a) == 1
+    assert rendered.count(link_b) == 1
+    assert f"Fixed bug A. {link_a}" in rendered
+    assert f"wraps across two lines. {link_b}" in rendered
+
+
+def test_fragment_with_markdown_sub_bullets_preserves_structure():
+    """
+    A fragment that uses Markdown-style indented sub-bullets must still
+    produce a single top-level bullet, with the sub-bullets nested under it.
+    """
+    text = (
+        "Refactored server-side PKI to support cache interface\n"
+        "  - optimization: defer _pki_minions fetch\n"
+        "  - refactor: push salt.utils.minions bits into salt.key"
+    )
+    link = "[#67799](https://github.com/saltstack/salt/issues/67799)"
+    template_src = TEMPLATE_PATH.read_text()
+    template = jinja2.Template(template_src)
+    sections = {"": {"added": {text: [link]}}}
+    rendered = template.render(sections=sections, definitions=DEFINITIONS)
+
+    top_level_bullets = [
+        line for line in rendered.splitlines() if line.startswith("- ")
+    ]
+    assert (
+        len(top_level_bullets) == 1
+    ), f"Expected one top-level bullet; got:\n{rendered}"
+    # The link appears exactly once.
+    assert rendered.count(link) == 1
+    # The sub-bullets remain present as indented list items.
+    assert "- optimization: defer _pki_minions fetch" in rendered
+    assert "- refactor: push salt.utils.minions bits into salt.key" in rendered


### PR DESCRIPTION
### What does this PR do?

Fixes the towncrier-based changelog generator, which has been splitting every multi-line
changelog fragment into one bullet per source line and appending the `[#NNNN]` issue link
to every single bullet. The template is replaced with a single-bullet render that uses
Jinja's `indent(2)` filter so wrapped fragments stay one bullet with the link appended
once. Already-published broken entries in `CHANGELOG.md`, `pkg/rpm/salt.spec` and
`pkg/debian/changelog` are also cleaned up.

### What issues does this PR fix or reference?

Fixes #69454

### Previous Behavior

A fragment such as `changelog/69031.fixed.md`, wrapped at ~72 columns, rendered in
`CHANGELOG.md` as:

```
- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that [#69031](https://github.com/saltstack/salt/issues/69031)
- together prevented it from being usable. `start()` no longer raises [#69031](https://github.com/saltstack/salt/issues/69031)
- `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3 [#69031](https://github.com/saltstack/salt/issues/69031)
...
```

Eight bullets, each with the same duplicated `[#69031]` link, sentences sheared in half
at the source line breaks. Repeated for every multi-line fragment in the
`v3008.0`/`v3008.1` release notes and across `pkg/rpm/salt.spec` and `pkg/debian/changelog`.

### New Behavior

```
- Fixed two distinct bugs in the `salt.engines.redis_sentinel` engine that
  together prevented it from being usable. `start()` no longer raises
  `AttributeError: 'dict_values' object has no attribute 'pop'` on Python 3
  ...
  working unchanged. [#69031](https://github.com/saltstack/salt/issues/69031)
```

One top-level bullet, continuation lines indented under it (Markdown reads them as part
of the same list item), and the issue link appended exactly once at the end.

Fragments that intentionally include Markdown-style nested sub-bullets (`  - item`) are
unaffected: their indentation is preserved verbatim and they continue to render as a
nested sub-list under the single top-level bullet.

### Scope of the diff

1. `changelog/.template.jinja` — replace the per-line loop introduced in
   `808241d3154d` with a single-bullet `indent(2)` render.
2. `tests/pytests/unit/changelog/test_template.py` — new TDD-verified unit
   tests covering single-line, multi-line wrapped, multi-fragment, and
   nested-sub-bullet cases. The multi-line test fails on the unmodified
   template (8 top-level bullets where 1 is expected) and passes with the
   fix.
3. `CHANGELOG.md`, `pkg/rpm/salt.spec`, `pkg/debian/changelog` — 118
   already-published broken multi-bullet entries consolidated back into
   single bullets. Original sentence content is preserved verbatim; only
   the broken line breaks between adjacent same-link bullets are stitched
   back together. Affected release sections: `3008.1`, `3008.0`,
   `3008.0rc4`, `3008.0rc3`, `3008.0rc2`, `3008.0rc1`, `3006.25`.

### Merge requirements satisfied?

- [x] Docs (no documented behavior change; only the rendered output of an internal tool)
- [x] Changelog (`changelog/69454.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/changelog/test_template.py`)

### Commits signed with GPG?

Yes
