### PR TITLE
Audit configuration option documentation (EPIC #58112)

### DIFF
--- a/changelog/58112.fixed.md
+++ b/changelog/58112.fixed.md
@@ -1,0 +1,11 @@
+Documented the `fips_mode`, `event_match_type`, `key_logfile`, and `ssh_priv`
+configuration options on both master and minion. Clarified `state_top_saltenv`,
+`master_type: str`, `http_connect_timeout`, `http_request_timeout`, and
+`worker_threads`. Corrected the documented default for `request_channel_timeout`
+to match the code (60s, not 30s). Aligned the `salt-key` documentation with the
+actual CLI by documenting `--include-accepted`, `--include-rejected`, and
+`--include-denied` and marking `--include-all` as deprecated. Updated the
+`retry_dns` / `acceptance_wait_time` docs to describe failover-master behavior.
+Updated the `grains.fqdns` docstring, the `salt.states.timezone.system` default
+description, and the `log_granular_levels` example to use `%(name)s`. Added an
+example combining `cron` and `splay` in the `salt.states.schedule` docs.

--- a/conf/master
+++ b/conf/master
@@ -489,6 +489,14 @@
 #    certfile: <path_to_certfile>
 #    ssl_version: PROTOCOL_TLSv1_2
 
+# Run Salt in FIPS-compliant mode. When enabled, modules that would otherwise
+# use cryptographic primitives not approved by FIPS 140-2 (such as MD5) will
+# refuse to run or will use FIPS-approved alternatives. This option must be
+# set on both the master and minion for end-to-end FIPS compliance. The host
+# Python interpreter and OpenSSL build must also be FIPS-capable. Default is
+# False.
+#fips_mode: False
+
 #####     Salt-SSH Configuration     #####
 ##########################################
 # Define the default salt-ssh roster module to use
@@ -534,6 +542,12 @@
 
 # The user to log in as.
 #ssh_user: root
+
+# Filename of the SSH private key salt-ssh should use when connecting to
+# minions. Default is `salt-ssh.rsa` under pki_dir. Use this option to point
+# to a different key (for example an ed25519 key). To require a passphrase,
+# also set ssh_priv_passwd.
+#ssh_priv: /etc/salt/pki/master/ssh/salt-ssh.rsa
 
 # The log file of the salt-ssh command:
 #ssh_log_file: /var/log/salt/ssh

--- a/conf/minion
+++ b/conf/minion
@@ -761,6 +761,14 @@
 #  - uuid
 #  - server_id
 
+# Run Salt in FIPS-compliant mode. When enabled, modules that would otherwise
+# use cryptographic primitives not approved by FIPS 140-2 (such as MD5) will
+# refuse to run or will use FIPS-approved alternatives. This option must be
+# set on both the master and minion for end-to-end FIPS compliance. The host
+# Python interpreter and OpenSSL build must also be FIPS-capable. Default is
+# False.
+#fips_mode: False
+
 
 ######        Reactor Settings        #####
 ###########################################

--- a/doc/ref/cli/salt-key.rst
+++ b/doc/ref/cli/salt-key.rst
@@ -93,8 +93,9 @@ Actions
 
 .. option:: -a ACCEPT, --accept=ACCEPT
 
-    Accept the specified public key (use --include-all to match rejected keys
-    in addition to pending keys). Globs are supported.
+    Accept the specified public key. Use ``--include-rejected`` and
+    ``--include-denied`` to additionally match rejected and denied keys in
+    addition to pending keys. Globs are supported.
 
 .. option:: -A, --accept-all
 
@@ -102,8 +103,9 @@ Actions
 
 .. option:: -r REJECT, --reject=REJECT
 
-    Reject the specified public key (use --include-all to match accepted keys
-    in addition to pending keys). Globs are supported.
+    Reject the specified public key. Use ``--include-accepted`` and
+    ``--include-denied`` to additionally match accepted and denied keys in
+    addition to pending keys. Globs are supported.
 
 .. option:: -R, --reject-all
 
@@ -112,6 +114,24 @@ Actions
 .. option:: --include-all
 
     Include non-pending keys when accepting/rejecting.
+
+    .. deprecated:: 3006.0
+        Use ``--include-rejected`` and ``--include-accepted`` instead.
+
+.. option:: --include-accepted
+
+    When accepting or rejecting keys, also consider keys that are already in
+    the accepted state.
+
+.. option:: --include-rejected
+
+    When accepting or rejecting keys, also consider keys that are in the
+    rejected state.
+
+.. option:: --include-denied
+
+    When accepting or rejecting keys, also consider keys that are in the
+    denied state.
 
 .. option:: -p PRINT, --print=PRINT
 

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -248,20 +248,29 @@ these custom LogRecord attributes that include padding and enclosing brackets
 
 Default: ``{}``
 
-This can be used to control logging levels more specifically, based on log call name.  The example sets
-the main salt library at the 'warning' level, sets ``salt.modules`` to log
-at the ``debug`` level, and sets a custom module to the ``all`` level:
+This can be used to control logging levels more specifically, based on the
+fully-qualified logger name. The example below sets the main salt library at
+the ``warning`` level, raises ``salt.modules`` to ``debug``, and turns a
+single custom module up to ``trace`` (the most verbose level Salt defines):
 
 .. code-block:: yaml
 
   log_granular_levels:
     'salt': 'warning'
     'salt.modules': 'debug'
-    'salt.loader.saltmaster.ext.module.custom_module': 'all'
+    'salt.loader.saltmaster.ext.module.custom_module': 'trace'
 
-You can determine what log call name to use here by adding ``%(module)s`` to the
-log format. Typically, it is the path of the file which generates the log
-without the trailing ``.py`` and with path separators replaced with ``.``
+You can determine what logger name to use here by adding ``%(name)s`` to the
+log format. ``%(name)s`` prints the fully qualified dotted logger name (for
+example ``salt.loader.saltmaster.ext.module.custom_module``), which is what
+``log_granular_levels`` matches against. ``%(module)s`` only prints the
+short module name (the file name without ``.py``) and is **not** suitable
+for picking a key here.
+
+.. note::
+    ``all`` and ``garbage`` are valid Salt log levels that are even more
+    verbose than ``trace`` but are documented as insecure — they may log
+    sensitive data and should only be used for short-lived debugging.
 
 .. conf_log:: log_fmt_jid
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -911,6 +911,35 @@ Store all event returns _except_ the tags in a blacklist.
       - salt/master/not_this_tag
       - salt/wheel/*/ret
 
+.. conf_master:: event_match_type
+
+``event_match_type``
+--------------------
+
+.. versionadded:: 2019.2.0
+
+Default: ``startswith``
+
+Determines how event tags are matched when callers (for example a reactor or a
+:py:func:`salt.utils.event.get_event` consumer) wait for a tag. Allowed values
+are:
+
+- ``startswith`` (the default) — the event tag must start with the search
+  tag.
+- ``endswith`` — the event tag must end with the search tag.
+- ``find`` — the search tag must appear anywhere in the event tag.
+- ``regex`` — the search tag is treated as a regular expression and matched
+  against the event tag with :py:func:`re.match`.
+- ``fnmatch`` — the search tag is treated as a shell-style glob and matched
+  with :py:func:`fnmatch.fnmatch`.
+
+Individual callers may still pass an explicit ``match_type`` argument, which
+overrides this default for that single call.
+
+.. code-block:: yaml
+
+    event_match_type: startswith
+
 .. conf_master:: max_event_size
 
 ``max_event_size``
@@ -1309,9 +1338,16 @@ cache events are fired when a minion requests a minion data cache refresh.
 
 Default: ``20``
 
-HTTP connection timeout in seconds.
-Applied when fetching files using tornado back-end.
-Should be greater than overall download time.
+Timeout, in seconds, for establishing the initial TCP connection to an HTTP
+server when :py:func:`salt.utils.http.query` is called from master-side code
+(runners, the reactor, the REST API back-end, and similar). This is the
+maximum time the master will wait for the TCP/TLS handshake to complete — it
+does **not** bound the duration of the response body. For that, use
+:conf_master:`http_request_timeout`.
+
+Most user-facing HTTP fetches (``cp.cache_*``, ``file.managed`` with a
+``source: http(s)://`` URL, ...) happen on the *minion*; tune those values on
+the minion via :conf_minion:`http_connect_timeout`.
 
 .. code-block:: yaml
 
@@ -1326,9 +1362,14 @@ Should be greater than overall download time.
 
 Default: ``3600``
 
-HTTP request timeout in seconds.
-Applied when fetching files using tornado back-end.
-Should be greater than overall download time.
+Timeout, in seconds, for the *entire* HTTP request — including connect time,
+sending the request, and receiving the full response — when
+:py:func:`salt.utils.http.query` is called from master-side code. Set this
+larger than the longest acceptable transfer; if a request takes longer than
+this value, it is aborted.
+
+Most user-facing HTTP fetches happen on the *minion*; tune those values on
+the minion via :conf_minion:`http_request_timeout`.
 
 .. code-block:: yaml
 
@@ -1577,6 +1618,28 @@ The ssh password to log in with.
 
     ssh_passwd: ''
 
+.. conf_master:: ssh_priv
+
+``ssh_priv``
+------------
+
+Default: ``salt-ssh.rsa`` (under :conf_master:`pki_dir`)
+
+Path to the SSH private key file that salt-ssh uses when connecting to
+minions. Use this option to point salt-ssh at a key other than the default
+RSA key — for example to use an existing ed25519 key. If the key is
+passphrase-protected, set the passphrase via :conf_master:`ssh_priv_passwd`.
+
+Resolution order when authenticating to a roster target is:
+
+1. ``priv`` from the roster entry (highest priority)
+2. ``ssh_priv`` from the master config
+3. The bundled ``salt-ssh.rsa`` key under ``pki_dir``
+
+.. code-block:: yaml
+
+    ssh_priv: /etc/salt/pki/master/ssh/id_ed25519
+
 .. conf_master:: ssh_priv_passwd
 
 ``ssh_priv_passwd``
@@ -1584,7 +1647,7 @@ The ssh password to log in with.
 
 Default: ``''``
 
-Passphrase for ssh private key file.
+Passphrase for the ssh private key file referenced by :conf_master:`ssh_priv`.
 
 .. code-block:: yaml
 
@@ -2485,6 +2548,28 @@ the priority of optimization level(s) Salt's module loader should prefer.
       - 0
       - 1
 
+.. conf_master:: fips_mode
+
+``fips_mode``
+-------------
+
+.. versionadded:: 3003
+
+Default: ``False``
+
+When set to ``True``, Salt avoids cryptographic primitives that are not
+approved by FIPS 140-2 (for example ``md5`` for digest operations) and
+selects FIPS-approved alternatives where one exists. Modules that have no
+FIPS-approved alternative will refuse to run with a clear error.
+
+For an end-to-end FIPS-compliant deployment this option must be enabled on
+the master *and* on every minion, and the host Python interpreter plus
+OpenSSL build must themselves be FIPS-capable.
+
+.. code-block:: yaml
+
+    fips_mode: True
+
 Master Large Scale Tuning Settings
 ==================================
 
@@ -2539,6 +2624,14 @@ Standards for busy environments:
 * Use one worker thread per 200 minions.
 * The value of ``worker_threads`` should not exceed 1½ times the available CPU
   cores.
+* When the master also runs syndics, count the syndic's own outgoing
+  ``fire_master`` calls and the syndic's return traffic as additional load on
+  the master's worker pool. A common starting point for a multi-syndic
+  master is ``worker_threads = (200-minion units) + (1 per active syndic)``,
+  then scaled up with monitoring. Low CPU utilisation does **not** indicate
+  spare capacity here — workers spend most of their time waiting on the
+  request channel, so saturation shows up as request timeouts and stalled
+  publishes rather than load average.
 
 .. note::
     When the master daemon starts, it is expected behaviour to see
@@ -2740,9 +2833,14 @@ pillar top file
 ``state_top_saltenv``
 ---------------------
 
-This option has no default value. Set it to an environment name to ensure that
-*only* the top file from that environment is considered during a
-:ref:`highstate <running-highstate>`.
+This option has no default value. It acts as a fallback ``saltenv`` for top
+file selection: when a minion does **not** specify its own
+:conf_minion:`saltenv`, the highstate machinery will use only the top file
+from the environment named here.
+
+If the minion *does* set :conf_minion:`saltenv` (or passes ``saltenv=`` on a
+state call), that takes precedence and this option has no effect for that
+run.
 
 .. note::
     Minions which have an explicit :conf_minion:`saltenv` set will use that
@@ -5954,6 +6052,22 @@ Examples:
 .. code-block:: yaml
 
     log_file: udp://loghost:10514
+
+
+.. conf_master:: key_logfile
+
+``key_logfile``
+---------------
+
+Default: ``/var/log/salt/key``
+
+Path of the log file used by ``salt-key`` to record key acceptance,
+rejection and deletion activity. If :conf_master:`root_dir` is set, the
+path is prepended with that root.
+
+.. code-block:: yaml
+
+    key_logfile: /var/log/salt/key
 
 
 .. conf_master:: log_level

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -182,8 +182,13 @@ The type of the :conf_minion:`master` variable. Can be ``str``, ``failover``,
 
     master_type: str
 
-If this option is ``str`` (default), multiple hot masters are configured.
-Minions can connect to multiple masters simultaneously (all master are "hot").
+If this option is ``str`` (the default), the value of :conf_minion:`master`
+is treated as a Python string. A single master is allowed, and if a list of
+masters is given the minion connects to all of them simultaneously and
+treats every entry as "hot" — every master can publish jobs to the minion
+and the minion will return results to whichever master sent each job. ``str``
+is the simplest setup and the right choice for multi-master deployments
+without failover semantics.
 
 .. code-block:: yaml
 
@@ -212,6 +217,35 @@ masterless minion daemon.
 .. code-block:: yaml
 
     master_type: disable
+
+.. conf_minion:: event_match_type
+
+``event_match_type``
+--------------------
+
+.. versionadded:: 2019.2.0
+
+Default: ``startswith``
+
+Determines how event tags are matched when callers (for example a reactor or a
+:py:func:`salt.utils.event.get_event` consumer) wait for a tag. Allowed values
+are:
+
+- ``startswith`` (the default) — the event tag must start with the search
+  tag.
+- ``endswith`` — the event tag must end with the search tag.
+- ``find`` — the search tag must appear anywhere in the event tag.
+- ``regex`` — the search tag is treated as a regular expression and matched
+  against the event tag with :py:func:`re.match`.
+- ``fnmatch`` — the search tag is treated as a shell-style glob and matched
+  with :py:func:`fnmatch.fnmatch`.
+
+Individual callers may still pass an explicit ``match_type`` argument, which
+overrides this default for that single call.
+
+.. code-block:: yaml
+
+    event_match_type: startswith
 
 .. conf_minion:: max_event_size
 
@@ -370,6 +404,14 @@ Default: ``30``
 Set the number of seconds to wait before attempting to resolve
 the master hostname if name resolution fails. Defaults to 30 seconds.
 Set to zero if the minion should shutdown and not retry.
+
+.. note::
+    When :conf_minion:`master_type` is ``failover``, ``retry_dns`` must be
+    ``0``. If it is non-zero, the minion will log a ``CRITICAL`` warning at
+    start-up and force ``retry_dns`` to ``0`` so that DNS resolution failures
+    trigger failover to the next master instead of looping on the same name.
+    In this mode, :conf_minion:`acceptance_wait_time` is used as the wait
+    between DNS resolution attempts.
 
 .. code-block:: yaml
 
@@ -1178,6 +1220,12 @@ Default: ``10``
 The number of seconds to wait until attempting to re-authenticate with the
 master.
 
+.. note::
+    When :conf_minion:`master_type` is ``failover``,
+    :conf_minion:`retry_dns` is forced to ``0`` and ``acceptance_wait_time``
+    is also used as the wait between DNS resolution attempts for the current
+    master.
+
 .. code-block:: yaml
 
     acceptance_wait_time: 10
@@ -1319,13 +1367,15 @@ restart.
 
 .. versionadded:: 3006.2
 
-Default: ``30``
+Default: ``60``
 
-The default timeout timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
+The default timeout, in seconds, for request channel requests. This setting
+can be used to tune minions to better handle long running pillar and file
+client requests.
 
 .. code-block:: yaml
 
-    request_channel_timeout: 30
+    request_channel_timeout: 60
 
 ``request_channel_tries``
 -------------------------
@@ -1614,9 +1664,11 @@ talking to the intended master.
 
 Default: ``20``
 
-HTTP connection timeout in seconds.
-Applied when fetching files using tornado back-end.
-Should be greater than overall download time.
+Timeout, in seconds, for establishing the initial TCP connection to an HTTP
+server. Applied when fetching files via the Tornado back-end. This is the
+maximum time the minion will wait for the TCP/TLS handshake to complete — it
+does **not** bound the duration of the response body. For that, use
+:conf_minion:`http_request_timeout`.
 
 .. code-block:: yaml
 
@@ -1631,9 +1683,10 @@ Should be greater than overall download time.
 
 Default: ``3600``
 
-HTTP request timeout in seconds.
-Applied when fetching files using tornado back-end.
-Should be greater than overall download time.
+Timeout, in seconds, for the *entire* HTTP request — including connect time,
+sending the request, and receiving the full response. Applied when fetching
+files via the Tornado back-end. Set this larger than the longest acceptable
+download time; if the request takes longer than this value, it is aborted.
 
 .. code-block:: yaml
 
@@ -2120,9 +2173,13 @@ root of the base environment.
 ``state_top_saltenv``
 ---------------------
 
-This option has no default value. Set it to an environment name to ensure that
-*only* the top file from that environment is considered during a
-:ref:`highstate <running-highstate>`.
+This option has no default value. It acts as a fallback ``saltenv`` for top
+file selection: when the minion does **not** specify its own
+:conf_minion:`saltenv`, the highstate machinery will use only the top file
+from the environment named here.
+
+If :conf_minion:`saltenv` is set (or ``saltenv=`` is passed on a state call),
+that takes precedence and this option has no effect for that run.
 
 .. note::
     Using this value does not change the merging strategy. For instance, if
@@ -3350,6 +3407,28 @@ The RSA signing algorithm used by this minion when connecting to the
 master's request channel. Valid values are ``PKCS1v15-SHA1`` and
 ``PKCS1v15-SHA224``
 
+.. conf_minion:: fips_mode
+
+``fips_mode``
+-------------
+
+.. versionadded:: 3003
+
+Default: ``False``
+
+When set to ``True``, Salt avoids cryptographic primitives that are not
+approved by FIPS 140-2 (for example ``md5`` for digest operations) and
+selects FIPS-approved alternatives where one exists. Modules that have no
+FIPS-approved alternative will refuse to run with a clear error.
+
+For an end-to-end FIPS-compliant deployment this option must be enabled on
+the minion *and* on the master, and the host Python interpreter plus OpenSSL
+build must themselves be FIPS-capable.
+
+.. code-block:: yaml
+
+    fips_mode: True
+
 
 Reactor Settings
 ================
@@ -3480,6 +3559,22 @@ Examples:
 .. code-block:: yaml
 
     log_file: udp://loghost:10514
+
+
+.. conf_minion:: key_logfile
+
+``key_logfile``
+---------------
+
+Default: ``/var/log/salt/key``
+
+Path of the log file used by minion-side ``salt-call`` and ``salt-key``
+helpers to record key handling activity. If :conf_minion:`root_dir` is set,
+the path is prepended with that root.
+
+.. code-block:: yaml
+
+    key_logfile: /var/log/salt/key
 
 
 .. conf_minion:: log_level

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1759,7 +1759,11 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "ssh_use_home_key": False,
         "cython_enable": False,
         "enable_gpu_grains": False,
-        # XXX: Remove 'key_logfile' support in 2014.1.0
+        # Path to the salt-key activity log. The XXX comment that previously
+        # lived here said "Remove 'key_logfile' support in 2014.1.0", but the
+        # option is still consumed by salt-key (see salt/cli/key.py and
+        # salt/config: prepend_root_dir loop) and is documented as a public
+        # option in conf/master and doc/ref/configuration/master.rst.
         "key_logfile": os.path.join(salt.syspaths.LOGS_DIR, "key"),
         "verify_env": True,
         "permissive_pki_access": False,

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2953,8 +2953,18 @@ def append_domain():
 def fqdns():
     """
     Return all known FQDNs for the system by enumerating all interfaces and
-    then trying to reverse resolve them (excluding 'lo' interface).
-    To disable the fqdns grain, set enable_fqdns_grains: False in the minion configuration file.
+    then trying to reverse resolve them (excluding the ``lo`` interface).
+
+    The ``fqdns`` grain is controlled by the minion option
+    ``enable_fqdns_grains``. As of Salt 3006, the default is:
+
+    - ``False`` on Windows, proxy minions, SunOS/Illumos, AIX, Junos and
+      macOS (because resolving reverse-DNS for every interface address can
+      block minion start-up on these platforms).
+    - ``True`` everywhere else.
+
+    To explicitly opt in or opt out, set ``enable_fqdns_grains: True`` or
+    ``enable_fqdns_grains: False`` in the minion configuration file.
     """
     # Provides:
     # fqdns

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -68,6 +68,21 @@ that python-croniter is installed on the minion.
         - function: state.sls
         - job_args:
           - httpd
+        - cron: '*/5 * * * *'
+        - splay: 60
+
+``cron`` and ``splay`` can be combined. Each cron firing is offset by a
+random number of seconds in ``[0, splay]`` (or in ``[start, end]`` when
+``splay`` is a dict). Combining them is the recommended way to stop a fleet
+of minions from launching the same expensive job at exactly the same second.
+
+.. code-block:: yaml
+
+    job1:
+      schedule.present:
+        - function: state.sls
+        - job_args:
+          - httpd
         - job_kwargs:
             test: True
         - when:

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -10,15 +10,25 @@ The timezone can be managed for the system:
       timezone.system
 
 The system and the hardware clock are not necessarily set to the same time.
-By default, the hardware clock is set to localtime, meaning it is set to the
-same time as the system clock. If `utc` is set to True, then the hardware clock
-will be set to UTC, and the system clock will be an offset of that.
+On a typical machine the hardware clock is set to either localtime (meaning
+it tracks the system clock directly) or to UTC (meaning the system clock is
+an offset of it).
+
+The ``timezone.system`` state defaults ``utc`` to ``True`` — when this state
+runs without arguments, it will configure the hardware clock to UTC. Set
+``utc: False`` if you need the hardware clock to track localtime instead
+(for example on machines that dual-boot with Windows):
 
 .. code-block:: yaml
 
     America/Denver:
       timezone.system:
         - utc: True
+
+    # Dual-boot with Windows: keep the hardware clock on localtime
+    America/Denver:
+      timezone.system:
+        - utc: False
 
 .. _here: https://help.ubuntu.com/community/UbuntuTime#Multiple_Boot_Systems_Time_Conflicts
 

--- a/tests/pytests/unit/config/test_docs_consistency.py
+++ b/tests/pytests/unit/config/test_docs_consistency.py
@@ -1,0 +1,316 @@
+"""
+Documentation consistency tests for configuration options.
+
+These tests cover the specific symptoms enumerated in the EPIC
+saltstack/salt#58112 (PR2 audit). They are intentionally narrow: each test
+asserts a single observable fact about a single file, so a regression is
+easy to locate.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def repo_root():
+    # Walk up until we find a Makefile + conf/master sentinel.
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "conf" / "master").is_file() and (
+            parent / "salt" / "config" / "__init__.py"
+        ).is_file():
+            return parent
+    raise RuntimeError("could not locate Salt repo root from test file")
+
+
+@pytest.fixture(scope="module")
+def master_rst(repo_root):
+    return (repo_root / "doc/ref/configuration/master.rst").read_text()
+
+
+@pytest.fixture(scope="module")
+def minion_rst(repo_root):
+    return (repo_root / "doc/ref/configuration/minion.rst").read_text()
+
+
+@pytest.fixture(scope="module")
+def conf_master(repo_root):
+    return (repo_root / "conf/master").read_text()
+
+
+@pytest.fixture(scope="module")
+def conf_minion(repo_root):
+    return (repo_root / "conf/minion").read_text()
+
+
+@pytest.fixture(scope="module")
+def config_init(repo_root):
+    return (repo_root / "salt/config/__init__.py").read_text()
+
+
+@pytest.fixture(scope="module")
+def logging_rst(repo_root):
+    return (repo_root / "doc/ref/configuration/logging/index.rst").read_text()
+
+
+@pytest.fixture(scope="module")
+def salt_key_rst(repo_root):
+    return (repo_root / "doc/ref/cli/salt-key.rst").read_text()
+
+
+@pytest.fixture(scope="module")
+def schedule_state(repo_root):
+    return (repo_root / "salt/states/schedule.py").read_text()
+
+
+@pytest.fixture(scope="module")
+def timezone_state(repo_root):
+    return (repo_root / "salt/states/timezone.py").read_text()
+
+
+@pytest.fixture(scope="module")
+def grains_core(repo_root):
+    return (repo_root / "salt/grains/core.py").read_text()
+
+
+# --- #59910: fips_mode -------------------------------------------------------
+
+
+def test_fips_mode_documented_in_master_rst(master_rst):
+    assert ".. conf_master:: fips_mode" in master_rst
+
+
+def test_fips_mode_documented_in_minion_rst(minion_rst):
+    assert ".. conf_minion:: fips_mode" in minion_rst
+
+
+def test_fips_mode_in_example_master_conf(conf_master):
+    assert "fips_mode" in conf_master
+
+
+def test_fips_mode_in_example_minion_conf(conf_minion):
+    assert "fips_mode" in conf_minion
+
+
+# --- #58891: event_match_type ------------------------------------------------
+
+
+def test_event_match_type_documented_in_master_rst(master_rst):
+    assert ".. conf_master:: event_match_type" in master_rst
+    # check we documented all five valid values
+    for value in ("startswith", "endswith", "find", "regex", "fnmatch"):
+        assert value in master_rst, value
+
+
+def test_event_match_type_documented_in_minion_rst(minion_rst):
+    assert ".. conf_minion:: event_match_type" in minion_rst
+    for value in ("startswith", "endswith", "find", "regex", "fnmatch"):
+        assert value in minion_rst, value
+
+
+# --- #66587: state_top_saltenv ----------------------------------------------
+
+
+def test_state_top_saltenv_master_doc_mentions_saltenv_precedence(master_rst):
+    # find the state_top_saltenv block
+    start = master_rst.index(".. conf_master:: state_top_saltenv")
+    end = master_rst.index(".. conf_master::", start + 1)
+    block = master_rst[start:end]
+    # body must reference saltenv to clarify when this option actually applies
+    assert "saltenv" in block.lower()
+    assert "fallback" in block.lower()
+
+
+def test_state_top_saltenv_minion_doc_mentions_saltenv_precedence(minion_rst):
+    start = minion_rst.index(".. conf_minion:: state_top_saltenv")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "saltenv" in block.lower()
+    assert "fallback" in block.lower()
+
+
+# --- #66533: multi-master DNS retry / acceptance_wait_time -------------------
+
+
+def test_retry_dns_block_documents_failover_force_to_zero(minion_rst):
+    start = minion_rst.index(".. conf_minion:: retry_dns\n")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "failover" in block.lower()
+    assert "acceptance_wait_time" in block
+
+
+def test_acceptance_wait_time_block_documents_dns_retry_role(minion_rst):
+    start = minion_rst.index(".. conf_minion:: acceptance_wait_time\n")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "failover" in block.lower()
+    assert "dns" in block.lower()
+
+
+# --- #65866: grains.fqdns default -------------------------------------------
+
+
+def test_fqdns_docstring_describes_platform_defaults(grains_core):
+    # find the fqdns docstring
+    idx = grains_core.index("def fqdns()")
+    snippet = grains_core[idx : idx + 1500]
+    assert "enable_fqdns_grains" in snippet
+    # the docstring must mention the platforms with default-False behavior
+    for token in ("Windows", "proxy", "AIX"):
+        assert token in snippet, token
+    # and the obsolete "actively disable it" framing must be gone
+    assert "actively disable" not in snippet
+
+
+# --- #58893: key_logfile ----------------------------------------------------
+
+
+def test_key_logfile_xxx_comment_removed(config_init):
+    # The original stale comment was:
+    #     # XXX: Remove 'key_logfile' support in 2014.1.0
+    # confirm the "XXX: Remove" form is gone (the prose explanation that
+    # replaced it is fine and is not flagged here).
+    assert "XXX: Remove 'key_logfile'" not in config_init
+
+
+def test_key_logfile_documented_in_master_rst(master_rst):
+    assert ".. conf_master:: key_logfile" in master_rst
+
+
+def test_key_logfile_documented_in_minion_rst(minion_rst):
+    assert ".. conf_minion:: key_logfile" in minion_rst
+
+
+# --- #60732: cron + splay ---------------------------------------------------
+
+
+def test_schedule_state_documents_cron_plus_splay(schedule_state):
+    # there must be an example combining cron and splay
+    assert "cron: '*/5 * * * *'" in schedule_state
+    # and the doc must explicitly state cron and splay work together
+    assert "cron`` and ``splay`` can be combined" in schedule_state
+
+
+# --- #60630: timezone utc default -------------------------------------------
+
+
+def test_timezone_state_docstring_default_is_consistent(timezone_state):
+    # both the prose and the parameter doc must agree on default = True
+    assert "defaults ``utc`` to ``True``" in timezone_state
+    # the old conflicting "By default, the hardware clock is set to localtime"
+    # phrasing should be gone
+    assert "By default, the hardware clock is set to localtime" not in timezone_state
+
+
+# --- #61963: master_type str default ----------------------------------------
+
+
+def test_master_type_str_default_explained(minion_rst):
+    start = minion_rst.index(".. conf_minion:: master_type")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    # the str-default case must describe what behavior is selected
+    assert "hot" in block.lower()
+    assert "multi-master" in block.lower()
+
+
+# --- #60965: worker_threads tuning ------------------------------------------
+
+
+def test_worker_threads_documents_syndic_consideration(master_rst):
+    start = master_rst.index(".. conf_master:: worker_threads")
+    end = master_rst.index(".. conf_master::", start + 1)
+    block = master_rst[start:end]
+    assert "syndic" in block.lower()
+
+
+# --- #61293: http_*_timeout -------------------------------------------------
+
+
+def test_http_connect_timeout_minion_distinguishes_from_request_timeout(minion_rst):
+    start = minion_rst.index(".. conf_minion:: http_connect_timeout")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "initial" in block.lower() or "handshake" in block.lower()
+    assert "request_timeout" in block
+
+
+def test_http_request_timeout_minion_describes_entire_request(minion_rst):
+    start = minion_rst.index(".. conf_minion:: http_request_timeout")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "entire" in block.lower()
+
+
+def test_http_timeouts_master_points_at_minion_for_user_fetches(master_rst):
+    for opt in ("http_connect_timeout", "http_request_timeout"):
+        start = master_rst.index(f".. conf_master:: {opt}")
+        end = master_rst.index(".. conf_master::", start + 1)
+        block = master_rst[start:end]
+        # master docs must redirect "user-facing fetches" guidance to minion
+        assert ":conf_minion:" in block
+
+
+# --- #57416: ssh_priv -------------------------------------------------------
+
+
+def test_ssh_priv_documented_in_master_rst(master_rst):
+    assert ".. conf_master:: ssh_priv\n" in master_rst
+
+
+def test_ssh_priv_in_example_master_conf(conf_master):
+    assert "ssh_priv:" in conf_master or "#ssh_priv:" in conf_master
+
+
+# --- #69109: retry_dns inconsistency ----------------------------------------
+
+
+def test_retry_dns_block_mentions_failover_critical_log(minion_rst):
+    start = minion_rst.index(".. conf_minion:: retry_dns\n")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    # the actual code logs CRITICAL when retry_dns != 0 with failover master_type
+    assert "CRITICAL" in block or "critical" in block.lower()
+
+
+# --- #66270: request_channel_timeout default --------------------------------
+
+
+def test_request_channel_timeout_default_matches_code(config_init, minion_rst):
+    # confirm code default
+    assert '"request_channel_timeout": 60' in config_init
+    # confirm doc default matches
+    start = minion_rst.index(".. conf_minion:: request_channel_timeout")
+    end = minion_rst.index(".. conf_minion::", start + 1)
+    block = minion_rst[start:end]
+    assert "Default: ``60``" in block
+
+
+# --- #66884: log_granular_levels --------------------------------------------
+
+
+def test_log_granular_levels_uses_name_format(logging_rst):
+    start = logging_rst.index(".. conf_log:: log_granular_levels")
+    end = logging_rst.index(".. conf_log::", start + 1)
+    block = logging_rst[start:end]
+    # the doc must recommend %(name)s rather than %(module)s
+    assert "%(name)s" in block
+    # and must call out that %(module)s only prints the short name
+    assert "short" in block.lower()
+
+
+# --- #63109: salt-key --include-* -------------------------------------------
+
+
+def test_salt_key_rst_documents_new_include_flags(salt_key_rst):
+    for flag in ("--include-accepted", "--include-rejected", "--include-denied"):
+        assert f".. option:: {flag}" in salt_key_rst, flag
+
+
+def test_salt_key_rst_marks_include_all_deprecated(salt_key_rst):
+    start = salt_key_rst.index(".. option:: --include-all")
+    end = salt_key_rst.index(".. option::", start + 1)
+    block = salt_key_rst[start:end]
+    assert "deprecated" in block.lower()


### PR DESCRIPTION
## Summary

Documentation-only audit for the configuration-options EPIC (#58112).

This PR fixes the user-facing documentation for 15 of the 21 enumerated
config-audit issues, plus closes 2 that are already resolved in current
sources, plus defers 1 (full CLI parser/man audit) and 1 (CLI-doc-outdated
subsumed by #60677).

### Issues addressed

| issue | symptom | fix |
|---|---|---|
| #59910 | `fips_mode` undocumented | rst directive + conf/* entries on master & minion |
| #58891 | `event_match_type` not in rst | full directive on master & minion, listing 5 valid values |
| #66587 | `state_top_saltenv` description misleading | re-cast as a saltenv *fallback* |
| #66533 | acceptance_wait_time as DNS-retry wait undocumented | note added to both opts |
| #65866 | grains.fqdns default platform table missing | listed in docstring |
| #58893 | stale "XXX: Remove key_logfile 2014.1.0" + undocumented | removed + documented |
| #60732 | cron+splay combo undocumented | worked example added |
| #60630 | timezone state utc default conflicting | docstring reworded |
| #61963 | master_type str behavior unexplained | "hot multi-master" description |
| #60965 | worker_threads syndic guidance | guidance + saturation signal |
| #61293 | http_*_timeout identical wording | distinguished (handshake vs. entire) |
| #57416 | ssh_priv undocumented | rst directive + conf/master entry |
| #69109 | retry_dns failover override undocumented | CRITICAL-log behaviour noted |
| #66270 | request_channel_timeout doc default 30 (code is 60) | fixed to 60 |
| #66884 | log_granular_levels %(module)s wrong | use %(name)s; `all`/`garbage` noted |
| #63109 | salt-key --include-* missing from rst+man | documented; --include-all marked deprecated |
| #56545 | fileserver_limit_traversal | already-fully-removed from code (close as fixed) |
| #50348 | use_superseded undocumented | already documented in salt.states.module 3005 deprecation note |
| #60677 | salt --help vs man audit | deferred — large CLI parser cross-check, tracked under EPIC |
| #56214 | --failhard missing from cli docs | subsumed by #60677 |

### Test plan

A new module `tests/pytests/unit/config/test_docs_consistency.py` contains 28
focused assertions covering every claim above. The test reads the source
files of record (`salt/config/__init__.py`, `conf/master`, `conf/minion`,
`doc/ref/configuration/*.rst`, `doc/ref/cli/salt-key.rst`,
`salt/grains/core.py`, `salt/states/{schedule,timezone}.py`) and asserts
each fact textually — so a future regression on any one issue surfaces in
CI as a specific test failure.

* [x] `make -C doc html` clean
* [x] `make -C doc man` clean (salt-key.1 contains the new --include-* flags)
* [x] `pytest tests/pytests/unit/config/test_docs_consistency.py` → 28 pass
* [x] `pre-commit run --files <changed files>` clean