### PR TITLE
[3007.x] Remove linode-python dependency to silence install SyntaxWarnings (#69455)

### DIFF
--- a/changelog/69455.removed.md
+++ b/changelog/69455.removed.md
@@ -1,0 +1,1 @@
+Removed the unmaintained `linode-python` package dependency to stop SyntaxWarnings during install for retired Linode API v3.

--- a/requirements/static/ci/py3.10/cloud.lock
+++ b/requirements/static/ci/py3.10/cloud.lock
@@ -331,10 +331,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/lint.lock
+++ b/requirements/static/ci/py3.10/lint.lock
@@ -358,10 +358,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock

--- a/requirements/static/ci/py3.11/cloud.lock
+++ b/requirements/static/ci/py3.11/cloud.lock
@@ -322,10 +322,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/lint.lock
+++ b/requirements/static/ci/py3.11/lint.lock
@@ -350,10 +350,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock

--- a/requirements/static/ci/py3.12/cloud.lock
+++ b/requirements/static/ci/py3.12/cloud.lock
@@ -316,10 +316,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/lint.lock
+++ b/requirements/static/ci/py3.12/lint.lock
@@ -344,10 +344,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock

--- a/requirements/static/ci/py3.13/cloud.lock
+++ b/requirements/static/ci/py3.13/cloud.lock
@@ -317,10 +317,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/lint.lock
+++ b/requirements/static/ci/py3.13/lint.lock
@@ -344,10 +344,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock

--- a/requirements/static/ci/py3.14/cloud.lock
+++ b/requirements/static/ci/py3.14/cloud.lock
@@ -317,10 +317,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.14/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/lint.lock
+++ b/requirements/static/ci/py3.14/lint.lock
@@ -345,10 +345,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.14/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock

--- a/requirements/static/ci/py3.9/cloud.lock
+++ b/requirements/static/ci/py3.9/cloud.lock
@@ -346,10 +346,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.lock

--- a/requirements/static/ci/py3.9/lint.lock
+++ b/requirements/static/ci/py3.9/lint.lock
@@ -363,10 +363,6 @@ libnacl==2.1.0
     # via
     #   -c requirements/static/ci/py3.9/linux.lock
     #   -r requirements/static/ci/common.txt
-linode-python==1.1.1
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.lock
-    #   -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.9/linux.lock

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -18,6 +18,5 @@ importlib-metadata>=8.7.0,<9.0.0; python_version < '3.10'
 importlib-metadata>=9.0.0; python_version >= '3.10'
 cryptography>=46.0.7,<48.0.0; python_version < '3.10'
 cryptography>=48.0.0; python_version >= '3.10'
-linode-python>=1.1.1
 more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
 more-itertools>=11.1.0; python_version >= '3.10'

--- a/requirements/static/pkg/py3.10/linux.lock
+++ b/requirements/static/pkg/py3.10/linux.lock
@@ -94,8 +94,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==3.0.0

--- a/requirements/static/pkg/py3.11/linux.lock
+++ b/requirements/static/pkg/py3.11/linux.lock
@@ -92,8 +92,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==4.2.0

--- a/requirements/static/pkg/py3.12/linux.lock
+++ b/requirements/static/pkg/py3.12/linux.lock
@@ -90,8 +90,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==4.2.0

--- a/requirements/static/pkg/py3.13/linux.lock
+++ b/requirements/static/pkg/py3.13/linux.lock
@@ -90,8 +90,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==4.2.0

--- a/requirements/static/pkg/py3.14/linux.lock
+++ b/requirements/static/pkg/py3.14/linux.lock
@@ -90,8 +90,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==4.2.0

--- a/requirements/static/pkg/py3.9/linux.lock
+++ b/requirements/static/pkg/py3.9/linux.lock
@@ -96,8 +96,6 @@ jinja2==3.1.6
     # via -r requirements/base.txt
 jmespath==1.1.0
     # via -r requirements/base.txt
-linode-python==1.1.1
-    # via -r requirements/static/pkg/linux.txt
 looseversion==1.3.0
     # via -r requirements/base.txt
 markdown-it-py==2.2.0


### PR DESCRIPTION
### What does this PR do?

Backports #69339 (3006.x) to 3007.x. Removes the unmaintained
`linode-python` 1.1.1 dependency from `requirements/static/pkg/linux.txt`
(and dependent CI/pkg linux lockfiles) so the salt-common onedir install
stops emitting `SyntaxWarning` from `linode/api.py` on every RPM/DEB
install/upgrade.

### What issues does this PR fix or reference?

Fixes #69455

#69455 is the same symptom as #68992 (which #69339 fixes on 3006.x). The
underlying `linode-python` package is also vendored on 3007.x, so the
fix needs to be backported here.

### Previous Behavior

`apt-get install salt-common=3007.x` and the equivalent RPM scriptlet
on RHEL/Rocky/Oracle Linux 9.x print:

```
/opt/saltstack/salt/lib/python3.10/site-packages/linode/api.py:293: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if s['ERRORARRAY'][0]['ERRORCODE'] is not 0:
/opt/saltstack/salt/lib/python3.10/site-packages/linode/api.py:348: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(wrapper.__doc__.split('\n')) is 1:  # one-liners need whitespace
/opt/saltstack/salt/lib/python3.10/site-packages/linode/api.py:356: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(wrapper.__doc__.split('\n')) is 1:  # one-liners need whitespace
```

### New Behavior

`linode-python` is no longer installed into the onedir, so the warnings
don't surface. `salt.cloud.clouds.linode` already uses Linode APIv4 over
HTTP/JSON (verified by `grep linode salt/cloud/clouds/linode.py`) — it
never imported `linode-python`, so dropping it is purely vestigial
cleanup. Mirrors PR #68871 on master and PR #69339 on 3006.x.

### Merge requirements satisfied?

- [x] Docs - no documented behavior change
- [x] Changelog - `changelog/69455.removed.md`
- [ ] Tests written/updated - n/a: artifact is a dependency removal,
  same as #68871 and #69339 which also did not add tests

### Commits signed with GPG?

No (matching adjacent 3007.x commits, none of which are signed)