### PR TITLE
Change zypperpkg to only parse stdout from rpm

### DIFF
--- a/changelog/69502.fixed.md
+++ b/changelog/69502.fixed.md
@@ -1,0 +1,1 @@
+Change zypperpkg's parsing of rpm output to no longer crash if rpm returns warnings.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -932,7 +932,9 @@ def list_pkgs(versions_as_list=False, root=None, includes=None, **kwargs):
             salt.utils.pkg.rpm.QUERYFORMAT.replace("%{REPOID}", "(none)") + "\n",
         ]
     )
-    output = __salt__["cmd.run"](cmd, python_shell=False, output_loglevel="trace")
+    output = __salt__["cmd.run_all"](cmd, python_shell=False, output_loglevel="trace")[
+        "stdout"
+    ]
     for line in output.splitlines():
         pkginfo = salt.utils.pkg.rpm.parse_pkginfo(line, osarch=__grains__["osarch"])
         if pkginfo:
@@ -3065,9 +3067,9 @@ def list_provides(root=None, **kwargs):
             cmd.extend(["--root", root])
         cmd.extend(["-qa", "--queryformat", "%{PROVIDES}_|-%{NAME}\n"])
         ret = dict()
-        for line in __salt__["cmd.run"](
+        for line in __salt__["cmd.run_all"](
             cmd, output_loglevel="trace", python_shell=False
-        ).splitlines():
+        )["stdout"].splitlines():
             provide, realname = line.split("_|-")
 
             if provide == realname:

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -354,6 +354,97 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     )
                 cmd_run_all.assert_has_calls([mock_call])
 
+    def test_list_provides(self):
+        """
+        Test if the PROVIDES query is correctly parsed
+        """
+
+        rpm_stdout = [
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)_|-gpg-pubkey",
+            "libxkbcommon.so.0()(64bit)_|-libxkbcommon0",
+            "libmpfr.so.6()(64bit)_|-libmpfr6",
+            "ca-certificates-mozilla_|-ca-certificates-mozilla",
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)_|-gpg-pubkey",
+            "pacemaker-schemas_|-pacemaker-schemas",
+            "config(qemu-tools)_|-qemu-tools",
+            "suse-kernel-rpm-scriptlets_|-suse-module-tools",
+            "config(libsemanage-conf)_|-libsemanage-conf",
+            "python3-pycparser_|-python3-pycparser",
+        ]
+
+        salt_out = {
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)": [
+                "gpg-pubkey",
+                "gpg-pubkey",
+            ],
+            "libxkbcommon.so.0()(64bit)": ["libxkbcommon0"],
+            "libmpfr.so.6()(64bit)": ["libmpfr6"],
+            "config(qemu-tools)": ["qemu-tools"],
+            "suse-kernel-rpm-scriptlets": ["suse-module-tools"],
+            "config(libsemanage-conf)": ["libsemanage-conf"],
+        }
+
+        with patch.dict(
+            zypper.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "",
+                        "stdout": os.linesep.join(rpm_stdout),
+                    }
+                )
+            },
+        ):
+            self.assertEqual(zypper.list_provides(), salt_out)
+
+    # TODO: fold into previous function using pytest.mark.parametrize, once available in the test class
+    def test_list_provides_with_warning(self):
+        """
+        Test if the PROVIDES query is correctly parsed
+        """
+
+        rpm_stdout = [
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)_|-gpg-pubkey",
+            "libxkbcommon.so.0()(64bit)_|-libxkbcommon0",
+            "libmpfr.so.6()(64bit)_|-libmpfr6",
+            "ca-certificates-mozilla_|-ca-certificates-mozilla",
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)_|-gpg-pubkey",
+            "pacemaker-schemas_|-pacemaker-schemas",
+            "config(qemu-tools)_|-qemu-tools",
+            "suse-kernel-rpm-scriptlets_|-suse-module-tools",
+            "config(libsemanage-conf)_|-libsemanage-conf",
+            "python3-pycparser_|-python3-pycparser",
+        ]
+
+        salt_out = {
+            "gpg(openSUSE Project Signing Key <opensuse@opensuse.org>)": [
+                "gpg-pubkey",
+                "gpg-pubkey",
+            ],
+            "libxkbcommon.so.0()(64bit)": ["libxkbcommon0"],
+            "libmpfr.so.6()(64bit)": ["libmpfr6"],
+            "config(qemu-tools)": ["qemu-tools"],
+            "suse-kernel-rpm-scriptlets": ["suse-module-tools"],
+            "config(libsemanage-conf)": ["libsemanage-conf"],
+        }
+
+        with patch.dict(
+            zypper.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "warning: Found NDB Packages.db database while attempting bdb backend: using ndb backend.",
+                        "stdout": os.linesep.join(rpm_stdout),
+                    }
+                )
+            },
+        ):
+            self.assertEqual(zypper.list_provides(), salt_out)
+
     def test_refresh_db(self):
         """
         Test if refresh DB handled correctly
@@ -708,7 +799,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         ]
         with patch.dict(zypper.__grains__, {"osarch": "x86_64"}), patch.dict(
             zypper.__salt__,
-            {"cmd.run": MagicMock(return_value=os.linesep.join(rpm_out))},
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "",
+                        "stdout": os.linesep.join(rpm_out),
+                    }
+                )
+            },
         ), patch.dict(zypper.__salt__, {"pkg_resource.add_pkg": _add_data}), patch.dict(
             zypper.__salt__,
             {"pkg_resource.format_pkg_list": pkg_resource.format_pkg_list},
@@ -756,7 +856,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         ]
         with patch.dict(zypper.__grains__, {"osarch": "x86_64"}), patch.dict(
             zypper.__salt__,
-            {"cmd.run": MagicMock(return_value=os.linesep.join(rpm_out))},
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "",
+                        "stdout": os.linesep.join(rpm_out),
+                    }
+                )
+            },
         ), patch.dict(zypper.__salt__, {"pkg_resource.add_pkg": _add_data}), patch.dict(
             zypper.__salt__,
             {"pkg_resource.format_pkg_list": pkg_resource.format_pkg_list},
@@ -798,7 +907,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         ]
         with patch.dict(
             zypper.__salt__,
-            {"cmd.run": MagicMock(return_value=os.linesep.join(rpm_out))},
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "",
+                        "stdout": os.linesep.join(rpm_out),
+                    }
+                )
+            },
         ), patch.dict(zypper.__grains__, {"osarch": "x86_64"}), patch.dict(
             zypper.__salt__, {"pkg_resource.add_pkg": _add_data}
         ), patch.dict(
@@ -917,7 +1035,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(zypper.__grains__, {"osarch": "x86_64"}), patch.dict(
             zypper.__salt__,
-            {"cmd.run": MagicMock(return_value=os.linesep.join(rpm_out))},
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 0,
+                        "retcode": 0,
+                        "stderr": "",
+                        "stdout": os.linesep.join(rpm_out),
+                    }
+                )
+            },
         ), patch.dict(zypper.__salt__, {"pkg_resource.add_pkg": _add_data}), patch.dict(
             zypper.__salt__,
             {"pkg_resource.format_pkg_list": pkg_resource.format_pkg_list},


### PR DESCRIPTION
### What does this PR do?

If `rpm` on a system returns warnings on stderr, parsing would fail

```
...
    provide, realname = line.split("_|-")
ValueError: not enough values to unpack (expected 2, got 1)
```

and render related functions unusable.

Generally, query output to process should only be expected on stdout. Hence, solve the issue and ensure functionality regardless of warnings by discarding stderr.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/69502.

### Previous Behavior

pkg states fail if rpm returns warnings.

### New Behavior

pkg states work regardless of rpm returning warnings, matching native zypper behavior.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
