### PR TITLE
Replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/changelog/69580.fixed.md
+++ b/changelog/69580.fixed.md
@@ -1,0 +1,1 @@
+Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `salt/utils/event.py` and `salt/cluster/consensus/raft/scheduler.py` to avoid DeprecationWarning on Python 3.12+ (slated for removal in Python 3.16).

--- a/salt/cluster/consensus/raft/scheduler.py
+++ b/salt/cluster/consensus/raft/scheduler.py
@@ -9,6 +9,7 @@ use :class:`ManualTimeoutScheduler` for deterministic time.
 """
 
 import asyncio
+import inspect
 import logging
 import threading
 import time
@@ -106,7 +107,7 @@ class AsyncTimeoutScheduler:
         def _wrapper():
             if state.cancelled:
                 return
-            if asyncio.iscoroutinefunction(callback):
+            if inspect.iscoroutinefunction(callback):
                 self.loop.create_task(callback())
             else:
                 callback()

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -53,6 +53,7 @@ import asyncio
 import datetime
 import errno
 import fnmatch
+import inspect
 import logging
 import os
 import time
@@ -359,7 +360,7 @@ class SaltEvent:
 
         loop = salt.utils.asynchronous.aioloop(self.io_loop)
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             loop.create_task(func(*args, **kwargs))
             return
 

--- a/tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+import warnings
 
 import pytest
 
@@ -254,5 +255,30 @@ def test_async_scheduler_cancelled_wrapper_returns_early():
         handle.cancel()
         await asyncio.sleep(0.02)
         assert fired == [], "callback must not fire after cancel"
+
+    asyncio.run(_body())
+
+
+def test_async_scheduler_no_deprecation_warning_for_coroutine_callback():
+    """
+    AsyncTimeoutScheduler must use inspect.iscoroutinefunction, not the
+    deprecated asyncio.iscoroutinefunction, so no DeprecationWarning is
+    emitted when scheduling a coroutine callback (Python 3.12+).
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        scheduler = AsyncTimeoutScheduler(loop=loop)
+        fired = []
+
+        async def coro_cb():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            scheduler.schedule(0.001, coro_cb)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "coroutine callback must have been called"
 
     asyncio.run(_body())

--- a/tests/pytests/unit/utils/event/test_salt_event_schedule.py
+++ b/tests/pytests/unit/utils/event/test_salt_event_schedule.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for SaltEvent._schedule coroutine-function detection.
+
+Verifies that _schedule uses inspect.iscoroutinefunction (not the deprecated
+asyncio.iscoroutinefunction) so no DeprecationWarning is emitted on Python 3.12+.
+"""
+
+import asyncio
+import warnings
+
+from salt.utils.event import SaltEvent
+
+
+def _make_salt_event(loop):
+    """Create a minimal SaltEvent instance with an asyncio loop attached."""
+    evt = SaltEvent.__new__(SaltEvent)
+    evt.io_loop = loop
+    evt._run_io_loop_sync = False
+    return evt
+
+
+def test_salt_event_schedule_coroutine_no_deprecation_warning():
+    """
+    SaltEvent._schedule must use inspect.iscoroutinefunction, not the deprecated
+    asyncio.iscoroutinefunction, to avoid DeprecationWarning on Python 3.12+.
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        evt = _make_salt_event(loop)
+        fired = []
+
+        async def coro_func():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            evt._schedule(coro_func)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "coroutine function was not called by _schedule"
+
+    asyncio.run(_body())
+
+
+def test_salt_event_schedule_regular_callable():
+    """
+    SaltEvent._schedule correctly calls a regular (non-coroutine) callable.
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        evt = _make_salt_event(loop)
+        fired = []
+
+        def regular_func():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            evt._schedule(regular_func)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "regular callable was not called by _schedule"
+
+    asyncio.run(_body())


### PR DESCRIPTION
## Summary

- `asyncio.iscoroutinefunction()` was deprecated in Python 3.12 and is slated for removal in Python 3.16
- Replace it with `inspect.iscoroutinefunction()` in `salt/utils/event.py` and `salt/cluster/consensus/raft/scheduler.py`
- Add tests that verify no `DeprecationWarning` is emitted when scheduling coroutine callbacks

Fixes #69580

## Test plan

- [ ] `pytest tests/pytests/unit/cluster/consensus/test_raft_scheduler.py` — 16 tests pass including new `test_async_scheduler_no_deprecation_warning_for_coroutine_callback`
- [ ] `pytest tests/pytests/unit/utils/event/test_salt_event_schedule.py` — 2 new tests pass