### PR TITLE
Don't warn about random_master for multi-master child minions

### DIFF
--- a/changelog/69571.fixed.md
+++ b/changelog/69571.fixed.md
@@ -1,0 +1,1 @@
+Stopped logging a spurious ``random_master is True but there is only one master specified. Ignoring.`` warning once per master at startup for an all-hot multi-master minion. The warning now fires only for a genuinely single-master configuration.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -846,7 +846,14 @@ class MinionBase:
 
         # single master sign in
         else:
-            if opts["random_master"]:
+            # In multi-master mode the MinionManager spawns one Minion per
+            # master, each bound to a single master but inheriting the
+            # operator's ``random_master`` setting -- a documented way to
+            # spread salt-call load across an all-hot master list (see the
+            # ``random_master`` minion config docs). Those children are
+            # single-master by design, so only warn about a pointless
+            # ``random_master`` for a genuinely single-master minion.
+            if opts["random_master"] and not opts.get("multimaster"):
                 log.warning(
                     "random_master is True but there is only one master specified."
                     " Ignoring."

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1575,3 +1575,67 @@ async def test_minion_manager_async_stop(io_loop, minion_opts, tmp_path):
     parent_signal_handler.assert_called_once_with(signal.SIGTERM, None)
     assert mm.event_publisher is None
     assert mm.event is None
+
+
+def _run_eval_master(opts):
+    """
+    Drive MinionBase.eval_master far enough to hit the single-master branch
+    (where the random_master warning lives) without touching the network:
+    DNS resolution is stubbed and the pub channel connects immediately.
+    """
+    io_loop = salt.ext.tornado.ioloop.IOLoop()
+    minion = salt.minion.MinionBase(opts)
+    mock_channel = MagicMock()
+    mock_channel.connect.return_value = salt.ext.tornado.gen.maybe_future(None)
+    mock_channel.auth.gen_token.return_value = b"token"
+    try:
+        with patch(
+            "salt.channel.client.AsyncPubChannel.factory", return_value=mock_channel
+        ), patch("salt.minion.resolve_dns", return_value={}), patch(
+            "salt.minion.prep_ip_port", return_value={}
+        ):
+            io_loop.run_sync(lambda: minion.eval_master(opts))
+    finally:
+        io_loop.close()
+
+
+def _single_master_opts(minion_opts):
+    minion_opts["master"] = "salt-master-1"
+    minion_opts["master_type"] = "str"
+    minion_opts["random_master"] = True
+    minion_opts["transport"] = "zeromq"
+    minion_opts["acceptance_wait_time"] = 0
+    minion_opts["master_tries"] = 1
+    return minion_opts
+
+
+def test_eval_master_random_master_warning_suppressed_for_multimaster(
+    minion_opts, caplog
+):
+    """
+    In multi-master mode the MinionManager spawns one Minion per master, each
+    bound to a single master but inheriting random_master (multimaster=True).
+    Those children must NOT emit the "random_master ... only one master ...
+    Ignoring" warning. Regression test for the spurious per-master warning.
+    """
+    opts = _single_master_opts(minion_opts)
+    opts["multimaster"] = True
+    with caplog.at_level(logging.WARNING):
+        _run_eval_master(opts)
+    assert (
+        "random_master is True but there is only one master specified"
+        not in caplog.text
+    )
+
+
+def test_eval_master_random_master_warning_for_real_single_master(minion_opts, caplog):
+    """
+    A genuinely single-master minion (not a multimaster child) with
+    random_master set still gets warned -- random_master really is a no-op
+    there. Guards against over-suppressing the warning.
+    """
+    opts = _single_master_opts(minion_opts)
+    opts.pop("multimaster", None)
+    with caplog.at_level(logging.WARNING):
+        _run_eval_master(opts)
+    assert "random_master is True but there is only one master specified" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Stops a minion from logging a spurious `random_master is True but there is only one master specified. Ignoring.` warning -- once per master -- for a valid, documented all-hot multi-master configuration.

### What issues does this PR fix or reference?

Fixes #69571.

### Why this configuration is valid (and why the warning is confusing)

Two documented features combine here:

- **All-hot multi-master** ([Multi-Master Tutorial](https://docs.saltproject.io/en/latest/topics/tutorials/multimaster.html)): "all masters are running hot, and any active master can be used to send commands out to the minions" -- configured with a `master:` list, for master redundancy.
- **`random_master`** ([minion config ref](https://docs.saltproject.io/en/latest/ref/configuration/minion.html#random-master)): with a `master:` list, shuffles it on startup "to distribute the load of many minions executing `salt-call` requests, for example, from a cron job."

So `master: [a, b]` + `random_master: True` is a sensible, documented config: both masters hot for redundancy, and `salt-call` load spread across them. Those same docs note the warning is meant for the *single-master* case, where `random_master` is a no-op.

### Previous behavior

With `master_type: str` and a master list, `MinionManager._spawn_minions` creates one `Minion` per master -- each bound to a single master but inheriting `random_master: True` and flagged `multimaster: True`. Each child then takes the single-master branch of `eval_master` and logs the warning. Result: a correct multi-master minion logs it once per master at every startup, reading like a misconfiguration even though `random_master` is doing exactly its documented job for `salt-call`.

### New behavior

The warning is emitted only for a genuinely single-master minion -- skipped when `opts["multimaster"]` is set (i.e. a per-master child of the manager). A real single-master config with `random_master` still warns. Unit tests cover both cases.

### Merge requirements satisfied?

- [x] Tests written/updated (the multimaster regression test fails without the fix)
- [x] Changelog (`changelog/69571.fixed.md`)

#### Commits signed with GPG?

No
