### PR TITLE
Fix vm_overrides nested-merge in Cloud.vm_config() (#63351)

### DIFF
--- a/changelog/63351.fixed.md
+++ b/changelog/63351.fixed.md
@@ -1,0 +1,1 @@
+Fixed `Cloud.vm_config()` to deep-merge `vm_overrides` into the profile so nested keys such as `devices.disk` are preserved instead of being replaced by a shallow `dict.update`.

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1306,7 +1306,7 @@ class Cloud:
         vm = main.copy()
         vm = salt.utils.dictupdate.update(vm, provider)
         vm = salt.utils.dictupdate.update(vm, profile)
-        vm.update(overrides)
+        vm = salt.utils.dictupdate.update(vm, overrides)
         vm["name"] = name
         return vm
 

--- a/tests/pytests/unit/cloud/test_cloud.py
+++ b/tests/pytests/unit/cloud/test_cloud.py
@@ -130,6 +130,51 @@ def test_vm_config_merger():
     assert expected == vm
 
 
+def test_vm_config_merger_with_overrides():
+    """
+    Nested keys supplied via ``overrides`` (vm_overrides) must be
+    deep-merged into the profile, not shallow-replaced.
+
+    https://github.com/saltstack/salt/issues/63351
+    """
+    main = {}
+    provider = {}
+    profile = {
+        "profile": "default",
+        "provider": "vmware-default:vmware",
+        "devices": {
+            "disk": {
+                "Hard disk 1": {"size": 30},
+            },
+            "network": {
+                "Network adapter 1": {
+                    "name": "VM Network",
+                    "switch_type": "standard",
+                },
+            },
+        },
+    }
+    overrides = {
+        "devices": {
+            "network": {
+                "Network adapter 1": {"ip": "192.168.0.10"},
+            },
+        },
+    }
+    vm = Cloud.vm_config("test_vm", main, provider, profile, overrides)
+    # Nested top-level branch that was not mentioned in the overrides
+    # must be preserved.
+    assert "disk" in vm["devices"]
+    assert vm["devices"]["disk"] == {"Hard disk 1": {"size": 30}}
+    # Nested sub-key that was mentioned must be merged, not replaced.
+    assert vm["devices"]["network"]["Network adapter 1"] == {
+        "name": "VM Network",
+        "switch_type": "standard",
+        "ip": "192.168.0.10",
+    }
+    assert vm["name"] == "test_vm"
+
+
 @pytest.mark.skip_on_fips_enabled_platform
 def test_cloud_run_profile_create_returns_boolean(master_config):
 


### PR DESCRIPTION
### What does this PR do?
`salt.cloud.Cloud.vm_config()` deep-merged the `main`, `provider` and `profile` config layers with `salt.utils.dictupdate.update()` but then applied `vm_overrides` with a shallow `vm.update(overrides)`. Any top-level key present in `vm_overrides` clobbered the corresponding nested branch coming from the profile. Use `salt.utils.dictupdate.update()` for the `overrides` layer too so nested keys round-trip correctly.

### What issues does this PR fix or reference?
Fixes #63351

Same root cause as the already-fixed sibling issue #64610 (commit `2c72c0471b8`, which landed on 3007.x and later). That fix also changed the calling contract on 3007.x+ (`overrides` is now keyed by VM name); this backport keeps the 3006.x calling contract unchanged and only restores the nested merge.

### Previous Behavior
Setting a nested field via `vm_overrides` (e.g. `devices.network."Network adapter 1".ip`) dropped every sibling branch of `devices` from the profile (e.g. `devices.disk`, other adapters, other fields on the same adapter). Users reported the disk section disappearing entirely.

### New Behavior
`vm_overrides` is deep-merged into the composed VM config; nested keys not mentioned in the override are preserved from the profile.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change; docstring semantics are what the profile users already expected)
- [x] Changelog
- [x] Tests written/updated (`test_vm_config_merger_with_overrides` covers the exact reporter scenario)

### Commits signed with GPG?
No — 3006.x history is not GPG-signed; matching branch policy.
