### PR TITLE
Fix dependabot lock-sync workflow and hold vcert/pylint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
     labels:
       - "test:full"
     open-pull-requests-limit: 5
+    # vcert 0.18+ hard-pins pynacl/cryptography/six against the rest of CI, and
+    # pylint 4.x turns pre-existing warnings into hard CI failures; both are
+    # deliberately held (see the comments in requirements/static/ci/*.txt).
+    ignore:
+      - dependency-name: "vcert"
+        versions: [">=0.10.0"]
+      - dependency-name: "pylint"
+        versions: [">=4.0.0"]
     groups:
       all-pip-updates:
         patterns:
@@ -27,6 +35,11 @@ updates:
     labels:
       - "test:full"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "vcert"
+        versions: [">=0.10.0"]
+      - dependency-name: "pylint"
+        versions: [">=4.0.0"]
     groups:
       all-pip-updates:
         patterns:
@@ -43,6 +56,11 @@ updates:
     labels:
       - "test:full"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "vcert"
+        versions: [">=0.10.0"]
+      - dependency-name: "pylint"
+        versions: [">=4.0.0"]
     groups:
       all-pip-updates:
         patterns:
@@ -59,6 +77,11 @@ updates:
     labels:
       - "test:full"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "vcert"
+        versions: [">=0.10.0"]
+      - dependency-name: "pylint"
+        versions: [">=4.0.0"]
     groups:
       all-pip-updates:
         patterns:

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -16,8 +16,10 @@ permissions:
 jobs:
   sync-requirements:
     name: Sync .lock files
-    # Trigger for any dependabot actor
-    if: contains(github.actor, 'dependabot') || github.event_name == 'workflow_dispatch'
+    # Trigger for dependabot, and for the salt-pr-bot rebases that re-push
+    # dependabot branches (github.actor is salt-pr-bot[bot] on those events,
+    # which otherwise skips this job and leaves the lock files stale).
+    if: contains(github.actor, 'dependabot') || contains(github.actor, 'salt-pr-bot') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: workflow-restart
     steps:


### PR DESCRIPTION
## What

Durable fixes so the automated Dependabot lock-file sync works and stops
producing PRs that can never pass CI.

### Workflow (`.github/workflows/dependabot-sync.yml`)
- Widen the `Sync .lock files` actor guard to also fire for `salt-pr-bot`.
  When the rebase bot re-pushes a dependabot branch, `github.actor` becomes
  `salt-pr-bot[bot]`, which previously skipped the job and left the lock
  files stale (the root cause of the recent "deps weren't generated" PRs).

### Dependabot config (`.github/dependabot.yml`)
- Ignore `vcert >= 0.10.0` and `pylint >= 4.0.0` on every target branch.
  vcert 0.18+ hard-pins pynacl/cryptography/six against the rest of CI, and
  pylint 4.x turns pre-existing warnings into hard failures. Both are already
  deliberately held in `requirements/static/ci/*.txt`, so this stops
  Dependabot from re-proposing them each week and reintroducing the conflict.

## Notes
- The branch-filter gap (workflows on `3007.x`/`3008.x` omit their own branch
  in `on.pull_request.branches`) is fixed in the companion PRs to those
  branches; `master`'s workflow already lists all four.
- No requirements changes: `master` already relocks clean.

## Follow-up
After this and the companion branch PRs merge, the four stale Dependabot PRs
(#69586–#69589) can be closed so Dependabot regenerates fresh ones against the
fixed workflow.