### PR TITLE
Fix re.subn DeprecationWarning in file module

### DIFF
--- a/changelog/69497.fixed.md
+++ b/changelog/69497.fixed.md
@@ -1,0 +1,1 @@
+Fixed `DeprecationWarning: 'count' is passed as positional argument` emitted by all three `re.subn` calls in `salt.modules.file.replace` on Python 3.12+.

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2543,7 +2543,7 @@ def replace(
             cpattern,
             repl_str.replace("\\", "\\\\") if backslash_literal else repl_str,
             orig_contents,
-            count,
+            count=count,
         )
 
         found = nrepl > 0
@@ -2700,7 +2700,7 @@ def replace(
                     cpattern,
                     repl.replace(b"\\", b"\\\\") if backslash_literal else repl,
                     r_data,
-                    count,
+                    count=count,
                 )
 
                 # found anything? (even if no change)
@@ -2759,7 +2759,7 @@ def replace(
                             cpattern,
                             repl.replace(b"\\", b"\\\\") if backslash_literal else repl,
                             r_data,
-                            count,
+                            count=count,
                         )
                         try:
                             w_file.write(salt.utils.stringutils.to_str(result))

--- a/tests/pytests/functional/modules/file/test_replace.py
+++ b/tests/pytests/functional/modules/file/test_replace.py
@@ -211,3 +211,17 @@ def test_replace_no_modify_time_update_on_no_change(file, multiline_file):
 def test_backslash_literal(file, multiline_file):
     file.replace(str(multiline_file), r"Etiam", "Emma", backslash_literal=True)
     assert "Emma" in multiline_file.read_text()
+
+
+def test_replace_count_no_deprecation_warning(file, multiline_file):
+    """
+    Regression test for https://github.com/saltstack/salt/pull/69497.
+    file.replace must not emit a DeprecationWarning for passing 'count'
+    as a positional argument to re.subn.
+    """
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        file.replace(str(multiline_file), r"Etiam", "Salticus", count=1)
+    assert "Salticus" in multiline_file.read_text()


### PR DESCRIPTION
### What issues does this PR fix or reference?
This is a drive-by fix for a trivial Python DeprecationWarning.

### Previous Behavior
```
/opt/saltstack/salt/lib/python3.14/site-packages/salt/modules/file.py:2833: DeprecationWarning: 'count' is passed as positional argument
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated