### PR TITLE
ci: register the nightly stress workflow on master

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -1,0 +1,90 @@
+name: Nightly Stress Test
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Duration of the stress test (e.g., 30m, 1h)'
+        required: true
+        default: '30m'
+
+jobs:
+  stress-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and Start Environment
+        run: |
+          cd tests/monitoring
+          docker compose build
+          docker compose up -d
+          sleep 30 # Wait for initialization
+
+      - name: Verify Connections
+        run: |
+          docker exec salt-master salt '*' test.ping
+
+      - name: Run Aggressive Stress Test
+        run: |
+          cd tests/monitoring
+          chmod +x stress_test.sh stress_api.sh
+          # Run in background and wait for defined duration
+          ./stress_test.sh &
+          STRESS_PID=$!
+
+          # Default to 30m if not workflow_dispatch
+          DURATION="${{ github.event.inputs.duration || '30m' }}"
+          echo "Running stress test for $DURATION..."
+
+          # Use sleep with suffix support (m, h)
+          sleep $DURATION
+
+          echo "Stopping stress test..."
+          pkill -P $STRESS_PID || true
+          kill $STRESS_PID || true
+
+      - name: Analyze Results
+        run: |
+          cd tests/monitoring
+          # Give Prometheus a moment to finish scraping the final points
+          sleep 30
+          python3 analyze_stats.py
+
+      - name: Snapshot Metrics
+        if: always()
+        run: |
+          # Stop containers to ensure data is flushed to disk
+          cd tests/monitoring
+          docker compose stop prometheus
+          sudo tar -czf ../../prometheus-data.tar.gz ./prometheus_data
+
+      - name: Collect Logs on Failure
+        if: failure()
+        run: |
+          mkdir -p artifacts
+          docker logs salt-master > artifacts/salt-master.log
+          docker logs salt-minion-1 > artifacts/salt-minion-1.log
+          cp tests/monitoring/event_log.txt artifacts/ || true
+
+      - name: Upload Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-test-results
+          path: |
+            artifacts/
+            prometheus-data.tar.gz


### PR DESCRIPTION
The Nightly Stress Test workflow was added to 3006.x in #69227 but the scheduled ``cron`` only fires for workflows that live on the repository's default branch -- so the nightly run never triggers until the file lands on master.

This change copies just the workflow file across so the schedule registers and ``workflow_dispatch`` works against master too.  The supporting ``tests/monitoring/`` scaffolding is intentionally left to arrive via the natural 3006.x -> 3007.x -> 3008.x -> master forward merges; runs invoked before that landing will fail in the "Build and Start Environment" step with a clear missing-directory error, which is acceptable for the short gap.

Also fixes a stale path in the "Collect Logs on Failure" step -- ``monitoring/event_log.txt`` -> ``tests/monitoring/event_log.txt``.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
