### PR TITLE
Extend unmask parameter to remaining pillar module functions (#69453)

### DIFF
--- a/changelog/69453.added.md
+++ b/changelog/69453.added.md
@@ -1,0 +1,1 @@
+Added ``unmask`` parameter to ``pillar.ls``, ``pillar.raw``, ``pillar.ext``, ``pillar.keys``, and ``pillar.obfuscate`` for API consistency with ``pillar.get`` / ``pillar.items`` / ``pillar.item`` / ``pillar.data``. Default masking behavior is unchanged.

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -376,7 +376,14 @@ def _obfuscate_inner(var):
         return f"<{var.__class__.__name__}>"
 
 
-def obfuscate(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None):
+def obfuscate(
+    *args,
+    pillar=None,
+    pillar_enc=None,
+    pillarenv=None,
+    saltenv=None,
+    unmask=None,
+):
     """
     .. versionadded:: 2015.8.0
 
@@ -396,6 +403,14 @@ def obfuscate(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None)
     * ``{'login': 'somelogin', 'pwd': 'secret'}`` becomes
       ``{'login': '<str>', 'pwd': '<str>'}``
 
+    unmask
+        Forwarded to :py:func:`items` when sourcing the pillar data. The
+        returned structure is then obfuscated, so the practical effect of
+        this flag is limited; it is accepted for API consistency with the
+        other ``pillar`` functions.
+
+        .. versionadded:: 3008.2
+
     CLI Examples:
 
     .. code-block:: bash
@@ -410,13 +425,21 @@ def obfuscate(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None)
             pillar_enc=pillar_enc,
             pillarenv=pillarenv,
             saltenv=saltenv,
+            unmask=unmask,
         )
     )
 
 
 # naming chosen for consistency with grains.ls, although it breaks the short
 # identifier rule.
-def ls(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None):
+def ls(
+    *args,
+    pillar=None,
+    pillar_enc=None,
+    pillarenv=None,
+    saltenv=None,
+    unmask=None,
+):
     """
     .. versionadded:: 2015.8.0
 
@@ -454,6 +477,14 @@ def ls(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None):
         Included only for compatibility with
         :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
 
+    unmask
+        Forwarded to :py:func:`items` when sourcing the pillar data. Top-level
+        pillar keys are not masked, so this flag is a practical no-op for
+        ``ls``; it is accepted for API consistency with the other ``pillar``
+        functions.
+
+        .. versionadded:: 3008.2
+
     CLI Examples:
 
     .. code-block:: bash
@@ -468,6 +499,7 @@ def ls(*args, pillar=None, pillar_enc=None, pillarenv=None, saltenv=None):
             pillar_enc=pillar_enc,
             pillarenv=pillarenv,
             saltenv=saltenv,
+            unmask=unmask,
         )
     )
 
@@ -563,12 +595,19 @@ def item(
         return salt.utils.secret.serial(ret)
 
 
-def raw(key=None):
+def raw(key=None, unmask=None):
     """
     Return the raw pillar data that is currently loaded into the minion.
 
     Contrast with :py:func:`items` which calls the master to fetch the most
     up-to-date Pillar.
+
+    unmask
+        Defaults to ``True``: ``pillar.raw`` has historically returned
+        unmasked data, since the intent of the call is to inspect the in-memory
+        pillar verbatim. Set to ``False`` to receive masked values instead.
+
+        .. versionadded:: 3008.2
 
     CLI Example:
 
@@ -581,15 +620,20 @@ def raw(key=None):
 
         salt '*' pillar.raw key='roles'
     """
+    if unmask is None:
+        unmask = True
+
     if key:
-        ret = salt.utils.secret.expose(__pillar__.get(key, {}))
+        value = __pillar__.get(key, {})
     else:
-        ret = dict(salt.utils.secret.expose(__pillar__))
+        value = dict(__pillar__)
 
-    return ret
+    if unmask:
+        return salt.utils.secret.expose(value)
+    return salt.utils.secret.serial(value)
 
 
-def ext(external, pillar=None):
+def ext(external, pillar=None, unmask=None):
     '''
     .. versionchanged:: 2016.3.6,2016.11.3,2017.7.0
         The supported ext_pillar types are now tunable using the
@@ -633,6 +677,15 @@ def ext(external, pillar=None):
 
         .. versionadded:: 2015.5.0
 
+    unmask
+        If set to ``True``, the pillar data will be returned unmasked. If set
+        to ``False``, masked values are returned. The default of ``None``
+        auto-detects from the :func:`salt.utils.secret.mask_pillar` context
+        variable so direct user invocations see plain values while invocations
+        from inside the renderer/state pipeline stay masked.
+
+        .. versionadded:: 3008.2
+
     CLI Examples:
 
     .. code-block:: bash
@@ -654,10 +707,15 @@ def ext(external, pillar=None):
 
     ret = pillar_obj.compile_pillar()
 
+    if unmask is None:
+        unmask = not salt.utils.secret.mask_pillar.get()
+
+    if unmask:
+        return salt.utils.secret.expose(ret)
     return salt.utils.secret.serial(ret)
 
 
-def keys(key, delimiter=DEFAULT_TARGET_DELIM):
+def keys(key, delimiter=DEFAULT_TARGET_DELIM, unmask=None):
     """
     .. versionadded:: 2015.8.0
 
@@ -669,12 +727,23 @@ def keys(key, delimiter=DEFAULT_TARGET_DELIM):
     delimiter
         Specify an alternate delimiter to use when traversing a nested dict
 
+    unmask
+        Nested pillar keys are not masked, so this flag is a practical no-op
+        for ``keys``; it is accepted for API consistency with the other
+        ``pillar`` functions.
+
+        .. versionadded:: 3008.2
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pillar.keys web:sites
     """
+    # ``unmask`` is accepted purely for API uniformity; keys themselves are
+    # never masked. Reference the parameter so static analyzers don't flag it.
+    del unmask
+
     ret = salt.utils.data.traverse_dict_and_list(__pillar__, key, KeyError, delimiter)
 
     if ret is KeyError:

--- a/tests/pytests/unit/modules/test_pillar.py
+++ b/tests/pytests/unit/modules/test_pillar.py
@@ -45,7 +45,13 @@ def test_obfuscate_with_kwargs(pillar_value):
         ret = pillarmod.obfuscate(saltenv="saltenv")
         # ensure the kwargs are passed along to pillar.items
         assert (
-            call(pillar=None, pillar_enc=None, pillarenv=None, saltenv="saltenv")
+            call(
+                pillar=None,
+                pillar_enc=None,
+                pillarenv=None,
+                saltenv="saltenv",
+                unmask=None,
+            )
             in pillar_items_mock.mock_calls
         )
         assert ret == dict(a="<int>", b="<str>")
@@ -205,3 +211,89 @@ def test_ls_pass_kwargs(pillar_value):
     with patch("salt.modules.pillar.items", MagicMock(return_value=pillar_value)):
         ls = sorted(pillarmod.ls(pillarenv="base"))
         assert ls == ["a", "b"]
+
+
+def test_ls_accepts_and_forwards_unmask(pillar_value):
+    """``pillar.ls`` accepts ``unmask`` and forwards it to ``items``."""
+    with patch(
+        "salt.modules.pillar.items", MagicMock(return_value=pillar_value)
+    ) as items_mock:
+        result = sorted(pillarmod.ls(unmask=True))
+        assert result == ["a", "b"]
+        assert (
+            call(
+                pillar=None,
+                pillar_enc=None,
+                pillarenv=None,
+                saltenv=None,
+                unmask=True,
+            )
+            in items_mock.mock_calls
+        )
+
+
+def test_obfuscate_forwards_unmask(pillar_value):
+    """``pillar.obfuscate`` forwards ``unmask`` to ``items``."""
+    with patch(
+        "salt.modules.pillar.items", MagicMock(return_value=pillar_value)
+    ) as items_mock:
+        pillarmod.obfuscate(unmask=False)
+        assert (
+            call(
+                pillar=None,
+                pillar_enc=None,
+                pillarenv=None,
+                saltenv=None,
+                unmask=False,
+            )
+            in items_mock.mock_calls
+        )
+
+
+def test_keys_accepts_unmask():
+    """``pillar.keys`` accepts ``unmask`` (no-op since keys aren't masked)."""
+    with patch.dict(pillarmod.__pillar__, {"pkg": {"apache": "httpd"}}):
+        # Both calls should return the same list regardless of unmask value.
+        assert pillarmod.keys("pkg", unmask=True) == ["apache"]
+        assert pillarmod.keys("pkg", unmask=False) == ["apache"]
+        assert pillarmod.keys("pkg") == ["apache"]
+
+
+def test_raw_default_returns_unmasked_values():
+    """``pillar.raw`` defaults to unmasked, preserving historical behavior."""
+    with patch.dict(pillarmod.__pillar__, {"secret": "swordfish"}):
+        assert pillarmod.raw() == {"secret": "swordfish"}
+        assert pillarmod.raw(key="secret") == "swordfish"
+
+
+def test_raw_unmask_false_returns_masked_values():
+    """``pillar.raw(unmask=False)`` returns masked values."""
+    with patch.dict(pillarmod.__pillar__, {"secret": "swordfish"}):
+        masked = pillarmod.raw(unmask=False)
+        assert masked["secret"] != "swordfish"
+        assert "*" in masked["secret"]
+
+        masked_key = pillarmod.raw(key="secret", unmask=False)
+        assert masked_key != "swordfish"
+        assert "*" in masked_key
+
+
+def test_ext_forwards_unmask_to_expose():
+    """``pillar.ext(unmask=True)`` returns unmasked compiled pillar."""
+    compiled = {"a": "plain", "b": "secret"}
+    pillar_obj = MagicMock()
+    pillar_obj.compile_pillar = MagicMock(return_value=compiled)
+    grains = MagicMock()
+    grains.value = MagicMock(return_value={})
+    with patch(
+        "salt.pillar.get_pillar", MagicMock(return_value=pillar_obj)
+    ), patch.dict(
+        pillarmod.__opts__, {"id": "minion", "saltenv": "base"}
+    ), patch.object(
+        pillarmod, "__grains__", grains, create=True
+    ):
+        unmasked = pillarmod.ext({"libvirt": "_"}, unmask=True)
+        assert unmasked == compiled
+        masked = pillarmod.ext({"libvirt": "_"}, unmask=False)
+        for key in compiled:
+            assert "*" in masked[key]


### PR DESCRIPTION
### What does this PR do?

`pillar.get`, `pillar.items`, `pillar.item`, and `pillar.data` accept an
`unmask` kwarg (added in 3008.0). This PR extends that same parameter to the
remaining functions in `salt/modules/pillar.py`:

* `pillar.ls`
* `pillar.raw`
* `pillar.ext`
* `pillar.keys`
* `pillar.obfuscate`

so callers have a uniform interface across the module.

### Default semantics preserved

* `ls`, `obfuscate` forward `unmask` to `items`, whose default is auto-detect
  via the `mask_pillar` ContextVar.
* `ext` mirrors `items`: auto-detect when `unmask=None`, explicit `True`/`False`
  honored.
* `raw` keeps its historical always-unmask default; setting `unmask=False`
  now lets callers receive masked values.
* `keys` accepts `unmask` for API uniformity; nested pillar keys are never
  masked, so the parameter is a no-op for this function.

No default masking behavior is changed by this PR. Issue #69453's underlying
report (`pillar.get nodegroups` returning `**********`) is already addressable
via the existing `unmask=True` kwarg on `pillar.get`; this PR closes the API
gap for the rest of the module.

### What issues does this PR fix or reference?

Refs #69453.
Replaces #69464 (which proposed changing default semantics; redirected per
maintainer feedback).

### Merge requirements satisfied?
- [x] Docs - `unmask` parameter documented in each affected docstring
- [x] Changelog - `changelog/69453.added.md`
- [x] Tests written/updated - new tests for `ls`, `obfuscate`, `keys`,
      `raw` (default + masked), and `ext` (unmask True/False)

### Commits signed with GPG?
No