### PR TITLE
Fix sql_base ext_pillar crashing on str/bytes JSON rows (#63684)

### DIFF
--- a/changelog/63684.fixed.md
+++ b/changelog/63684.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``sql_base`` ext_pillar with ``as_json: True`` crashing with ``TypeError: Cannot update using non-dict types in dictupdate.update()`` when the database driver returns JSON columns as ``str`` or ``bytes`` (for example MySQLdb and some PyMySQL configurations). The row is now JSON-decoded before merging.

--- a/salt/pillar/sql_base.py
+++ b/salt/pillar/sql_base.py
@@ -199,6 +199,7 @@ More complete example for MySQL (to also show configuration)
 """
 
 import abc
+import json
 import logging
 from collections import OrderedDict
 
@@ -346,10 +347,23 @@ class SqlBaseExtPillar(metaclass=abc.ABCMeta):
             # crd is the Current Return Data level, to make this non-recursive.
             crd = self.focus
 
-            # We have just one field without any key, assume returned row is already a dict
-            # aka JSON storage
+            # We have just one field without any key, assume returned row is a
+            # JSON document (aka JSON storage). Some database drivers (for
+            # example MySQLdb and some PyMySQL configurations) return JSON
+            # columns as ``str`` or ``bytes`` rather than as a pre-decoded
+            # ``dict``, so decode the value first if needed.
             if self.as_json and self.num_fields == 1:
-                crd = update(crd, ret[0], merge_lists=self.as_list)
+                row = ret[0]
+                if isinstance(row, (bytes, bytearray)):
+                    row = row.decode("utf-8")
+                if isinstance(row, str):
+                    row = json.loads(row)
+                if not isinstance(row, dict):
+                    raise TypeError(
+                        "as_json rows must decode to a dict, got "
+                        f"{type(row).__name__}"
+                    )
+                crd = update(crd, row, merge_lists=self.as_list)
                 continue
 
             # Walk and create dicts above the final layer

--- a/tests/pytests/unit/pillar/test_sql_base.py
+++ b/tests/pytests/unit/pillar/test_sql_base.py
@@ -42,3 +42,78 @@ def test_process_results_as_json(as_list):
         "c": {"d": [4, 5], "e": 6, "g": 8},
         "f": [{"g": 7, "h": "test"}],
     }
+
+
+@pytest.mark.parametrize("as_list", [True, False])
+def test_process_results_as_json_string_rows(as_list):
+    """
+    Regression test for #63684: MySQLdb (and some PyMySQL configurations)
+    return JSON columns as ``str`` rather than as pre-decoded dicts.
+    ``process_results`` must decode string rows before merging so it does
+    not raise ``TypeError`` from ``dictupdate.update``.
+    """
+    return_data = FakeExtPillar()
+    return_data.as_list = as_list
+    return_data.as_json = True
+    return_data.with_lists = None
+    return_data.enter_root(None)
+    return_data.process_fields(["json_data"], 0)
+    test_rows = [
+        ('{"a": [1]}',),
+        ('{"b": [2, 3]}',),
+        ('{"a": [4]}',),
+        ('{"c": {"d": [4, 5], "e": 6}}',),
+        ('{"f": [{"g": 7, "h": "test"}], "c": {"g": 8}}',),
+    ]
+    return_data.process_results(test_rows)
+    assert return_data.result == {
+        "a": [1, 4] if as_list else [4],
+        "b": [2, 3],
+        "c": {"d": [4, 5], "e": 6, "g": 8},
+        "f": [{"g": 7, "h": "test"}],
+    }
+
+
+@pytest.mark.parametrize("as_list", [True, False])
+def test_process_results_as_json_bytes_rows(as_list):
+    """
+    Regression test for #63684: some driver/charset combinations return JSON
+    columns as ``bytes``. ``process_results`` must decode bytes rows before
+    merging so it does not raise ``TypeError`` from ``dictupdate.update``.
+    """
+    return_data = FakeExtPillar()
+    return_data.as_list = as_list
+    return_data.as_json = True
+    return_data.with_lists = None
+    return_data.enter_root(None)
+    return_data.process_fields(["json_data"], 0)
+    test_rows = [
+        (b'{"a": [1]}',),
+        (b'{"b": [2, 3]}',),
+        (b'{"a": [4]}',),
+        (b'{"c": {"d": [4, 5], "e": 6}}',),
+        (b'{"f": [{"g": 7, "h": "test"}], "c": {"g": 8}}',),
+    ]
+    return_data.process_results(test_rows)
+    assert return_data.result == {
+        "a": [1, 4] if as_list else [4],
+        "b": [2, 3],
+        "c": {"d": [4, 5], "e": 6, "g": 8},
+        "f": [{"g": 7, "h": "test"}],
+    }
+
+
+def test_process_results_as_json_non_dict_string_row_raises():
+    """
+    Regression test for #63684: if a JSON row decodes to a non-dict value
+    (e.g. a scalar), raise a clear ``TypeError`` instead of blowing up
+    deep inside ``dictupdate.update``.
+    """
+    return_data = FakeExtPillar()
+    return_data.as_list = False
+    return_data.as_json = True
+    return_data.with_lists = None
+    return_data.enter_root(None)
+    return_data.process_fields(["json_data"], 0)
+    with pytest.raises(TypeError):
+        return_data.process_results([("42",)])


### PR DESCRIPTION
### What does this PR do?

`sql_base.process_results` assumed the database driver had already decoded the single JSON column of an `as_json: True` query into a Python `dict`. That is true for `psycopg2` with the `json` type and some `PyMySQL` configurations, but MySQLdb (and some PyMySQL setups) return the JSON column as `str` or `bytes`, so `dictupdate.update` immediately raised `TypeError: Cannot update using non-dict types in dictupdate.update()` and pillar compilation failed.

Decode `str`/`bytes` rows via `json.loads` before merging, and raise a clear `TypeError` when the decoded value is not a `dict`.

### What issues does this PR fix or reference?

Fixes #63684

### Previous Behavior

`sql_base` ext_pillar (via `mysql`, `postgres`, etc.) with `as_json: True` produced:

```
TypeError: Cannot update using non-dict types in dictupdate.update()
  File ".../salt/pillar/sql_base.py", line 352, in process_results
    crd = update(crd, ret[0], merge_lists=self.as_list)
  File ".../salt/utils/dictupdate.py", line 38, in update
    raise TypeError("Cannot update using non-dict types in dictupdate.update()")
```

whenever the driver returned the JSON column as a string (MySQLdb default; also reported by users on Postgres in comment threads).

### New Behavior

Rows returned as `str`/`bytes` are decoded via `json.loads` before being merged. Rows already returned as `dict` continue to work unchanged. If a row decodes to a non-dict scalar the ext_pillar now raises a clear `TypeError` naming the offending type instead of failing deep inside `dictupdate`.

Regression tests: `tests/pytests/unit/pillar/test_sql_base.py::test_process_results_as_json_string_rows`, `::test_process_results_as_json_bytes_rows`, and `::test_process_results_as_json_non_dict_string_row_raises`.

### Merge requirements satisfied?

- [x] Docs (no user-facing doc change; behavior now matches the module docstring's description of `as_json` merging)
- [x] Changelog (`changelog/63684.fixed.md`)
- [x] Tests written/updated

### Commits signed with GPG?

Yes
