### PR TITLE
feat(macOS): add Homebrew trust/untrust support to mac_brew_pkg

### DIFF
--- a/changelog/69496.added.md
+++ b/changelog/69496.added.md
@@ -1,0 +1,1 @@
+Added ``pkg.trust``, ``pkg.untrust``, ``pkg.is_trusted``, and ``pkg.list_trusted`` to ``salt.modules.mac_brew_pkg`` to manage Homebrew's trust list for non-official taps, formulae, casks and external commands. Added ``pkg.trusted`` and ``pkg.untrusted`` state functions to ``salt.states.pkg`` to enforce trust state declaratively on macOS.

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -33,6 +33,8 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = "pkg"
 
+_TRUST_TYPES = ("tap", "formula", "cask", "command")
+
 
 def __virtual__():
     """
@@ -895,3 +897,156 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
 
 unpin = unhold
+
+
+def list_trusted(type=None):
+    """
+    List trusted taps, formulae, casks and commands.
+
+    .. versionadded:: 3008.2
+
+    type
+        Filter by type. Valid values: ``tap``, ``formula``, ``cask``, ``command``.
+        When ``None`` (default), returns a dict with all trusted items grouped by
+        type (keys: ``taps``, ``formulae``, ``casks``, ``commands``). When a type
+        is specified, returns a list of trusted items of that type.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.list_trusted
+        salt '*' pkg.list_trusted type=tap
+    """
+    if type is not None and type not in _TRUST_TYPES:
+        raise SaltInvocationError(
+            f"Invalid type '{type}'. Valid values: {', '.join(_TRUST_TYPES)}"
+        )
+
+    cmd = ["trust", "--json=v1"]
+    if type is not None:
+        cmd.append(f"--{type}")
+
+    result = _call_brew(*cmd)
+    try:
+        return salt.utils.json.loads(result["stdout"])
+    except ValueError as err:
+        msg = f'Unable to interpret output from "brew trust": {err}'
+        log.error(msg)
+        raise CommandExecutionError(msg)
+
+
+def trust(name, type=None):
+    """
+    Trust a tap, formula, cask or command so Homebrew may load it when
+    ``$HOMEBREW_REQUIRE_TAP_TRUST`` is set.
+
+    .. versionadded:: 3008.2
+
+    name
+        The name of the tap, formula, cask or command to trust. Can also be a
+        remote URL for taps.
+
+    type
+        The type of the item. Valid values: ``tap``, ``formula``, ``cask``,
+        ``command``. If not specified, Homebrew will auto-detect the type.
+
+    Returns ``True`` on success (including when the item was already trusted),
+    ``False`` on failure.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.trust cdalvaro/tap
+        salt '*' pkg.trust cdalvaro/tap type=tap
+        salt '*' pkg.trust cdalvaro/tap/salt type=formula
+    """
+    if type is not None and type not in _TRUST_TYPES:
+        raise SaltInvocationError(
+            f"Invalid type '{type}'. Valid values: {', '.join(_TRUST_TYPES)}"
+        )
+
+    cmd = ["trust"]
+    if type is not None:
+        cmd.append(f"--{type}")
+    cmd.append(name)
+
+    try:
+        _call_brew(*cmd)
+    except CommandExecutionError:
+        log.error('Failed to trust "%s"', name)
+        return False
+
+    return True
+
+
+def untrust(name, type=None):
+    """
+    Stop trusting a tap, formula, cask or command.
+
+    .. versionadded:: 3008.2
+
+    name
+        The name of the tap, formula, cask or command to untrust.
+
+    type
+        The type of the item. Valid values: ``tap``, ``formula``, ``cask``,
+        ``command``. If not specified, Homebrew will auto-detect the type.
+
+    Returns ``True`` on success (including when the item was not trusted),
+    ``False`` on failure.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.untrust cdalvaro/tap
+        salt '*' pkg.untrust cdalvaro/tap type=tap
+        salt '*' pkg.untrust cdalvaro/tap/salt type=formula
+    """
+    if type is not None and type not in _TRUST_TYPES:
+        raise SaltInvocationError(
+            f"Invalid type '{type}'. Valid values: {', '.join(_TRUST_TYPES)}"
+        )
+
+    cmd = ["untrust"]
+    if type is not None:
+        cmd.append(f"--{type}")
+    cmd.append(name)
+
+    try:
+        _call_brew(*cmd)
+    except CommandExecutionError:
+        log.error('Failed to untrust "%s"', name)
+        return False
+
+    return True
+
+
+def is_trusted(name, type=None):
+    """
+    Check whether a tap, formula, cask or command is trusted.
+
+    .. versionadded:: 3008.2
+
+    name
+        The name of the tap, formula, cask or command to check.
+
+    type
+        The type of the item. Valid values: ``tap``, ``formula``, ``cask``,
+        ``command``. If not specified, checks across all types.
+
+    Returns ``True`` if the item is trusted, ``False`` otherwise.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_trusted cdalvaro/tap
+        salt '*' pkg.is_trusted cdalvaro/tap type=tap
+    """
+    trusted = list_trusted(type=type)
+    if isinstance(trusted, list):
+        return name in trusted
+    return any(name in items for items in trusted.values())

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -3936,6 +3936,120 @@ def held(name, version=None, pkgs=None, replace=False, **kwargs):
     return ret
 
 
+def trusted(name, **kwargs):
+    """
+    Ensure a package source or component is marked as trusted by the package
+    manager. Only available for package managers that implement a trust model
+    (e.g. Homebrew on macOS).
+
+    .. versionadded:: 3008.2
+
+    name
+        The identifier of the package source or component to trust. The exact
+        format depends on the package manager (e.g. a tap name, a formula, a
+        URL).
+
+    kwargs
+        Additional keyword arguments are passed through to the underlying
+        ``pkg.trust`` and ``pkg.is_trusted`` module functions, allowing
+        package-manager-specific options to be supplied. For example, on macOS
+        with Homebrew, ``type`` can be set to ``tap``, ``formula``, ``cask``
+        or ``command`` to disambiguate the target.
+
+    Examples:
+
+    .. code-block:: yaml
+
+        # Homebrew: trust a third-party tap
+        cdalvaro/tap:
+          pkg.trusted:
+            - type: tap
+
+        # Homebrew: trust a specific formula from a third-party tap
+        cdalvaro/tap/salt:
+          pkg.trusted:
+            - type: formula
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    if "pkg.trust" not in __salt__:
+        ret["result"] = False
+        ret["comment"] = "`trust` is not available for this package manager."
+        return ret
+
+    if __salt__["pkg.is_trusted"](name, **kwargs):
+        ret["comment"] = f"{name} is already trusted."
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"{name} would be trusted."
+        return ret
+
+    if not __salt__["pkg.trust"](name, **kwargs):
+        ret["result"] = False
+        ret["comment"] = f"Failed to trust {name}."
+        return ret
+
+    ret["changes"] = {name: {"old": "untrusted", "new": "trusted"}}
+    ret["comment"] = f"{name} is now trusted."
+    return ret
+
+
+def untrusted(name, **kwargs):
+    """
+    Ensure a package source or component is not marked as trusted by the
+    package manager. Only available for package managers that implement a
+    trust model (e.g. Homebrew on macOS).
+
+    .. versionadded:: 3008.2
+
+    name
+        The identifier of the package source or component to untrust. The
+        exact format depends on the package manager.
+
+    kwargs
+        Additional keyword arguments are passed through to the underlying
+        ``pkg.untrust`` and ``pkg.is_trusted`` module functions, allowing
+        package-manager-specific options to be supplied. For example, on macOS
+        with Homebrew, ``type`` can be set to ``tap``, ``formula``, ``cask``
+        or ``command`` to disambiguate the target.
+
+    Example:
+
+    .. code-block:: yaml
+
+        # Homebrew: remove trust from a third-party tap
+        cdalvaro/tap:
+          pkg.untrusted:
+            - type: tap
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    if "pkg.untrust" not in __salt__:
+        ret["result"] = False
+        ret["comment"] = "`untrust` is not available for this package manager."
+        return ret
+
+    if not __salt__["pkg.is_trusted"](name, **kwargs):
+        ret["comment"] = f"{name} is already not trusted."
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"{name} would be untrusted."
+        return ret
+
+    if not __salt__["pkg.untrust"](name, **kwargs):
+        ret["result"] = False
+        ret["comment"] = f"Failed to untrust {name}."
+        return ret
+
+    ret["changes"] = {name: {"old": "trusted", "new": "untrusted"}}
+    ret["comment"] = f"{name} is no longer trusted."
+    return ret
+
+
 def unheld(name, version=None, pkgs=None, all=False, **kwargs):
     """
     .. versionadded:: 3005

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -1608,3 +1608,192 @@ def test_list_upgrades_with_options():
         mock_call_brew.assert_called_once_with(
             "outdated", "--json=v2", "--greedy", "--fetch-HEAD"
         )
+
+
+# 'list_trusted' function tests
+
+
+def test_list_trusted():
+    """
+    Tests that list_trusted returns all trusted items as a dict.
+    """
+    expected = {
+        "taps": ["thirdparty/foo"],
+        "formulae": ["thirdparty/foo/bar"],
+        "casks": [],
+        "commands": [],
+    }
+    mock_call_brew = MagicMock(
+        return_value={
+            "retcode": 0,
+            "stdout": '{"taps": ["thirdparty/foo"], "formulae": ["thirdparty/foo/bar"], "casks": [], "commands": []}',
+            "stderr": "",
+        }
+    )
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.list_trusted() == expected
+        mock_call_brew.assert_called_once_with("trust", "--json=v1")
+
+
+def test_list_trusted_by_type():
+    """
+    Tests that list_trusted with a type returns a list of trusted items.
+    """
+    mock_call_brew = MagicMock(
+        return_value={
+            "retcode": 0,
+            "stdout": '["thirdparty/foo"]',
+            "stderr": "",
+        }
+    )
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.list_trusted(type="tap") == ["thirdparty/foo"]
+        mock_call_brew.assert_called_once_with("trust", "--json=v1", "--tap")
+
+
+def test_list_trusted_invalid_type():
+    """
+    Tests that list_trusted raises SaltInvocationError for an invalid type.
+    """
+    with pytest.raises(
+        salt.exceptions.SaltInvocationError, match="Invalid type 'invalid'"
+    ):
+        mac_brew.list_trusted(type="invalid")
+
+
+# 'trust' function tests
+
+
+def test_trust():
+    """
+    Tests successfully trusting a tap.
+    """
+    mock_call_brew = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.trust("thirdparty/foo") is True
+        mock_call_brew.assert_called_once_with("trust", "thirdparty/foo")
+
+
+def test_trust_with_type():
+    """
+    Tests trusting an item with an explicit type flag.
+    """
+    mock_call_brew = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.trust("thirdparty/foo", type="tap") is True
+        mock_call_brew.assert_called_once_with("trust", "--tap", "thirdparty/foo")
+
+
+def test_trust_failure():
+    """
+    Tests that trust returns False when brew trust fails.
+    """
+    mock_call_brew = MagicMock(side_effect=CommandExecutionError("brew failed"))
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.trust("thirdparty/foo") is False
+
+
+def test_trust_invalid_type():
+    """
+    Tests that trust raises SaltInvocationError for an invalid type.
+    """
+    with pytest.raises(
+        salt.exceptions.SaltInvocationError, match="Invalid type 'invalid'"
+    ):
+        mac_brew.trust("thirdparty/foo", type="invalid")
+
+
+# 'untrust' function tests
+
+
+def test_untrust():
+    """
+    Tests successfully untrusting a tap.
+    """
+    mock_call_brew = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.untrust("thirdparty/foo") is True
+        mock_call_brew.assert_called_once_with("untrust", "thirdparty/foo")
+
+
+def test_untrust_with_type():
+    """
+    Tests untrusting an item with an explicit type flag.
+    """
+    mock_call_brew = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.untrust("thirdparty/foo/bar", type="formula") is True
+        mock_call_brew.assert_called_once_with(
+            "untrust", "--formula", "thirdparty/foo/bar"
+        )
+
+
+def test_untrust_failure():
+    """
+    Tests that untrust returns False when brew untrust fails.
+    """
+    mock_call_brew = MagicMock(side_effect=CommandExecutionError("brew failed"))
+    with patch("salt.modules.mac_brew_pkg._call_brew", mock_call_brew):
+        assert mac_brew.untrust("thirdparty/foo") is False
+
+
+def test_untrust_invalid_type():
+    """
+    Tests that untrust raises SaltInvocationError for an invalid type.
+    """
+    with pytest.raises(
+        salt.exceptions.SaltInvocationError, match="Invalid type 'invalid'"
+    ):
+        mac_brew.untrust("thirdparty/foo", type="invalid")
+
+
+# 'is_trusted' function tests
+
+
+def test_is_trusted_found():
+    """
+    Tests is_trusted returns True when the item is in the trusted list.
+    """
+    trusted = {
+        "taps": ["thirdparty/foo"],
+        "formulae": [],
+        "casks": [],
+        "commands": [],
+    }
+    with patch("salt.modules.mac_brew_pkg.list_trusted", return_value=trusted):
+        assert mac_brew.is_trusted("thirdparty/foo") is True
+
+
+def test_is_trusted_not_found():
+    """
+    Tests is_trusted returns False when the item is not trusted.
+    """
+    trusted = {
+        "taps": [],
+        "formulae": [],
+        "casks": [],
+        "commands": [],
+    }
+    with patch("salt.modules.mac_brew_pkg.list_trusted", return_value=trusted):
+        assert mac_brew.is_trusted("thirdparty/foo") is False
+
+
+def test_is_trusted_with_type():
+    """
+    Tests is_trusted with a type filter delegates to list_trusted with that type.
+    """
+    with patch(
+        "salt.modules.mac_brew_pkg.list_trusted", return_value=["thirdparty/foo"]
+    ) as mock_list:
+        assert mac_brew.is_trusted("thirdparty/foo", type="tap") is True
+        mock_list.assert_called_once_with(type="tap")
+
+
+def test_is_trusted_with_type_not_found():
+    """
+    Tests is_trusted with a type filter returns False when not in list.
+    """
+    with patch(
+        "salt.modules.mac_brew_pkg.list_trusted", return_value=["other/tap"]
+    ):
+        assert mac_brew.is_trusted("thirdparty/foo", type="tap") is False

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -1793,7 +1793,5 @@ def test_is_trusted_with_type_not_found():
     """
     Tests is_trusted with a type filter returns False when not in list.
     """
-    with patch(
-        "salt.modules.mac_brew_pkg.list_trusted", return_value=["other/tap"]
-    ):
+    with patch("salt.modules.mac_brew_pkg.list_trusted", return_value=["other/tap"]):
         assert mac_brew.is_trusted("thirdparty/foo", type="tap") is False

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1345,3 +1345,175 @@ def test_latest_no_change_windows():
     with patch.dict(pkg.__salt__, salt_dict):
         ret = pkg.latest(pkg_name)
         assert ret.get("result", False) is True
+
+
+# 'trusted' state tests
+
+
+def test_trusted_not_available():
+    """
+    Test pkg.trusted when pkg.trust is not available for the package manager.
+    """
+    with patch.dict(pkg.__salt__, {}):
+        ret = pkg.trusted("cdalvaro/tap")
+        assert ret["result"] is False
+        assert "not available" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_trusted_already_trusted():
+    """
+    Test pkg.trusted when the item is already trusted.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.trust": MagicMock(return_value=True),
+            "pkg.is_trusted": MagicMock(return_value=True),
+        },
+    ):
+        ret = pkg.trusted("cdalvaro/tap", type="tap")
+        assert ret["result"] is True
+        assert "already trusted" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_trusted_test_mode():
+    """
+    Test pkg.trusted in test mode when the item would be trusted.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.trust": MagicMock(return_value=True),
+            "pkg.is_trusted": MagicMock(return_value=False),
+        },
+    ), patch.dict(pkg.__opts__, {"test": True}):
+        ret = pkg.trusted("cdalvaro/tap")
+        assert ret["result"] is None
+        assert "would be trusted" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_trusted_success():
+    """
+    Test pkg.trusted successfully trusts an item.
+    """
+    trust_mock = MagicMock(return_value=True)
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.trust": trust_mock,
+            "pkg.is_trusted": MagicMock(return_value=False),
+        },
+    ):
+        ret = pkg.trusted("cdalvaro/tap", type="tap")
+        assert ret["result"] is True
+        assert ret["changes"] == {
+            "cdalvaro/tap": {"old": "untrusted", "new": "trusted"}
+        }
+        assert "now trusted" in ret["comment"]
+        trust_mock.assert_called_once_with("cdalvaro/tap", type="tap")
+
+
+def test_trusted_failure():
+    """
+    Test pkg.trusted when the brew trust command fails.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.trust": MagicMock(return_value=False),
+            "pkg.is_trusted": MagicMock(return_value=False),
+        },
+    ):
+        ret = pkg.trusted("cdalvaro/tap")
+        assert ret["result"] is False
+        assert "Failed to trust" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+# 'untrusted' state tests
+
+
+def test_untrusted_not_available():
+    """
+    Test pkg.untrusted when pkg.untrust is not available for the package manager.
+    """
+    with patch.dict(pkg.__salt__, {}):
+        ret = pkg.untrusted("cdalvaro/tap")
+        assert ret["result"] is False
+        assert "not available" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_untrusted_already_not_trusted():
+    """
+    Test pkg.untrusted when the item is already not trusted.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.untrust": MagicMock(return_value=True),
+            "pkg.is_trusted": MagicMock(return_value=False),
+        },
+    ):
+        ret = pkg.untrusted("cdalvaro/tap", type="tap")
+        assert ret["result"] is True
+        assert "already not trusted" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_untrusted_test_mode():
+    """
+    Test pkg.untrusted in test mode when the item would be untrusted.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.untrust": MagicMock(return_value=True),
+            "pkg.is_trusted": MagicMock(return_value=True),
+        },
+    ), patch.dict(pkg.__opts__, {"test": True}):
+        ret = pkg.untrusted("cdalvaro/tap")
+        assert ret["result"] is None
+        assert "would be untrusted" in ret["comment"]
+        assert ret["changes"] == {}
+
+
+def test_untrusted_success():
+    """
+    Test pkg.untrusted successfully untrusts an item.
+    """
+    untrust_mock = MagicMock(return_value=True)
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.untrust": untrust_mock,
+            "pkg.is_trusted": MagicMock(return_value=True),
+        },
+    ):
+        ret = pkg.untrusted("cdalvaro/tap", type="tap")
+        assert ret["result"] is True
+        assert ret["changes"] == {
+            "cdalvaro/tap": {"old": "trusted", "new": "untrusted"}
+        }
+        assert "no longer trusted" in ret["comment"]
+        untrust_mock.assert_called_once_with("cdalvaro/tap", type="tap")
+
+
+def test_untrusted_failure():
+    """
+    Test pkg.untrusted when the brew untrust command fails.
+    """
+    with patch.dict(
+        pkg.__salt__,
+        {
+            "pkg.untrust": MagicMock(return_value=False),
+            "pkg.is_trusted": MagicMock(return_value=True),
+        },
+    ):
+        ret = pkg.untrusted("cdalvaro/tap")
+        assert ret["result"] is False
+        assert "Failed to untrust" in ret["comment"]
+        assert ret["changes"] == {}


### PR DESCRIPTION
### What does this PR do?

Adds support for Homebrew's `brew trust` and `brew untrust` commands to the `mac_brew_pkg` execution module, and introduces two new state functions (`pkg.trusted` / `pkg.untrusted`) to the `pkg` state module.

Homebrew introduced a trust system for non-official taps, formulae, casks and external commands so they can be explicitly allowed when `$HOMEBREW_REQUIRE_TAP_TRUST` is set. This PR brings that capability to Salt.

**New execution module functions (`salt.modules.mac_brew_pkg`):**

- `pkg.list_trusted([type])` — returns all trusted items via `brew trust --json=v1`. Without a `type` filter, returns a dict keyed by `taps`, `formulae`, `casks`, `commands`. With a `type` filter, returns a plain list.
- `pkg.trust(name, [type])` — trusts a tap, formula, cask or command. Accepts an optional `type` (`tap`, `formula`, `cask`, `command`); Homebrew auto-detects when omitted. Also accepts remote URLs for taps.
- `pkg.untrust(name, [type])` — removes trust from a tap, formula, cask or command.
- `pkg.is_trusted(name, [type])` — returns `True` if the item is currently trusted.

**New state functions (`salt.states.pkg`):**

- `pkg.trusted` — ensures an item is trusted (idempotent, supports `test` mode).
- `pkg.untrusted` — ensures an item is not trusted (idempotent, supports `test` mode).

Both state functions degrade gracefully on non-Homebrew package managers by returning `result: False` with an explanatory message.

### What issues does this PR fix or reference?

Fixes

Related Homebrew PRs that introduced the trust feature:
- https://github.com/Homebrew/brew/pull/22472 — `brew trust` / `brew untrust` commands
- https://github.com/Homebrew/brew/pull/22613 — `trusted` field in `brew tap-info --json`
- https://github.com/Homebrew/brew/pull/22624 — `brew trust --json=v1` machine-readable output
- https://github.com/Homebrew/brew/pull/22611 — support trusting taps by remote URL

### Previous Behavior

There was no way to manage Homebrew's trust list via Salt. Non-official taps, formulae, casks and external commands could not be trusted or untrusted programmatically, and their trust state could not be queried.

### New Behavior

Salt can now manage Homebrew trust via the execution module:

```bash
# List all trusted items
salt '*' pkg.list_trusted

# List trusted taps only
salt '*' pkg.list_trusted type=tap

# Trust a tap
salt '*' pkg.trust cdalvaro/tap type=tap

# Untrust a formula
salt '*' pkg.untrust cdalvaro/tap/salt type=formula

# Check trust state
salt '*' pkg.is_trusted cdalvaro/tap
```

And via Salt states:

```yaml
# Ensure a tap is trusted
cdalvaro/tap:
  pkg.trusted:
    - type: tap

# Ensure a formula is trusted
cdalvaro/tap/salt:
  pkg.trusted:
    - type: formula

# Ensure a tap is not trusted
untrusted_tap:
  pkg.untrusted:
    - name: cdalvaro/tap
    - type: tap
```

### Merge requirements satisfied?

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

**Tests added:**
- `tests/pytests/unit/modules/test_mac_brew_pkg.py` — 15 new unit tests covering `list_trusted`, `trust`, `untrust` and `is_trusted` (success, failure, type validation and type filtering).
- `tests/pytests/unit/states/test_pkg.py` — 10 new unit tests covering `pkg.trusted` and `pkg.untrusted` (function unavailable, already in desired state, test mode, success, and failure).

### Commits signed with GPG?

Yes
