### PR TITLE
Fix intermittent installer Abort (exit 2) on salt-minion service re-registration

### DIFF
--- a/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
@@ -243,6 +243,7 @@ Var SSMBin
 Var SysDrive
 Var ExistingInstallation
 Var CustomLocation
+Var SvcInstallTries
 
 
 ###############################################################################
@@ -1077,10 +1078,36 @@ Section -Post
     SetRegView 32  # Set it back to the 32 bit portion of the registry
 
     # Register the Salt-Minion Service
+    #
+    # "ssm install" calls CreateService, which can transiently fail with
+    # ERROR_SERVICE_MARKED_FOR_DELETE (1072) or ERROR_SERVICE_EXISTS (1073)
+    # when a previous salt-minion deletion is still pending in the Service
+    # Control Manager.  This shows up on uninstall/reinstall and on back-to-back
+    # test iterations: the uninstaller's SimpleSC::RemoveService marks the
+    # service for deletion, but the SCM does not actually remove it until every
+    # open handle is closed -- which happens asynchronously, after the
+    # uninstaller has already exited.  CreateService for the new service then
+    # races that pending delete and fails, which used to Abort the install
+    # (NSIS error level 2 -- the intermittent installer failure).
+    #
+    # The condition is self-clearing within a second or two once the handles
+    # close, so retry a handful of times before giving up rather than aborting
+    # on the first failure.
     ${LogMsg} "Registering the salt-minion service"
+    StrCpy $SvcInstallTries 0
+    retry_svc_install:
     nsExec::ExecToStack `"$INSTDIR\ssm.exe" install salt-minion "$INSTDIR\salt-minion.exe" -c """$RootDir\conf""" -l quiet`
     pop $0  # ExitCode
     pop $1  # StdOut
+    ${If} $0 != 0
+    ${AndIf} $SvcInstallTries < 5
+        IntOp $SvcInstallTries $SvcInstallTries + 1
+        ${LogMsg} "Service registration failed (ExitCode: $0). \
+            Retry $SvcInstallTries/5 in 2s (SCM delete may still be pending)"
+        ${LogMsg} "StdOut: $1"
+        Sleep 2000
+        Goto retry_svc_install
+    ${EndIf}
     ${IfNot} $0 == 0
         StrCpy $msg "Failed to register the salt minion service.$\n\
             ExitCode: $0$\n\
@@ -1315,6 +1342,33 @@ Function ${un}uninstallSalt
         nsExec::Exec 'taskkill /F /IM ssm.exe /T'
         Pop $0
         ${LogMsg} "Done (exit $0)"
+
+        # Wait (bounded) for the SCM to actually remove the service key.
+        # SimpleSC::RemoveService only *marks* the service for deletion; the SCM
+        # does not remove the HKLM\...\Services\salt-minion key until every open
+        # handle is closed, which only happens once the taskkills above have
+        # fully torn down salt-minion.exe and ssm.exe.  Waiting until the key is
+        # gone here makes a reinstall (or the next test iteration) far less
+        # likely to hit ERROR_SERVICE_MARKED_FOR_DELETE from CreateService.
+        #
+        # This only narrows the window -- the install-side retry around
+        # "ssm install" remains the authoritative guard, since in the field
+        # uninstall and reinstall are separate processes and nothing here can
+        # constrain a future installer invocation.
+        ${LogMsg} "Waiting for SCM to remove the salt-minion service key"
+        StrCpy $R0 0
+        wait_svc_deleted:
+        ClearErrors
+        ReadRegDWORD $R1 HKLM "SYSTEM\CurrentControlSet\Services\salt-minion" "Type"
+        ${If} ${Errors}
+            ${LogMsg} "Service key removed"
+        ${ElseIf} $R0 < 20
+            IntOp $R0 $R0 + 1
+            Sleep 500
+            Goto wait_svc_deleted
+        ${Else}
+            ${LogMsg} "Service key still present after 10s — continuing anyway"
+        ${EndIf}
 
     ${Else}
 


### PR DESCRIPTION
### What does this PR do?
Silent installs intermittently failed with NSIS error level 2 -- a script-driven Abort, not the exit-path hang fixed previously. The only Section Abort reachable on the happy path is the salt-minion service registration: "ssm install salt-minion" (CreateService) returning non-zero.

The cause is an SCM race against the prior uninstall. The uninstaller's SimpleSC::RemoveService only *marks* the service for deletion; the SCM does not remove the HKLM\...\Services\salt-minion key until every open handle closes, which happens asynchronously after the uninstaller has exited. When the next install's CreateService races that pending delete, Windows returns ERROR_SERVICE_MARKED_FOR_DELETE (1072) or ERROR_SERVICE_EXISTS (1073), ssm exits non-zero, and the Section aborts. This is why it only fails occasionally and recovers on the next run -- it is purely a timing window between back-to-back uninstall/install.

Fix it at the point of failure: retry "ssm install" up to 5 times with a 2s pause instead of aborting on first failure. The condition is self-clearing once handles close, so the retry rides it out. This also covers real-world upgrades, where uninstall and reinstall are separate processes and nothing in the uninstaller can constrain a future installer invocation.

As defense-in-depth, also wait (bounded, 10s) in un.Uninstall for the SCM to actually remove the service key -- placed after the salt-minion.exe and ssm.exe taskkills, since the key cannot clear until those handles are gone. This narrows the race window for the common case but is not sufficient alone; the install-side retry remains the authoritative guard.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
