### PR TITLE
Pin runner Python to 3.14.6 to unblock Windows nightlies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/ci.yml.jinja'
+
 ---
 name: CI
 run-name: "CI (${{ github.event_name == 'pull_request' && format('pr: #{0}', github.event.number) || format('{0}: {1}', startsWith(github.event.ref, 'refs/tags') && 'tag' || 'branch', github.ref_name) }})"
@@ -143,10 +144,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -234,7 +235,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -254,7 +255,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -266,10 +267,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
 
       - name: Setup Python Tools Scripts
@@ -395,10 +396,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -443,7 +444,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -460,7 +461,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -477,7 +478,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -492,7 +493,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -510,7 +511,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -526,7 +527,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
@@ -549,10 +550,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
 
       - name: Setup Python Tools Scripts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,6 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/nightly.yml.jinja'
+
 ---
 
 name: Nightly
@@ -202,10 +203,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -293,7 +294,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -313,7 +314,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -325,10 +326,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
 
       - name: Setup Python Tools Scripts
@@ -459,10 +460,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -507,7 +508,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -524,7 +525,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -545,7 +546,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -564,7 +565,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -582,7 +583,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -598,7 +599,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,5 +1,6 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/scheduled.yml.jinja'
+
 ---
 
 name: Scheduled
@@ -192,10 +193,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -283,7 +284,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -303,7 +304,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -315,10 +316,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
 
       - name: Setup Python Tools Scripts
@@ -444,10 +445,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -492,7 +493,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -509,7 +510,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -526,7 +527,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -541,7 +542,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -559,7 +560,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -575,7 +576,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,5 +1,6 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/staging.yml.jinja'
+
 ---
 
 name: Stage Release
@@ -165,10 +166,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -256,7 +257,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -276,7 +277,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -288,10 +289,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
 
       - name: Setup Python Tools Scripts
@@ -418,10 +419,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14"
+          python-version: "3.14.6"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -466,7 +467,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -484,7 +485,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -506,7 +507,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -525,7 +526,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -543,7 +544,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -559,7 +560,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14"
+      ci-python-version: "3.14.6"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/templates/layout.yml.jinja
+++ b/.github/workflows/templates/layout.yml.jinja
@@ -8,7 +8,14 @@
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}") %>
 <%- set gpg_key_id = "64CBBC8173D76B3F" %>
 <%- set prepare_actual_release = prepare_actual_release | default(False) %>
-<%- set gh_actions_workflows_python_version = "3.14" %>
+{# Pin the runner-host Python patch level. actions/setup-python's tool-cache
+   currently resolves "3.14" to 3.14.5 on the windows-2025-vs2026 image,
+   which bundles OpenSSL 3.0.20 and fails to parse the cert pypi.org now
+   serves with `[ASN1: NOT_ENOUGH_DATA]` during the CI-Deps `pip install`
+   step on Windows. 3.14.6 ships OpenSSL 3.5.7, which handles the cert.
+   Drop back to "3.14" once setup-python's "3.14" default reliably resolves
+   to a build with OpenSSL >= 3.5.x. #}
+<%- set gh_actions_workflows_python_version = "3.14.6" %>
 <%- set nox_archive_hashfiles = "${{ hashFiles('requirements/**/*.txt', 'requirements/**/*.lock', 'cicd/golden-images.json', 'noxfile.py', 'pkg/common/env-cleanup-rules.yml', '.github/workflows/build-deps-ci-action.yml') }}" %>
 ---
 <%- block name %>

--- a/changelog/69486.fixed.md
+++ b/changelog/69486.fixed.md
@@ -1,0 +1,1 @@
+Fixed 3006.x Windows nightly CI by pinning the runner-host Python to 3.14.6 (OpenSSL 3.5.7); the setup-python default `3.14` was resolving to a cached 3.14.5 build whose OpenSSL 3.0.20 rejected the cert pypi.org currently serves.

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -7,15 +7,21 @@ import os
 import sys
 import warnings
 
-# Work around cpython#104135: ssl._load_windows_store_certs feeds every cert
-# in the Windows root store to load_verify_locations(cadata=...) as one blob,
-# so a single ASN.1-malformed cert aborts the whole load. OpenSSL 3.5.x
+# Work around cpython#104135 on Windows: ssl._load_windows_store_certs feeds
+# every cert in the OS root store to load_verify_locations(cadata=...) as one
+# blob, so a single ASN.1-malformed cert aborts the whole load. OpenSSL 3.5.x
 # (shipped by relenv >= 0.22.13) is strict enough to reject certs the prior
 # OpenSSL accepted, which breaks ssl.create_default_context() at import time
 # for salt and for any third-party lib (aiohttp, requests, urllib3, ...)
 # running under the salt onedir on Windows. Replace the loader with the
-# iterate-and-skip variant proposed upstream. Remove this once relenv ships
-# a cpython with the upstream fix.
+# iterate-and-skip variant proposed upstream.
+#
+# This block is Python-3.10-only: cpython merged the iterate-and-skip fix
+# directly into Lib/ssl.py for the 3.11 branch, but the patch was never
+# backported to 3.10 (which is in security-only mode). The salt 3006.x onedir
+# is the only branch shipping Python 3.10 via relenv; 3008.x and later use
+# Python 3.14, whose stdlib already has the upstream fix. DO NOT forward-merge
+# this block to a branch whose onedir Python is >= 3.11 - delete it instead.
 if sys.platform == "win32":
     import ssl as _ssl
 

--- a/salt/ext/tornado/netutil.py
+++ b/salt/ext/tornado/netutil.py
@@ -275,8 +275,17 @@ if hasattr(ssl, 'SSLContext'):
         # which reads the OS root store as a single blob; a single malformed
         # cert there aborts the whole load with ASN1 NOT_ENOUGH_DATA under
         # OpenSSL 3.5.x (shipped by relenv >= 0.22.13). See cpython#104135.
-        # Point at certifi to bypass the OS store until relenv ships a
-        # patched cpython.
+        # Point at certifi to bypass the OS store.
+        #
+        # Python-3.10-only workaround: cpython merged the iterate-and-skip
+        # variant of _load_windows_store_certs into Lib/ssl.py for the 3.11
+        # branch but never backported it to 3.10 (security-only mode). The
+        # salt 3006.x onedir is the only branch shipping Python 3.10 via
+        # relenv; 3008.x and later use Python 3.14 whose stdlib already has
+        # the upstream fix and does not need this branch. DO NOT
+        # forward-merge this special-case to a branch whose onedir Python
+        # is >= 3.11 - collapse it back to the unconditional
+        # ssl.create_default_context() form instead.
         if sys.platform == 'win32' and certifi is not None:
             _client_ssl_defaults = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH, cafile=certifi.where())


### PR DESCRIPTION
## Summary

The 3006.x nightly's **CI Deps / Windows (amd64)** and **(x86)** jobs have been failing since 2026-06-17 (runs [27658212708](https://github.com/saltstack/salt/actions/runs/27658212708), [27728715751](https://github.com/saltstack/salt/actions/runs/27728715751)) with:

\`\`\`
SSLError(142, '[ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4040)')
\`\`\`

…during pip's first HTTPS request to pypi.org from the freshly-created nox virtualenv.

Diagnosis: \`actions/setup-python\`'s tool cache resolves \`python-version: "3.14"\` to **3.14.5** on the \`windows-2025-vs2026 / 20260608.135.2\` image, which bundles **OpenSSL 3.0.20**. That OpenSSL build's ASN.1 parser rejects the cert pypi.org currently serves. 3008.x's nightly doesn't fail because its CI-Deps step happens to be invoked with an explicit \`3.14.6\` somewhere upstream, and 3.14.6 ships **OpenSSL 3.5.7**, which handles the cert fine.

## Fix

Pin \`gh_actions_workflows_python_version\` to \`"3.14.6"\` in \`.github/workflows/templates/layout.yml.jinja\` so the runner-host Python is consistently 3.14.6 across the matrix. Regenerated workflows pick up the bump.

## Not the same as the cpython#104135 work-around

The \`salt/__init__.py\` + \`salt/ext/tornado/netutil.py\` monkey-patches dwoz merged last week ([\`4d1e4db01a\`](https://github.com/saltstack/salt/commit/4d1e4db01a), [\`e68db2220d\`](https://github.com/saltstack/salt/commit/e68db2220d), [\`f222fe37e7\`](https://github.com/saltstack/salt/commit/f222fe37e7)) patch the **salt-runtime** ssl loader for the Python 3.10 onedir and only fire after \`import salt\`. The CI-Deps step dies before salt is even on disk - pip runs under the host Python before the onedir is installed - so those patches cannot help here.

While I was in this area I expanded the comments on both work-arounds so future forward-merges to 3008.x (which uses Python 3.14, whose stdlib already has the upstream iter-and-skip fix) drop them instead of carrying them along. The cpython#104135 fix landed on \`main\` and was backported to 3.11+, but it was **never backported to 3.10** - 3.10 is in security-only mode and this is classified as a bug fix. So 3006.x is the only branch that needs the salt-runtime monkey-patches, and 3008.x onward must not inherit them.

## Test plan

- [ ] \`CI Deps / Windows (amd64)\` and \`CI Deps / Windows (x86)\` go green on this branch's CI run.
- [ ] Nightly on 3006.x recovers.
- [ ] No regression on the Linux/macOS CI-Deps shards (Python-version bump applies to those too but is benign).