### PR TITLE
Drop cpython#104135 sitecustomize into onedir Python during CI Deps

### DIFF
--- a/.github/workflows/build-deps-ci-action.yml
+++ b/.github/workflows/build-deps-ci-action.yml
@@ -292,6 +292,21 @@ jobs:
           cd artifacts
           tar xvf ${{ inputs.package-name }}-${{ inputs.salt-version }}-onedir-windows-${{ matrix.arch }}.tar.xz
 
+      - name: Apply cpython#104135 sitecustomize to onedir Python
+        # The ci-test-onedir nox session creates a virtualenv from the onedir
+        # Python (3.10 on this branch) and runs pip *inside it* before salt is
+        # importable; Python 3.10's _load_windows_store_certs feeds the whole
+        # Windows root store to load_verify_locations as one blob, which
+        # OpenSSL 3.5.x (relenv >= 0.22.13) rejects on a single bad cert.
+        # Dropping the sitecustomize at the onedir site-packages root means
+        # the venv inherits it via --system-site-packages and the iter-and-
+        # skip patch fires at every interpreter start. Self-disables on
+        # Python 3.11+; remove with the rest of the cpython#104135 trio.
+        if: steps.nox-dependencies-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cp cicd/windows-ssl-104135-sitecustomize.py artifacts/salt/Lib/site-packages/sitecustomize.py
+
       - name: Set up Python ${{ inputs.ci-python-version }}
         if: steps.nox-dependencies-cache.outputs.cache-hit != 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/ci.yml.jinja'
-
 ---
 name: CI
 run-name: "CI (${{ github.event_name == 'pull_request' && format('pr: #{0}', github.event.number) || format('{0}: {1}', startsWith(github.event.ref, 'refs/tags') && 'tag' || 'branch', github.ref_name) }})"
@@ -144,10 +143,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -235,7 +234,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -255,7 +254,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -267,10 +266,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
 
       - name: Setup Python Tools Scripts
@@ -396,10 +395,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -444,7 +443,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -461,7 +460,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -478,7 +477,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -493,7 +492,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -511,7 +510,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -527,7 +526,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
@@ -550,10 +549,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
 
       - name: Setup Python Tools Scripts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,5 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/nightly.yml.jinja'
-
 ---
 
 name: Nightly
@@ -203,10 +202,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -294,7 +293,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -314,7 +313,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -326,10 +325,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
 
       - name: Setup Python Tools Scripts
@@ -460,10 +459,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -508,7 +507,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -525,7 +524,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -546,7 +545,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -565,7 +564,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -583,7 +582,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -599,7 +598,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,6 +1,5 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/scheduled.yml.jinja'
-
 ---
 
 name: Scheduled
@@ -193,10 +192,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -284,7 +283,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -304,7 +303,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -316,10 +315,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
 
       - name: Setup Python Tools Scripts
@@ -445,10 +444,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -493,7 +492,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -510,7 +509,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -527,7 +526,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -542,7 +541,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -560,7 +559,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -576,7 +575,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,6 +1,5 @@
 # Do not edit these workflows directly as the changes made will be overwritten.
 # Instead, edit the template '.github/workflows/templates/staging.yml.jinja'
-
 ---
 
 name: Stage Release
@@ -166,10 +165,10 @@ jobs:
                 - *tests_added_modified
                 - *pkg_tests_added_modified
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -257,7 +256,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       pre-commit-version: "4.3.0"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
 
   lint:
@@ -277,7 +276,7 @@ jobs:
     with:
       changed-files: ${{ needs.prepare-workflow.outputs.changed-files }}
       full: ${{ fromJSON(needs.prepare-workflow.outputs.config)['testrun']['type'] == 'full' }}
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
 
   prepare-release:
     name: "Prepare Release: ${{ needs.prepare-workflow.outputs.salt-version }}"
@@ -289,10 +288,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
 
       - name: Setup Python Tools Scripts
@@ -419,10 +418,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python 3.14
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.14.6"
+          python-version: "3.14"
 
       - name: Setup Python Tools Scripts
         uses: ./.github/actions/setup-python-tools-scripts
@@ -467,7 +466,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
 
@@ -485,7 +484,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -507,7 +506,7 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.14"
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -526,7 +525,7 @@ jobs:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
       python-version: "3.10.20"
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
@@ -544,7 +543,7 @@ jobs:
       nox-session: ci-test-onedir
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
@@ -560,7 +559,7 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      ci-python-version: "3.14.6"
+      ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.20

--- a/.github/workflows/templates/layout.yml.jinja
+++ b/.github/workflows/templates/layout.yml.jinja
@@ -8,14 +8,7 @@
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}") %>
 <%- set gpg_key_id = "64CBBC8173D76B3F" %>
 <%- set prepare_actual_release = prepare_actual_release | default(False) %>
-{# Pin the runner-host Python patch level. actions/setup-python's tool-cache
-   currently resolves "3.14" to 3.14.5 on the windows-2025-vs2026 image,
-   which bundles OpenSSL 3.0.20 and fails to parse the cert pypi.org now
-   serves with `[ASN1: NOT_ENOUGH_DATA]` during the CI-Deps `pip install`
-   step on Windows. 3.14.6 ships OpenSSL 3.5.7, which handles the cert.
-   Drop back to "3.14" once setup-python's "3.14" default reliably resolves
-   to a build with OpenSSL >= 3.5.x. #}
-<%- set gh_actions_workflows_python_version = "3.14.6" %>
+<%- set gh_actions_workflows_python_version = "3.14" %>
 <%- set nox_archive_hashfiles = "${{ hashFiles('requirements/**/*.txt', 'requirements/**/*.lock', 'cicd/golden-images.json', 'noxfile.py', 'pkg/common/env-cleanup-rules.yml', '.github/workflows/build-deps-ci-action.yml') }}" %>
 ---
 <%- block name %>

--- a/changelog/69490.fixed.md
+++ b/changelog/69490.fixed.md
@@ -1,0 +1,1 @@
+Fixed 3006.x Windows nightly CI Deps by dropping a sitecustomize hook into the salt onedir's `Lib/site-packages` that applies the cpython#104135 iter-and-skip patch before pip touches TLS; the prior runner-host Python pin in #69486 targeted the wrong interpreter (the failing pip runs in a venv created from the relenv-bundled Python 3.10) and is reverted.

--- a/cicd/windows-ssl-104135-sitecustomize.py
+++ b/cicd/windows-ssl-104135-sitecustomize.py
@@ -1,0 +1,62 @@
+"""
+sitecustomize hook applied to the salt onedir Python during CI builds.
+
+The build-deps-ci Windows job extracts the salt onedir, then runs
+``nox --install-only -e ci-test-onedir``. ``noxfile.py``'s
+``ci-test-onedir`` session targets the onedir's relenv-bundled Python -
+on 3006.x that is Python 3.10.20 - and nox creates a virtualenv from it
+with ``--system-site-packages``. pip then runs inside that venv and
+fetches setuptools/pip/wheel from pypi.org over HTTPS *before* salt
+itself has been installed.
+
+Python 3.10's stdlib ``ssl._load_windows_store_certs`` concatenates
+every cert from the Windows root store and feeds them to
+``load_verify_locations(cadata=...)`` as one blob. Under the strict
+ASN.1 parser shipped by OpenSSL 3.5.x (which relenv >= 0.22.13 bundles)
+one malformed cert in the OS store aborts the whole load with
+``[ASN1: NOT_ENOUGH_DATA]``, so pip fails to verify pypi.org's TLS
+cert chain and the CI-Deps job dies before any deps get installed.
+See cpython#104135.
+
+cpython merged the iterate-and-skip variant of
+``_load_windows_store_certs`` into ``Lib/ssl.py`` for the 3.11 branch
+but never backported it to 3.10 (security-only). The salt-runtime
+work-around dwoz landed in ``salt/__init__.py`` cannot help here -
+salt is not yet importable in the CI-Deps venv. Dropping this file
+into the onedir's ``Lib/site-packages`` makes Python apply the same
+fix at interpreter start-up, before pip's TLS code runs.
+
+Python-3.10-only: self-disables on Python 3.11+ (whose stdlib already
+has the upstream fix). Delete this file together with the
+``salt/__init__.py`` block and the ``salt/ext/tornado/netutil.py``
+``sys.platform == 'win32'`` special-case on any branch whose onedir
+Python is >= 3.11.
+"""
+
+import sys
+
+if sys.platform == "win32" and sys.version_info < (3, 11):
+    import ssl as _ssl
+
+    # _SSLError captured as a default-arg so this stays callable after the
+    # surrounding names go out of scope.
+    def _salt_safe_load_windows_store_certs(
+        self, storename, purpose, _SSLError=_ssl.SSLError
+    ):
+        try:
+            from _ssl import enum_certificates
+        except ImportError:
+            return
+        try:
+            for cert, encoding, trust in enum_certificates(storename):
+                if encoding != "x509_asn":
+                    continue
+                if trust is True or purpose.oid in trust:
+                    try:
+                        self.load_verify_locations(cadata=cert)
+                    except _SSLError:
+                        pass
+        except PermissionError:
+            pass
+
+    _ssl.SSLContext._load_windows_store_certs = _salt_safe_load_windows_store_certs

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -22,6 +22,13 @@ import warnings
 # is the only branch shipping Python 3.10 via relenv; 3008.x and later use
 # Python 3.14, whose stdlib already has the upstream fix. DO NOT forward-merge
 # this block to a branch whose onedir Python is >= 3.11 - delete it instead.
+#
+# Companion work-arounds (delete together with this block):
+#   - salt/ext/tornado/netutil.py: certifi.where() pin on Windows
+#   - cicd/windows-ssl-104135-sitecustomize.py + the Apply-sitecustomize step
+#     in .github/workflows/build-deps-ci-action.yml's Windows job, which
+#     re-applies this same patch to the onedir Python *before* salt is
+#     importable (covers pip during the CI-Deps step).
 if sys.platform == "win32":
     import ssl as _ssl
 

--- a/salt/ext/tornado/netutil.py
+++ b/salt/ext/tornado/netutil.py
@@ -286,6 +286,11 @@ if hasattr(ssl, 'SSLContext'):
         # forward-merge this special-case to a branch whose onedir Python
         # is >= 3.11 - collapse it back to the unconditional
         # ssl.create_default_context() form instead.
+        #
+        # Companion work-arounds (delete together with this block):
+        #   - salt/__init__.py: _load_windows_store_certs monkey-patch
+        #   - cicd/windows-ssl-104135-sitecustomize.py + the Apply-
+        #     sitecustomize step in build-deps-ci-action.yml's Windows job.
         if sys.platform == 'win32' and certifi is not None:
             _client_ssl_defaults = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH, cafile=certifi.where())


### PR DESCRIPTION
## Summary

#69486's "3.14" → "3.14.6" pin did not fix the Windows nightlies (run [27799109831](https://github.com/saltstack/salt/actions/runs/27799109831) still fails the same way) - the venv that pip is running in **isn't created from the runner-host Python at all**.

`noxfile.py:1182` defines the `ci-test-onedir` session as `python=str(ONEDIR_PYTHON_PATH)`, so the venv's interpreter is the salt onedir's relenv-bundled Python - **3.10.20** on 3006.x. Python 3.10's stdlib `ssl._load_windows_store_certs` concatenates every cert in the Windows root store and feeds them to `load_verify_locations(cadata=...)` as one blob, which OpenSSL 3.5.x (relenv ≥ 0.22.13) refuses to parse if any single cert is ASN.1-malformed - exactly cpython#104135. pip's first HTTPS GET to pypi.org dies with `[ASN1: NOT_ENOUGH_DATA]` and the dep install never starts.

dwoz's `salt/__init__.py` monkey-patch ([\`4d1e4db01a\`](https://github.com/saltstack/salt/commit/4d1e4db01a), [\`e68db2220d\`](https://github.com/saltstack/salt/commit/e68db2220d), [\`f222fe37e7\`](https://github.com/saltstack/salt/commit/f222fe37e7)) fires correctly at salt-runtime but cannot help during build-deps-ci: salt is not yet installed when pip first runs in the new venv.

## Fix

Ship the iter-and-skip patch as `cicd/windows-ssl-104135-sitecustomize.py` and add a workflow step in the Windows job of `build-deps-ci-action.yml` that copies it to `artifacts/salt/Lib/site-packages/sitecustomize.py` between **Decompress Onedir Tarball** and **Install Nox**. Because the `ci-test-onedir` nox session creates its venv with `--system-site-packages` (noxfile.py:1184), the venv inherits the onedir's site-packages directory, so Python loads the sitecustomize at every interpreter start - including the pip invocation that's been failing - before any TLS code runs.

The new file self-disables on Python 3.11+ (whose stdlib already has the upstream iter-and-skip fix), so it's safe to forward-merge as a no-op into branches whose onedir uses Python 3.14.

Also reverts the "3.14" → "3.14.6" pin from #69486 - that targeted the wrong Python and only adds churn.

## Cleanup discipline

All three Python-3.10-only work-arounds now cross-reference each other in their comments:

- `salt/__init__.py` (salt-runtime monkey-patch)
- `salt/ext/tornado/netutil.py` (certifi pin on Windows)
- `cicd/windows-ssl-104135-sitecustomize.py` + the Apply-sitecustomize step in `build-deps-ci-action.yml`

When 3006.x's onedir eventually moves off Python 3.10 (or these get forward-merged to a branch whose onedir Python is ≥ 3.11), drop them as a unit.

## Test plan

- [ ] `CI Deps / Windows (amd64)` and `CI Deps / Windows (x86)` go green on this branch's CI run.
- [ ] 3006.x nightly recovers.
- [ ] No regression on Linux/macOS CI Deps (the new workflow step is gated on the Windows job only).