### PR TITLE
docs: cleanup module and state docstrings to match behavior (3006.x)

### DIFF
--- a/changelog/58845.fixed.md
+++ b/changelog/58845.fixed.md
@@ -1,0 +1,30 @@
+Cleaned up a batch of state and execution-module docstrings to match
+actual behavior. Addressed reports from #58845 (slack_notify.call_hook
+documented the configuration key as ``identifier`` rather than ``hook``),
+#67074 (file.seek_read used ``seek`` instead of ``size`` in the
+description), #67911 (file.find listed ``user`` filter but the option is
+``owner``), #54802 (pkgrepo.managed said ``enabled=False`` assumes
+``disabled=False`` instead of ``True``), #61671 (pkgrepo.managed had no
+note about the ``hkp://`` keyserver scheme), #62002 (wheel.key
+``__func_alias__`` aliases were not documented), #56729 / #65756
+(virtualenv state docstring referred to ``virtualenv_mod`` and did not
+point at ``virtualenv_mod.create`` for unmapped kwargs), #61886 / #59666
+(aptpkg and groupadd state/module docstrings did not surface the
+``apt`` and ``group`` virtual names), #55916 / #50568 / #64075 / #60773
+(file state docstrings for ``rename``, ``copy``, ``blockreplace`` and
+the octal-mode warning), #34929 / #57606 / #60784 / #63852
+(service.running ``sig`` special-character handling, missing ``reload``
+and ``full_restart`` docs, and the systemd daemon-reload note), #57505 /
+#57949 (cmd.run ``runas`` privilege drop semantics and Windows password
+requirement), #61689 (user.present Windows-unsupported uid/gid/allow_*
+arguments), #64021 (win_pki available certificate stores), #56182
+(netmiko_px ``keepalive`` vs. ``always_alive``), #51213
+(postgres_privileges ``maintenance_db`` copy-paste), #57405 (file_tree
+pillar example mismatched the rendered pillar tree), #63364 (saltcheck
+duplicate "Example with jinja" section and unclear assertion
+definition), #61405 (file.chown broken-symlink ``lchown`` fallback),
+#60406 (jobs.last_run runner description and parameters), #55881
+(docker_container.running ``command`` accepts list as well as string),
+#56956 (docker_image.present ``sls`` does not accept a YAML list), and
+#66409 (docker_container.running hostname does not fall back to
+``name``). No behavior changes; documentation only.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1171,6 +1171,18 @@ def run(
 
                 cmd.run 'echo '\''h=\"baz\"'\''' runas=macuser
 
+        .. note::
+
+            On Linux ``runas`` switches the effective user but does **not**
+            run a login shell, so the supplementary groups, ``$HOME`` and
+            ``$PATH`` of the target account are not loaded. The primary
+            group of the salt-minion process (typically ``root``) is kept,
+            which is why ``id`` from inside the executed command may report
+            ``gid=0(root)``. Pass ``group=`` to switch the primary group as
+            well, or invoke a login shell explicitly (for example
+            ``su - <user> -c '...'``) when the full target environment is
+            required.
+
     :param str group: Group to run command as. Not currently supported
         on Windows.
 
@@ -1180,6 +1192,14 @@ def run(
         privileges it can obtain a logon token for the target user through
         Windows impersonation APIs without needing their credentials. This
         parameter is ignored on non-Windows platforms.
+
+        .. note::
+
+            On Windows, when ``runas`` is supplied but no logon token is
+            available (i.e. the salt-minion is not running as SYSTEM or as
+            an elevated Administrator), ``password`` must also be provided.
+            Omitting it surfaces as an opaque "embedded null character"
+            error.
 
         .. versionadded:: 2016.3.0
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -487,7 +487,18 @@ def chown(path, user, group):
     Chown a file, pass the file the desired user and group
 
     path
-        path to the file or directory
+        path to the file or directory.
+
+        .. note::
+            For an existing target this function follows symlinks and
+            modifies the resolved file. When ``path`` is a broken
+            symlink (its target does not exist), the symlink itself is
+            chowned via ``lchown`` rather than raising an error. This
+            differs from :py:func:`file.chgrp` /
+            :py:func:`file.lchown` which expose an explicit
+            ``follow_symlinks`` parameter; use
+            :py:func:`file.lchown` if you need to chown a *good* symlink
+            without dereferencing it.
 
     user
         user owner
@@ -983,7 +994,7 @@ def find(path, *args, **kwargs):
         regex   = path-regex                # case sensitive
         iregex  = path-regex                # case insensitive
         type    = file-types                # match any listed type
-        user    = users                     # match any listed user
+        owner   = users                     # match any listed user
         group   = groups                    # match any listed group
         size    = [+-]number[size-unit]     # default unit = byte
         mtime   = interval                  # modified since date
@@ -3710,7 +3721,7 @@ def seek_read(path, size, offset):
     path
         path to file
 
-    seek
+    size
         amount to read at once
 
     offset

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -2,10 +2,12 @@
 Manage groups on Linux, OpenBSD and NetBSD
 
 .. important::
-    If you feel that Salt should be using this module to manage groups on a
-    minion, and it is using a different module (or gives an error similar to
-    *'group.info' is not available*), see :ref:`here
-    <module-provider-override>`.
+    This module is loaded under the ``group`` virtual name. Address it as
+    ``group.<function>`` (for example ``group.add``) and not as
+    ``groupadd.<function>``. If you feel that Salt should be using this
+    module to manage groups on a minion, and it is using a different
+    module (or gives an error similar to *'group.info' is not available*),
+    see :ref:`here <module-provider-override>`.
 """
 
 import functools

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -87,8 +87,13 @@ Saltcheck Keywords
 **kwargs:**
     (dict) Optional keyword arguments to be passed to the salt module
 **assertion:**
-    (str) One of the supported assertions and required except for ``saltcheck.state_apply``
-    Tests which fail the assertion and expected_return, cause saltcheck to exit which a non-zero exit code.
+    (str) The name of one of the supported assertions (for example
+    ``assertEqual``, ``assertTrue``, ``assertIn``). Required for every
+    test except those whose ``module_and_function`` is
+    ``saltcheck.state_apply`` (which represents a setup/teardown step
+    rather than an assertion). When a test fails its assertion (or its
+    ``expected_return`` does not match) the overall ``saltcheck`` run
+    exits with a non-zero status code.
 **expected_return:**
     (str) Required except by ``assertEmpty``, ``assertNotEmpty``, ``assertTrue``,
     ``assertFalse``. The return of module_and_function is compared to this value in the assertion.
@@ -160,39 +165,6 @@ Example with setup state including pillar
       args:
         - common
       pillar_data:
-        data: value
-
-    verify_vim:
-      module_and_function: pkg.version
-      args:
-        - vim
-      assertion: assertNotEmpty
-
-Example with jinja
-------------------
-
-.. code-block:: jinja
-
-    {% for package in ["apache2", "openssh"] %}
-    {# or another example #}
-    {# for package in salt['pillar.get']("packages") #}
-    test_{{ package }}_latest:
-      module_and_function: pkg.upgrade_available
-      args:
-        - {{ package }}
-      assertion: assertFalse
-    {% endfor %}
-
-Example with setup state including pillar
------------------------------------------
-
-.. code-block:: yaml
-
-    setup_test_environment:
-      module_and_function: saltcheck.state_apply
-      args:
-        - common
-      pillar-data:
         data: value
 
     verify_vim:

--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -260,7 +260,12 @@ def call_hook(
     :param color:       The color of border of left side
     :param short:       An optional flag indicating whether the value is short
                         enough to be displayed side-by-side with other values.
-    :param identifier:  The identifier of WebHook.
+    :param identifier:  The identifier of the WebHook (the part of the URL
+                        after ``https://hooks.slack.com/services/``). When not
+                        passed on the command line the value is read from the
+                        ``slack.hook`` minion configuration option (or the
+                        nested ``slack: hook:`` form). The configuration key
+                        is ``hook``, not ``identifier``.
     :param channel:     The channel to use instead of the WebHook default.
     :param username:    Username to use instead of WebHook default.
     :param icon_emoji:  Icon to use instead of WebHook default.
@@ -270,7 +275,15 @@ def call_hook(
 
     .. code-block:: bash
 
-        salt '*' slack.call_hook message='Hello, from SaltStack'
+        salt '*' slack.call_hook message='Hello, from SaltStack' \\
+            identifier='T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+
+    Minion configuration example:
+
+    .. code-block:: yaml
+
+        slack:
+          hook: T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 
     """
     base_url = "https://hooks.slack.com/services/"

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -112,34 +112,31 @@ For example, the following ``root_dir`` tree:
     ./hosts/test-host/files/another-testdir/
     ./hosts/test-host/files/another-testdir/symlink-to-file1.txt
 
-will result in the following pillar tree for minion with ID ``test-host``:
+will result in the following pillar tree for minion with ID ``test-host``
+(each leaf is the file's contents):
 
 .. code-block:: text
 
     test-host:
         ----------
-        apache:
+        files:
             ----------
-            config.d:
+            testdir:
                 ----------
-                00_important.conf:
-                    <important_config important_setting="yes" />
-                20_bob_extra.conf:
-                    <bob_specific_cfg has_freeze_ray="yes" />
-        corporate_app:
-            ----------
-            settings:
+                file1.txt:
+                    <contents of ./hosts/test-host/files/testdir/file1.txt>
+                file2.txt:
+                    <contents of ./hosts/test-host/files/testdir/file2.txt>
+            another-testdir:
                 ----------
-                common_settings:
-                    // This is the main settings file for the corporate
-                    // internal web app
-                    main_setting: probably
-                bob_settings:
-                    role: bob
+                symlink-to-file1.txt:
+                    <contents pointed to by the symlink>
 
 .. note::
 
-    The leaf data in the example shown is the contents of the pillar files.
+    Each subdirectory under the per-host (or per-nodegroup) root becomes a
+    nested pillar key; each file becomes a leaf whose value is the file's
+    contents (subject to the ``keep_newline`` and templating options).
 """
 
 import fnmatch

--- a/salt/proxy/netmiko_px.py
+++ b/salt/proxy/netmiko_px.py
@@ -135,9 +135,14 @@ to connect to the network device:
 - ``session_timeout`` - Set a timeout for parallel requests, in seconds
   (default: ``60``)
 
-- ``keepalive`` - Send SSH keepalive packets at a specific interval, in
-  seconds. Currently defaults to ``0``, for backwards compatibility (it will
-  not attempt to keep the connection alive using the KEEPALIVE packets).
+- ``keepalive`` - Interval, in seconds, at which to send SSH KEEPALIVE
+  packets on a *currently open* connection so the remote device does not
+  drop the session for inactivity. Currently defaults to ``0`` for
+  backwards compatibility (no KEEPALIVE packets are sent). This option
+  only takes effect while a connection is open; it does not influence
+  whether a new connection is opened. To control whether the proxy keeps
+  a single persistent connection or reconnects per call, use
+  ``always_alive`` (see below).
 
 - ``default_enter`` - Character(s) to send to correspond to enter key (default:
   ``\\n``)
@@ -145,11 +150,15 @@ to connect to the network device:
 - ``response_return`` - Character(s) to use in normalized return data to
   represent enter key (default: ``\\n``)
 
-- ``always_alive`` - In certain less dynamic environments, maintaining the
-  remote connection permanently open with the network device is not always
-  beneficial. In that case, the user can select to initialize the connection
-  only when needed, by setting this option to ``False``. By default this option
-  is set to ``True`` (maintains the connection with the remote network device)
+- ``always_alive`` - Controls connection lifecycle. When ``True`` (the
+  default), the proxy opens a single SSH session on start-up and reuses
+  it for every call. When ``False``, the proxy opens a fresh SSH session
+  for each call and closes it on completion -- useful in less dynamic
+  environments, when the target device has aggressive idle timers, or
+  when many proxies share a single connection limit on the device. This
+  setting governs whether a connection is opened at all; the
+  ``keepalive`` setting governs whether KEEPALIVE packets are sent on an
+  open connection.
 
 - ``multiprocessing`` - Overrides the :conf_minion:`multiprocessing` option,
   per proxy minion, as the Netmiko communication channel is mainly SSH

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -498,7 +498,32 @@ def last_run(
     """
     .. versionadded:: 2015.8.0
 
-    List all detectable jobs and associated functions
+    Return the most recent job (the one with the highest JID) that matches
+    the supplied filters. With no filters this returns the single most
+    recent job recorded by the active master job cache.
+
+    ext_source
+        The external job cache to read from. Defaults to the master job
+        cache configured via ``master_job_cache``.
+
+    outputter
+        Override the default outputter when returning the job result.
+
+    metadata
+        A dictionary of metadata values to filter on. Only jobs whose
+        recorded metadata matches every key/value pair will be considered.
+
+    function
+        Only consider jobs that invoked the named execution function (for
+        example ``cmd.run``).
+
+    target
+        Only consider jobs that ran against the specified target.
+
+    display_progress
+        When ``True``, display progress events while scanning jobs.
+
+    Returns ``False`` when no matching job is found.
 
     CLI Example:
 

--- a/salt/states/aptpkg.py
+++ b/salt/states/aptpkg.py
@@ -1,6 +1,12 @@
 """
 Package management operations specific to APT- and DEB-based systems
 ====================================================================
+
+.. note::
+
+    This state module is loaded under the ``apt`` virtual name. Use
+    ``apt.held`` (and not ``aptpkg.held``) when referring to functions
+    from this module in your state SLS files.
 """
 
 import logging

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -583,7 +583,10 @@ def running(
             This option requires Docker 1.2.0 or newer.
 
     command (or *cmd*)
-        Command to run in the container
+        Command to run in the container. May be specified either as a string
+        or as a YAML list of arguments. A list maps directly to Docker's
+        ``Cmd`` array, which is preferred when the container takes multiple
+        arguments (each list item is passed as its own argv element).
 
         .. code-block:: yaml
 
@@ -591,6 +594,15 @@ def running(
               docker_container.running:
                 - image: bar/baz:latest
                 - command: bash
+
+        .. code-block:: yaml
+
+            foo:
+              docker_container.running:
+                - image: prom/prometheus:latest
+                - command:
+                  - --config.file=/etc/prometheus/prometheus.yml
+                  - --storage.tsdb.path=/prometheus
 
     cpuset_cpus (or *cpuset*)
         CPUs on which which to allow execution, specified as a string
@@ -946,8 +958,9 @@ def running(
                   - network
 
     hostname
-        Hostname of the container. If not provided, the value passed as the
-        container's``name`` will be used for the hostname.
+        Hostname of the container. When omitted, Docker assigns a hostname
+        derived from the short container ID rather than from the
+        container's ``name``.
 
         .. code-block:: yaml
 

--- a/salt/states/docker_image.py
+++ b/salt/states/docker_image.py
@@ -164,16 +164,16 @@ def present(
     sls
         Allow for building of image with :py:func:`docker.sls_build
         <salt.modules.dockermod.sls_build>` by specifying the SLS files with
-        which to build. This can be a list or comma-separated string.
+        which to build. Provide a comma-separated string of SLS file names;
+        YAML lists are not accepted by the underlying ``docker.sls_build``
+        execution module.
 
         .. code-block:: yaml
 
             myuser/myimage:
               docker_image.present:
                 - tag: latest
-                - sls:
-                    - webapp1
-                    - webapp2
+                - sls: webapp1,webapp2
                 - base: centos
                 - saltenv: base
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -97,11 +97,14 @@ In this example ``foo.conf`` in the ``dev`` environment will be used instead.
         - mode: '0644'
         - attrs: i
 
-.. warning::
+.. note::
 
-    When using a mode that includes a leading zero you must wrap the
-    value in single quotes. If the value is not wrapped in quotes it
-    will be read by YAML as an integer and evaluated as an octal.
+    Salt's YAML loader special-cases octal-looking file modes, so all of
+    ``644``, ``0644``, ``0o644``, ``'644'``, ``'0644'`` and ``'0o644'``
+    resolve to the same value (octal ``0o644``). Quoting a mode with a
+    leading zero is therefore not required for correctness; some operators
+    still prefer to quote (for example ``'0644'``) so the literal mode is
+    visually obvious in the SLS file.
 
 The ``names`` parameter, which is part of the state compiler, can be used to
 expand the contents of a single state declaration into multiple, single state
@@ -5959,6 +5962,14 @@ def blockreplace(
         marker will be replaced, so it's important to ensure that your marker
         includes the beginning of the text you wish to replace.
 
+        .. note::
+
+            ``marker_end`` must not contain ``marker_start`` as a substring,
+            and the two markers must not be equal. When the start marker is
+            also present inside the end marker the block cannot be located
+            and the state fails with ``Unterminated marked block. End of
+            file reached before marker_end.``.
+
     content
         The content to be used between the two lines identified by
         ``marker_start`` and ``marker_end``
@@ -7523,7 +7534,10 @@ def copy_(
     .. note::
         This state only copies files from one location on a minion to another
         location on the same minion. For copying files from the master, use a
-        :py:func:`file.managed <salt.states.file.managed>` state.
+        :py:func:`file.managed <salt.states.file.managed>` state. To fetch
+        a single file from the master inside an execution module, runner or
+        Jinja template, use
+        :py:func:`cp.get_file <salt.modules.cp.get_file>`.
 
     name
         The location of the file to copy to
@@ -7752,15 +7766,17 @@ def copy_(
 
 def rename(name, source, force=False, makedirs=False, **kwargs):
     """
-    If the source file exists on the system, rename it to the named file. The
-    named file will not be overwritten if it already exists unless the force
-    option is set to True.
+    If the source path exists on the system, rename it to the named path.
+    Both files and directories are supported. The named path will not be
+    overwritten if it already exists unless the force option is set to
+    ``True``.
 
     name
-        The location of the file to rename to
+        The location to rename the source to (file or directory)
 
     source
-        The location of the file to move to the location specified with name
+        The location of the file or directory to move to the location
+        specified with ``name``
 
     force
         If the target location is present then the file will not be moved,

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -264,7 +264,7 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
         Included to reduce confusion due to YUM/DNF/Zypper's use of the
         ``enabled`` argument. If this is passed for an APT-based distro, then
         the reverse will be passed as ``disabled``. For example, passing
-        ``enabled=False`` will assume ``disabled=False``.
+        ``enabled=False`` will assume ``disabled=True``.
 
     architectures
         On apt-based systems, ``architectures`` can restrict the available
@@ -292,6 +292,13 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
     keyserver
         This is the name of the keyserver to retrieve GPG keys from. The
         ``keyid`` option must also be set for this option to work.
+
+        .. note::
+
+            If retrieval fails with an error such as ``gpg: keyserver
+            receive failed: End of file``, try specifying the keyserver
+            using the explicit ``hkp://`` scheme (and port), for example
+            ``hkp://keyserver.ubuntu.com:80``.
 
     key_url
         URL to retrieve a GPG key from. Allows the usage of

--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -144,7 +144,11 @@ def present(
         provided if the object is not under the default `public` schema
 
     maintenance_db
-        The name of the database in which the language is to be installed
+        The name of the database to connect to as the maintenance database
+        when issuing the privilege change. Defaults to the value of the
+        ``postgres.maintenance_db`` configuration option (typically
+        ``postgres``). The privilege itself is applied to the target object
+        identified by ``object_name``, not to ``maintenance_db``.
 
     user
         System user all operations should be performed on behalf of
@@ -271,7 +275,11 @@ def absent(
         provided if the object is not under the default `public` schema
 
     maintenance_db
-        The name of the database in which the language is to be installed
+        The name of the database to connect to as the maintenance database
+        when issuing the privilege change. Defaults to the value of the
+        ``postgres.maintenance_db`` configuration option (typically
+        ``postgres``). The privilege itself is applied to the target object
+        identified by ``object_name``, not to ``maintenance_db``.
 
     user
         System user all operations should be performed on behalf of

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -397,7 +397,13 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         default is ``None``, which does not enable or disable anything.
 
     sig
-        The string to search for when looking for the service process with ps
+        The string to search for when looking for the service process with
+        ``ps``. The lookup uses an unanchored substring match against the
+        process command line, so embedded shell metacharacters (``()``,
+        ``|``, ``&``, ``;``, ``$``, backticks, quotes, etc.) are matched
+        literally. Prefer a substring of the actual executable name (for
+        example ``twistd``) over a full command line containing special
+        characters.
 
     init_delay
         Some services may not be truly available for a short period after their
@@ -443,6 +449,31 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         determine whether the service is running or not.
 
         .. versionadded:: 2019.2.3
+
+    reload : False
+        Honored when this state is the target of a ``watch`` requisite. When
+        ``True`` the service is reloaded (``systemctl reload``) rather than
+        restarted on watch-triggered refresh. The argument is consumed by
+        :py:func:`mod_watch <salt.states.service.mod_watch>`; passing
+        ``reload`` outside of a ``watch`` context has no effect.
+
+    full_restart : False
+        Honored when this state is the target of a ``watch`` requisite. When
+        ``True`` the service is fully restarted (``service.full_restart``)
+        rather than restarted on watch-triggered refresh.
+
+    .. note::
+
+        On systemd minions, a change to a ``.service`` unit file does **not**
+        automatically trigger ``systemctl daemon-reload`` unless that unit
+        file is detected and managed by ``systemd_service`` itself. When a
+        ``file.managed`` state installs or modifies a unit file, you should
+        either run :py:func:`module.run <salt.states.module.run>` with
+        ``service.systemctl_reload`` (or call
+        :py:func:`systemd_service.systemctl_reload
+        <salt.modules.systemd_service.systemctl_reload>` from a Jinja
+        template) before restarting the service, or arrange the requisites
+        so that the daemon-reload happens first.
 
     .. note::
         ``watch`` can be used with service.running to restart a service when
@@ -627,7 +658,11 @@ def dead(name, enable=None, sig=None, init_delay=None, **kwargs):
         default is ``None``, which does not enable or disable anything.
 
     sig
-        The string to search for when looking for the service process with ps
+        The string to search for when looking for the service process with
+        ``ps``. The lookup uses an unanchored substring match against the
+        process command line, so embedded shell metacharacters (``()``,
+        ``|``, ``&``, ``;``, ``$``, backticks, quotes, etc.) are matched
+        literally. Prefer a substring of the actual executable name.
 
     init_delay
         Add a sleep command (in seconds) before the check to make sure service

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -337,18 +337,33 @@ def present(
         The user id to assign. If not specified, and the user does not exist,
         then the next available uid will be assigned.
 
+        .. note::
+            Not supported on Windows. On Windows the account SID is fixed by
+            the operating system at user creation time and cannot be chosen
+            or changed; ``uid`` and ``allow_uid_change`` have no effect there
+            and will surface as a permissions error if used.
+
     gid
         The id of the default group to assign to the user. Either a group name
         or gid can be used. If not specified, and the user does not exist, then
         the next available gid will be assigned.
 
+        .. note::
+            Not supported on Windows.
+
     allow_uid_change : False
         Set to ``True`` to allow the state to update the uid.
+
+        .. note::
+            Not supported on Windows -- see ``uid``.
 
         .. versionadded:: 2018.3.1
 
     allow_gid_change : False
         Set to ``True`` to allow the state to update the gid.
+
+        .. note::
+            Not supported on Windows.
 
         .. versionadded:: 2018.3.1
 

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -2,6 +2,12 @@
 Setup of Python virtualenv sandboxes.
 
 .. versionadded:: 0.17.0
+
+.. note::
+
+    This state module is loaded under the ``virtualenv`` virtual name. Use
+    ``virtualenv.managed`` (and not ``virtualenv_mod.managed``) in your
+    state SLS files.
 """
 
 import logging
@@ -122,8 +128,15 @@ def managed(
 
         .. versionadded:: 2017.7.0
 
-    Also accepts any kwargs that the virtualenv module will. However, some
-    kwargs, such as the ``pip`` option, require ``- distribute: True``.
+    Also accepts any keyword argument accepted by
+    :py:func:`virtualenv.create <salt.modules.virtualenv_mod.create>` --
+    including ``system_site_packages``, ``distribute``, ``clear``,
+    ``extra_search_dir``, ``never_download``, ``prompt``, ``index_url``,
+    ``extra_index_url``, ``pre_releases``, ``pip_download``,
+    ``pip_download_cache``, ``pip_ignore_installed``, ``use_vt``,
+    ``pip_no_cache_dir`` and ``pip_cache_dir``. Refer to that execution
+    module for argument semantics. Some kwargs, such as the ``pip`` option,
+    require ``- distribute: True``.
 
     .. code-block:: yaml
 

--- a/salt/states/win_pki.py
+++ b/salt/states/win_pki.py
@@ -4,6 +4,19 @@ Microsoft certificate management via the Pki PowerShell module.
 :platform:      Windows
 
 .. versionadded:: 2016.11.0
+
+The ``context`` argument refers to the certificate-store location, either
+``LocalMachine`` or ``CurrentUser``. The ``store`` argument refers to one of
+the standard Microsoft certificate stores within that location (for example
+``My``, ``Root``, ``CA``, ``AuthRoot``, ``TrustedPublisher``,
+``TrustedPeople``, ``Disallowed``, ``WebHosting``, ``Remote Desktop``).
+List the stores actually available on a minion with PowerShell::
+
+    PS C:\\> Set-Location Cert:\\LocalMachine
+    PS Cert:\\LocalMachine> Get-ChildItem
+
+or by calling :py:func:`win_pki.get_stores
+<salt.modules.win_pki.get_stores>`.
 """
 
 _DEFAULT_CONTEXT = "LocalMachine"

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -24,6 +24,14 @@ be called from a Python interpreter.
 
 The wheel key functions can also be called via a ``salt`` command at the CLI
 using the :mod:`saltutil execution module <salt.modules.saltutil>`.
+
+.. note::
+
+    This module defines ``__func_alias__`` to expose some functions under
+    different public names. The Python function ``list_`` is published as
+    ``key.list`` and ``key_str`` is published as ``key.print``. Always
+    call the aliased name (``key.list`` / ``key.print``) when invoking
+    these functions through salt-api, salt-call or the wheel client.
 """
 
 import hashlib


### PR DESCRIPTION
## Summary

Batch cleanup of state and execution-module docstrings to match
actual behavior. No code changes; documentation only.

## Issues addressed (each linked below as `Refs #N`)

- #58845 `slack_notify.call_hook` — documented the configuration key
  as ``identifier`` instead of ``hook``; added a minion-config example.
- #67074 `salt.modules.file.seek_read` — second parameter is `size`,
  not `seek`.
- #67911 `salt.modules.file.find` — the option name is `owner`, not
  `user`.
- #54802 `salt.states.pkgrepo.managed` — passing `enabled=False` is
  equivalent to `disabled=True`, not `disabled=False`.
- #61671 `salt.states.pkgrepo.managed` — added the `hkp://` keyserver
  workaround note.
- #62002 `salt.wheel.key` — documented the `__func_alias__` mapping
  (`list_` → `key.list`, `key_str` → `key.print`).
- #56729 / #65756 `salt.states.virtualenv_mod` — surfaced the
  `virtualenv` virtual name and pointed at
  `salt.modules.virtualenv_mod.create` for unmapped kwargs.
- #61886 `salt.states.aptpkg` — surfaced the `apt` virtual name.
- #59666 `salt.modules.groupadd` — surfaced the `group` virtual name.
- #55916 `salt.states.file.rename` — documented directory support.
- #50568 `salt.states.file.copy_` — added a pointer to
  `salt.modules.cp.get_file`.
- #64075 `salt.states.file.blockreplace` — documented the
  start/end marker overlap restriction.
- #60773 — corrected the misleading "must quote octal modes" warning.
- #34929 `salt.states.service.running` — documented `sig` matching
  against shell special characters.
- #57606 / #60784 / #63852 `salt.states.service.running` — documented
  the `reload` and `full_restart` mod-watch options, and added a
  note about systemd `daemon-reload` ordering.
- #57505 / #57949 `salt.modules.cmdmod.run` — documented `runas`
  group preservation on Linux and the Windows password requirement.
- #61689 `salt.states.user.present` — flagged Windows-unsupported
  `uid`, `gid`, `allow_uid_change`, `allow_gid_change`.
- #64021 `salt.states.win_pki` — listed the available certificate
  stores and how to enumerate them with PowerShell.
- #56182 `salt.proxy.netmiko_px` — distinguished `keepalive` (in-band
  KEEPALIVE packets) from `always_alive` (connection lifecycle).
- #51213 `salt.states.postgres_privileges` — fixed copy-pasted
  `maintenance_db` description.
- #57405 `salt.pillar.file_tree` — corrected the example so the
  rendered pillar tree matches the on-disk layout.
- #63364 `salt.modules.saltcheck` — removed a duplicated jinja/setup
  example block; clarified the `assertion` definition.
- #61405 `salt.modules.file.chown` — documented the broken-symlink
  `lchown` fallback.
- #60406 `salt.runners.jobs.last_run` — rewrote the description and
  added parameter documentation.
- #55881 `salt.states.docker_container.running` — documented that
  `command` accepts either a string or a YAML list.
- #56956 `salt.states.docker_image.present` — clarified that `sls`
  accepts a comma-separated string only (not a YAML list).
- #66409 `salt.states.docker_container.running` — corrected the
  hostname fallback wording.

## Branches

Per-branch PR — each release branch is being shipped separately because
the affected docstrings have drifted independently across the lines.

| issue group | 3006.x | 3007.x | 3008.x | master |
|-------------|:------:|:------:|:------:|:------:|
| modules / states / runners / wheel / pillar (above) | yes | yes | yes | yes |
| docker_container / docker_image / aptpkg / netmiko_px / ddns | yes | yes | n/a (extracted) | n/a (extracted) |

## Out of scope (issues from the original list that are no longer
applicable on this branch and need no doc change)

- #66891 `linux_acl.list_absent perms` — already removed from the
  docstring on every active branch.
- #61374 "SaltStack, Inc" references — `git grep` finds zero hits
  inside `salt/` and `tests/`; the remaining hits are in
  `AUTHORS`, the Windows installer and a tutorial RST file that PR9
  is not allowed to touch.
- #67145 `keystore` references — the module itself still exists on
  3006.x / 3007.x and has been removed entirely on 3008.x / master,
  so the docs are correct on each branch.
- #57053 — the missing-space `param:default` formatting reported
  6 years ago is no longer present in `salt/modules/state.py`.
- #61366 (universal `__virtualname__` listing) — handled for the
  modules that are also flagged by other linked issues
  (`groupadd → group`, `aptpkg → apt`, `virtualenv_mod →
  virtualenv`). A blanket sweep across the remaining ~50 modules
  is deferred to a follow-up PR to keep this one reviewable.
- #66628 (custom-grains topic guide), #65939 (states_pt3 tutorial),
  #52650 (DDNS minion-config layout) and #64283 (Salt-API kwarg
  schema) all want changes inside `doc/**.rst` files; PR9 is
  docstring-only by charter — those are deferred to PR8 (states) /
  PR5 (pillar) RST passes.

## Test plan

- [ ] CI green on the per-branch base.
- [ ] `pre-commit run --all-files` clean on the touched files
  (verified locally with isolated `PRE_COMMIT_HOME`).
- [ ] `make -C doc html` produces no Sphinx warnings on the rendered
  pages for each touched module.
- [ ] `python -c "help(salt.modules.<m>.<f>)"` round-trips for each
  edited function.

🤖 Generated with Claude Code (Claude Opus 4.7).
