### PR TITLE
Fix pillar.get returning '**********' for explicit user queries (#69453)

### DIFF
--- a/changelog/69453.fixed.md
+++ b/changelog/69453.fixed.md
@@ -1,0 +1,1 @@
+Fixed `pillar.get`, `pillar.items`, `pillar.item`, and `pillar.data` returning every string value as `**********` when called directly (e.g. `salt-call pillar.get nodegroups`). Explicit pillar queries now default to plain values, matching 3007.x and earlier behavior; the `unmask=False` opt-in still returns the `serial()`-redacted shape for callers that need it.

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -118,9 +118,15 @@ def get(
         .. versionadded:: 2017.7.0
 
     unmask
-        If set to ``True``, the pillar data will be unmasked.
+        Defaults to ``True``: the pillar data is returned plain so direct
+        callers (CLI, ``salt-call``, ``__salt__['pillar.get']``) see the
+        real values.  Set to ``False`` to receive a ``serial()``-redacted
+        copy where every non-empty string is replaced with ``**********``.
 
         .. versionadded:: 3008.0
+        .. versionchanged:: 3008.2
+            Default flipped from ``False`` to ``True`` so explicit pillar
+            queries return plain values (#69453).
 
     CLI Example:
 
@@ -146,7 +152,12 @@ def get(
     )
 
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        # ``pillar.get`` is an explicit user-facing request for pillar data
+        # (CLI / salt-call / ``__salt__['pillar.get']`` from SLS).  Default
+        # to plain values so callers get the real pillar entries, matching
+        # 3007.x and earlier behavior (#69453).  ``serial()`` masking is
+        # reserved for callers that explicitly pass ``unmask=False``.
+        unmask = True
 
     if merge:
         if isinstance(default, dict):
@@ -254,9 +265,15 @@ def items(
         :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
 
     unmask
-        If set to ``True``, the pillar data will be unmasked.
+        Defaults to ``True``: the pillar data is returned plain so direct
+        callers (CLI, ``salt-call``, ``__salt__['pillar.get']``) see the
+        real values.  Set to ``False`` to receive a ``serial()``-redacted
+        copy where every non-empty string is replaced with ``**********``.
 
         .. versionadded:: 3008.0
+        .. versionchanged:: 3008.2
+            Default flipped from ``False`` to ``True`` so explicit pillar
+            queries return plain values (#69453).
 
     CLI Example:
 
@@ -297,7 +314,9 @@ def items(
     )
     ret = pillar.compile_pillar()
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        # See note in ``get()`` -- explicit pillar APIs default to plain
+        # values so direct callers see real pillar data (#69453).
+        unmask = True
     if unmask:
         return salt.utils.secret.expose(ret)
     else:
@@ -520,9 +539,15 @@ def item(
         .. versionadded:: 2017.7.6,2018.3.1
 
     unmask
-        If set to ``True``, the pillar data will be unmasked.
+        Defaults to ``True``: the pillar data is returned plain so direct
+        callers (CLI, ``salt-call``, ``__salt__['pillar.get']``) see the
+        real values.  Set to ``False`` to receive a ``serial()``-redacted
+        copy where every non-empty string is replaced with ``**********``.
 
         .. versionadded:: 3008.0
+        .. versionchanged:: 3008.2
+            Default flipped from ``False`` to ``True`` so explicit pillar
+            queries return plain values (#69453).
 
     CLI Examples:
 
@@ -547,7 +572,9 @@ def item(
     )
 
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        # See note in ``get()`` -- explicit pillar APIs default to plain
+        # values so direct callers see real pillar data (#69453).
+        unmask = True
 
     try:
         for arg in args:

--- a/tests/pytests/unit/modules/test_pillar.py
+++ b/tests/pytests/unit/modules/test_pillar.py
@@ -205,3 +205,56 @@ def test_ls_pass_kwargs(pillar_value):
     with patch("salt.modules.pillar.items", MagicMock(return_value=pillar_value)):
         ls = sorted(pillarmod.ls(pillarenv="base"))
         assert ls == ["a", "b"]
+
+
+def test_pillar_get_returns_plain_list_values_69453():
+    """
+    Regression test for #69453.
+
+    ``salt-call pillar.get nodegroups`` regressed in 3008.x and returned
+    every list element as ``'**********'`` because ``pillar.get`` ran the
+    return value through ``salt.utils.secret.serial()`` whenever the
+    ``mask_pillar`` ContextVar was True (its default).
+
+    Calling ``pillar.get`` is an explicit user request for pillar data --
+    callers (CLI, salt-call, salt cli) expect plain values, the same way
+    they did in 3007.x and earlier.  Mask the return only when the caller
+    explicitly opts in via ``unmask=False``.
+    """
+    with patch.dict(
+        pillarmod.__pillar__, {"nodegroups": ["specialhost", "specialserver"]}
+    ):
+        assert pillarmod.get("nodegroups") == ["specialhost", "specialserver"]
+
+
+def test_pillar_get_returns_plain_string_value_69453():
+    """Regression test for #69453 - scalar string values must not be masked."""
+    with patch.dict(pillarmod.__pillar__, {"role": "webserver"}):
+        assert pillarmod.get("role") == "webserver"
+
+
+def test_pillar_get_returns_plain_dict_value_69453():
+    """Regression test for #69453 - dict values must not be masked."""
+    with patch.dict(pillarmod.__pillar__, {"users": {"admin": "alice", "ops": "bob"}}):
+        assert pillarmod.get("users") == {"admin": "alice", "ops": "bob"}
+
+
+def test_pillar_item_returns_plain_values_69453():
+    """Regression test for #69453 - pillar.item must return plain values."""
+    with patch.dict(
+        pillarmod.__pillar__, {"nodegroups": ["specialhost", "specialserver"]}
+    ):
+        assert pillarmod.item("nodegroups") == {
+            "nodegroups": ["specialhost", "specialserver"]
+        }
+
+
+def test_pillar_get_explicit_unmask_false_still_masks():
+    """When the caller explicitly opts in to masking, ``serial()`` runs."""
+    import salt.utils.secret
+
+    with patch.dict(pillarmod.__pillar__, {"password": "hunter2"}):
+        assert (
+            pillarmod.get("password", unmask=False)
+            == salt.utils.secret.REDACT_PLACEHOLDER
+        )


### PR DESCRIPTION
### What does this PR do?

`pillar.get`, `pillar.items`, `pillar.item`, and `pillar.data` now default to
returning plain pillar values when called directly (e.g. `salt-call pillar.get
nodegroups`).  Before this change they ran the return value through
`salt.utils.secret.serial()` which replaced every non-empty string with
`**********`, making the explicit pillar query useless.

The implicit safety nets are unchanged: `MaskedDict` / `MaskedList` `__repr__`
still redact in log output (gated by the `mask_pillar` ContextVar), and
`salt.state`'s `no_log` handling still scrubs state `comment`/`changes`.
Callers that want the redacted return shape can still pass `unmask=False`
explicitly.

### What issues does this PR fix or reference?

Fixes #69453

### Previous Behavior

```
# salt-call pillar.get nodegroups
local:
    - **********
    - **********
```

### New Behavior

```
# salt-call pillar.get nodegroups
local:
    - specialhost
    - specialserver
```

Matches 3007.x and earlier, and the original design intent of #68907 ("Direct
pillar inspection: pillar.items and pillar.get return plain structures so
operators still see real values when they intentionally call those
functions").

### Merge requirements satisfied?
- [x] Docs - updated `unmask` parameter docstrings to reflect the new default
- [x] Changelog - `changelog/69453.fixed.md`
- [x] Tests written/updated - five new regression tests in
      `tests/pytests/unit/modules/test_pillar.py`

### Commits signed with GPG?
No
