### PR TITLE
Expose cidr_to_ipv4_netmask as a Jinja filter

### DIFF
--- a/changelog/69538.added.md
+++ b/changelog/69538.added.md
@@ -1,0 +1,1 @@
+Exposed the existing ``salt.utils.network.cidr_to_ipv4_netmask`` function as the ``cidr_to_ipv4_netmask`` Jinja filter, so templates can render a dotted-decimal IPv4 netmask from a CIDR prefix length (e.g. ``{{ 24 | cidr_to_ipv4_netmask }}``).

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -2145,6 +2145,28 @@ Returns:
   "2001:db8::250:56ff:fe01:203"
 
 
+.. jinja_ref:: cidr_to_ipv4_netmask
+
+``cidr_to_ipv4_netmask``
+------------------------
+
+.. versionadded:: 3009.0
+
+Returns the dotted-decimal IPv4 netmask for a CIDR prefix length.
+
+Example:
+
+.. code-block:: jinja
+
+  {{ 24 | cidr_to_ipv4_netmask }}
+
+Returns:
+
+.. code-block:: python
+
+  "255.255.255.0"
+
+
 .. jinja_ref:: network_hosts
 
 ``network_hosts``

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -653,9 +653,13 @@ def rpad_ipv4_network(ip_addr):
     return ".".join(itertools.islice(itertools.chain(ip_addr.split("."), "0000"), 0, 4))
 
 
+@jinja_filter("cidr_to_ipv4_netmask")
 def cidr_to_ipv4_netmask(cidr_bits):
     """
     Returns an IPv4 netmask
+
+    .. versionchanged:: 3009.0
+        Exposed as the ``cidr_to_ipv4_netmask`` Jinja filter.
     """
     try:
         cidr_bits = int(cidr_bits)

--- a/tests/pytests/unit/utils/test_network.py
+++ b/tests/pytests/unit/utils/test_network.py
@@ -581,6 +581,20 @@ def test_cidr_to_ipv4_netmask(addr, expected):
     assert network.cidr_to_ipv4_netmask(addr) == expected
 
 
+def test_cidr_to_ipv4_netmask_is_registered_jinja_filter():
+    """
+    cidr_to_ipv4_netmask is exposed as a Jinja filter so templates can render
+    a dotted netmask from a prefix length, e.g. ``{{ 24 | cidr_to_ipv4_netmask }}``.
+    """
+    from salt.utils.decorators.jinja import JinjaFilter
+
+    assert "cidr_to_ipv4_netmask" in JinjaFilter.salt_jinja_filters
+    assert (
+        JinjaFilter.salt_jinja_filters["cidr_to_ipv4_netmask"]
+        is network.cidr_to_ipv4_netmask
+    )
+
+
 def test_number_of_set_bits_to_ipv4_netmask():
     set_bits_to_netmask = network._number_of_set_bits_to_ipv4_netmask(0xFFFFFF00)
     assert set_bits_to_netmask == "255.255.255.0"


### PR DESCRIPTION
### What does this PR do?
Exposes the existing `salt.utils.network.cidr_to_ipv4_netmask()` function as a Jinja filter so templates can render a dotted-decimal IPv4 netmask from a CIDR prefix length:

```jinja
{{ 24 | cidr_to_ipv4_netmask }}
```

renders `255.255.255.0`.

### What issues does this PR fix or reference?
Follow-up to #69231, which added the other IP/network Jinja filters. `cidr_to_ipv4_netmask()` has shipped in `salt.utils.network` for years; only the `@jinja_filter` registration was missing, so it could be called from Python but not used as a Jinja filter.

### Previous Behavior
`cidr_to_ipv4_netmask()` was not registered as a Jinja filter, so `{{ prefix | cidr_to_ipv4_netmask }}` raised an undefined-filter error.

### New Behavior
The function is registered with `@jinja_filter("cidr_to_ipv4_netmask")` (the decorator is already imported in `salt/utils/network.py`), documented alongside the other network filters, and covered by a test asserting it is registered. No behavior change to the function itself.

### Merge requirements satisfied?
- [x] Tests written/updated (registration test fails without the decorator, passes with it; the existing function-correctness test is unchanged)
- [x] Changelog entry
- [x] Documentation added (`doc/topics/jinja/index.rst`)

#### Commits signed with GPG?
No
