### PR TITLE
Fix master-initiated jobs on Py3.12 by installing asyncio loop in SyncWrapper (#65702)

### DIFF
--- a/changelog/65702.fixed.md
+++ b/changelog/65702.fixed.md
@@ -1,0 +1,1 @@
+Fixed master-initiated jobs failing on Python 3.12+ with "There is no current event loop in thread 'Thread-N (_target)'" by installing an asyncio event loop on the SyncWrapper worker thread.

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -2,6 +2,7 @@
 Helpers/utils for working with tornado asynchronous stuff
 """
 
+import asyncio
 import contextlib
 import logging
 import sys
@@ -51,6 +52,15 @@ class SyncWrapper:
         loop_kwarg=None,
     ):
         self.io_loop = salt.ext.tornado.ioloop.IOLoop(make_current=False)
+        # Create a dedicated asyncio event loop and install it on the
+        # worker thread before running coroutines.  Without this,
+        # libraries that call ``asyncio.get_event_loop()`` (notably pyzmq's
+        # ``zmq.eventloop.future`` sockets used by master-initiated job
+        # publishes) raise ``RuntimeError: There is no current event loop``
+        # on Python 3.12+, because Py3.12 removed the implicit
+        # auto-creation of an event loop in non-main threads.
+        # See issue #65702.
+        self.asyncio_loop = asyncio.new_event_loop()
         if args is None:
             args = []
         if kwargs is None:
@@ -103,6 +113,14 @@ class SyncWrapper:
         io_loop = self.io_loop
         io_loop.stop()
         io_loop.close(all_fds=True)
+        # Close the asyncio loop created for this wrapper.  Suppress
+        # exceptions so close() remains best-effort even if the loop was
+        # never used or was already closed by a wrapped coroutine.
+        try:
+            if not self.asyncio_loop.is_closed():
+                self.asyncio_loop.close()
+        except Exception:  # pylint: disable=broad-except
+            log.debug("Exception while closing SyncWrapper asyncio loop", exc_info=True)
 
     def __getattr__(self, key):
         if key in self._async_methods:
@@ -127,6 +145,13 @@ class SyncWrapper:
         return wrap
 
     def _target(self, key, args, kwargs, results, io_loop):
+        # Install the SyncWrapper's dedicated asyncio event loop on this
+        # worker thread so that code paths which call
+        # ``asyncio.get_event_loop()`` (notably pyzmq's
+        # ``zmq.eventloop.future`` sockets) succeed on Python 3.12+,
+        # where the implicit per-thread loop creation was removed.
+        # See issue #65702.
+        asyncio.set_event_loop(self.asyncio_loop)
         try:
             result = io_loop.run_sync(lambda: getattr(self.obj, key)(*args, **kwargs))
             results.append(True)

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -2,7 +2,6 @@
 Helpers/utils for working with tornado asynchronous stuff
 """
 
-import asyncio
 import contextlib
 import logging
 import sys
@@ -10,6 +9,11 @@ import threading
 
 import salt.ext.tornado.concurrent
 import salt.ext.tornado.ioloop
+
+# ``asyncio`` is imported lazily inside ``SyncWrapper`` so importing this
+# module does not pull in the asyncio chain on legacy Python targets (e.g.
+# the salt-ssh py3.6/3.7 thin tarball, where ``contextvars`` -> ``immutables``
+# -> ``typing_extensions`` is not shipped).  See issue #65702.
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +55,12 @@ class SyncWrapper:
         close_methods=None,
         loop_kwarg=None,
     ):
+        # Imported lazily so this module loads cleanly on the salt-ssh
+        # py3.6/3.7 thin tarball (which does not ship ``typing_extensions``
+        # and therefore can't import ``asyncio`` -> ``contextvars`` ->
+        # ``immutables``).  See issue #65702.
+        import asyncio
+
         self.io_loop = salt.ext.tornado.ioloop.IOLoop(make_current=False)
         # Create a dedicated asyncio event loop and install it on the
         # worker thread before running coroutines.  Without this,
@@ -145,6 +155,9 @@ class SyncWrapper:
         return wrap
 
     def _target(self, key, args, kwargs, results, io_loop):
+        # Imported lazily, see ``__init__`` for rationale (#65702).
+        import asyncio
+
         # Install the SyncWrapper's dedicated asyncio event loop on this
         # worker thread so that code paths which call
         # ``asyncio.get_event_loop()`` (notably pyzmq's

--- a/tests/pytests/unit/utils/test_asynchronous.py
+++ b/tests/pytests/unit/utils/test_asynchronous.py
@@ -1,0 +1,50 @@
+"""
+Regression tests for salt.utils.asynchronous.SyncWrapper.
+
+Issue #65702: on Python 3.12+ the worker thread spawned by
+``SyncWrapper._wrap`` had no asyncio event loop installed.  Any wrapped
+coroutine that touched ``asyncio.get_event_loop`` (notably pyzmq's
+future-based sockets, which back every master-initiated job) raised
+``RuntimeError: There is no current event loop in thread 'Thread-N
+(_target)'`` and aborted the publish.
+"""
+
+import asyncio
+
+import salt.ext.tornado.gen
+import salt.utils.asynchronous as asynchronous
+
+
+class _LoopProbe:
+    """
+    Minimal async helper whose coroutine calls ``asyncio.get_event_loop``
+    from inside the SyncWrapper worker thread - the same call pyzmq's
+    ``zmq.eventloop.future`` machinery performs on every send/poll.
+    """
+
+    async_methods = ["check_loop"]
+
+    def __init__(self, io_loop=None):
+        pass
+
+    @salt.ext.tornado.gen.coroutine
+    def check_loop(self):
+        # On Python 3.12+ this raises RuntimeError unless an asyncio loop
+        # has been installed on the current thread.  Pre-3.12 it returns
+        # (and may auto-create) the loop.
+        loop = asyncio.get_event_loop()
+        raise salt.ext.tornado.gen.Return(loop is not None)
+
+
+def test_sync_wrapper_thread_has_asyncio_loop_65702():
+    """
+    SyncWrapper's worker thread must expose an asyncio event loop so that
+    libraries which call ``asyncio.get_event_loop`` (e.g. pyzmq's
+    future-based sockets used by master-initiated job publishes) work on
+    Python 3.12+.
+    """
+    sync = asynchronous.SyncWrapper(_LoopProbe)
+    try:
+        assert sync.check_loop() is True
+    finally:
+        sync.close()


### PR DESCRIPTION
### What does this PR do?

Fixes `salt`-CLI publishes failing on Python 3.12+ with `RuntimeError:
There is no current event loop in thread 'Thread-N (_target)'`.

`salt.utils.asynchronous.SyncWrapper` spawns a worker thread
(`threading.Thread(target=self._target, ...)` -> Python names it
`"Thread-N (_target)"`) and runs `io_loop.run_sync(...)` inside it.
Any wrapped coroutine that touches `asyncio.get_event_loop()` -
notably pyzmq's `zmq.eventloop.future` sockets used by every
`LocalClient.pub` send through `AsyncReqChannel` - hits that call
from the worker thread, and on Python 3.12+ it raises because the
implicit per-thread loop creation was removed.

Create a dedicated `asyncio.new_event_loop()` per `SyncWrapper` and
install it on the worker thread via `asyncio.set_event_loop()`
before `io_loop.run_sync(...)`. Close the asyncio loop in
`SyncWrapper.close`. The vendored Tornado IOLoop on 3006.x continues
to drive the coroutine itself; this change only ensures
`asyncio.get_event_loop()` returns a usable loop on the worker
thread for any code path that asks for one.

### What issues does this PR fix or reference?

Fixes #65702

### Previous Behavior

On Python 3.12+ (Fedora 39+, Ubuntu 24.04, etc.), running
`salt '*' test.ping` or `salt '*' state.apply` on the salt master
produced:

```
[TRACE   ] Failed to send msg RuntimeError("There is no current event loop in thread 'Thread-2 (_target)'.")
```

and the publish was dropped, so no minion ever ran the job. Every
master-initiated job collapsed.

### New Behavior

`SyncWrapper` installs an asyncio event loop on its worker thread,
so pyzmq's `zmq.eventloop.future` socket calls (and any other code
that calls `asyncio.get_event_loop()`) succeed and the publish
goes through normally.

### Regression test

`tests/pytests/unit/utils/test_asynchronous.py::
test_sync_wrapper_thread_has_asyncio_loop_65702` constructs a
`SyncWrapper` around a coroutine that calls
`asyncio.get_event_loop()` from inside `io_loop.run_sync`. Without
this patch it fails on Py3.12+ with the exact reported error.
With the patch it passes on both Py3.10 and Py3.12.

### Merge requirements satisfied?

- [x] Docs (no user-facing doc change; internal threading fix)
- [x] Changelog (`changelog/65702.fixed.md`)
- [x] Tests written/updated

### Commits signed with GPG?

Yes
