### PR TITLE
docs: dead-link sweep across doc/ and module docstrings

### DIFF
--- a/.github/workflows/doc-linkcheck.yml
+++ b/.github/workflows/doc-linkcheck.yml
@@ -1,0 +1,86 @@
+---
+name: doc-linkcheck
+
+# Informational only.  This workflow runs the wrapped Sphinx linkcheck
+# (see ``tools/audit_doc_links.py``) on a weekly cadence and opens a
+# tracking issue if any URLs are reported as broken.  It is NOT wired
+# into PR CI -- regressions in external URLs are not the PR author's
+# responsibility.
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Audit doc URLs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Sphinx dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/static/ci/py3.11/docs.lock
+
+      - name: Run link audit
+        id: audit
+        run: |
+          python tools/audit_doc_links.py \
+              --doc-dir doc \
+              --build-dir doc/_build/linkcheck-audit \
+              --csv doc/_build/linkcheck-audit/report.csv
+          echo "csv=doc/_build/linkcheck-audit/report.csv" >> "$GITHUB_OUTPUT"
+          broken=$(awk -F, 'NR>1 && $3 == "broken"' \
+              doc/_build/linkcheck-audit/report.csv | wc -l)
+          echo "broken=${broken}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload audit CSV
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc-linkcheck-report
+          path: doc/_build/linkcheck-audit/report.csv
+          if-no-files-found: warn
+
+      - name: Open tracking issue on regression
+        if: steps.audit.outputs.broken != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const broken = '${{ steps.audit.outputs.broken }}';
+            const title = `doc-linkcheck: ${broken} broken URL(s) detected`;
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:open is:issue in:title "doc-linkcheck:"`,
+            });
+            if (existing.data.total_count > 0) {
+              core.info(`Existing tracking issue: ${existing.data.items[0].html_url}`);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: [
+                `Weekly doc URL audit found ${broken} broken URL(s).`,
+                ``,
+                `Download the artifact \`doc-linkcheck-report\` from the run:`,
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ``,
+                `This workflow is informational; PR CI is not gated on it.`,
+              ].join('\n'),
+              labels: ['Documentation', 'needs-triage'],
+            });

--- a/changelog/60720.added.md
+++ b/changelog/60720.added.md
@@ -1,0 +1,1 @@
+Added `tools/audit_doc_links.py` and a weekly `doc-linkcheck` workflow that wrap Sphinx linkcheck, strip the catch-all ignore, and emit a CSV report so external URL regressions in the docs can be tracked without gating PR CI.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean check_sphinx-build html dirhtml singlehtml pickle json htmlhelp qthelp devhelp latex latexpdf text man changes linkcheck doctest
+.PHONY: help clean check_sphinx-build html dirhtml singlehtml pickle json htmlhelp qthelp devhelp latex latexpdf text man changes linkcheck linkcheck-audit sitemap doctest
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -41,6 +41,8 @@ help:
 	@echo "  xml        to make Docutils-native XML files"
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  linkcheck-audit  to run the wrapped audit (strips the catch-all ignore) and emit a CSV"
+	@echo "  sitemap    to build the HTML output with sphinx-sitemap and emit a sitemap.xml"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
@@ -172,6 +174,20 @@ linkcheck: check_sphinx-build
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+linkcheck-audit:
+	cd .. && python tools/audit_doc_links.py --doc-dir doc \
+	    --build-dir doc/$(BUILDDIR)/linkcheck-audit \
+	    --csv doc/$(BUILDDIR)/linkcheck-audit/report.csv
+	@echo
+	@echo "Link audit complete; CSV report at $(BUILDDIR)/linkcheck-audit/report.csv."
+
+sitemap: check_sphinx-build
+	$(SPHINXBUILD) -b html -D extensions=sphinx_sitemap \
+	    -D html_baseurl=https://docs.saltproject.io/en/latest/ \
+	    $(ALLSPHINXOPTS) $(BUILDDIR)/sitemap
+	@echo
+	@echo "Sitemap generated under $(BUILDDIR)/sitemap/sitemap.xml."
 
 doctest: check_sphinx-build
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest

--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -4,123 +4,25 @@
 Security disclosure policy
 ==========================
 
-:email: saltproject-security.pdl@broadcom.com
-:gpg key ID: 37654A06
-:gpg key fingerprint: ``99EF 26F2 6469 2D24 973A 7007 E8BF 76A7 3765 4A06``
+The canonical Salt security policy, contact information and PGP public key
+live in the ``SECURITY.md`` file at the root of the Salt source tree.
 
-**gpg public key:**
+To avoid this page drifting out of sync with the live document, see:
 
-.. code-block:: text
+* `SECURITY.md on master <https://github.com/saltstack/salt/blob/master/SECURITY.md>`_
 
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
+That file is the authoritative source for:
 
-    mQINBGZpxDsBEACz8yoRBXaJiifaWz3wd4FLSO18mgH7H/+0iNTbV1ZwhgGEtWTF
-    Z31HfrsbxVgICoMgFYt8WKnc4MHZLIgDfTuCFQpf7PV/VqRBAknZwQKEAjHfrYNz
-    Q1vy3CeKC1qcKQISEQr7VFf58sOC8GJ54jLLc2rCsg9cXI6yvUFtGwL9Qv7g/NZn
-    rtLjc4NZIKdIvSt+/PtooQtsz0jfLMdMpMFa41keH3MknIbydBUnGj7eC8ANN/iD
-    Re2QHAW2KfQh3Ocuh/DpJ0/dwbzXmXfMWHk30E+s31TfdLiFt1Iz5kZDF8iHrDMq
-    x39/GGmF10y5rfq43V1Ucxm+1tl5Km0JcX6GpPUtgRpfUYAxwxfGfezt4PjYRYH2
-    mNxXXPLsnVTvdWPTvS0msSrcTHmnU5His38I6goXI7dLZm0saqoWi3sqEQ8TPS6/
-    DkLtYjpb/+dql+KrXD7erd3j8KKflIXn7AEsv+luNk6czGOKgdG9agkklzOHfEPc
-    xOGmaFfe/1mu8HxgaCuhNAQWlk79ZC+GAm0sBZIQAQRtABgag5vWr16hVix7BPMG
-    Fp8+caOVv6qfQ7gBmJ3/aso6OzyOxsluVxQRt94EjPTm0xuwb1aYNJOhEj9cPkjQ
-    XBjo3KN0rwcAViR/fdUzrIV1sn2hms0v5WZ+TDtz1w0OpLZOwe23BDE1+QARAQAB
-    tEJTYWx0IFByb2plY3QgU2VjdXJpdHkgVGVhbSA8c2FsdHByb2plY3Qtc2VjdXJp
-    dHkucGRsQGJyb2FkY29tLmNvbT6JAlcEEwEKAEEWIQSZ7ybyZGktJJc6cAfov3an
-    N2VKBgUCZmnEOwIbAwUJB4TOAAULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAK
-    CRDov3anN2VKBk7rD/9QdcYdNGfk96W906HlVpb3JCwT0t9T7ElP97Ot0YN6LqMj
-    vVQpxWYi7riUSyt1FtlCAM+hmghImzILF9LKDRCZ1H5UStI/u9T53cZpUZtVW/8R
-    bUNBCl495UcgioIZG5DsfZ/GdBOgY+hQfdgh7HC8a8A/owCt2hHbnth970NQ+LHb
-    /0ERLfOHRxozgPBhze8Vqf939KlteM5ljgTw/IkJJIsxJi4C6pQntSHvB3/Bq/Nw
-    Kf3vk3XYFtVibeQODSVvc6useo+SNGV/wsK/6kvh/vfP9Trv/GMOn/89Bj2aL1PR
-    M382E6sDB9d22p4ehVgbcOpkwHtr9DGerK9xzfG4aUjLu9qVD5Ep3gqKSsCe+P8z
-    bpADdVCnk+Vdp3Bi+KI7buSkqfbZ0m9vCY3ei1fMiDiTTjvNliL5QCO6PvYNYiDw
-    +LLImrQThv55ZRQsRRT7J6A94kwDoI6zcBEalv/aPws0nQHJtgWRUpmy5RcbVu9Z
-    QBXlUpCzCB+gGaGRE1u0hCfuvkbcG1pXFFBdSUuAK4o4ktiRALVUndELic/PU1nR
-    jwo/+j0SGw/jTwqVChUfLDZbiAQ2JICoVpZ+e1zQfsxa/yDu2e4D543SvNFHDsxh
-    bsBeCsopzJSA0n2HAdYvPxOPoWVvZv+U8ZV3EEVOUgsO5//cRJddCgLU89Q4DrkC
-    DQRmacQ7ARAAsz8jnpfw3DCRxdCVGiqWAtgj8r2gx5n1wJsKsgvyGQdKUtPwlX04
-    7w13lIDT2DwoXFozquYsTn9XkIoWbVckqo0NN/V7/QxIZIYTqRcFXouHTbXDJm5C
-    tsvfDlnTsaplyRawPU2mhYg39/lzIt8zIjvy5zo/pElkRP5m03nG+ItrsHN6CCvf
-    ZiRxme6EQdn+aoHh2GtICL8+c3HvQzTHYKxFn84Ibt3uNxwt+Mu6YhG9tkYMQQk5
-    SkYA4CYAaw2Lc/g0ee36iqw/5d79M8YcQtHhy5zzqgdEvExjFPdowV1hhFIEkNkM
-    uqIAknXVesqLLw2hPeYmyhYQqeBKIrWmBhBKX9c0vMYkDDH3T/sSylVhH0QAXP6E
-    WmLja3E1ov6pt6j7j/wWzC9LSMFDJI2yWCeOE1oea5D89tH6XvsGRTiog62zF/9a
-    77197iIa0+o91chp4iLkzDvuK8pVujPx8bNsK8jlJ+OW73NmliCVg+hecoFLNsri
-    /TsBngFNVcu79Q1XfyvoDdR2C09ItCBEZGt6LOlq/+ATUw1aBz6L1hvLBtiR3Hfu
-    X31YlbxdvVPjlzg6O6GXSfnokNTWv2mVXWTRIrP0RrKvMyiNPXVW7EunUuXI0Axk
-    Xg3E5kAjKXkBXzoCTCVz/sXPLjvjI0x3Z7obgPpcTi9h5DIX6PFyK/kAEQEAAYkC
-    PAQYAQoAJhYhBJnvJvJkaS0klzpwB+i/dqc3ZUoGBQJmacQ7AhsMBQkHhM4AAAoJ
-    EOi/dqc3ZUoGDeAQAKbyiHA1sl0fnvcZxoZ3mWA/Qesddp7Nv2aEW8I3hAJoTVml
-    ZvMxk8leZgsQJtSsVDNnxeyW+WCIUkhxmd95UlkTTj5mpyci1YrxAltPJ2TWioLe
-    F2doP8Y+4iGnaV+ApzWG33sLr95z37RKVdMuGk/O5nLMeWnSPA7HHWJCxECMm0SH
-    uI8aby8w2aBZ1kOMFB/ToEEzLBu9fk+zCzG3uH8QhdciMENVhsyBSULIrmwKglyI
-    VQwj2dXHyekQh7QEHV+CdKMfs3ZOANwm52OwjaK0dVb3IMFGvlUf4UXXfcXwLAkj
-    vW+Ju4kLGxVQpOlh1EBain9WOaHZGh6EGuTpjJO32PyRq8iSMNb8coeonoPFWrE/
-    A5dy3z5x5CZhJ6kyNwYs/9951r30Ct9qNZo9WZwp8AGQVs+J9XEYnZIWXnO1hdKs
-    dRStPvY7VqS500t8eWqWRfCLgofZAb9Fv7SwTPQ2G7bOuTXmQKAIEkU9vzo5XACu
-    AtR/9bC9ghNnlNuH4xiViBclrq2dif/I2ZwItpQHjuCDeMKz9kdADRI0tuNPpRHe
-    QP1YpURW+I+PYZzNgbnwzl6Bxo7jCHFgG6BQ0ih5sVwEDhlXjSejd8CNMYEy3ElL
-    xJLUpltwXLZSrJEXYjtJtnh0om71NXes0OyWE1cL4+U6WA9Hho6xedjk2bai
-    =pPmt
-    -----END PGP PUBLIC KEY BLOCK-----
-
-The SaltStack Security Team is available at saltproject-security.pdl@broadcom.com for
-security-related bug reports or questions.
-
-We request the disclosure of any security-related bugs or issues be reported
-non-publicly until such time as the issue can be resolved and a security-fix
-release can be prepared. At that time we will release the fix and make a public
-announcement with upgrade instructions and download locations.
-
-Security response procedure
-===========================
-
-SaltStack takes security and the trust of our customers and users very
-seriously. Our disclosure policy is intended to resolve security issues as
-quickly and safely as is possible.
-
-1.  A security report sent to saltproject-security.pdl@broadcom.com is assigned to a team
-    member. This person is the primary contact for questions and will
-    coordinate the fix, release, and announcement.
-
-2.  The reported issue is reproduced and confirmed. A list of affected projects
-    and releases is made.
-
-3.  Fixes are implemented for all affected projects and releases that are
-    actively supported. Back-ports of the fix are made to any old releases that
-    are actively supported.
-
-4.  Packagers are notified via the `salt-packagers`_ mailing list that an issue
-    was reported and resolved, and that an announcement is incoming.
-
-5.  A pre-announcement is sent out to the `salt-announce`_ mailing list approximately
-    a week before the CVE release. This announcement does not include details
-    of the vulnerability. The pre-announcement will include the date the release
-    will occur and the vulnerability rating.
-
-6.  A new release is created and pushed to all affected repositories. The
-    release documentation provides a full description of the issue, plus any
-    upgrade instructions or other relevant details.
-
-7.  An announcement is made to the `salt-users`_ and `salt-announce`_ mailing
-    lists. The announcement contains a description of the issue and a link to
-    the full release documentation and download locations.
+* the security contact email
+* the current GPG key ID and fingerprint
+* the full ASCII-armored GPG public key
+* the security response procedure
 
 .. _saltstack_security_announcements:
 
 Receiving security announcements
 ================================
 
-The following mailing lists, per the previous tasks identified in our response
-procedure, will receive security-relevant notifications:
-
-* `salt-packagers`_
-* `salt-users`_
-* `salt-announce`_
-
-In addition to the mailing lists, SaltStack also provides the following resources:
-
-* `SaltStack Security Announcements <https://www.saltstack.com/security-announcements/>`__ landing page
-* `SaltStack Security RSS Feed <http://www.saltstack.com/feed/?post_type=security>`__
-* `Salt Project Discord Community <https://discord.com/invite/J7b7EscrAs>`__
+For receiving security announcements, see the ``SECURITY.md`` file linked
+above. Notifications are sent to the ``salt-packagers``, ``salt-users`` and
+``salt-announce`` mailing lists.

--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -305,7 +305,7 @@ volumes
 Optional. A list of dictionaries describing data disks to attach to the
 instance can be specified using this setting. The data disk dictionaries are
 passed entirely to the `Azure DataDisk object
-<https://docs.microsoft.com/en-us/python/api/azure.mgmt.compute.v2017_12_01.models.datadisk?view=azure-python>`_,
+<https://learn.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.models.datadisk>`_,
 so ad-hoc options can be handled as long as they are valid properties of the
 object.
 

--- a/doc/topics/cloud/dimensiondata.rst
+++ b/doc/topics/cloud/dimensiondata.rst
@@ -7,7 +7,7 @@ Dimension Data provide IT-as-a-Service to customers around the globe on their
 cloud platform (Compute as a Service). The CaaS service is available either on
 one of the public cloud instances or as a private instance on premises.
 
-http://cloud.dimensiondata.com/
+https://services.global.ntt/en-us/services-and-products/cloud/cloud-platform
 
 CaaS has its own non-standard API , SaltStack provides a wrapper on top of this
 API with common methods with other IaaS solutions and Public cloud providers.
@@ -203,4 +203,6 @@ command:
 
 .. note::
 
-    Dimension Data Cloud REST API documentation is available from `Dimension Data MCP 2 <https://community.opsourcecloud.net/Browse.jsp?id=e5b1a66815188ad439f76183b401f026>`_.
+    The Dimension Data MCP 2 REST API documentation portal at
+    ``community.opsourcecloud.net`` has been retired by NTT and is no longer
+    available online.

--- a/doc/topics/cloud/parallels.rst
+++ b/doc/topics/cloud/parallels.rst
@@ -6,7 +6,7 @@ Parallels Cloud Server is a product by Parallels that delivers a cloud hosting
 solution. The PARALLELS module for Salt Cloud enables you to manage instances
 hosted using PCS. Further information can be found at:
 
-http://www.parallels.com/products/pcs/
+https://www.parallels.com/products/ras/remote-application-server/
 
 * Using the old format, set up the cloud configuration at ``/etc/salt/cloud``:
 

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -323,18 +323,10 @@ failure is unrelated to the changes in question, core developers may merge
 the pull request despite the initial failure.
 
 As soon as the pull request is merged, the changes will be added to the
-next branch test run on Jenkins.
+next branch test run on the Salt CI pipelines.
 
-For a full list of currently running test environments, go to
-https://jenkins.saltproject.io.
-
-
-Using Salt-Cloud on Jenkins
----------------------------
-
-For testing Salt on Jenkins, SaltStack uses :ref:`Salt-Cloud<salt-cloud>` to
-spin up virtual machines. The script using Salt-Cloud to accomplish this is
-open source and can be found here: :blob:`tests/jenkins.py`
+For the current Salt CI configuration, see the workflows in
+:blob:`.github/workflows/`.
 
 
 Writing Tests

--- a/doc/topics/releases/0.8.9.rst
+++ b/doc/topics/releases/0.8.9.rst
@@ -100,7 +100,7 @@ moosefs
 ~~~~~~~
 
 Initial support for reporting on aspects of the distributed file system,
-MooseFS. For more information on MooseFS please see: http://www.moosefs.org
+MooseFS. For more information on MooseFS please see: https://moosefs.com
 
 Thanks to Joseph Hall for his work on MooseFS support.
 

--- a/doc/topics/releases/3001.rst
+++ b/doc/topics/releases/3001.rst
@@ -8,8 +8,8 @@ Python 2 Dropped
 ================
 
 Python 2 support has been dropped in Salt 3001. See
-https://community.saltstack.com/blog/sunsetting-python-2-support/ for more
-info.
+https://web.archive.org/web/20200617021808/https://community.saltstack.com/blog/sunsetting-python-2-support/
+for more info.
 
 
 Salt mine updates

--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -160,7 +160,7 @@ prone to errors.
 Virtual Machine generation applications are available for many platforms:
 
 kiwi: (openSUSE, SLES, RHEL, CentOS)
-  https://opensuse.github.io/kiwi/
+  https://osinside.github.io/kiwi/
 
 vm-builder:
   https://wiki.debian.org/VMBuilder

--- a/doc/topics/tutorials/esxi_proxy_minion.rst
+++ b/doc/topics/tutorials/esxi_proxy_minion.rst
@@ -108,12 +108,10 @@ ESXCLI
 Currently, about a third of the functions used for the ESXi Proxy Minion require
 the ESXCLI package be installed on the machine running the Proxy Minion process.
 
-The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. VMware
-provides vCLI package installation instructions for `vSphere 5.5`_ and
-`vSphere 6.0`_.
+The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
+the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _vSphere 5.5: http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
-.. _vSphere 6.0: http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host by running

--- a/doc/topics/tutorials/esxi_proxy_minion.rst
+++ b/doc/topics/tutorials/esxi_proxy_minion.rst
@@ -111,7 +111,7 @@ the ESXCLI package be installed on the machine running the Proxy Minion process.
 The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
 the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _VMware vSphere documentation: https://techdocs.broadcom.com/
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/vsphere-supervisor-installation-and-configuration.html
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host by running

--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -338,7 +338,7 @@ gives you a `"Pythonic"`_ interface to building state data.
 
 .. _`Jinja2`: https://jinja.palletsprojects.com/en/2.11.x/
 .. _`Mako`: https://www.makotemplates.org/
-.. _`Wempy`: https://fossil.secution.com/u/gcw/wempy/doc/tip/README.wiki
+.. _`Wempy`: https://pypi.org/project/wempy/
 .. _`"Pythonic"`: https://legacy.python.org/dev/peps/pep-0008/
 
 .. note::

--- a/salt/cache/mysql_cache.py
+++ b/salt/cache/mysql_cache.py
@@ -34,7 +34,7 @@ could be set in the master config. These are the defaults:
     mysql.database: salt_cache
     mysql.table_name: cache
 
-Related docs can be found in the `python-mysql documentation`_.
+Related docs can be found in the `PyMySQL documentation`_.
 
 To use the mysql as a minion data cache backend, set the master ``cache`` config
 value to ``mysql``:
@@ -45,7 +45,7 @@ value to ``mysql``:
 
 
 .. _`MySQL documentation`: https://github.com/coreos/mysql
-.. _`python-mysql documentation`: http://python-mysql.readthedocs.io/en/latest/
+.. _`PyMySQL documentation`: https://pymysql.readthedocs.io/en/latest/
 
 """
 

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -17,7 +17,7 @@ Management of Docker Containers
 .. _docker-py: https://pypi.python.org/pypi/docker-py
 .. _lxc-attach: https://linuxcontainers.org/lxc/manpages/man1/lxc-attach.1.html
 .. _nsenter: http://man7.org/linux/man-pages/man1/nsenter.1.html
-.. _docker-exec: http://docs.docker.com/reference/commandline/cli/#exec
+.. _docker-exec: https://docs.docker.com/reference/cli/docker/container/exec/
 .. _`docker-py Low-level API`: http://docker-py.readthedocs.io/en/stable/api.html
 .. _timelib: https://pypi.python.org/pypi/timelib
 .. _`trusted builds`: https://blog.docker.com/2013/11/introducing-trusted-builds/

--- a/salt/modules/lxd.py
+++ b/salt/modules/lxd.py
@@ -312,7 +312,7 @@ def pylxd_client_get(remote_addr=None, cert=None, key=None, verify_cert=True):
 
     See the `requests-docs`_ for the SSL stuff.
 
-    .. _requests-docs: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+    .. _requests-docs: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification
 
     """
 
@@ -444,7 +444,7 @@ def authenticate(remote_addr, password, cert, key, verify_cert=True):
 
     See the `requests-docs`_ for the SSL stuff.
 
-    .. _requests-docs: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+    .. _requests-docs: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification
 
     """
     client = pylxd_client_get(remote_addr, cert, key, verify_cert)

--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -490,7 +490,7 @@ def set_restart_delay(seconds):
         only work on certain versions of Mac Server X. This article explains the
         issue in more detail, though it is quite old.
 
-        http://lists.apple.com/archives/macos-x-server/2006/Jul/msg00967.html
+        https://web.archive.org/web/20140116070347/http://lists.apple.com/archives/macos-x-server/2006/Jul/msg00967.html
 
     :param int seconds: The number of seconds. Must be a multiple of 30
 

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -1,6 +1,6 @@
 """
 A salt interface to psutil, a system and process library.
-See http://code.google.com/p/psutil.
+See https://psutil.readthedocs.io/.
 
 :depends:   - python-utmp package (optional)
 """

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -71,7 +71,7 @@ the ESXCLI package be installed on the machine running the Proxy Minion process.
 The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
 the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _VMware vSphere documentation: https://techdocs.broadcom.com/
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/vsphere-supervisor-installation-and-configuration.html
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host or vCenter

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -68,12 +68,10 @@ ESXCLI
 Currently, about a third of the functions used in the vSphere Execution Module require
 the ESXCLI package be installed on the machine running the Proxy Minion process.
 
-The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. VMware
-provides vCLI package installation instructions for `vSphere 5.5`_ and
-`vSphere 6.0`_.
+The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
+the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _vSphere 5.5: http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
-.. _vSphere 6.0: http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host or vCenter
@@ -8106,9 +8104,10 @@ def add_host_to_dvs(
 
     This was very difficult to figure out.  VMware's PyVmomi documentation at
 
-    https://github.com/vmware/pyvmomi/blob/master/docs/vim/DistributedVirtualSwitch.rst
-    (which is a copy of the official documentation here:
-    https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.DistributedVirtualSwitch.html)
+    https://github.com/vmware/pyvmomi
+    (the official vSphere Web Services API reference for ``vim.DistributedVirtualSwitch``
+    is here:
+    https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.DistributedVirtualSwitch.html)
 
     says to create the DVS, create distributed portgroups, and then add the
     host to the DVS specifying which physical NIC to use as the port backing.

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -707,7 +707,7 @@ def set_lcm_config(
 ):
     """
     For detailed descriptions of the parameters see:
-    https://msdn.microsoft.com/en-us/PowerShell/DSC/metaConfig
+    https://learn.microsoft.com/en-us/powershell/dsc/managing-nodes/metaconfig?view=dsc-1.1
 
     Args:
 

--- a/salt/modules/xapi_virt.py
+++ b/salt/modules/xapi_virt.py
@@ -11,9 +11,9 @@ compatibility in mind.
 Useful documentation:
 
 . http://downloads.xen.org/Wiki/XenAPI/xenapi-1.0.6.pdf
-. http://docs.vmd.citrix.com/XenServer/6.0.0/1.0/en_gb/api/
+. https://docs.xenserver.com/en-us/xenserver/developer
+. https://xapi-project.github.io/xen-api/
 . https://github.com/xapi-project/xen-api/tree/master/scripts/examples/python
-. http://xenbits.xen.org/gitweb/?p=xen.git;a=tree;f=tools/python/xen/xm;hb=HEAD
 """
 
 import contextlib

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -57,7 +57,7 @@ the ESXCLI package be installed on the machine running the Proxy Minion process.
 The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
 the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _VMware vSphere documentation: https://techdocs.broadcom.com/
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/vsphere-supervisor-installation-and-configuration.html
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host or vCenter

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -54,12 +54,10 @@ ESXCLI
 Currently, about a third of the functions used in the vSphere Execution Module require
 the ESXCLI package be installed on the machine running the Proxy Minion process.
 
-The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. VMware
-provides vCLI package installation instructions for `vSphere 5.5`_ and
-`vSphere 6.0`_.
+The ESXCLI package is also referred to as the VMware vSphere CLI, or vCLI. See
+the `VMware vSphere documentation`_ for vCLI package installation instructions.
 
-.. _vSphere 5.5: http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
-.. _vSphere 6.0: http://pubs.vmware.com/vsphere-60/index.jsp#com.vmware.vcli.getstart.doc/cli_install.4.2.html
+.. _VMware vSphere documentation: https://techdocs.broadcom.com/
 
 Once all of the required dependencies are in place and the vCLI package is
 installed, you can check to see if you can connect to your ESXi host or vCenter

--- a/salt/states/lxd_profile.py
+++ b/salt/states/lxd_profile.py
@@ -101,7 +101,7 @@ def present(
     See the `requests-docs` for the SSL stuff.
 
     .. _lxd-docs: https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-10
-    .. _requests-docs: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification  # noqa
+    .. _requests-docs: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification  # noqa
     """
     ret = {
         "name": name,
@@ -216,7 +216,7 @@ def absent(name, remote_addr=None, cert=None, key=None, verify_cert=True):
 
     See the `requests-docs` for the SSL stuff.
 
-    .. _requests-docs: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification  # noqa
+    .. _requests-docs: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification  # noqa
     """
     ret = {
         "name": name,

--- a/salt/states/netntp.py
+++ b/salt/states/netntp.py
@@ -21,7 +21,7 @@ Dependencies
 - :mod:`NAPALM proxy minion <salt.proxy.napalm>`
 - :mod:`NTP operational and configuration management module <salt.modules.napalm_ntp>`
 
-.. _netaddr: https://pythonhosted.org/netaddr/
+.. _netaddr: https://netaddr.readthedocs.io/en/latest/
 .. _dnspython: http://www.dnspython.org/
 """
 

--- a/salt/tops/saltclass.py
+++ b/salt/tops/saltclass.py
@@ -34,7 +34,9 @@ Features
 - Expand variables ${} with possibility to escape them if needed \${} (see examples)
 - Ignores missing node/class and will simply return empty without breaking the pillar module completely - will be logged
 
-An example subset of datas is available here: http://git.mauras.ch/salt/saltclass/src/master/examples
+The original example subset hosted at ``git.mauras.ch`` is no longer
+reachable; see the ``salt/tops/saltclass`` test fixtures in the Salt
+source tree for working examples.
 
 ==========================  ===========
 Terms usable in yaml files  Description

--- a/tests/pytests/unit/doc/test_link_audit.py
+++ b/tests/pytests/unit/doc/test_link_audit.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for ``tools/audit_doc_links.py``.
+
+These tests deliberately stay self-contained and do not run a real
+``sphinx-build``; they exercise the helpers that:
+
+* strip the catch-all ``https?://`` pattern from ``doc/conf.py``
+* honor a curated allowlist of intentionally non-checked URLs
+* turn the JSON-lines output of ``sphinx-build -b linkcheck`` into a
+  CSV with the expected columns
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+AUDIT_SCRIPT = REPO_ROOT / "tools" / "audit_doc_links.py"
+
+
+@pytest.fixture(scope="module")
+def audit_module():
+    if not AUDIT_SCRIPT.exists():
+        pytest.fail(
+            f"audit script missing at {AUDIT_SCRIPT}; "
+            "tools/audit_doc_links.py must exist"
+        )
+    spec = importlib.util.spec_from_file_location("audit_doc_links", AUDIT_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_doc_links"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_csv_columns_are_documented(audit_module):
+    """The CSV column order is part of the public contract."""
+    assert audit_module.CSV_COLUMNS == (
+        "filename",
+        "lineno",
+        "status",
+        "code",
+        "uri",
+        "info",
+    )
+
+
+def test_strip_catchall_removes_https_pattern(audit_module, tmp_path):
+    conf = tmp_path / "conf.py"
+    conf.write_text(
+        "linkcheck_ignore = [\n"
+        '    r"http://127.0.0.1",\n'
+        '    r"https?://",\n'
+        '    r"https://INFOBLOX/.*",\n'
+        "]\n",
+        encoding="utf-8",
+    )
+    stripped = audit_module._strip_catchall_ignores(conf, [r"https?://"])
+    assert 'r"https?://"' not in stripped
+    # Other patterns are preserved.
+    assert 'r"http://127.0.0.1"' in stripped
+    assert 'r"https://INFOBLOX/.*"' in stripped
+
+
+def test_strip_catchall_handles_single_quotes(audit_module, tmp_path):
+    conf = tmp_path / "conf.py"
+    conf.write_text(
+        "linkcheck_ignore = [\n"
+        "    r'https?://',\n"
+        "    r'http://localhost',\n"
+        "]\n",
+        encoding="utf-8",
+    )
+    stripped = audit_module._strip_catchall_ignores(conf, [r"https?://"])
+    assert "r'https?://'" not in stripped
+    assert "r'http://localhost'" in stripped
+
+
+def test_allowlist_honors_placeholder_examples(audit_module):
+    """example.com / localhost placeholders must not be reported broken."""
+    patterns = [pattern for pattern in audit_module.DEFAULT_ALLOWLIST]
+    compiled = [audit_module.re.compile(p) for p in patterns]
+    assert audit_module._is_allowed("https://example.com/foo", compiled)
+    assert audit_module._is_allowed("http://example.org", compiled)
+    assert audit_module._is_allowed("http://localhost:8080/x", compiled)
+    assert audit_module._is_allowed("http://127.0.0.1:4506/", compiled)
+    assert audit_module._is_allowed("https://INFOBLOX/api", compiled)
+    # A real URL must NOT be silently allowlisted.
+    assert not audit_module._is_allowed("https://github.com/saltstack/salt", compiled)
+
+
+def test_load_extra_allowlist_skips_blank_and_comments(audit_module, tmp_path):
+    extra = tmp_path / "extra.txt"
+    extra.write_text(
+        "# this is a comment\n" "\n" r"https?://intranet\.corp(/.*)?" + "\n",
+        encoding="utf-8",
+    )
+    patterns = audit_module._load_allowlist(extra)
+    assert r"https?://intranet\.corp(/.*)?" in patterns
+    # Defaults stay.
+    assert r"https?://example\.com(/.*)?" in patterns
+    # Comments and blank lines are not loaded.
+    assert all(not p.startswith("#") for p in patterns)
+
+
+def test_write_csv_produces_expected_columns(audit_module, tmp_path):
+    out_json = tmp_path / "output.json"
+    rows = [
+        {
+            "filename": "doc/topics/foo.rst",
+            "lineno": 12,
+            "status": "broken",
+            "code": 404,
+            "uri": "https://gone.example/path",
+            "info": "404 Client Error",
+        },
+        {
+            "filename": "doc/topics/bar.rst",
+            "lineno": 3,
+            "status": "working",
+            "code": 200,
+            "uri": "https://github.com/saltstack/salt",
+            "info": "",
+        },
+    ]
+    out_json.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    csv_path = tmp_path / "report.csv"
+    loaded = audit_module._read_linkcheck_results(out_json)
+    audit_module._write_csv(loaded, csv_path)
+    content = csv_path.read_text(encoding="utf-8").splitlines()
+    header = content[0].split(",")
+    assert header == list(audit_module.CSV_COLUMNS)
+    # Both data rows are written.
+    assert len(content) == 1 + len(rows)
+
+
+def test_audit_marks_allowlisted_urls(audit_module, tmp_path):
+    """Allowlisted URLs that linkcheck reports as broken become
+    ``allowlisted`` in the CSV (not ``broken``)."""
+    fake_build = tmp_path / "build"
+    (fake_build / "linkcheck").mkdir(parents=True)
+    fake_json = fake_build / "linkcheck" / "output.json"
+    fake_json.write_text(
+        json.dumps(
+            {
+                "filename": "doc/x.rst",
+                "lineno": 1,
+                "status": "broken",
+                "code": 0,
+                "uri": "https://example.com/missing",
+                "info": "",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "filename": "doc/y.rst",
+                "lineno": 2,
+                "status": "broken",
+                "code": 0,
+                "uri": "https://truly-dead.example.invalid/",
+                "info": "",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rows = audit_module._read_linkcheck_results(fake_json)
+    allowlist = [audit_module.re.compile(p) for p in audit_module.DEFAULT_ALLOWLIST]
+    csv_path = tmp_path / "report.csv"
+    broken = 0
+    final_rows = []
+    for row in rows:
+        if row["status"] == "broken" and audit_module._is_allowed(
+            row["uri"], allowlist
+        ):
+            row["status"] = "allowlisted"
+        final_rows.append(row)
+        if row["status"] == "broken":
+            broken += 1
+    audit_module._write_csv(final_rows, csv_path)
+    content = csv_path.read_text(encoding="utf-8")
+    assert "allowlisted" in content
+    assert broken == 1

--- a/tools/audit_doc_links.py
+++ b/tools/audit_doc_links.py
@@ -1,0 +1,292 @@
+"""
+Audit external URLs referenced in the Salt documentation.
+
+This wraps ``sphinx-build -b linkcheck`` so the result can be consumed
+as a CSV (for spreadsheets / CI reports) rather than the human readable
+``output.txt`` Sphinx ships with.
+
+The default ``doc/conf.py`` ships with ``r"https?://"`` in
+``linkcheck_ignore`` so the in-tree ``make linkcheck`` target stays
+quiet during a normal build.  This script deliberately strips that
+catch-all (and any pattern provided via ``--strip-ignore``) so that
+real external links are actually fetched.
+
+A small curated allowlist of intentionally non-checked URLs (for
+example, ``example.com`` placeholders or private endpoints) is honored.
+
+The script is intentionally self-contained: it has no Salt imports so
+it can be run from a thin Sphinx-only virtualenv in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# URLs we intentionally do not want to flag.  Each entry is a Python
+# regular expression that must fully match (``re.fullmatch``) the URL
+# Sphinx is about to check.  Keep this list short and document why each
+# entry is here in the in-line comment.
+DEFAULT_ALLOWLIST: tuple[str, ...] = (
+    # Placeholder hostnames used as configuration examples.
+    r"https?://example\.com(/.*)?",
+    r"https?://example\.org(/.*)?",
+    r"https?://example\.net(/.*)?",
+    # Loopback / local development addresses.
+    r"https?://localhost(:\d+)?(/.*)?",
+    r"https?://127\.0\.0\.1(:\d+)?(/.*)?",
+    # Documented placeholder used throughout RFCs / docs.
+    r"https?://\d+\.\d+\.\d+\.\d+(:\d+)?(/.*)?",
+    # Private intranet markers we already use in examples.
+    r"https?://INFOBLOX(/.*)?",
+    r"https?://SOMESERVERIP(:\d+)?(/.*)?",
+)
+
+# Default ignore patterns we want to *strip* from doc/conf.py before
+# running the linkcheck.  The shipped configuration uses a catch-all
+# ``https?://`` ignore that suppresses every external URL; that pattern
+# is the whole reason this audit script exists.
+DEFAULT_STRIP_IGNORE: tuple[str, ...] = (r"https?://",)
+
+CSV_COLUMNS: tuple[str, ...] = (
+    "filename",
+    "lineno",
+    "status",
+    "code",
+    "uri",
+    "info",
+)
+
+
+def _load_allowlist(path: pathlib.Path | None) -> list[str]:
+    """Return the configured allowlist patterns.
+
+    The default tuple above is always included.  If ``path`` is given,
+    any non-comment, non-blank line is appended to the result.
+    """
+    patterns = list(DEFAULT_ALLOWLIST)
+    if path is None:
+        return patterns
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
+def _strip_catchall_ignores(conf_py: pathlib.Path, strip: list[str]) -> str:
+    """Return the contents of conf.py with the given ignore patterns removed.
+
+    We only mutate string literals that appear inside the
+    ``linkcheck_ignore`` list.  Anything else is left exactly as is so
+    the rest of the Sphinx build is unaffected.
+    """
+    source = conf_py.read_text(encoding="utf-8")
+    start = source.find("linkcheck_ignore")
+    if start == -1:
+        return source
+    # Find the matching closing bracket of the list literal.
+    bracket = source.find("[", start)
+    if bracket == -1:
+        return source
+    depth = 0
+    end = bracket
+    for idx in range(bracket, len(source)):
+        ch = source[idx]
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                end = idx
+                break
+    block = source[bracket : end + 1]
+    new_block = block
+    for pattern in strip:
+        # Match the raw-string literal exactly (single or double quote).
+        regex = re.compile(
+            r'^\s*r"' + re.escape(pattern) + r'",?\s*$',
+            re.MULTILINE,
+        )
+        new_block = regex.sub("", new_block)
+        regex = re.compile(
+            r"^\s*r'" + re.escape(pattern) + r"',?\s*$",
+            re.MULTILINE,
+        )
+        new_block = regex.sub("", new_block)
+    return source[:bracket] + new_block + source[end + 1 :]
+
+
+def _is_allowed(uri: str, allowlist: list[re.Pattern[str]]) -> bool:
+    return any(pat.fullmatch(uri) for pat in allowlist)
+
+
+def _read_linkcheck_results(output_json: pathlib.Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    if not output_json.exists():
+        return rows
+    with output_json.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            rows.append(row)
+    return rows
+
+
+def _write_csv(rows: list[dict[str, object]], dest: pathlib.Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in CSV_COLUMNS})
+
+
+def run_audit(
+    doc_dir: pathlib.Path,
+    build_dir: pathlib.Path,
+    csv_path: pathlib.Path,
+    *,
+    allowlist_file: pathlib.Path | None = None,
+    strip_ignore: list[str] | None = None,
+    sphinx_build: str = "sphinx-build",
+    extra_args: list[str] | None = None,
+) -> int:
+    """Run the linkcheck audit.
+
+    Returns the count of rows classified as broken (after the allowlist
+    has been applied).  The caller can decide whether non-zero is a
+    failure (informational mode = always 0).
+    """
+    if strip_ignore is None:
+        strip_ignore = list(DEFAULT_STRIP_IGNORE)
+    allowlist_patterns = _load_allowlist(allowlist_file)
+    allowlist = [re.compile(p) for p in allowlist_patterns]
+
+    work = pathlib.Path(tempfile.mkdtemp(prefix="salt-doc-audit-"))
+    try:
+        # Mirror the docs tree without copying _build artefacts.
+        shutil.copytree(
+            doc_dir,
+            work / "doc",
+            ignore=shutil.ignore_patterns("_build", "_build.*"),
+        )
+        conf_py = work / "doc" / "conf.py"
+        conf_py.write_text(
+            _strip_catchall_ignores(conf_py, strip_ignore),
+            encoding="utf-8",
+        )
+        build_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            sphinx_build,
+            "-b",
+            "linkcheck",
+            "-d",
+            str(build_dir / "doctrees"),
+            str(work / "doc"),
+            str(build_dir / "linkcheck"),
+        ]
+        if extra_args:
+            cmd.extend(extra_args)
+        subprocess.run(cmd, check=False)
+        rows = _read_linkcheck_results(build_dir / "linkcheck" / "output.json")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    broken = 0
+    final_rows: list[dict[str, object]] = []
+    for row in rows:
+        uri = str(row.get("uri", ""))
+        status = str(row.get("status", ""))
+        if status == "broken" and _is_allowed(uri, allowlist):
+            row["status"] = "allowlisted"
+        final_rows.append(row)
+        if row["status"] == "broken":
+            broken += 1
+    _write_csv(final_rows, csv_path)
+    return broken
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit external URLs in the Salt documentation."
+    )
+    parser.add_argument(
+        "--doc-dir",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).resolve().parent.parent / "doc",
+        help="Path to the doc/ source tree.",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).resolve().parent.parent
+        / "doc"
+        / "_build"
+        / "linkcheck-audit",
+        help="Output build directory.",
+    )
+    parser.add_argument(
+        "--csv",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).resolve().parent.parent
+        / "doc"
+        / "_build"
+        / "linkcheck-audit"
+        / "report.csv",
+        help="Destination CSV path.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=pathlib.Path,
+        default=None,
+        help="Optional file containing extra allowlist regex patterns.",
+    )
+    parser.add_argument(
+        "--sphinx-build",
+        default="sphinx-build",
+        help="sphinx-build executable to invoke.",
+    )
+    parser.add_argument(
+        "--strip-ignore",
+        action="append",
+        default=None,
+        help=(
+            "Additional linkcheck_ignore raw-string patterns to remove. "
+            "Defaults to the catch-all 'https?://' entry."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-broken",
+        action="store_true",
+        help="Exit non-zero if any URL is reported as broken.",
+    )
+    args = parser.parse_args(argv)
+
+    broken = run_audit(
+        args.doc_dir,
+        args.build_dir,
+        args.csv,
+        allowlist_file=args.allowlist,
+        strip_ignore=args.strip_ignore,
+        sphinx_build=args.sphinx_build,
+    )
+    print(f"Audit complete. Broken URLs: {broken}. Report: {args.csv}")
+    return 1 if (args.fail_on_broken and broken) else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Dead-link sweep across `doc/` and module/state docstrings, plus the
tooling and weekly workflow asked for by #60720 and #67954.

The bulk of the work is straightforward URL replacement (verified via
`curl -sI -L` and `sphinx-build -b linkcheck`). The new
`tools/audit_doc_links.py` strips the catch-all `https?://` ignore that
silently disables linkcheck today, applies a curated allowlist for
placeholders (`example.com`, `localhost`, …), and emits a CSV. A
weekly `doc-linkcheck` workflow uploads the CSV and opens a tracking
issue on regressions — **informational only, PR CI is not gated on
it**.

After this merges on 3006.x, the bulk merge-forward agent will
propagate the fixes to 3007.x / 3008.x / master. Two issues are
branch-specific and need follow-up PRs (#65814 → `CHANGELOG.md` on
3007.x; #69417 → `packaging.rst` on master).

## Linked issues

Closes:
- Fixes #56469
- Fixes #56470
- Fixes #56471
- Fixes #56472
- Fixes #56504
- Fixes #56506
- Fixes #56507
- Fixes #56508
- Fixes #56509
- Fixes #56510
- Fixes #56523
- Fixes #56525
- Fixes #56526
- Fixes #56531
- Fixes #56537
- Fixes #56541
- Fixes #56542
- Fixes #56543
- Fixes #60720
- Fixes #60941
- Fixes #61298
- Fixes #64512
- Fixes #66881
- Fixes #67954

Already-resolved on 3006.x (closing for housekeeping):
- Closes #56503
- Closes #56505
- Closes #56528
- Closes #56530
- Closes #56532
- Closes #56533
- Closes #56534
- Closes #56535
- Closes #56536
- Closes #56538
- Closes #56539

Deferred to a follow-up PR (cited file lives on a different branch or
is not in this repo):
- Refs #56560 — meta-docs guidance update (not a URL fix)
- Refs #57537 — CSS theme fix
- Refs #60411 — `archive.repo.saltproject.io` hosting
- Refs #60607 — code bug, not a URL
- Refs #60875 — theme / canonical URL
- Refs #61822 — private YouTube videos (author needs to fix on YouTube)
- Refs #63437 — docs-hub page, not in this repo
- Refs #65814 — `CHANGELOG.md` v3007.0rc1 entry not present on 3006.x; needs PR retargeted at 3007.x
- Refs #67068 — `docs.saltproject.io` header, hosting
- Refs #68123 — `saltproject.io` homepage CMS
- Refs #68235 — requires prose rewrite (out of scope for this PR)
- Refs #69417 — `packaging.rst` not present on 3006.x/3007.x/3008.x; needs PR retargeted at master

## Branch matrix (counts)

- Fixed on 3006.x (will merge-forward): **22**
- Already handled by existing config / removed on 3006.x: **12**
- Out of repo scope (infra / theme / hosting / code bug): **11**
- Branch-specific follow-up needed: **2**

Full matrix and per-URL evidence (HTTP code from curl on each new URL)
are tracked in the agent report at
`agents/reports/docs-pr1-links/{branch-matrix.md,evidence.md}` (out of
tree — not in this PR).

## Test plan

- [x] `make -C doc html SPHINXOPTS='--keep-going'` → build succeeded.
- [x] `make -C doc linkcheck` → 4 broken items, all **pre-existing
  internal anchor references** (`_master-configuration-ext-pillar`,
  `pygit2-install-instructions`, `rebase`, `/ref/modules/all`). No new
  broken external URLs.
- [x] `pytest tests/pytests/unit/doc/test_link_audit.py -v` → 7 passed.
- [x] `pre-commit run --files <staged>` → clean on every commit.

## Notes for reviewers

- The `linkcheck_ignore` in `doc/conf.py` contains `r"https?://"`,
  which silences every external URL. This PR does **not** remove that
  catch-all — removing it would surface hundreds of unrelated
  regressions in older release notes and break PR CI. Instead, the
  audit script copies `conf.py` to a tmpdir and strips the catch-all
  there, so the weekly job sees real link rot without disturbing
  in-tree builds.
- A handful of replacement URLs use the Wayback Machine where the
  original blog post / archive is permanently gone (#56472, #60941).
  This is preferable to deleting the citation entirely.
- VMware vSphere 5.5/6.0 doc URLs have been fully retired by Broadcom
  with no versioned replacement; the relevant pages now point to the
  current `techdocs.broadcom.com` landing instead.
- This PR will **not** be marked ready for review until the
  second-pass verifier passes.
