### PR TITLE
Accept salt:/// (3-slash) URLs in salt.utils.url.parse

### DIFF
--- a/changelog/69472.fixed.md
+++ b/changelog/69472.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt.utils.url.parse`` so ``salt:///path`` (three-slash URLs with an empty authority) resolves the same as ``salt://path``. Restores ``cp.get_file salt:///path/to/file`` and similar fileclient calls that previously failed because the surplus leading slash was rejected by the master fileserver's absolute-path guard.

--- a/salt/utils/url.py
+++ b/salt/utils/url.py
@@ -30,6 +30,13 @@ def parse(url):
     else:
         path, saltenv = resource, None
 
+    # Treat an empty authority (``salt:///foo``) the same as ``salt://foo``.
+    # Per RFC 3986 ``scheme:///path`` is a valid form, and historically Salt
+    # accepted it; without this normalization the surplus leading slashes
+    # propagate to the master fileserver which rejects absolute paths in
+    # ``find_file`` (CVE-2024-22231 / CVE-2024-22232 hardening).
+    path = path.lstrip("/")
+
     if salt.utils.platform.is_windows():
         path = salt.utils.path.sanitize_win_path(path)
 

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -42,6 +42,31 @@ class UrlTestCase(TestCase):
 
         self.assertEqual(salt.utils.url.parse(url), (path, saltenv))
 
+    def test_parse_salt_three_slash_url(self):
+        """
+        Regression test for #69472: ``salt:///foo`` (empty authority, RFC 3986
+        valid) must resolve to the same path as ``salt://foo``. Without this
+        normalization the surplus leading slash propagates to the master
+        fileserver which rejects absolute paths in ``find_file``, breaking
+        ``cp.get_file salt:///path/to/file`` and similar calls.
+        """
+        path = "path/to/file"
+        url = "salt:///" + path
+
+        self.assertEqual(salt.utils.url.parse(url), (path, None))
+
+    def test_parse_salt_three_slash_url_with_saltenv(self):
+        """
+        Regression test for #69472: ``salt:///foo?saltenv=bar`` must also be
+        accepted and produce the same ``(path, saltenv)`` tuple as the
+        equivalent two-slash form.
+        """
+        saltenv = "ambience"
+        path = "path/to/file"
+        url = "salt:///" + path + "?saltenv=" + saltenv
+
+        self.assertEqual(salt.utils.url.parse(url), (path, saltenv))
+
     # create tests
 
     def test_create_url(self):


### PR DESCRIPTION
## Summary

- Fix #69472: `cp.get_file salt:///path/to/file` (3-slash URL) failed on 3008.x with `""` because `salt.utils.url.parse('salt:///foo')` returned `('/foo', None)` (leading slash preserved), and the master fileserver's `find_file` rejects absolute paths since the CVE-2024-22231 / CVE-2024-22232 hardening.
- Strip leading slashes in `parse()` so `salt:///foo` and `salt://foo` behave identically. RFC 3986 considers both spellings valid; the fileserver always interprets `salt://` paths as relative to a `file_roots` entry, so a leading `/` was never meaningful.
- Existing tests in `tests/pytests/unit/modules/file/test_file_module.py` and `tests/unit/modules/test_saltcheck.py` already use the 3-slash form, indicating the spelling was always intended to work.

## Why it became user-visible on 3008.x

On older releases a `parse()` -> `create()` round-trip silently laundered the leading slash away because `create()` built `urlunparse(("file", "", path, "", "", ""))` and chopped a literal `file:///` prefix. For both `path` and `/path` the result was the same. Once that round-trip was removed for Python 3.13 compatibility (4cdd334e2f6c on master, ce0284239c1 on 3007.x -- both fix #66898 / #68421) the surplus slash started reaching the fileserver and the bug became user-visible end-to-end for `cp.get_file` and friends.

## Test plan

- [x] `venv310/bin/pytest tests/unit/utils/test_url.py` -- 39 passed, includes 2 new regression tests
- [x] `pre-commit run --files salt/utils/url.py changelog/69472.fixed.md tests/unit/utils/test_url.py` -- all hooks pass
- [ ] CI green on PR
