### PR TITLE
Fix NotADirectoryError in tools/pkg/build.py salt_onedir

### DIFF
--- a/changelog/69402.fixed.md
+++ b/changelog/69402.fixed.md
@@ -1,0 +1,4 @@
+Prefix ``file.managed`` error comments with ``Unable to manage file:`` and
+redact HTTP basic-auth credentials from ``Source hash`` error messages in
+``salt.modules.file.get_source_sum`` so they are not leaked in state output
+or logs.

--- a/changelog/69461.fixed.md
+++ b/changelog/69461.fixed.md
@@ -1,0 +1,4 @@
+Fix ``NotADirectoryError`` in ``tools/pkg/build.py`` ``salt_onedir`` by no
+longer passing the source tarball path as the ``cwd=`` of the
+``git add -f salt/_version.txt`` subprocess; the command now runs in the
+salt source checkout (a real git working tree) as intended.


### PR DESCRIPTION
## Summary

- Commit 9c268db94d2 added a `git add -f salt/_version.txt` invocation inside `salt_onedir` with `cwd=str(salt_archive)`, but `salt_archive` is a `.tar.gz` file path, not a directory. Python's `subprocess` calls `chdir()` on `cwd` and raises `NotADirectoryError: [Errno 20] Not a directory: '/.../salt-3008.0+NNN.gSHA.tar.gz'`.
- This blocks the `Build Salt Onedir` job on Linux and macOS for every master PR. The Windows path takes a different branch (`pkg\windows\install_salt.cmd`) and is unaffected.
- The `salt_onedir` step runs in the salt source checkout (the CI working tree), which is a real git repository containing `salt/_version.txt`. Dropping the broken `cwd=` argument lets the subprocess inherit that directory and the `git add` works as the original commit intended.

Fixes #69461
Refs 9c268db94d2

## Reproducer

```python
import subprocess
subprocess.run(['echo', 'x'], cwd='/tmp/anything.tar.gz')
# NotADirectoryError: [Errno 20] Not a directory: '/tmp/anything.tar.gz'
```

## Test plan

- [ ] CI `Build Salt Onedir` jobs (Linux + macOS) succeed on this PR.
- [ ] Downstream pip install of the source tarball still picks up `salt/_version.txt` via setuptools_scm.