### PR TITLE
Add regression test + changelog for #65360 Py3.12 netutil import

### DIFF
--- a/changelog/65360.fixed.md
+++ b/changelog/65360.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt.ext.tornado.netutil`` import on Python 3.12+ where ``ssl.match_hostname`` was removed and the unmaintained ``backports.ssl_match_hostname`` package is unavailable, which previously broke any Salt master-initiated job (e.g. ``test.ping``, ``state.apply``) on Fedora 39+/Ubuntu 24.04 masters.

--- a/tests/pytests/unit/test_ext_importers.py
+++ b/tests/pytests/unit/test_ext_importers.py
@@ -48,3 +48,62 @@ def test_regression_56063():
         importer.find_module("tornado")
     except TypeError:
         assert False, "TornadoImporter raised type error when one argument passed"
+
+
+def test_regression_65360_tornado_netutil_imports_without_backports(tmp_path):
+    """
+    Regression test for #65360.
+
+    On Python 3.12 ``ssl.match_hostname`` was removed, which made the
+    vendored ``salt.ext.tornado.netutil`` module fall through to
+    ``import backports.ssl_match_hostname``. The ``backports`` package
+    is not part of the standard library and is not installed by default
+    on Fedora 39+/Ubuntu 24.04 (both ship Python 3.12), which broke any
+    Salt master-initiated job on those platforms because nearly every
+    Salt transport import path eventually imports ``netutil``.
+
+    Ensure ``salt.ext.tornado.netutil`` imports successfully without
+    requiring the ``backports`` package, and that the public attributes
+    consumed by the rest of vendored tornado (``ssl_match_hostname`` and
+    ``SSLCertificateError``) are populated.
+    """
+    test_source = """
+import sys
+
+# Force ImportError for the optional backports package so we exercise
+# the standalone match_hostname path even if backports happens to be
+# installed in the test environment.
+class _BlockBackports:
+    def find_module(self, name, path=None):
+        if name == "backports" or name.startswith("backports."):
+            return self
+        return None
+
+    def load_module(self, name):
+        raise ImportError("backports blocked for regression test")
+
+sys.meta_path.insert(0, _BlockBackports())
+
+import salt.ext.tornado.netutil as netutil
+
+assert netutil.ssl_match_hostname is not None, "ssl_match_hostname unset"
+assert netutil.SSLCertificateError is not None, "SSLCertificateError unset"
+print("OK")
+"""
+    with pytest.helpers.temp_file(
+        "test_65360.py", directory=tmp_path, contents=test_source
+    ) as test_source_path:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+        ret = subprocess.run(
+            [sys.executable, str(test_source_path)],
+            capture_output=True,
+            env=env,
+            shell=False,
+            check=False,
+            text=True,
+        )
+        assert (
+            ret.returncode == 0
+        ), f"netutil import failed:\nstdout: {ret.stdout}\nstderr: {ret.stderr}"
+        assert ret.stdout.strip().endswith("OK")


### PR DESCRIPTION
### What does this PR do?

The underlying fix for #65360 landed in `8169fb56d45` ("ssl.match_hostname has been deprecated") which inlined the standalone `match_hostname` implementation into `salt.ext.tornado.netutil` so the vendored tornado no longer falls through to `import backports.ssl_match_hostname` on Python 3.12+. That commit shipped without a regression test or changelog entry, so the issue stayed open and there was no guard against a future tornado patch reintroducing the `backports` fallback.

This PR adds the missing regression test and changelog fragment so the issue can close on the next release and a future regression would be caught by CI.

### What issues does this PR fix or reference?

Fixes #65360

### Previous Behavior

On Python 3.12+ (Fedora 39+/Ubuntu 24.04), `ssl.match_hostname` was removed from the stdlib, causing `salt/ext/tornado/netutil.py` to fall through to `import backports.ssl_match_hostname`. Since the `backports` package isn't shipped by default on those platforms, the import failed with `ModuleNotFoundError: No module named 'backports'`. That import is on the load path of `salt.utils.event` (via `salt.ext.tornado.iostream`), so essentially every master-initiated job (`test.ping`, `state.apply`, etc.) collapsed at import time.

### New Behavior

`salt.ext.tornado.netutil` already imports cleanly on Python 3.12+ (the inline `match_hostname` path lands in `8169fb56d45`). The new test asserts that property stays true even if the `backports` package is hard-blocked at import time, and the changelog fragment closes the issue on the next 3006.x release.

### Merge requirements satisfied?

- [x] Docs (no doc change needed; the bug is internal-import-only)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
