### PR TITLE
Fix load_yaml AttributeError under the libyaml loader

### DIFF
--- a/changelog/69533.fixed.md
+++ b/changelog/69533.fixed.md
@@ -1,0 +1,1 @@
+Fixed `SerializerExtension.load_yaml` raising `AttributeError` instead of a `TemplateRuntimeError` when YAML parsing fails under PyYAML's libyaml (C) loader, which leaves `problem_mark.buffer` unset.

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -1186,10 +1186,17 @@ class SerializerExtension(Extension):
                 # to the stringified version of the exception.
                 msg += str(exc)
             else:
-                msg += f"{problem}\n"
-                msg += salt.utils.stringutils.get_context(
-                    buf, line, marker="    <======================"
-                )
+                if buf is None:
+                    # The libyaml (C) loader populates problem_mark but leaves
+                    # its buffer unset, so there is no source text to render
+                    # context from; fall back to the stringified exception
+                    # rather than crash in get_context.
+                    msg += str(exc)
+                else:
+                    msg += f"{problem}\n"
+                    msg += salt.utils.stringutils.get_context(
+                        buf, line, marker="    <======================"
+                    )
             raise TemplateRuntimeError(msg)
         except AttributeError:
             raise TemplateRuntimeError(f"Unable to load yaml from {value}")

--- a/tests/pytests/unit/utils/jinja/test_custom_extensions.py
+++ b/tests/pytests/unit/utils/jinja/test_custom_extensions.py
@@ -25,6 +25,7 @@ from salt.exceptions import SaltRenderError
 from salt.utils.decorators.jinja import JinjaFilter
 from salt.utils.jinja import SerializerExtension, ensure_sequence_filter
 from salt.utils.templates import render_jinja_tmpl
+from tests.support.mock import patch
 
 try:
     import timelib  # pylint: disable=W0611
@@ -1295,3 +1296,21 @@ def test_ifelse(minion_opts, local_salt):
         dict(opts=minion_opts, saltenv="test", salt=local_salt),
     )
     assert rendered == ("default\n" "fooval\n" "barval\n" "barval\n" "default")
+
+
+def test_load_yaml_handles_marked_error_without_buffer():
+    """A YAML error whose problem_mark has no buffer (as produced by the
+    libyaml C loader) must raise a clean TemplateRuntimeError, not crash."""
+    env = Environment(extensions=[SerializerExtension])
+
+    class _Mark:
+        line = 0
+        buffer = None
+
+    err = salt.utils.yaml.YAMLError()
+    err.problem = "found unexpected end of stream"
+    err.problem_mark = _Mark()
+
+    with patch("salt.utils.yaml.safe_load", side_effect=err):
+        with pytest.raises(exceptions.TemplateRuntimeError):
+            env.from_string("{{ 'x' | load_yaml }}").render()


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in `SerializerExtension.load_yaml`. Under PyYAML's libyaml (C) loader a YAML error's `problem_mark.buffer` is `None`, which `load_yaml` passed into `salt.utils.stringutils.get_context()`, raising `AttributeError: 'NoneType' object has no attribute 'splitlines'` instead of the intended `TemplateRuntimeError`. It now falls back to the stringified exception when the buffer is missing.

### What issues does this PR fix or reference?

Fixes #69533

### Previous Behavior

Malformed YAML loaded via the `load_yaml` filter or the `{% load_yaml %}` / `{% import_yaml %}` tags crashed with an unhandled `AttributeError` when libyaml was active (the default in most packages).

### New Behavior

`load_yaml` raises a clean `TemplateRuntimeError` regardless of which YAML loader is active. Adds a regression test.

### Merge requirements satisfied?

- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

No
