### PR TITLE
Fix silent-mode installer hang on exit via TerminateProcess

### DIFF
--- a/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
@@ -1172,7 +1172,8 @@ Function .onInstSuccess
     # This eliminates the cross-thread deadlock that the old Exec approach
     # caused: since no background process is left alive, the NSIS exec thread
     # returns cleanly from this function without interfering with the message
-    # loop.  ExitProcess below remains as belt-and-suspenders for silent mode.
+    # loop.  The TerminateProcess call below remains as belt-and-suspenders for
+    # silent mode.
     ${If} $StartMinion == 1
         ${LogMsg} "Starting the salt-minion service"
         SimpleSC::StartService "salt-minion" "" 30
@@ -1186,15 +1187,21 @@ Function .onInstSuccess
 
     ${LogMsg} "Salt installation complete"
 
-    # In silent mode, exit immediately via ExitProcess rather than letting
-    # NSIS advance to the finish page.  The finish page exists only for
-    # interactive checkbox state (StartMinion / StartMinionDelayed), which is
-    # already set from command-line parsing and does not need to be re-read
-    # from UI controls.  ExitProcess bypasses the NSIS message loop entirely,
-    # avoiding any cross-thread deadlock between the exec thread and the main
-    # UI thread during page transition.
+    # In silent mode, exit immediately rather than letting NSIS advance to the
+    # finish page.  The finish page exists only for interactive checkbox state
+    # (StartMinion / StartMinionDelayed), which is already set from command-line
+    # parsing and does not need to be re-read from UI controls.
+    #
+    # Use TerminateProcess on our own process (pseudo-handle -1), NOT
+    # ExitProcess.  ExitProcess runs orderly DLL_PROCESS_DETACH for every loaded
+    # plugin DLL on the calling thread while holding the loader lock; if a plugin
+    # worker thread was terminated mid-loader-lock or is otherwise stuck, that
+    # detach deadlocks and the process never exits -- the intermittent
+    # silent-mode hang.  TerminateProcess kills immediately with no DLL detach
+    # and no loader-lock dependency: the native, Win11-safe equivalent of the
+    # old wmic force-kill workaround.
     ${If} ${Silent}
-        System::Call "kernel32::ExitProcess(i 0)"
+        System::Call "kernel32::TerminateProcess(i -1, i 0)"
     ${EndIf}
 
 FunctionEnd
@@ -1576,11 +1583,13 @@ Function un.onUninstSuccess
     ${LogMsg} $msg
     MessageBox MB_OK|MB_USERICON $msg /SD IDOK
 
-    # Same issue as .onInstSuccess: Quit posts WM_QUIT but the message loop
-    # may be stuck with background processes alive.  Call ExitProcess directly
-    # to terminate the uninstaller process immediately.
+    # Same issue as .onInstSuccess: Quit posts WM_QUIT but the message loop may
+    # be stuck.  TerminateProcess on our own process (pseudo-handle -1) kills the
+    # uninstaller immediately with no DLL_PROCESS_DETACH and no loader-lock
+    # dependency.  ExitProcess would run orderly per-DLL detach under the loader
+    # lock and could deadlock if a plugin worker thread is stuck holding it.
     ${If} ${Silent}
-        System::Call "kernel32::ExitProcess(i 0)"
+        System::Call "kernel32::TerminateProcess(i -1, i 0)"
     ${EndIf}
 
 FunctionEnd


### PR DESCRIPTION
### What does this PR do?
Silent (/S) installs and uninstalls intermittently hung after the script had finished: the logs in %TEMP%\SaltInstaller\*.log showed completion, but the process never exited.

The cause is the silent-mode self-termination call. ExitProcess is not a brute-force kill: it terminates the other threads, then runs DLL_PROCESS_DETACH for every loaded plugin DLL on the calling thread while holding the loader lock. If a plugin worker thread (SimpleSC, nsExec, EnVar, AccessControl, System) was terminated mid-loader-lock or is otherwise stuck, that detach deadlocks and the process hangs forever.

Replace ExitProcess with TerminateProcess on our own process (pseudo-handle -1) in both .onInstSuccess and un.onUninstSuccess. TerminateProcess kills immediately with no DLL detach and no loader-lock dependency -- the native, Win11-safe equivalent of the old wmic force-kill that upstream 3006.x originally relied on. Both calls remain guarded by ${If} ${Silent}; GUI installs exit via the normal message loop unchanged.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
