### PR TITLE
Add dnfmodule execution and state modules for DNF modularity

### DIFF
--- a/changelog/67398.added.md
+++ b/changelog/67398.added.md
@@ -1,0 +1,3 @@
+Added the ``dnfmodule`` execution and state modules to manage DNF modularity
+(AppStream) module streams on RHEL 8/9 and derivatives (enable, disable,
+install, remove, reset and list module streams).

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -63,6 +63,7 @@ execution modules
     devmap
     dig
     disk
+    dnfmodule
     dnsutil
     dpkg_lowpkg
     dummyproxy_pkg

--- a/doc/ref/modules/all/salt.modules.dnfmodule.rst
+++ b/doc/ref/modules/all/salt.modules.dnfmodule.rst
@@ -1,0 +1,5 @@
+salt.modules.dnfmodule
+======================
+
+.. automodule:: salt.modules.dnfmodule
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -26,6 +26,7 @@ state modules
     cron
     debconfmod
     disk
+    dnfmodule
     environ
     etcd_mod
     event

--- a/doc/ref/states/all/salt.states.dnfmodule.rst
+++ b/doc/ref/states/all/salt.states.dnfmodule.rst
@@ -1,0 +1,5 @@
+salt.states.dnfmodule
+=====================
+
+.. automodule:: salt.states.dnfmodule
+    :members:

--- a/salt/modules/dnfmodule.py
+++ b/salt/modules/dnfmodule.py
@@ -1,0 +1,418 @@
+"""
+Support for managing DNF modules (modularity / AppStreams)
+
+DNF modularity (also known as AppStreams) was introduced in RHEL 8 and is
+available on RHEL/CentOS/Rocky/Alma/Oracle Linux 8 and 9, where it allows
+multiple versions of the same software to be shipped within a single
+repository. This module wraps the ``dnf module`` sub-command to enable,
+disable, install, remove and reset module streams in a Pythonic, idempotent
+way instead of resorting to :py:func:`cmd.run <salt.modules.cmdmod.run>`.
+
+.. note::
+    Modularity is a feature of DNF (``dnf``/``dnf4``) only. It is not provided
+    by ``yum``, ``tdnf`` or ``dnf5`` (modularity was dropped in ``dnf5``), so
+    this module is confined to systems where the ``dnf`` binary is present.
+
+.. versionadded:: 3008.0
+"""
+
+import logging
+import re
+
+import salt.utils.environment
+import salt.utils.path
+import salt.utils.systemd
+from salt.exceptions import CommandExecutionError, SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = "dnfmodule"
+
+__func_alias__ = {"list_": "list"}
+
+
+def __virtual__():
+    """
+    Confine this module to DNF based systems that provide modularity.
+    """
+    try:
+        os_family = __grains__["os_family"].lower()
+    except (KeyError, AttributeError):
+        return (False, "Module dnfmodule: no RedHat based system detected")
+
+    if os_family != "redhat":
+        return (False, "Module dnfmodule: only available on RedHat based systems")
+
+    if _dnf() is None:
+        return (
+            False,
+            "Module dnfmodule: the 'dnf' binary is required for module management",
+        )
+
+    return __virtualname__
+
+
+def _dnf():
+    """
+    Return the path to the ``dnf`` binary, or ``None`` if it is not available.
+
+    Modularity is implemented by ``dnf`` (a.k.a. ``dnf4``) only, so ``dnf5``,
+    ``yum`` and ``tdnf`` are intentionally not considered here.
+    """
+    return salt.utils.path.which("dnf")
+
+
+def _call_dnf(args, **kwargs):
+    """
+    Run a ``dnf`` command and return the ``cmd.run_all`` result dictionary.
+    """
+    params = {
+        "output_loglevel": "trace",
+        "python_shell": False,
+        "env": salt.utils.environment.get_module_environment(globals()),
+    }
+    params.update(kwargs)
+
+    cmd = []
+    if salt.utils.systemd.has_scope(__context__) and __salt__["config.get"](
+        "systemd.scope", True
+    ):
+        cmd.extend(["systemd-run", "--scope"])
+    cmd.append(_dnf())
+    cmd.extend(args)
+
+    return __salt__["cmd.run_all"](cmd, **params)
+
+
+def _parse_module_list(output):
+    """
+    Parse the table produced by ``dnf module list`` into a list of dicts.
+
+    ``dnf module list`` groups its output under per-repository headers, each
+    followed by a ``Name  Stream  Profiles  Summary`` column header. Only the
+    rows that follow a column header (and precede the next blank line) are
+    actual module rows; everything else (metadata notices, repository headers
+    and the trailing hint) is ignored.
+    """
+    modules = []
+    in_table = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            # A blank line terminates the current per-repository table.
+            in_table = False
+            continue
+        low = stripped.lower()
+        if low.startswith("name") and "stream" in low and "profiles" in low:
+            in_table = True
+            continue
+        if low.startswith("hint:"):
+            in_table = False
+            continue
+        if not in_table:
+            # Repository header or metadata noise.
+            continue
+
+        parts = stripped.split()
+        if len(parts) < 2:
+            continue
+        name = parts[0]
+        stream = parts[1]
+
+        # Collect the ``[d][e][x]`` markers that immediately follow the stream.
+        rest = parts[2:]
+        stream_markers = ""
+        while rest and re.fullmatch(r"(\[[a-z]\])+", rest[0]):
+            stream_markers += rest.pop(0)
+        line_markers = re.findall(r"\[([a-z])\]", stripped)
+
+        modules.append(
+            {
+                "name": name,
+                "stream": stream,
+                "profiles": " ".join(rest[:-1]) if len(rest) > 1 else "",
+                "summary": rest[-1] if rest else "",
+                "default": "d" in stream_markers,
+                "enabled": "e" in stream_markers,
+                "disabled": "x" in stream_markers,
+                "installed": "i" in line_markers,
+            }
+        )
+    return modules
+
+
+def list_(name=None, enabled=False, disabled=False, installed=False):
+    """
+    Return the modules known to DNF as a list of dictionaries.
+
+    Each dictionary contains the ``name``, ``stream``, ``profiles`` and
+    ``summary`` of the module as well as the ``default``, ``enabled``,
+    ``disabled`` and ``installed`` boolean flags.
+
+    name
+        Limit the listing to the named module (a module name, optionally with a
+        ``:stream`` suffix).
+
+    enabled
+        Only list modules that have an enabled stream
+        (``dnf module list --enabled``).
+
+    disabled
+        Only list modules that have a disabled stream
+        (``dnf module list --disabled``).
+
+    installed
+        Only list modules that have an installed profile
+        (``dnf module list --installed``).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.list
+        salt '*' dnfmodule.list nodejs
+        salt '*' dnfmodule.list enabled=True
+    """
+    cmd = ["--quiet", "module", "list"]
+    if enabled:
+        cmd.append("--enabled")
+    if disabled:
+        cmd.append("--disabled")
+    if installed:
+        cmd.append("--installed")
+    if name:
+        # Drop any stream so the listing matches the whole module.
+        cmd.append(name.split(":", 1)[0])
+
+    out = _call_dnf(cmd, ignore_retcode=True)
+    return _parse_module_list(out["stdout"])
+
+
+def _split_name(name):
+    """
+    Split ``module[:stream]`` into a ``(module, stream)`` tuple. ``stream`` is
+    ``None`` when no stream was supplied.
+    """
+    if not name:
+        raise SaltInvocationError("A module name is required")
+    module, _, stream = name.partition(":")
+    # ``name`` may also carry a ``/profile`` suffix (module:stream/profile).
+    stream = stream.split("/", 1)[0]
+    return module, (stream or None)
+
+
+def is_enabled(name):
+    """
+    Return ``True`` if the given module (and stream, if specified) currently has
+    an enabled stream.
+
+    name
+        The module name, optionally with a ``:stream`` suffix
+        (e.g. ``nodejs`` or ``nodejs:18``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.is_enabled nodejs:18
+    """
+    module, stream = _split_name(name)
+    for entry in list_(name=module):
+        if (
+            entry["name"] == module
+            and entry["enabled"]
+            and (stream is None or entry["stream"] == stream)
+        ):
+            return True
+    return False
+
+
+def is_disabled(name):
+    """
+    Return ``True`` if the given module currently has a disabled stream.
+
+    name
+        The module name, optionally with a ``:stream`` suffix.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.is_disabled nodejs
+    """
+    module, stream = _split_name(name)
+    for entry in list_(name=module):
+        if (
+            entry["name"] == module
+            and entry["disabled"]
+            and (stream is None or entry["stream"] == stream)
+        ):
+            return True
+    return False
+
+
+def is_installed(name):
+    """
+    Return ``True`` if the given module currently has an installed profile.
+
+    name
+        The module name, optionally with a ``:stream`` suffix.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.is_installed nodejs:18
+    """
+    module, stream = _split_name(name)
+    for entry in list_(name=module):
+        if (
+            entry["name"] == module
+            and entry["installed"]
+            and (stream is None or entry["stream"] == stream)
+        ):
+            return True
+    return False
+
+
+def enabled_stream(name):
+    """
+    Return the stream that is currently enabled for the given module, or
+    ``None`` if the module has no enabled stream. Only one stream of a module
+    can be enabled at a time.
+
+    name
+        The module name (any ``:stream`` suffix is ignored).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.enabled_stream nodejs
+    """
+    module, _ = _split_name(name)
+    for entry in list_(name=module):
+        if entry["name"] == module and entry["enabled"]:
+            return entry["stream"]
+    return None
+
+
+def _run_action(action, name):
+    """
+    Run ``dnf -y module <action> <name>`` and return ``True`` on success.
+    """
+    if not name:
+        raise SaltInvocationError("A module name is required")
+    out = _call_dnf(["-y", "module", action, name])
+    if out["retcode"] != 0:
+        raise CommandExecutionError(
+            f"Failed to {action} module '{name}'",
+            info={"result": out},
+        )
+    return True
+
+
+def enable(name, switch=False):
+    """
+    Enable a module stream. Enabling a stream makes the packages from that
+    stream available for installation but does not install them.
+
+    name
+        The module name with the stream to enable (e.g. ``nodejs:18``). If no
+        stream is given, the default stream is enabled.
+
+    switch
+        DNF refuses to enable a stream while a *different* stream of the same
+        module is already enabled. When ``False`` (the default) a clear error
+        is raised describing the conflict rather than DNF's raw multi-line
+        message. When ``True`` the module is reset first and the requested
+        stream is then enabled, switching the enabled stream.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.enable nodejs:18
+        salt '*' dnfmodule.enable nodejs:18 switch=True
+    """
+    module, requested = _split_name(name)
+    current = enabled_stream(module)
+    if current is not None and requested is not None and current != requested:
+        if not switch:
+            raise CommandExecutionError(
+                f"Module '{module}' already has stream '{current}' enabled; "
+                f"refusing to switch to stream '{requested}'. Reset the module "
+                f"first ('dnfmodule.reset {module}') or pass switch=True."
+            )
+        reset(module)
+    return _run_action("enable", name)
+
+
+def disable(name):
+    """
+    Disable a module. All of the module's streams become unavailable and any
+    enabled stream is reset.
+
+    name
+        The module name to disable (e.g. ``nodejs``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.disable nodejs
+    """
+    return _run_action("disable", name)
+
+
+def install(name):
+    """
+    Install a module profile. This enables the corresponding stream (if it is
+    not already enabled) and installs the profile's packages.
+
+    name
+        The module to install, optionally with a stream and/or profile
+        (e.g. ``nodejs:18`` or ``nodejs:18/common``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.install nodejs:18/common
+    """
+    return _run_action("install", name)
+
+
+def remove(name):
+    """
+    Remove the installed packages of a module profile. The stream remains
+    enabled; use :py:func:`reset` or :py:func:`disable` to change the stream.
+
+    name
+        The module to remove, optionally with a stream and/or profile.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.remove nodejs:18/common
+    """
+    return _run_action("remove", name)
+
+
+def reset(name):
+    """
+    Reset a module to its initial state, neither enabled nor disabled. The
+    default stream (if any) becomes effective again.
+
+    name
+        The module name to reset (e.g. ``nodejs``).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnfmodule.reset nodejs
+    """
+    return _run_action("reset", name)

--- a/salt/states/dnfmodule.py
+++ b/salt/states/dnfmodule.py
@@ -1,0 +1,172 @@
+"""
+Management of DNF modules (modularity / AppStreams)
+
+This state manages `DNF modularity
+<https://docs.fedoraproject.org/en-US/modularity/>`_ (AppStream) module
+streams on RHEL 8/9 and derivatives, using the
+:mod:`dnfmodule <salt.modules.dnfmodule>` execution module.
+
+.. code-block:: yaml
+
+    nodejs:18:
+      dnfmodule.enabled
+
+    install_postgresql:
+      dnfmodule.installed:
+        - name: postgresql:15/client
+
+.. versionadded:: 3008.0
+"""
+
+
+def __virtual__():
+    """
+    Only load if the dnfmodule execution module is available.
+    """
+    if "dnfmodule.enable" in __salt__:
+        return "dnfmodule"
+    return (False, "The dnfmodule execution module is not available")
+
+
+def enabled(name, switch=False):
+    """
+    Ensure that the named module stream is enabled.
+
+    name
+        The module name with the stream to enable, e.g. ``nodejs:18``. If no
+        stream is given, the module's default stream is enabled.
+
+    switch
+        DNF refuses to enable a stream while a *different* stream of the same
+        module is already enabled. When ``False`` (the default) this state
+        fails with a clear message describing the conflict. When ``True`` the
+        module is first reset and the requested stream is then enabled,
+        switching the enabled stream.
+
+        .. note::
+            Switching streams does not remove packages that were installed from
+            the previously enabled stream; reset/switch only changes which
+            stream is enabled.
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    module = name.split(":", 1)[0]
+    requested = name.split(":", 1)[1].split("/", 1)[0] if ":" in name else None
+
+    if __salt__["dnfmodule.is_enabled"](name):
+        ret["comment"] = f"Module stream '{name}' is already enabled"
+        return ret
+
+    # ``is_enabled`` was False above, so any enabled stream reported here must
+    # be a different stream of the same module (a conflict).
+    current = __salt__["dnfmodule.enabled_stream"](name)
+    if current:
+        if not switch:
+            ret["result"] = False
+            ret["comment"] = (
+                f"Module '{module}' already has stream '{current}' enabled. "
+                f"Reset it first or pass 'switch: True' to switch to '{name}'."
+            )
+            return ret
+        if __opts__["test"]:
+            ret["result"] = None
+            ret["comment"] = (
+                f"Module '{module}' stream would be switched from "
+                f"'{current}' to '{requested}'"
+            )
+            ret["changes"] = {module: {"old": current, "new": requested}}
+            return ret
+        __salt__["dnfmodule.enable"](name, switch=True)
+        ret["changes"] = {module: {"old": current, "new": requested}}
+        ret["comment"] = (
+            f"Module '{module}' stream was switched from '{current}' to '{requested}'"
+        )
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Module stream '{name}' would be enabled"
+        ret["changes"] = {"enabled": name}
+        return ret
+
+    __salt__["dnfmodule.enable"](name)
+    ret["changes"] = {"enabled": name}
+    ret["comment"] = f"Module stream '{name}' was enabled"
+    return ret
+
+
+def disabled(name):
+    """
+    Ensure that the named module is disabled.
+
+    name
+        The module name to disable, e.g. ``nodejs``.
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    if __salt__["dnfmodule.is_disabled"](name):
+        ret["comment"] = f"Module '{name}' is already disabled"
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Module '{name}' would be disabled"
+        ret["changes"] = {"disabled": name}
+        return ret
+
+    __salt__["dnfmodule.disable"](name)
+    ret["changes"] = {"disabled": name}
+    ret["comment"] = f"Module '{name}' was disabled"
+    return ret
+
+
+def installed(name):
+    """
+    Ensure that the named module profile is installed. Installing a profile
+    also enables the corresponding stream if it is not already enabled.
+
+    name
+        The module to install, optionally with a stream and/or profile,
+        e.g. ``nodejs:18`` or ``nodejs:18/common``.
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    if __salt__["dnfmodule.is_installed"](name):
+        ret["comment"] = f"Module '{name}' is already installed"
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Module '{name}' would be installed"
+        ret["changes"] = {"installed": name}
+        return ret
+
+    __salt__["dnfmodule.install"](name)
+    ret["changes"] = {"installed": name}
+    ret["comment"] = f"Module '{name}' was installed"
+    return ret
+
+
+def removed(name):
+    """
+    Ensure that the named module profile is not installed. The module's stream
+    remains enabled; use :py:func:`disabled` to change the stream state.
+
+    name
+        The module to remove, optionally with a stream and/or profile.
+    """
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+
+    if not __salt__["dnfmodule.is_installed"](name):
+        ret["comment"] = f"Module '{name}' is already not installed"
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Module '{name}' would be removed"
+        ret["changes"] = {"removed": name}
+        return ret
+
+    __salt__["dnfmodule.remove"](name)
+    ret["changes"] = {"removed": name}
+    ret["comment"] = f"Module '{name}' was removed"
+    return ret

--- a/tests/pytests/unit/modules/test_dnfmodule.py
+++ b/tests/pytests/unit/modules/test_dnfmodule.py
@@ -1,0 +1,179 @@
+import pytest
+
+import salt.modules.dnfmodule as dnfmodule
+from salt.exceptions import CommandExecutionError, SaltInvocationError
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.skip_unless_on_linux,
+]
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        dnfmodule: {
+            "__grains__": {"os_family": "RedHat"},
+            "__context__": {},
+            "__salt__": {},
+        },
+    }
+
+
+# A representative ``dnf module list`` table, including the per-repository
+# headers, metadata noise and trailing hint that the parser must ignore.
+MODULE_LIST = """\
+Updating Subscription Management repositories.
+Last metadata expiration check: 0:10:00 ago on Sun 01 Jun 2025 12:00:00 AM UTC.
+Rocky Linux 8 - AppStream
+Name             Stream     Profiles               Summary
+nodejs           18 [d][e]  common [d] [i]         Javascript runtime
+postgresql       15         client, server [d]     PostgreSQL server
+
+Rocky Linux 8 - PowerTools
+Name      Stream    Profiles    Summary
+ruby      2.5 [x]   common      An interpreter of object-oriented scripting
+
+Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled, [a]ctive
+"""
+
+
+def _dnf_result(stdout="", retcode=0, stderr=""):
+    return {"stdout": stdout, "stderr": stderr, "retcode": retcode}
+
+
+def test_virtual_requires_redhat():
+    with patch.dict(dnfmodule.__grains__, {"os_family": "Debian"}):
+        ret = dnfmodule.__virtual__()
+    assert ret[0] is False
+
+
+def test_virtual_requires_dnf_binary():
+    with patch.object(dnfmodule, "_dnf", MagicMock(return_value=None)):
+        ret = dnfmodule.__virtual__()
+    assert ret[0] is False
+
+
+def test_virtual_available():
+    with patch.object(dnfmodule, "_dnf", MagicMock(return_value="/usr/bin/dnf")):
+        assert dnfmodule.__virtual__() == "dnfmodule"
+
+
+def test_parse_module_list_ignores_noise_and_extracts_flags():
+    modules = dnfmodule._parse_module_list(MODULE_LIST)
+    by_name = {m["name"]: m for m in modules}
+
+    # Repository headers and metadata lines must not appear as modules.
+    assert set(by_name) == {"nodejs", "postgresql", "ruby"}
+
+    assert by_name["nodejs"]["stream"] == "18"
+    assert by_name["nodejs"]["default"] is True
+    assert by_name["nodejs"]["enabled"] is True
+    assert by_name["nodejs"]["installed"] is True
+    assert by_name["nodejs"]["disabled"] is False
+
+    assert by_name["postgresql"]["enabled"] is False
+    assert by_name["postgresql"]["default"] is False
+
+    assert by_name["ruby"]["disabled"] is True
+    assert by_name["ruby"]["enabled"] is False
+
+
+def test_list_passes_filters_and_module_name():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        dnfmodule.list_(name="nodejs:18", enabled=True)
+    args = mock.call_args[0][0]
+    assert "--enabled" in args
+    # The stream suffix is stripped from the module name.
+    assert args[-1] == "nodejs"
+
+
+def test_is_enabled_true():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.is_enabled("nodejs:18") is True
+        assert dnfmodule.is_enabled("nodejs") is True
+
+
+def test_is_enabled_wrong_stream():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.is_enabled("nodejs:14") is False
+
+
+def test_is_disabled_true():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.is_disabled("ruby") is True
+        assert dnfmodule.is_disabled("nodejs") is False
+
+
+def test_is_installed_true():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.is_installed("nodejs") is True
+        assert dnfmodule.is_installed("postgresql") is False
+
+
+def test_enabled_stream():
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.enabled_stream("nodejs") == "18"
+        assert dnfmodule.enabled_stream("nodejs:18") == "18"
+        assert dnfmodule.enabled_stream("postgresql") is None
+
+
+def test_split_name_requires_name():
+    with pytest.raises(SaltInvocationError):
+        dnfmodule._split_name("")
+
+
+def test_split_name_variants():
+    assert dnfmodule._split_name("nodejs") == ("nodejs", None)
+    assert dnfmodule._split_name("nodejs:18") == ("nodejs", "18")
+    assert dnfmodule._split_name("nodejs:18/common") == ("nodejs", "18")
+
+
+def test_enable_builds_command():
+    mock = MagicMock(return_value=_dnf_result(retcode=0))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        assert dnfmodule.enable("nodejs:18") is True
+    assert mock.call_args[0][0] == ["-y", "module", "enable", "nodejs:18"]
+
+
+def test_enable_conflict_raises_clean_error():
+    # nodejs:18 is enabled in MODULE_LIST; enabling a different stream conflicts.
+    mock = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        with pytest.raises(CommandExecutionError) as exc:
+            dnfmodule.enable("nodejs:14")
+    assert "already has stream '18' enabled" in str(exc.value)
+
+
+def test_enable_switch_resets_then_enables():
+    calldnf = MagicMock(return_value=_dnf_result(stdout=MODULE_LIST))
+    reset = MagicMock(return_value=True)
+    with patch.object(dnfmodule, "_call_dnf", calldnf), patch.object(
+        dnfmodule, "reset", reset
+    ):
+        assert dnfmodule.enable("nodejs:14", switch=True) is True
+    reset.assert_called_once_with("nodejs")
+    # The final dnf invocation is the enable action for the requested stream.
+    assert calldnf.call_args[0][0] == ["-y", "module", "enable", "nodejs:14"]
+
+
+def test_disable_and_reset_actions():
+    mock = MagicMock(return_value=_dnf_result(retcode=0))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        dnfmodule.disable("nodejs")
+        assert mock.call_args[0][0] == ["-y", "module", "disable", "nodejs"]
+        dnfmodule.reset("nodejs")
+        assert mock.call_args[0][0] == ["-y", "module", "reset", "nodejs"]
+
+
+def test_action_raises_on_failure():
+    mock = MagicMock(return_value=_dnf_result(retcode=1, stderr="boom"))
+    with patch.object(dnfmodule, "_call_dnf", mock):
+        with pytest.raises(CommandExecutionError):
+            dnfmodule.enable("nodejs:18")

--- a/tests/pytests/unit/states/test_dnfmodule.py
+++ b/tests/pytests/unit/states/test_dnfmodule.py
@@ -1,0 +1,139 @@
+import pytest
+
+import salt.states.dnfmodule as dnfmodule
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.skip_unless_on_linux,
+]
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {dnfmodule: {"__opts__": {"test": False}}}
+
+
+def test_enabled_already_enabled():
+    salt_mock = {"dnfmodule.is_enabled": MagicMock(return_value=True)}
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.enabled("nodejs:18")
+    assert ret["result"] is True
+    assert ret["changes"] == {}
+    assert "already enabled" in ret["comment"]
+
+
+def test_enabled_test_mode():
+    salt_mock = {
+        "dnfmodule.is_enabled": MagicMock(return_value=False),
+        "dnfmodule.enabled_stream": MagicMock(return_value=None),
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock), patch.dict(
+        dnfmodule.__opts__, {"test": True}
+    ):
+        ret = dnfmodule.enabled("nodejs:18")
+    assert ret["result"] is None
+    assert ret["changes"] == {"enabled": "nodejs:18"}
+
+
+def test_enabled_conflict_without_switch_fails():
+    salt_mock = {
+        "dnfmodule.is_enabled": MagicMock(return_value=False),
+        "dnfmodule.enabled_stream": MagicMock(return_value="3.0"),
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.enabled("swig:4.0")
+    assert ret["result"] is False
+    assert ret["changes"] == {}
+    assert "already has stream '3.0' enabled" in ret["comment"]
+
+
+def test_enabled_switch_test_mode():
+    salt_mock = {
+        "dnfmodule.is_enabled": MagicMock(return_value=False),
+        "dnfmodule.enabled_stream": MagicMock(return_value="3.0"),
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock), patch.dict(
+        dnfmodule.__opts__, {"test": True}
+    ):
+        ret = dnfmodule.enabled("swig:4.0", switch=True)
+    assert ret["result"] is None
+    assert ret["changes"] == {"swig": {"old": "3.0", "new": "4.0"}}
+
+
+def test_enabled_switch_delegates_to_enable():
+    enable = MagicMock(return_value=True)
+    salt_mock = {
+        "dnfmodule.is_enabled": MagicMock(return_value=False),
+        "dnfmodule.enabled_stream": MagicMock(return_value="3.0"),
+        "dnfmodule.enable": enable,
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.enabled("swig:4.0", switch=True)
+    enable.assert_called_once_with("swig:4.0", switch=True)
+    assert ret["result"] is True
+    assert ret["changes"] == {"swig": {"old": "3.0", "new": "4.0"}}
+
+
+def test_enabled_applies_change_no_conflict():
+    enable = MagicMock(return_value=True)
+    salt_mock = {
+        "dnfmodule.is_enabled": MagicMock(return_value=False),
+        "dnfmodule.enabled_stream": MagicMock(return_value=None),
+        "dnfmodule.enable": enable,
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.enabled("nodejs:18")
+    enable.assert_called_once_with("nodejs:18")
+    assert ret["changes"] == {"enabled": "nodejs:18"}
+
+
+def test_disabled_applies_change():
+    disable = MagicMock(return_value=True)
+    salt_mock = {
+        "dnfmodule.is_disabled": MagicMock(return_value=False),
+        "dnfmodule.disable": disable,
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.disabled("nodejs")
+    disable.assert_called_once_with("nodejs")
+    assert ret["changes"] == {"disabled": "nodejs"}
+
+
+def test_installed_already_installed():
+    salt_mock = {"dnfmodule.is_installed": MagicMock(return_value=True)}
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.installed("nodejs:18/common")
+    assert ret["changes"] == {}
+    assert "already installed" in ret["comment"]
+
+
+def test_installed_applies_change():
+    install = MagicMock(return_value=True)
+    salt_mock = {
+        "dnfmodule.is_installed": MagicMock(return_value=False),
+        "dnfmodule.install": install,
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.installed("nodejs:18/common")
+    install.assert_called_once_with("nodejs:18/common")
+    assert ret["changes"] == {"installed": "nodejs:18/common"}
+
+
+def test_removed_when_not_installed():
+    salt_mock = {"dnfmodule.is_installed": MagicMock(return_value=False)}
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.removed("nodejs:18/common")
+    assert ret["changes"] == {}
+    assert ret["result"] is True
+
+
+def test_removed_applies_change():
+    remove = MagicMock(return_value=True)
+    salt_mock = {
+        "dnfmodule.is_installed": MagicMock(return_value=True),
+        "dnfmodule.remove": remove,
+    }
+    with patch.dict(dnfmodule.__salt__, salt_mock):
+        ret = dnfmodule.removed("nodejs:18/common")
+    remove.assert_called_once_with("nodejs:18/common")
+    assert ret["changes"] == {"removed": "nodejs:18/common"}


### PR DESCRIPTION
## What does this PR do?

Adds the `dnfmodule` execution and state modules to manage DNF modularity (AppStream) module streams on RHEL 8/9 and derivatives.

Supported operations: **enable, disable, install, remove, reset** and **list** module streams.

## What issues does this PR fix or reference?

Fixes #62146 (feature request, now discussion #67398)

## Previous Behavior

No native Salt support for managing DNF AppStream module streams; users had to shell out to `cmd.run` with `dnf module ...`.

## New Behavior

- `salt/modules/dnfmodule.py` — execution module
- `salt/states/dnfmodule.py` — state module
- Unit tests for both
- Reference documentation pages and index entries
- Changelog fragment

## Merge requirements satisfied?

- [x] Includes tests
- [x] Includes documentation
- [x] Includes changelog fragment
