### PR TITLE
Fix returner option parsing for falsy configured values (#63980)

### DIFF
--- a/changelog/63980.fixed.md
+++ b/changelog/63980.fixed.md
@@ -1,0 +1,1 @@
+Fixed returner option parsing so that configured falsy values (``0``, ``0.0``, ``False``, ``[]``) are no longer silently replaced by the returner's default value.

--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -164,7 +164,7 @@ def _options_browser(cfg, ret_config, defaults, virtualname, options):
         # default place for the option in the config
         value = _fetch_option(cfg, ret_config, virtualname, options[option])
 
-        if value:
+        if value != "":
             yield option, value
             continue
 

--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -164,7 +164,7 @@ def _options_browser(cfg, ret_config, defaults, virtualname, options):
         # default place for the option in the config
         value = _fetch_option(cfg, ret_config, virtualname, options[option])
 
-        if value != "":
+        if value is not None and value != "":
             yield option, value
             continue
 

--- a/tests/pytests/unit/returners/test_returners_init.py
+++ b/tests/pytests/unit/returners/test_returners_init.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for salt.returners package helpers (``get_returner_options`` /
+``_options_browser``).
+
+Regression coverage for https://github.com/saltstack/salt/issues/63980:
+configured falsy values (``0``, ``0.0``, ``False``, ``[]``) must be
+yielded by ``_options_browser`` rather than being replaced by the
+supplied defaults.
+"""
+
+import pytest
+
+import salt.returners
+from tests.support.mock import patch
+
+
+@pytest.mark.parametrize(
+    "configured_value",
+    [0, 0.0, False, []],
+    ids=["int-zero", "float-zero", "bool-false", "empty-list"],
+)
+def test_options_browser_yields_falsy_configured_value(configured_value):
+    """
+    A falsy-but-set configuration value must be returned as-is instead of
+    being masked by the returner's default value.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=configured_value):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": configured_value}
+
+
+def test_options_browser_falls_back_to_default_when_unset():
+    """
+    When ``_fetch_option`` returns the empty-string sentinel (i.e. the
+    option is not configured), the default value should be yielded.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=""):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": 42}
+
+
+def test_options_browser_yields_configured_truthy_value():
+    """
+    A configured, truthy value should be yielded unchanged.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value="hello"):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": "hello"}

--- a/tests/pytests/unit/returners/test_returners_init.py
+++ b/tests/pytests/unit/returners/test_returners_init.py
@@ -2,10 +2,17 @@
 Unit tests for salt.returners package helpers (``get_returner_options`` /
 ``_options_browser``).
 
-Regression coverage for https://github.com/saltstack/salt/issues/63980:
-configured falsy values (``0``, ``0.0``, ``False``, ``[]``) must be
-yielded by ``_options_browser`` rather than being replaced by the
-supplied defaults.
+Regression coverage for:
+
+- https://github.com/saltstack/salt/issues/63980 — configured falsy values
+  (``0``, ``0.0``, ``False``, ``[]``) must be yielded by
+  ``_options_browser`` rather than being replaced by the supplied
+  defaults.
+- Plain-dict fallback (``__salt__["config.option"]`` undefined,
+  ``cfg = __opts__``): ``_fetch_option`` returns ``None`` for a missing
+  attribute. That ``None`` must fall through to the ``defaults`` branch
+  rather than being yielded verbatim. Same class of bug as #69654 on
+  3007.x/3008.x, which #69669 fixed there.
 """
 
 import pytest
@@ -61,6 +68,65 @@ def test_options_browser_falls_back_to_default_when_unset():
         )
 
     assert result == {"my_option": 42}
+
+
+def test_options_browser_falls_back_to_default_when_fetch_returns_none():
+    """
+    Plain-dict fallback path: when ``__salt__["config.option"]`` is not
+    available, ``cfg`` is the plain ``__opts__`` dict and
+    ``_fetch_option`` returns ``None`` for a missing attribute (see
+    ``salt/returners/__init__.py::_fetch_option``). That ``None`` must
+    fall through to the ``defaults`` branch instead of being yielded
+    verbatim.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=None):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": 42}
+
+
+def test_options_browser_plain_dict_cfg_falls_back_to_defaults():
+    """
+    End-to-end plain-dict-``cfg`` regression test (no ``_fetch_option``
+    monkey-patching). Mirrors the ``saltext-prometheus`` failure mode
+    from #69654: a returner passing ``__opts__`` as ``cfg`` with a rich
+    ``defaults`` dict should receive the defaults for every unset
+    attribute, not a dict full of ``None`` values.
+    """
+    cfg = {}  # __opts__ with no returner options configured
+    defaults = {
+        "exe": None,
+        "filename": "/tmp/salt.prom",
+        "uid": -1,
+        "gid": -1,
+        "mode": None,
+        "match_exe": False,
+        "proc_name": "salt-minion",
+    }
+    options = {name: name for name in defaults}
+
+    result = dict(
+        salt.returners._options_browser(
+            cfg=cfg,
+            ret_config=None,
+            defaults=defaults,
+            virtualname="custom_returner",
+            options=options,
+        )
+    )
+
+    assert result == defaults
 
 
 def test_options_browser_yields_configured_truthy_value():


### PR DESCRIPTION
### What does this PR do?

Backports the one-line fix in `salt/returners/__init__.py::_options_browser` so
that a configured falsy option value (``0``, ``0.0``, ``False``, ``[]``, ``""``)
is no longer silently replaced by the returner's default. Adds a small unit
test covering the truthiness edge cases and the empty-string sentinel
fallback.

### What issues does this PR fix or reference?

Fixes #63980

The same one-liner is already shipped on 3007.x, 3008.x, and master via
commit e0bf24d17e1 ("Fix options parsing", PR #66828, which fixed the
sibling issue #66816). Only 3006.x still carries the bug.

### Previous Behavior

`_options_browser` used `if value:` on the value returned by `_fetch_option`.
`_fetch_option` falls back to `cfg(default_cfg_key)` which returns `""` when
the key is unset — the "not-found" sentinel. Because the check was truthiness,
it treated legitimately configured `0`, `0.0`, `False`, `[]`, and `""` the
same as the unset sentinel and yielded the returner's default value instead.

Reporter's example:

```
salt-call state.apply foo_state --return custom_returner \
    pillar='{"custom_returner.option_value": 0.0}'
```

produced `option_value=<default>` instead of `option_value=0.0`.

### New Behavior

`_options_browser` now compares against the empty-string sentinel explicitly
(`if value != "":`). Configured falsy values round-trip through the returner
options iterator; only the empty-string sentinel triggers the default
fallback.

### Merge requirements satisfied?

- [x] Docs (no documented behavior changes; only the buggy code path is
  fixed to match the documented intent)
- [x] Changelog (`changelog/63980.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/returners/test_returners_init.py`)

### Commits signed with GPG?

Yes
