### PR TITLE
Fix minion SIGTERM blocked by resolve_dns retry loop (#69466)

### DIFF
--- a/changelog/69466.fixed.md
+++ b/changelog/69466.fixed.md
@@ -1,0 +1,1 @@
+Fixed minion not honoring SIGTERM while stuck in the master DNS retry loop, which caused systemd to escalate to SIGKILL after 90 seconds.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -108,6 +108,45 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+
+# Event used to abort an in-progress resolve_dns() retry loop. The minion
+# signal handler sets this so that a SIGTERM arriving while the minion is
+# stuck retrying master DNS resolution can shut the io_loop down promptly
+# instead of waiting for ``retry_dns`` seconds * forever. See #69466.
+_RESOLVE_DNS_ABORT = threading.Event()
+
+
+def request_resolve_dns_abort():
+    """
+    Signal any in-progress resolve_dns() retry loop to abort on its next
+    wakeup. Used by the minion shutdown path so SIGTERM is not blocked by
+    a synchronous ``time.sleep`` inside the DNS retry loop.
+    """
+    _RESOLVE_DNS_ABORT.set()
+
+
+def _interruptible_sleep(duration, abort_event, chunk=1.0):
+    """
+    Sleep up to ``duration`` seconds in ``chunk``-second slices, returning
+    early if ``abort_event`` becomes set. Returns True if the event was
+    observed set (i.e. the sleep was aborted), False otherwise.
+
+    Using small chunks rather than ``abort_event.wait(duration)`` keeps
+    behavior consistent across platforms where ``Event.wait`` may starve
+    other threads sharing the GIL during very long timeouts.
+    """
+    if duration <= 0:
+        return abort_event.is_set()
+    deadline = time.monotonic() + duration
+    while True:
+        if abort_event.is_set():
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return abort_event.is_set()
+        time.sleep(min(chunk, remaining))
+
+
 # To set up a minion:
 # 1. Read in the configuration
 # 2. Generate the function mapping dict
@@ -139,6 +178,10 @@ def resolve_dns(opts, fallback=True):
         except SaltClientError:
             retry_dns_count = opts.get("retry_dns_count", None)
             if opts["retry_dns"]:
+                # Clear any leftover abort from a previous resolve. The flag
+                # is only meaningful for the duration of an active retry
+                # loop; if it is already set when we enter we honor it on
+                # the first iteration below.
                 while True:
                     if retry_dns_count is not None:
                         if retry_dns_count == 0:
@@ -150,7 +193,16 @@ def resolve_dns(opts, fallback=True):
                         opts["master"],
                         opts["retry_dns"],
                     )
-                    time.sleep(opts["retry_dns"])
+                    aborted = _interruptible_sleep(
+                        opts["retry_dns"], _RESOLVE_DNS_ABORT
+                    )
+                    if aborted:
+                        log.warning(
+                            "Master DNS retry loop aborted by shutdown "
+                            "request before '%s' could be resolved.",
+                            opts["master"],
+                        )
+                        raise SaltMasterUnresolvableError
                     try:
                         ret["master_ip"] = salt.utils.network.dns_check(
                             opts["master"], int(opts["master_port"]), True, opts["ipv6"]
@@ -1236,6 +1288,13 @@ class MinionManager(MinionBase):
         Called from cli.daemons.Minion._handle_signals().
         Adds stop_async as callback to the io_loop to prevent blocking.
         """
+        # Trip the resolve_dns() abort flag first so a minion currently
+        # stuck in the synchronous DNS retry loop wakes up and releases
+        # the io_loop, allowing stop_async (scheduled below) to actually
+        # run. Without this, a SIGTERM that arrives while a master
+        # hostname is unresolvable is silently swallowed until systemd
+        # escalates to SIGKILL. See #69466.
+        request_resolve_dns_abort()
         self.io_loop.add_callback(  # pylint: disable=not-callable
             self.stop_async, signum, parent_sig_handler
         )

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import os
 import signal
+import threading
 import time
 import uuid
 
@@ -970,6 +971,102 @@ def test_minion_retry_dns_count(minion_opts):
     )
     with pytest.raises(SaltMasterUnresolvableError):
         salt.minion.resolve_dns(minion_opts)
+
+
+def test_resolve_dns_retry_aborts_on_shutdown_request_69466(minion_opts):
+    """
+    Regression test for #69466.
+
+    The resolve_dns() retry loop must wake up promptly when a shutdown is
+    requested (e.g. SIGTERM via MinionManager.stop()) instead of blocking
+    the io_loop for the full ``retry_dns`` interval. Without the fix the
+    blocking ``time.sleep(opts["retry_dns"])`` inside resolve_dns starved
+    the io_loop and the shutdown callback never ran until systemd sent
+    SIGKILL.
+    """
+    # The fix exposes a public module-level abort hook used by
+    # MinionManager.stop(). Its absence is itself a regression.
+    assert hasattr(salt.minion, "request_resolve_dns_abort"), (
+        "salt.minion is missing request_resolve_dns_abort(); the SIGTERM "
+        "path cannot interrupt the DNS retry loop. See #69466."
+    )
+    assert hasattr(salt.minion, "_RESOLVE_DNS_ABORT"), (
+        "salt.minion is missing the _RESOLVE_DNS_ABORT event used to "
+        "wake an in-progress resolve_dns() retry. See #69466."
+    )
+
+    minion_opts.update(
+        {
+            "ipv6": False,
+            "master": "dummy",
+            "master_port": "4555",
+            # A retry interval that is much larger than the test deadline.
+            # If the abort path is not honored, this test would block for
+            # the full 90 seconds.
+            "retry_dns": 90,
+            "retry_dns_count": None,
+        },
+    )
+
+    # The resolve_dns abort flag is process-wide; make sure we leave it
+    # clean for other tests.
+    salt.minion._RESOLVE_DNS_ABORT.clear()
+
+    def trip_abort():
+        # Give resolve_dns a moment to enter its sleep, then request abort
+        # the same way MinionManager.stop() does on SIGTERM.
+        time.sleep(0.25)
+        salt.minion.request_resolve_dns_abort()
+
+    aborter = threading.Thread(target=trip_abort, daemon=True)
+    started = time.monotonic()
+    try:
+        aborter.start()
+        with pytest.raises(SaltMasterUnresolvableError):
+            salt.minion.resolve_dns(minion_opts)
+    finally:
+        aborter.join(timeout=5)
+        salt.minion._RESOLVE_DNS_ABORT.clear()
+
+    elapsed = time.monotonic() - started
+    # The fix should wake well under 5s; the broken code would sleep for
+    # the full retry_dns (90s) per iteration.
+    assert elapsed < 5, (
+        f"resolve_dns did not honor the shutdown abort flag "
+        f"(elapsed={elapsed:.2f}s); regression of #69466."
+    )
+
+
+def test_minion_manager_stop_unblocks_resolve_dns_69466(minion_opts):
+    """
+    Regression test for #69466.
+
+    ``MinionManager.stop()`` is the entry point invoked from the SIGTERM
+    handler. It must trip the resolve_dns abort flag before scheduling
+    the async shutdown so a minion currently stuck in the DNS retry loop
+    yields the io_loop. Without this, ``stop_async`` is queued but never
+    runs and systemd escalates to SIGKILL after 90 seconds.
+    """
+    # The abort flag must be cleared at entry; stop() should set it.
+    salt.minion._RESOLVE_DNS_ABORT.clear()
+    assert not salt.minion._RESOLVE_DNS_ABORT.is_set()
+
+    manager = salt.minion.MinionManager.__new__(salt.minion.MinionManager)
+    manager.io_loop = MagicMock()
+    # Populate the attributes __del__ -> destroy() touches so the
+    # interpreter does not log an AttributeError at GC time.
+    manager.minions = []
+    manager.event_publisher = None
+    manager.event = None
+    try:
+        manager.stop(signal.SIGTERM, lambda *a, **kw: None)
+        assert salt.minion._RESOLVE_DNS_ABORT.is_set(), (
+            "MinionManager.stop() did not request a resolve_dns abort; "
+            "a SIGTERM during the DNS retry loop will be ignored. See #69466."
+        )
+        manager.io_loop.add_callback.assert_called_once()
+    finally:
+        salt.minion._RESOLVE_DNS_ABORT.clear()
 
 
 @pytest.mark.slow_test


### PR DESCRIPTION
### What does this PR do?
Makes the minion shut down promptly on SIGTERM even while it is stuck retrying an unresolvable master hostname. The synchronous `time.sleep` inside `resolve_dns()`'s retry-DNS loop ran inside the io_loop coroutine context, so the `MinionManager.stop()` callback queued by the SIGTERM handler never ran until systemd escalated to SIGKILL after 90 seconds.

### What issues does this PR fix or reference?
Fixes #69466

### Previous Behavior
With a misconfigured / unreachable `master` hostname (e.g. the default `salt`), the minion logged `DNS lookup or connection check of 'salt' failed.` and slept for `retry_dns` seconds in a tight loop. A subsequent `systemctl stop salt-minion` (or `systemctl restart salt-minion`) sent SIGTERM, but the io_loop was starved by the blocking sleep — so the async shutdown callback added in #68209 (`MinionManager.stop_async`) never ran, and systemd escalated to SIGKILL after 90s, marking the service as `failed`.

### New Behavior
`MinionManager.stop()` trips a new module-level `_RESOLVE_DNS_ABORT` event before scheduling `stop_async` on the io_loop. The `resolve_dns()` retry loop sleeps in 1-second slices and checks the event between slices; if it is set, the loop raises `SaltMasterUnresolvableError` — the same exception the connect-minion loop already handles cleanly — releasing the io_loop so the queued shutdown callback can run. SIGTERM now takes effect within ~1 second instead of being silently swallowed for 90.

### Merge requirements satisfied?
- [x] Docs (no documented behavior changed)
- [x] Changelog (`changelog/69466.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/test_minion.py::test_resolve_dns_retry_aborts_on_shutdown_request_69466`, `::test_minion_manager_stop_unblocks_resolve_dns_69466`)

### Commits signed with GPG?
No
