### PR TITLE
Fix dependabot lock-sync workflow triggering on 3007.x

### DIFF
--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - master
+      - 3008.x
+      - 3007.x
       - 3006.x
 
 permissions:
@@ -14,8 +16,10 @@ permissions:
 jobs:
   sync-requirements:
     name: Sync .lock files
-    # Trigger for any dependabot actor
-    if: contains(github.actor, 'dependabot') || github.event_name == 'workflow_dispatch'
+    # Trigger for dependabot, and for the salt-pr-bot rebases that re-push
+    # dependabot branches (github.actor is salt-pr-bot[bot] on those events,
+    # which otherwise skips this job and leaves the lock files stale).
+    if: contains(github.actor, 'dependabot') || contains(github.actor, 'salt-pr-bot') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: workflow-restart
     steps:


### PR DESCRIPTION
## What

Make the automated Dependabot lock-file sync actually run for `3007.x` PRs.

Two bugs in `.github/workflows/dependabot-sync.yml` kept the `Sync .lock files`
job from running on `3007.x`, which is why recent Dependabot PRs landed with stale
/ inconsistent lock files:

- **Branch-filter gap:** `on.pull_request.branches` only listed `master` and
  `3006.x`, so the workflow never triggered for PRs whose base is `3007.x`. Now
  lists all four release branches.
- **Actor guard:** the job only fired for `dependabot`; it skipped whenever the
  `salt-pr-bot` rebase bot re-pushed the branch (`github.actor` becomes
  `salt-pr-bot[bot]`). Now also fires for `salt-pr-bot`.

## Notes
- No requirements changes: `3007.x` already relocks clean.
- The Dependabot `ignore` rules for vcert/pylint live in the companion
  `master` PR (Dependabot only reads config from the default branch).

## Follow-up
Once this and the companion branch PRs merge, the stale Dependabot PRs
(#69586–#69589) can be closed so Dependabot regenerates fresh ones.