### PR TITLE
[3008.x] Replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction (#69580)

### DIFF
--- a/changelog/69580.fixed.md
+++ b/changelog/69580.fixed.md
@@ -1,0 +1,1 @@
+Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `salt/utils/event.py` and `salt/cluster/consensus/raft/scheduler.py` to avoid DeprecationWarning on Python 3.12+ (slated for removal in Python 3.16).

--- a/salt/cluster/consensus/raft/scheduler.py
+++ b/salt/cluster/consensus/raft/scheduler.py
@@ -9,6 +9,7 @@ use :class:`ManualTimeoutScheduler` for deterministic time.
 """
 
 import asyncio
+import inspect
 import logging
 import threading
 import time
@@ -106,7 +107,7 @@ class AsyncTimeoutScheduler:
         def _wrapper():
             if state.cancelled:
                 return
-            if asyncio.iscoroutinefunction(callback):
+            if inspect.iscoroutinefunction(callback):
                 self.loop.create_task(callback())
             else:
                 callback()

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -53,6 +53,7 @@ import asyncio
 import datetime
 import errno
 import fnmatch
+import inspect
 import logging
 import os
 import time
@@ -393,7 +394,7 @@ class SaltEvent:
 
         loop = salt.utils.asynchronous.aioloop(self.io_loop)
 
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             loop.create_task(func(*args, **kwargs))
             return
 

--- a/tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_scheduler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+import warnings
 
 import pytest
 
@@ -254,5 +255,30 @@ def test_async_scheduler_cancelled_wrapper_returns_early():
         handle.cancel()
         await asyncio.sleep(0.02)
         assert fired == [], "callback must not fire after cancel"
+
+    asyncio.run(_body())
+
+
+def test_async_scheduler_no_deprecation_warning_for_coroutine_callback():
+    """
+    AsyncTimeoutScheduler must use inspect.iscoroutinefunction, not the
+    deprecated asyncio.iscoroutinefunction, so no DeprecationWarning is
+    emitted when scheduling a coroutine callback (Python 3.12+).
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        scheduler = AsyncTimeoutScheduler(loop=loop)
+        fired = []
+
+        async def coro_cb():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            scheduler.schedule(0.001, coro_cb)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "coroutine callback must have been called"
 
     asyncio.run(_body())

--- a/tests/pytests/unit/utils/event/test_salt_event_schedule.py
+++ b/tests/pytests/unit/utils/event/test_salt_event_schedule.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for SaltEvent._schedule coroutine-function detection.
+
+Verifies that _schedule uses inspect.iscoroutinefunction (not the deprecated
+asyncio.iscoroutinefunction) so no DeprecationWarning is emitted on Python 3.12+.
+"""
+
+import asyncio
+import warnings
+
+from salt.utils.event import SaltEvent
+
+
+def _make_salt_event(loop):
+    """Create a minimal SaltEvent instance with an asyncio loop attached."""
+    evt = SaltEvent.__new__(SaltEvent)
+    evt.io_loop = loop
+    evt._run_io_loop_sync = False
+    return evt
+
+
+def test_salt_event_schedule_coroutine_no_deprecation_warning():
+    """
+    SaltEvent._schedule must use inspect.iscoroutinefunction, not the deprecated
+    asyncio.iscoroutinefunction, to avoid DeprecationWarning on Python 3.12+.
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        evt = _make_salt_event(loop)
+        fired = []
+
+        async def coro_func():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            evt._schedule(coro_func)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "coroutine function was not called by _schedule"
+
+    asyncio.run(_body())
+
+
+def test_salt_event_schedule_regular_callable():
+    """
+    SaltEvent._schedule correctly calls a regular (non-coroutine) callable.
+    """
+
+    async def _body():
+        loop = asyncio.get_event_loop()
+        evt = _make_salt_event(loop)
+        fired = []
+
+        def regular_func():
+            fired.append(1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            evt._schedule(regular_func)
+
+        await asyncio.sleep(0.02)
+        assert fired == [1], "regular callable was not called by _schedule"
+
+    asyncio.run(_body())


### PR DESCRIPTION
## What does this PR do?

Backport of #69581 to `3008.x`.

`asyncio.iscoroutinefunction()` was deprecated in Python 3.12 and is slated for removal in Python 3.16. This PR replaces it with `inspect.iscoroutinefunction()` in:

- `salt/utils/event.py`
- `salt/cluster/consensus/raft/scheduler.py`

Tests are added that verify no `DeprecationWarning` is emitted when scheduling coroutine callbacks through `SaltEvent._schedule` and `AsyncTimeoutScheduler.schedule`.

## Why a sibling PR?

The original PR #69581 was merged to `master` (Potassium), but issue #69580 explicitly states:

> We need to ensure we stop using deprecated functions on **3008.x**.

So the master merge alone does not address the issue. This PR is the sibling backport that lands the same fix on `3008.x` (Argon).

## Related

- Fixes https://github.com/saltstack/salt/issues/69580
- Original master PR: https://github.com/saltstack/salt/pull/69581 (merge commit \`8b6c861d4df1a44a66be3cf838788d8b52bea393\`)

## Commits

- Cherry-pick of \`e70647eca19b2150098ae29c49ea29b127fc60c1\` applies cleanly on \`3008.x\` with no conflicts. Both \`salt/cluster/consensus/raft/scheduler.py\` and its test exist on 3008.x, so the full set of files from the master PR was applied (nothing skipped).

## Test plan

- [x] \`venv310/bin/pytest tests/pytests/unit/utils/event/test_salt_event_schedule.py -v\` -> 2 passed
- [x] \`venv310/bin/pytest tests/pytests/unit/cluster/consensus/test_raft_scheduler.py -v\` -> 16 passed
- [x] \`pre-commit run --files <touched>\` clean