### PR TITLE
Fix salt-ssh not refreshing gitfs_remotes (#66148)

### DIFF
--- a/changelog/66148.fixed.md
+++ b/changelog/66148.fixed.md
@@ -1,0 +1,9 @@
+Fixed salt-ssh failing to fetch ``gitfs_remotes``. ``salt.config.master_config``
+sets ``__fs_update = True`` to suppress fileserver refreshes done by ``FSChan``
+(the master daemon's maintenance thread handles them). salt-ssh inherits the
+master config but has no maintenance thread, so its ``FSClient`` never refreshed
+the fileserver backends and wrappers such as ``cp.list_states`` saw no gitfs
+content until the user ran ``salt-run fileserver.update`` or manually
+``git fetch``ed the cached repos. ``salt.client.ssh.SSH.__init__`` now removes
+the suppression flag before instantiating ``FSClient`` so gitfs is refreshed
+once at startup.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -310,6 +310,13 @@ class SSH(MultiprocessingStateMixin):
             )
             self.opts["ssh_wipe"] = "True"
         self.returners = salt.loader.returners(self.opts, {})
+        # salt-ssh has no maintenance thread to refresh fileserver backends
+        # (e.g. gitfs_remotes). master_config() sets ``__fs_update = True``
+        # to suppress the refresh done by FSChan, on the assumption that the
+        # master daemon's maintenance thread will keep things current. Remove
+        # the flag here so the FSClient instantiated for salt-ssh triggers an
+        # initial refresh of the fileserver backends.
+        self.opts.pop("__fs_update", None)
         self.fsclient = salt.fileclient.FSClient(self.opts)
         self.thin = salt.utils.thin.gen_thin(
             self.opts["cachedir"],

--- a/tests/pytests/unit/client/ssh/test_ssh.py
+++ b/tests/pytests/unit/client/ssh/test_ssh.py
@@ -129,6 +129,32 @@ def test_ssh_kwargs(test_opts):
         assert ssh_obj.opts.get(opt_key, None) == opt_value
 
 
+def test_ssh_fsclient_refreshes_fileserver(opts):
+    """
+    Regression test for #66148.
+
+    salt-ssh loads its opts via ``salt.config.master_config`` which sets
+    ``__fs_update = True`` to suppress fileserver refreshes for the master
+    daemon (which has its own maintenance thread). salt-ssh has no such
+    maintenance thread, so the ``FSClient`` it instantiates must refresh
+    the fileserver backends, otherwise ``gitfs_remotes`` are never fetched
+    and wrappers like ``cp.list_states`` see no gitfs content.
+    """
+    # Simulate the opts as they come out of ``salt.config.master_config``.
+    opts["__fs_update"] = True
+    opts["file_client"] = "local"
+    opts["tgt"] = "localhost"
+
+    with patch("salt.roster.get_roster_file", MagicMock(return_value="")), patch(
+        "salt.client.ssh.shell.gen_key"
+    ), patch("salt.utils.thin.gen_thin"), patch(
+        "salt.fileserver.Fileserver"
+    ) as fileserver_mock:
+        client = ssh.SSH(opts)
+
+    assert client.fsclient.channel.fs.update.call_count == 1
+
+
 @pytest.mark.slow_test
 def test_expand_target_ip_address(opts, roster):
     """


### PR DESCRIPTION
### What does this PR do?

Restores the pre-3006.7 behavior of salt-ssh refreshing `gitfs_remotes`
(and any other fileserver backend) when it starts. Without this fix,
salt-ssh wrappers like `cp.list_states` see no gitfs content until the
user runs `salt-run fileserver.update` or manually `git fetch`es the
cached repositories.

### What issues does this PR fix or reference?

Fixes #66148

### Previous Behavior

`salt-ssh minion cp.list_states` returned only `roots` content; gitfs
remotes were configured but never fetched. Workarounds were running
`salt-run fileserver.update` or `git fetch` inside every
`<cachedir>/gitfs/<hash>/_` directory.

### New Behavior

salt-ssh's `FSClient` triggers the one-time `Fileserver.update()` that
fetches all configured `gitfs_remotes` (and any other VCS-backed
fileserver backend) on startup, matching 3006.6 behavior.

### Root cause

PR #65990 (commit `adb9397b`, "Don't needlessly refresh fileserver
backends during Pillar rendering") added
`opts["__fs_update"] = True` to `salt.config.apply_master_config`. That
flag tells `salt.fileserver.FSChan.__init__` to skip the initial
fileserver refresh, on the assumption that the master daemon's
maintenance thread will keep things current.

salt-ssh inherits its configuration through `master_config()` but is a
short-lived CLI tool with no maintenance thread, so its `FSClient`
never refreshed the backends. `SSH.__init__` now pops the
`__fs_update` flag from `self.opts` before instantiating `FSClient`,
allowing the embedded `FSChan` to perform its one-time update. The
flag is re-set by `FSChan` after the refresh, so any subsequent
`FSChan` instances in the same salt-ssh run continue to skip
correctly.

### Merge requirements satisfied?

- [x] Docs (no doc change required; behavior matches documented and
      pre-3006.7 semantics)
- [x] Changelog (`changelog/66148.fixed.md`)
- [x] Tests written/updated
      (`tests/pytests/unit/client/ssh/test_ssh.py::test_ssh_fsclient_refreshes_fileserver`)

### Commits signed with GPG?

Yes
