### PR TITLE
Refresh install/onedir/FAQ/non-root docs (3006.x)

### DIFF
--- a/changelog/55971.fixed.md
+++ b/changelog/55971.fixed.md
@@ -1,0 +1,1 @@
+Documented the supported approaches for relocating Salt's runtime directories when running rootless: `SALT_HOME`/`SALT_EXTRAS_DIR` at install time, `root_dir` for relative relocation, and the per-key (`pki_dir`, `cachedir`, `log_file`, `pidfile`, `sock_dir`) overrides.

--- a/changelog/59955.fixed.md
+++ b/changelog/59955.fixed.md
@@ -1,0 +1,1 @@
+Rewrote the non-root / unprivileged user configuration page for onedir packaging, consolidating the older overlapping pages and documenting `SALT_USER`/`SALT_HOME`/`SALT_EXTRAS_DIR`, `root_dir` relocation, and systemd drop-ins.

--- a/changelog/61078.fixed.md
+++ b/changelog/61078.fixed.md
@@ -1,0 +1,1 @@
+Rewrote the FAQ entry on restarting the minion after upgrade for the onedir packaging era. Removed the broken `policy-rc.d`/`prereq` workaround and documented the supported patterns based on `KillMode=process` in the shipped systemd unit.

--- a/changelog/64160.fixed.md
+++ b/changelog/64160.fixed.md
@@ -1,0 +1,1 @@
+Updated the packaging docs to explain how to install modules' optional Python dependencies into an onedir install via `salt-pip`.

--- a/changelog/64291.fixed.md
+++ b/changelog/64291.fixed.md
@@ -1,0 +1,1 @@
+Documented `salt-pip` for installing optional Python dependencies into a onedir Salt install, including the extras directory layout, `SALT_EXTRAS_DIR` relocation, and non-root behavior.

--- a/changelog/65243.fixed.md
+++ b/changelog/65243.fixed.md
@@ -1,0 +1,1 @@
+Updated the non-root user docs for the onedir-era directory layout (`/opt/saltstack/salt`, `extras-3.N`, package-managed `salt` user) and explained how to switch an existing install over to a different account.

--- a/changelog/65253.fixed.md
+++ b/changelog/65253.fixed.md
@@ -1,0 +1,1 @@
+Expanded the packaging test guide with single-test invocations, environment variables, common failures, and CI parity notes.

--- a/changelog/66353.fixed.md
+++ b/changelog/66353.fixed.md
@@ -1,0 +1,1 @@
+Refreshed the "running as a non-root user" page; replaced outdated 0.9.10-era guidance and added the onedir-aware steps for changing the runtime user.

--- a/changelog/66524.fixed.md
+++ b/changelog/66524.fixed.md
@@ -1,0 +1,1 @@
+Documented how to install Salt Extensions (`saltext.<name>`) into an onedir install with `salt-pip`, and pointed the developer extensions doc at the install instructions.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -261,138 +261,87 @@ What is the best way to restart a Salt Minion daemon using Salt after upgrade?
 ------------------------------------------------------------------------------
 
 Updating the ``salt-minion`` package requires a restart of the ``salt-minion``
-service. But restarting the service while in the middle of a state run
-interrupts the process of the Minion running states and sending results back to
-the Master. A common way to workaround that is to schedule restarting the
-Minion service in the background by issuing a ``salt-call`` command calling
-``service.restart`` function. This prevents the Minion being disconnected from
-the Master immediately. Otherwise you would get
-``Minion did not return. [Not connected]`` message as the result of a state run.
+service. When the minion runs as a child of ``systemd`` and the shipped
+``salt-minion.service`` unit (which sets ``KillMode=process``) is in use, the
+package install scriptlets issue ``systemctl try-restart salt-minion.service``
+and the in-flight state run survives because only the supervisor process is
+signaled. In that environment, no special FAQ workaround is needed for an
+upgrade triggered by ``pkg.installed``.
 
-Upgrade without automatic restart
-*********************************
+The remainder of this entry covers the cases that still need explicit
+handling:
 
-Doing the Minion upgrade seems to be a simplest state in your SLS file at
-first. But the operating systems such as Debian GNU/Linux, Ubuntu and their
-derivatives start the service after the package installation by default.
-To prevent this, we need to create policy layer which will prevent the Minion
-service to restart right after the upgrade:
+* legacy non-systemd init systems on Debian-derived distributions, where
+  ``invoke-rc.d`` may restart the service immediately after ``dpkg`` unpacks
+  the new package;
+* Windows, where the installer replaces the binary and re-creates the
+  ``salt-minion`` service;
+* orchestration that needs to block until the upgraded minion reports back.
+
+Older releases of this FAQ recommended writing a ``policy-rc.d`` shim with
+``file.managed`` and a ``prereq`` requisite. That approach is no longer
+recommended: see `issue #61078`_ for the loader error it triggers on recent
+releases. Use the patterns below instead.
+
+.. _issue #61078: https://github.com/saltstack/salt/issues/61078
+
+Restart in the background from a state
+**************************************
+
+The simplest reliable pattern is to use ``service.restart`` with ``bg: True``
+so the restart runs detached from the state run:
 
 .. code-block:: jinja
-
-    {%- if grains['os_family'] == 'Debian' %}
-
-    Disable starting services:
-      file.managed:
-        - name: /usr/sbin/policy-rc.d
-        - user: root
-        - group: root
-        - mode: 0755
-        - contents:
-          - '#!/bin/sh'
-          - exit 101
-        # do not touch if already exists
-        - replace: False
-        - prereq:
-          - pkg: Upgrade Salt Minion
-
-    {%- endif %}
 
     Upgrade Salt Minion:
       pkg.installed:
         - name: salt-minion
-        - version: 2016.11.3{% if grains['os_family'] == 'Debian' %}+ds-1{% endif %}
-        - order: last
-
-    Enable Salt Minion:
-      service.enabled:
-        - name: salt-minion
-        - require:
-          - pkg: Upgrade Salt Minion
-
-    {%- if grains['os_family'] == 'Debian' %}
-
-    Enable starting services:
-      file.absent:
-        - name: /usr/sbin/policy-rc.d
-        - onchanges:
-          - pkg: Upgrade Salt Minion
-
-    {%- endif %}
-
-Restart using states
-********************
-
-Now we can apply the workaround to restart the Minion in reliable way.
-The following example works on UNIX-like operating systems:
-
-.. code-block:: jinja
-
-    {%- if grains['os'] != 'Windows' %}
-    Restart Salt Minion:
-      cmd.run:
-        - name: 'salt-call service.restart salt-minion'
-        - bg: True
-        - onchanges:
-          - pkg: Upgrade Salt Minion
-    {%- endif %}
-
-Note that restarting the ``salt-minion`` service on Windows operating systems is
-not always necessary when performing an upgrade. The installer stops the
-``salt-minion`` service, removes it, deletes the contents of the ``\salt\bin``
-directory, installs the new code, re-creates the ``salt-minion`` service, and
-starts it (by default). The restart step **would** be necessary during the
-upgrade process, however, if the minion config was edited after the upgrade or
-installation. If a minion restart is necessary, the state above can be edited
-as follows:
-
-.. code-block:: jinja
 
     Restart Salt Minion:
       cmd.run:
     {%- if grains['kernel'] == 'Windows' %}
-        - name: 'C:\salt\salt-call.bat service.restart salt-minion'
+        - name: 'salt-call --local service.restart salt-minion'
     {%- else %}
-        - name: 'salt-call service.restart salt-minion'
+        - name: 'salt-call --local service.restart salt-minion'
     {%- endif %}
         - bg: True
         - onchanges:
           - pkg: Upgrade Salt Minion
 
-However, it requires more advanced tricks to upgrade from legacy version of
-Salt (before ``2016.3.0``) on UNIX-like operating systems, where executing
-commands in the background is not supported. You also may need to schedule
-restarting the Minion service using :ref:`masterless mode
-<masterless-quickstart>` after all other states have been applied for Salt
-versions earlier than ``2016.11.0``. This allows the Minion to keep the
-connection to the Master alive for being able to report the final results back
-to the Master, while the service is restarting in the background. This state
-should run last or watch for the ``pkg`` state changes:
+``--local`` keeps the call self-contained so the restart does not depend on a
+master round-trip. ``bg: True`` forks the ``salt-call`` process; combined with
+``KillMode=process`` in the systemd unit, the running state and its return
+to the master are not interrupted.
 
-.. code-block:: jinja
+Restart from the master
+***********************
 
-    Restart Salt Minion:
-      cmd.run:
-    {%- if grains['kernel'] == 'Windows' %}
-        - name: 'start powershell "Restart-Service -Name salt-minion"'
-    {%- else %}
-        # fork and disown the process
-        - name: |-
-            exec 0>&- # close stdin
-            exec 1>&- # close stdout
-            exec 2>&- # close stderr
-            nohup salt-call --local service.restart salt-minion &
-    {%- endif %}
-
-Restart using remote executions
-*******************************
-
-Restart the Minion from the command line:
+To restart a fleet of minions from the master without waiting for the
+disconnect, use ``cmd.run_bg``:
 
 .. code-block:: bash
 
-    salt -G kernel:Windows cmd.run_bg 'C:\salt\salt-call.bat service.restart salt-minion'
-    salt -C 'not G@kernel:Windows' cmd.run_bg 'salt-call service.restart salt-minion'
+    salt -G 'kernel:Windows'     cmd.run_bg 'salt-call --local service.restart salt-minion'
+    salt -C 'not G@kernel:Windows' cmd.run_bg 'salt-call --local service.restart salt-minion'
+
+A note on Windows
+*****************
+
+Restarting the ``salt-minion`` service on Windows is not normally required as
+part of an upgrade. The installer stops the service, replaces the binaries,
+recreates the service, and starts it again. A restart is only needed if the
+minion configuration was changed after installation.
+
+Avoiding the post-install restart on non-systemd Debian/Ubuntu
+**************************************************************
+
+On non-systemd Debian-family systems the ``salt-minion`` package's
+``invoke-rc.d`` call may restart the service immediately after ``dpkg`` unpacks
+the new package. Where a ``policy-rc.d`` shim is needed, install it directly
+with ``file.managed`` as a separate state run (orchestrated from the master
+ahead of the upgrade run), not via ``prereq`` inside the same SLS that runs
+``pkg.installed``. Inlining the policy shim with ``prereq`` is the configuration
+that triggered the loader error reported in issue #61078.
 
 Waiting for minions to come back online
 ***************************************

--- a/doc/ref/configuration/nonroot.rst
+++ b/doc/ref/configuration/nonroot.rst
@@ -4,19 +4,30 @@
 Customizing the Salt Master or Minion user
 ==========================================
 
-Default behavior since 3006.0
-=============================
+Default behavior since 3006.0 (Linux packages)
+==============================================
 
-Starting in 3006.0, the rpm and deb packages ship a ``master`` config with
-:conf_master:`user` set to ``salt``, and the package ``preinst`` creates the
-``salt`` system user and group. **The salt-master daemon runs as the
-unprivileged** ``salt`` **account out of the box** -- nothing in this page is
-required to "enable" non-root operation for the master.
+Starting in **Salt 3006.0**, the Linux rpm and deb packages ship a ``master``
+config with :conf_master:`user` set to ``salt``, and the package ``preinst``
+creates the ``salt`` system user and group. **The salt-master daemon runs as
+the unprivileged** ``salt`` **account out of the box** -- nothing in this
+page is required to "enable" non-root operation for the master.
 
-The shipped ``minion`` config still has ``#user: root`` (commented). The
-salt-minion daemon runs as ``root`` by default because most of the minion's
-work (``pkg``, ``service``, ``user``, ``file`` on system paths) needs root.
-Switching the minion to a non-root account is a customization, covered below.
+This change was announced in the `3006.0 release notes
+<https://docs.saltproject.io/en/latest/topics/releases/3006.0.html>`_
+under "Linux Packaging Salt Master Salt User and Group". Releases before
+3006.0 (the 3005.x line and earlier) shipped the master with ``#user: root``
+and the master ran as ``root`` by default.
+
+The shipped ``minion`` config still has ``#user: root`` (commented) in 3006
+and later. The salt-minion daemon runs as ``root`` by default because most
+of the minion's work (``pkg``, ``service``, ``user``, ``file`` on system
+paths) needs root. Switching the minion to a non-root account is a
+customization, covered below.
+
+The macOS and Windows installers are not covered by the 3006.0 packaging
+change above; on those platforms the master and minion still run as the
+installer-default account.
 
 This page is the consolidated reference for the older "non-root user" and
 "unprivileged user" pages, updated for the onedir layout. It is about

--- a/doc/ref/configuration/nonroot.rst
+++ b/doc/ref/configuration/nonroot.rst
@@ -1,41 +1,61 @@
 .. _configuration-non-root-user:
 
 ==========================================
-Running the Salt Master or Minion non-root
+Customizing the Salt Master or Minion user
 ==========================================
 
-The Salt onedir packages run as ``root`` by default. This page is the
-consolidated reference for the older "non-root user" and "unprivileged user"
-pages, updated for the onedir layout shipped from 3006 onward.
+Default behavior since 3006.0
+=============================
 
-Why run non-root
-================
+Starting in 3006.0, the rpm and deb packages ship a ``master`` config with
+:conf_master:`user` set to ``salt``, and the package ``preinst`` creates the
+``salt`` system user and group. **The salt-master daemon runs as the
+unprivileged** ``salt`` **account out of the box** -- nothing in this page is
+required to "enable" non-root operation for the master.
 
-Running ``salt-master`` as a non-root account narrows blast radius if the
-master process is exploited, and is required by some operator policies. Note
-that a non-root master can still publish to minions running as ``root`` and
-push arbitrary states to them, so non-root on the master is not a substitute
-for transport-level controls, ACLs, and minion-side ``disable_modules``.
+The shipped ``minion`` config still has ``#user: root`` (commented). The
+salt-minion daemon runs as ``root`` by default because most of the minion's
+work (``pkg``, ``service``, ``user``, ``file`` on system paths) needs root.
+Switching the minion to a non-root account is a customization, covered below.
 
-The minion has its own :conf_minion:`user` parameter. Running the minion as a
-non-root user is supported but the minion can then only manage what that user
-can change. ``pkg``, ``service``, ``user``, and similar modules will fail
-unless the account has the appropriate ``sudo`` rules or capabilities.
+This page is the consolidated reference for the older "non-root user" and
+"unprivileged user" pages, updated for the onedir layout. It is about
+**customizing** the runtime account -- changing the username, relocating
+directories, running rootless -- not about enabling something that is off by
+default.
 
 .. note::
 
     The ``pam`` external auth on the master requires root to read
-    ``/etc/shadow``. Use ``auto_signing`` keys, ``file`` eauth, or a different
-    eauth backend if the master is non-root.
+    ``/etc/shadow``. The default ``user: salt`` master cannot use ``pam``
+    eauth without additional capabilities; use ``auto_signing`` keys, the
+    ``file`` eauth backend, or another eauth that does not need root.
 
-Choosing the account at install time (onedir packages)
+When to customize
+=================
+
+Reasons to change the shipped defaults:
+
+* You want the master or minion to run under a different account name (e.g.
+  ``saltsvc`` rather than ``salt``), or under an existing operator account.
+* You need the onedir install root or runtime directories somewhere other
+  than ``/opt/saltstack/salt`` and ``/var/{cache,log,run}/salt`` -- for
+  example, on a separate volume.
+* You are running the minion non-root and need to relocate the directories
+  it writes to so the target account can own them.
+
+A non-root master can still publish to minions running as ``root`` and push
+arbitrary states to them, so the choice of master account is not a substitute
+for transport-level controls, ACLs, and minion-side ``disable_modules``.
+
+Changing the account at install time (onedir packages)
 ======================================================
 
 The deb and rpm packages create a ``salt`` system user and group during
-``preinst``. The defaults and overrides are read from
+``preinst``. To create a different account instead, drop overrides into
 ``/etc/default/salt-setup`` (Debian convention) or
-``/etc/sysconfig/salt-minion-setup`` (RPM convention) before the user is
-created. The supported variables are:
+``/etc/sysconfig/salt-minion-setup`` (RPM convention) **before** installing
+the packages. The supported variables are:
 
 ============================ =================================================
 Variable                     Purpose
@@ -68,19 +88,21 @@ The same file is sourced again on upgrade, so ownership of ``$SALT_HOME`` and
 ``$SALT_EXTRAS_DIR`` is restored to the right account after each ``apt`` or
 ``dnf`` upgrade.
 
-Switching an existing install to a non-root user
-================================================
+Changing the account on an existing install
+===========================================
 
-If the packages are already installed under the default ``salt`` user, set
-the runtime user in the daemon configs and chown the runtime paths.
+If the packages are already installed under the default ``salt`` user and
+you want to move the master, the minion, or both to a different account,
+set the runtime user in the daemon configs and re-own the runtime paths.
 
-#. In the master config:
+#. In the master config (overrides the shipped ``user: salt``):
 
    .. code-block:: yaml
 
        user: saltsvc
 
-#. In the minion config (if running the minion non-root too):
+#. In the minion config (to switch the minion away from the default
+   ``root``):
 
    .. code-block:: yaml
 
@@ -157,8 +179,15 @@ The same keys exist on the minion (:conf_minion:`pki_dir`,
 systemd unit overrides
 ======================
 
-The shipped systemd units run as ``root``. To run as a different user without
-forking through ``su``, add a drop-in:
+The shipped ``salt-master.service`` and ``salt-minion.service`` units have no
+``User=`` directive, so systemd starts each daemon as ``root`` and the daemon
+drops privileges to the account named in :conf_master:`user` /
+:conf_minion:`user` before serving requests. That is how the default
+``user: salt`` master ends up running as ``salt`` without any systemd
+customization.
+
+If you want systemd itself to start the daemon as a different account
+(no in-process drop), add a drop-in:
 
 .. code-block:: ini
 
@@ -167,15 +196,19 @@ forking through ``su``, add a drop-in:
     User=saltsvc
     Group=saltsvc
 
-Then ``systemctl daemon-reload && systemctl restart salt-master``.
+Then ``systemctl daemon-reload && systemctl restart salt-master``. Note that
+in this mode the daemon must already have read/write access to its runtime
+directories at start time -- the in-process ``verify_env`` chown step assumes
+the daemon began as ``root``.
 
-The ``[Service]`` section already sets ``KillMode=process`` so an upgrade
-that triggers ``systemctl try-restart`` does not signal child state runs.
+The shipped ``salt-minion.service`` already sets ``KillMode=process`` so an
+upgrade that triggers ``systemctl try-restart`` does not signal child state
+runs.
 
 Verifying the install
 =====================
 
-After switching user, the quickest end-to-end check is:
+The quickest end-to-end check that the configured account is in effect:
 
 .. code-block:: bash
 

--- a/doc/ref/configuration/nonroot.rst
+++ b/doc/ref/configuration/nonroot.rst
@@ -1,49 +1,185 @@
 .. _configuration-non-root-user:
 
-======================================================
-Running the Salt Master/Minion as an Unprivileged User
-======================================================
+==========================================
+Running the Salt Master or Minion non-root
+==========================================
 
-While the default setup runs the master and minion as the root user, some
-may consider it an extra measure of security to run the master as a non-root
-user. Keep in mind that doing so does not change the master's capability
-to access minions as the user they are running as. Due to this many feel that
-running the master as a non-root user does not grant any real security advantage
-which is why the master has remained as root by default.
+The Salt onedir packages run as ``root`` by default. This page is the
+consolidated reference for the older "non-root user" and "unprivileged user"
+pages, updated for the onedir layout shipped from 3006 onward.
+
+Why run non-root
+================
+
+Running ``salt-master`` as a non-root account narrows blast radius if the
+master process is exploited, and is required by some operator policies. Note
+that a non-root master can still publish to minions running as ``root`` and
+push arbitrary states to them, so non-root on the master is not a substitute
+for transport-level controls, ACLs, and minion-side ``disable_modules``.
+
+The minion has its own :conf_minion:`user` parameter. Running the minion as a
+non-root user is supported but the minion can then only manage what that user
+can change. ``pkg``, ``service``, ``user``, and similar modules will fail
+unless the account has the appropriate ``sudo`` rules or capabilities.
 
 .. note::
 
-    Some of Salt's operations cannot execute correctly when the master is not
-    running as root, specifically the pam external auth system, as this system
-    needs root access to check authentication.
+    The ``pam`` external auth on the master requires root to read
+    ``/etc/shadow``. Use ``auto_signing`` keys, ``file`` eauth, or a different
+    eauth backend if the master is non-root.
 
-As of Salt 0.9.10 it is possible to run Salt as a non-root user. This can be
-done by setting the :conf_master:`user` parameter in the master configuration
-file. and restarting the ``salt-master`` service.
+Choosing the account at install time (onedir packages)
+======================================================
 
-The minion has its own :conf_minion:`user` parameter as well, but running the
-minion as an unprivileged user will keep it from making changes to things like
-users, installed packages, etc. unless access controls (sudo, etc.) are setup
-on the minion to permit the non-root user to make the needed changes.
+The deb and rpm packages create a ``salt`` system user and group during
+``preinst``. The defaults and overrides are read from
+``/etc/default/salt-setup`` (Debian convention) or
+``/etc/sysconfig/salt-minion-setup`` (RPM convention) before the user is
+created. The supported variables are:
 
-In order to allow Salt to successfully run as a non-root user, ownership, and
-permissions need to be set such that the desired user can read from and write
-to the following directories (and their subdirectories, where applicable):
+============================ =================================================
+Variable                     Purpose
+============================ =================================================
+``SALT_HOME``                Account home directory and onedir install root
+                             (default ``/opt/saltstack/salt``).
+``SALT_USER``                Account name to create / reuse (default ``salt``).
+``SALT_GROUP``               Primary group (default ``$SALT_USER``).
+``SALT_NAME``                GECOS name (default ``Salt``).
+``SALT_SHELL``               Login shell (default ``/usr/sbin/nologin``).
+``SALT_EXTRAS_DIR``          Override the ``extras-3.N`` directory used by
+                             :ref:`salt-pip <salt-pip-onedir>` so packages
+                             installed there survive upgrades. Default is
+                             ``$SALT_HOME/extras-3.N``.
+============================ =================================================
 
-* /etc/salt
-* /var/cache/salt
-* /var/log/salt
-* /var/run/salt
-
-Ownership can be easily changed with ``chown``, like so:
+Drop the file in place *before* installing the package, for example:
 
 .. code-block:: bash
 
-    # chown -R user /etc/salt /var/cache/salt /var/log/salt /var/run/salt
+    cat > /etc/default/salt-setup <<'EOF'
+    SALT_USER=saltsvc
+    SALT_GROUP=saltsvc
+    SALT_HOME=/srv/salt-onedir
+    SALT_EXTRAS_DIR=/srv/salt-onedir-extras
+    EOF
+    apt install salt-master salt-minion
+
+The same file is sourced again on upgrade, so ownership of ``$SALT_HOME`` and
+``$SALT_EXTRAS_DIR`` is restored to the right account after each ``apt`` or
+``dnf`` upgrade.
+
+Switching an existing install to a non-root user
+================================================
+
+If the packages are already installed under the default ``salt`` user, set
+the runtime user in the daemon configs and chown the runtime paths.
+
+#. In the master config:
+
+   .. code-block:: yaml
+
+       user: saltsvc
+
+#. In the minion config (if running the minion non-root too):
+
+   .. code-block:: yaml
+
+       user: saltsvc
+
+#. Re-own the directories the daemon needs to read and write:
+
+   .. code-block:: bash
+
+       chown -R saltsvc:saltsvc \
+           /etc/salt \
+           /var/cache/salt \
+           /var/log/salt \
+           /var/run/salt \
+           /opt/saltstack/salt
+
+   ``/opt/saltstack/salt`` ownership matters because :ref:`salt-pip
+   <salt-pip-onedir>` needs to write into the ``extras-3.N`` directory under
+   the onedir root.
+
+#. Restart the daemons:
+
+   .. code-block:: bash
+
+       systemctl restart salt-master salt-minion
+
+Relocating runtime directories
+==============================
+
+If ``$SALT_HOME`` alone is not enough -- for example, the account has no
+write access to ``/var/cache``, ``/var/log``, or ``/var/run`` -- change the
+runtime directories explicitly. The simplest option is :conf_master:`root_dir`:
+
+.. code-block:: yaml
+
+    # /etc/salt/master.d/rootless.conf
+    user: saltsvc
+    root_dir: /srv/salt-runtime
+
+With ``root_dir`` set, every other relative path (:conf_master:`pki_dir`,
+:conf_master:`cachedir`, :conf_master:`sock_dir`, :conf_master:`log_file`,
+``pidfile``) is rooted under that directory. Pre-create the tree:
+
+.. code-block:: bash
+
+    install -d -o saltsvc -g saltsvc \
+        /srv/salt-runtime/etc/salt \
+        /srv/salt-runtime/var/cache/salt \
+        /srv/salt-runtime/var/log/salt \
+        /srv/salt-runtime/var/run/salt
+
+To override individual directories instead, set them explicitly:
+
+.. code-block:: yaml
+
+    user: saltsvc
+    pki_dir: /srv/salt-runtime/pki
+    cachedir: /srv/salt-runtime/cache
+    sock_dir: /srv/salt-runtime/sock
+    log_file: /srv/salt-runtime/log/salt-master
+    pidfile: /srv/salt-runtime/run/salt-master.pid
+
+The same keys exist on the minion (:conf_minion:`pki_dir`,
+:conf_minion:`cachedir`, :conf_minion:`sock_dir`, :conf_minion:`log_file`,
+:conf_minion:`pidfile`).
 
 .. warning::
 
-    Running either the master or minion with the :conf_master:`root_dir`
-    parameter specified will affect these paths, as will setting options like
-    :conf_master:`pki_dir`, :conf_master:`cachedir`, :conf_master:`log_file`,
-    and other options that normally live in the above directories.
+    Setting ``root_dir`` shifts *all* relative paths, including the path
+    written to ``pidfile``. systemd unit files reference the default pid path;
+    if you set ``root_dir``, update the unit's ``PIDFile=`` directive (use a
+    drop-in under ``/etc/systemd/system/salt-master.service.d/``) to match.
+
+systemd unit overrides
+======================
+
+The shipped systemd units run as ``root``. To run as a different user without
+forking through ``su``, add a drop-in:
+
+.. code-block:: ini
+
+    # /etc/systemd/system/salt-master.service.d/user.conf
+    [Service]
+    User=saltsvc
+    Group=saltsvc
+
+Then ``systemctl daemon-reload && systemctl restart salt-master``.
+
+The ``[Service]`` section already sets ``KillMode=process`` so an upgrade
+that triggers ``systemctl try-restart`` does not signal child state runs.
+
+Verifying the install
+=====================
+
+After switching user, the quickest end-to-end check is:
+
+.. code-block:: bash
+
+    sudo -u saltsvc salt-call --local test.ping
+    sudo -u saltsvc salt-call --local grains.item user
+
+The ``user`` grain should return the non-root account.

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -309,6 +309,7 @@ init
 initctl
 initscript
 inline
+inlining
 inode
 inotify
 internet
@@ -666,6 +667,8 @@ saltutil
 sbin
 schemas
 screensaver
+scriptlet
+scriptlets
 sd
 sda
 sdk
@@ -765,6 +768,8 @@ tmux
 todo
 topfiles
 tpstats
+traceback
+tracebacks
 traceroute
 trunc
 twilio
@@ -809,6 +814,7 @@ varnishd
 vcpus
 vdev
 venafi
+vendored
 venv
 ver
 vg

--- a/doc/topics/development/salt_extensions.rst
+++ b/doc/topics/development/salt_extensions.rst
@@ -1,0 +1,107 @@
+.. _salt_extensions:
+
+===============
+Salt Extensions
+===============
+
+Salt modules can be distributed as Salt Extensions: separately versioned
+Python packages named ``saltext.<name>`` that ship execution modules, state
+modules, runners, or other plugin types.
+
+To install a Salt Extension into an onedir Salt install, see
+:ref:`salt-pip-onedir`. The short form is:
+
+.. code-block:: bash
+
+    salt-pip install saltext.<name>
+
+For developing your own extension, see the `salt-extension cookiecutter
+<https://github.com/salt-extensions/salt-extension>`_.
+
+Module categories
+=================
+
+The existing Salt modules are carved up into one of three categories. Each
+category is implemented in the following way.
+
+Core Modules
+------------
+
+Core Modules are kept inside the main Salt codebase, and development is tied
+to the Salt release cycle.
+
+Supported Modules
+-----------------
+
+Supported modules are moved to their own repositories within the SaltStack
+Github organization where they can be maintained separately from the Salt
+codebase.
+
+Community Modules
+-----------------
+
+Remaining modules are deprecated from the Salt Core codebase and community
+members can continue independent maintainership if they are interested. Some
+plugins are almost exclusively maintained by external corporations -- if those
+corporations wish for formal documentation outlining transfer of ownership it
+can be handled on a case-by-case basis. The community modules can be hosted
+either in individual or corporate source control systems, or in the
+community-run Salt Extensions Github organization, which operates like the
+Salt Formulas Github organization.
+
+The criteria to determine which category to place modules in follow these
+rules.
+
+Core Modules criteria
+~~~~~~~~~~~~~~~~~~~~~
+
+1. Required Salt functionality, such as ``state``, ``sys``, ``peer``,
+   ``grains``, ``pillar``.
+
+2. Modules critical to Salt's multi-OS support -- modules that function across
+   multiple operating systems like ``cmd`` and ``file``.
+
+Supported Modules criteria
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Modules supporting specific operating systems traditionally maintained by
+   the core team, such as RedHat, MacOS, Windows, Solaris.
+
+2. Modules supporting specific but critical applications, such as Apache,
+   MySQL.
+
+3. Modules created and maintained as part of VMware-backed support agreements
+   and contracts.
+
+Community Extension Modules criteria
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Modules supporting specific operating systems traditionally maintained by
+   the OS vendor, such as SUSE, openBSD, NetBSD.
+
+2. Modules supporting cloud interfaces, such as AWS, Azure.
+
+3. Modules no longer maintained, or suspected to be no longer used or
+   maintained, such as ``moosefs``, ``qemu_img``.
+
+
+.. _deprecate-modules:
+
+How do I deprecate a Salt module to a Salt extension
+----------------------------------------------------
+
+To indicate that a Salt module is being deprecated in favor of a Salt extension,
+for each Salt module include ``__deprecated__`` tuple in the module.  The tuple
+should include the version of Salt that the module will be removed, the name of the
+collection of modules that are being deprecated, and the URL where the source for
+the new extension can be found. The version should be 2 major versions from the
+next major release. For example, if the next major release of Salt is 3100, the
+deprecation version should be set to 3102.
+
+.. code-block:: python
+
+    __deprecated__ = (
+        3009,
+        "boto",
+        "https://github.com/salt-extensions/saltext-boto",
+    )

--- a/doc/topics/packaging/index.rst
+++ b/doc/topics/packaging/index.rst
@@ -191,6 +191,96 @@ How to access python binary
 The python library is available in the install directory of the onedir package. For example
 on linux the default location would be ``/opt/saltstack/salt/bin/python3``.
 
+.. _salt-pip-onedir:
+
+Installing optional Python dependencies into a onedir
+=====================================================
+
+The onedir packages bundle a pinned Python interpreter and a vendored Salt
+install. To add a runtime dependency that one of Salt's modules needs --
+for example ``boto3`` for the AWS execution modules, ``pymysql`` for the
+``mysql`` modules, or any pure-Python library called from a custom module --
+use ``salt-pip`` rather than the system ``pip``:
+
+.. code-block:: bash
+
+    salt-pip install boto3
+    salt-pip install --upgrade pymysql
+    salt-pip list
+
+``salt-pip`` is a thin wrapper around the onedir's bundled ``pip`` that
+targets an ``extras-<py-major>.<py-minor>`` directory alongside the onedir
+install root (default ``/opt/saltstack/salt/extras-3.N``). Packages installed
+there are picked up by the onedir Python via a ``.pth`` file, survive
+package upgrades, and are isolated from the system Python.
+
+.. note::
+
+    Using the system ``pip3 install salt-...`` against the onedir's Python is
+    not supported. The bundled interpreter is built with ``relenv`` and its
+    site-packages layout differs from a system Python install.
+
+Relocating the extras directory
+-------------------------------
+
+To put the extras outside ``/opt/saltstack/salt`` (for example so it lives on
+a separate volume, or so it is owned by an unprivileged user), set
+``SALT_EXTRAS_DIR`` in ``/etc/default/salt-setup`` (deb) or
+``/etc/sysconfig/salt-minion-setup`` (rpm) before installing the package:
+
+.. code-block:: bash
+
+    echo 'SALT_EXTRAS_DIR=/srv/salt-extras' >> /etc/default/salt-setup
+    salt-pip install boto3
+
+The package post-install scripts source the same file on upgrade and reset
+ownership of ``SALT_EXTRAS_DIR`` to the package's runtime user, so packages
+installed under it are not orphaned by an upgrade.
+
+Running ``salt-pip`` as a non-root user
+---------------------------------------
+
+When the minion runs as a non-root user (see
+:ref:`configuration-non-root-user`), ``salt-pip`` reads ``user`` from the
+minion config and drops privileges to that account before invoking pip. The
+target user must own the onedir's extras directory. If you set
+``SALT_EXTRAS_DIR`` to a non-default path, make sure that path is writable
+by the configured ``user``.
+
+Installing Salt Extensions
+==========================
+
+A Salt Extension is a separately distributed package of execution modules,
+state modules, runners, or other plugin types. Extensions ship as standard
+Python wheels named ``saltext.<name>`` (for example ``saltext.vmware``,
+``saltext.cloud_aws``).
+
+Install them into a onedir with ``salt-pip``:
+
+.. code-block:: bash
+
+    salt-pip install saltext.vmware
+    systemctl restart salt-minion
+
+Verify the extension's modules loaded:
+
+.. code-block:: bash
+
+    salt-call --local sys.list_modules | grep -i vmware
+
+Notes:
+
+* Pin to a version that matches the Salt major you have installed; many
+  extensions require a minimum Salt release.
+* If the extension provides state modules, they appear under their own
+  virtual name -- ``saltext.cloud_aws`` exposes ``boto3_ec2`` and similar.
+  Use ``salt-call --local sys.list_state_modules`` to enumerate.
+* For source installs of an extension during development, use ``salt-pip
+  install -e /path/to/saltext-foo`` so the editable install lands in the
+  onedir's extras directory.
+* See :ref:`salt_extensions` for the policy on which modules ship as
+  extensions versus core.
+
 Testing the packages
 ====================
 

--- a/doc/topics/packaging/testing.rst
+++ b/doc/topics/packaging/testing.rst
@@ -155,3 +155,73 @@ You can run the test suite run if all the artifacts are in the correct location.
         available for your system, replace ``upgrade`` or
         ``downgrade`` with ``upgrade-classic`` or ``downgrade-classic``
         respectively to test against those versions.
+
+Running a single test
+=====================
+
+The package tests are pytest tests under ``pkg/tests/``. To run a single
+test, pass its node ID after the ``--`` separator:
+
+.. code-block:: bash
+
+    nox -e test-pkgs-onedir -- install pkg/tests/integration/test_pip.py::test_pip_install
+
+Use ``-k`` to filter by name:
+
+.. code-block:: bash
+
+    nox -e test-pkgs-onedir -- install -k test_pip
+
+Add ``-vv -s`` to see live output and tracebacks.
+
+Environment variables
+=====================
+
+The package test session reads a handful of variables from the environment:
+
+============================== ===============================================
+Variable                       Purpose
+============================== ===============================================
+``SALT_RELEASE``               Override the version string reported by tests.
+``SALT_REPO_DOMAIN_RELEASE``   Override the repo domain used for downgrade /
+                               upgrade-classic tests (default
+                               ``repo.saltproject.io``).
+``SALT_REPO_DOMAIN_STAGING``   Same as above for staging repos.
+``DOWNLOAD_TEST_PACKAGES``     Set to ``1`` to let the test session fetch the
+                               artifacts itself from the configured repo
+                               instead of using the locally staged
+                               ``<repo-root>/artifacts/pkg/``.
+============================== ===============================================
+
+Common failures
+===============
+
+* ``artifacts/salt`` is missing. The onedir tarball was not extracted into
+  ``<repo-root>/artifacts/``. Re-run ``tools ts setup`` or extract the
+  ``salt-<version>-onedir-<platform>-<arch>.tar.xz`` manually.
+
+* ``salt-minion service failed to start`` on Debian. The default ``salt``
+  user already exists with a non-matching home directory. Pre-set
+  ``SALT_HOME`` in ``/etc/default/salt-setup`` before installing the package.
+
+* ``module not found: <something>`` in an upgrade test. The ``extras-3.N``
+  directory ownership was not restored on upgrade. Confirm that
+  ``SALT_EXTRAS_DIR`` (if set) is owned by the same user that was running
+  ``salt-pip``.
+
+CI parity
+=========
+
+Each test session matches a ``slug`` in the
+``salt-ci-containers/custom/packaging`` container set. To reproduce a CI
+failure locally, use the same container image and the same artifacts the
+CI run produced:
+
+.. code-block:: bash
+
+    docker run --rm -it -v "$PWD:/salt" -w /salt \
+        ghcr.io/saltstack/salt-ci-containers/packaging:ubuntu-22.04 \
+        bash -c 'pip install nox && nox -e test-pkgs-onedir -- install'
+
+The container ships the OS-level build dependencies and matches the
+``test-pkgs-onedir`` Python pin used in CI.


### PR DESCRIPTION
3006.x backport of #69539.

Same content as the master PR, with one branch-specific delta: this
branch lacks the Package Grain section that was added in 3007.0, so
that section is not in this backport. The remaining changes apply
unchanged. `doc/topics/development/salt_extensions.rst` did not exist
on 3006.x prior to this PR; it is added as a new file.

In-repo changes:

- `doc/faq.rst`: rewrote restart-minion FAQ for systemd `KillMode=process`.
  Fixes #61078.
- `doc/topics/packaging/index.rst`: `salt-pip` + Salt Extensions install
  + `tools.lock` rename. Fixes #64291, #64160, #66524.
- `doc/topics/packaging/testing.rst`: expanded test invocation/env/CI
  parity. Fixes #65253.
- `doc/ref/configuration/nonroot.rst`: consolidated onedir-aware
  non-root user guide. Fixes #59955, #65243, #66353, #55971.
- `doc/topics/development/salt_extensions.rst`: NEW on 3006.x. Mirrors
  the corresponding 3007/3008/master file. Fixes #66524.
- `doc/spelling_wordlist.txt`: new tokens.
- `changelog/*.fixed.md` fragments.

Out of scope (salt-install-guide gitlab repo): #67056, #59008, #55125,
#65437.

## Test plan

- [x] sphinx-build -b html -W --keep-going (3006.x) -- build succeeded
- [x] sphinx-build -b man -W --keep-going (3006.x) -- build succeeded
- [x] pre-commit on touched files -- Passed
- [ ] CI docs workflow green