### PR TITLE
Bump relenv to 0.22.16 (#69612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -458,7 +458,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -475,7 +475,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -505,7 +505,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -522,7 +522,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -543,7 +543,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -490,7 +490,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -507,7 +507,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -524,7 +524,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -464,7 +464,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -482,7 +482,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -504,7 +504,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.14"
+      relenv-version: "0.22.16"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/changelog/69612.fixed.md
+++ b/changelog/69612.fixed.md
@@ -1,0 +1,5 @@
+* Relenv 0.22.16
+  - 0.22.15: apply cpython#104135 workaround to bundled ssl.py on Windows
+  - 0.22.15: send relenv runtime debug/warning output to stderr (unblocks
+    maturin/pyo3 subprocess consumers)
+  - 0.22.16: pin libffi to cpython-bin-deps on Windows

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.11.15"
-relenv_version: "0.22.14"
+relenv_version: "0.22.16"
 release_branches:
   - "3006.x"
   - "3007.x"


### PR DESCRIPTION
### What does this PR do?

Bumps relenv `0.22.14` → `0.22.16` on 3006.x. Same shape as #69413 / #69414:
update `cicd/shared-gh-workflows-context.yml` and let the
`generate-workflows` pre-commit hook regenerate the four workflow YAMLs.

### What issues does this PR fix or reference?

Fixes #69612

### Previous Behavior

Onedir packages on 3006.x are built with relenv 0.22.14.

### New Behavior

Onedir packages on 3006.x are built with relenv 0.22.16:

- **0.22.15:** `ssl._load_windows_store_certs` iterate-and-skip workaround
  (cpython#104135) baked into bundled `Lib/ssl.py` on Windows. Lets Salt drop
  its own monkey-patches in `salt/__init__.py` / `salt/ext/tornado/netutil.py`
  in a follow-up PR.
- **0.22.15:** relenv runtime debug/warning output goes to stderr instead of
  stdout, so maturin/pyo3 subprocess JSON consumers (cryptography ≥48, etc.)
  no longer trip on it when `RELENV_DEBUG` is set.
- **0.22.16:** pin Windows libffi to `cpython-bin-deps` (auto-updater
  regression in 0.22.15 broke Windows onedir builds with missing `ffi.h`).

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated (N/A — version bump; CI onedir builds are the test)

### Commits signed with GPG?

No
