### PR TITLE
Fix regex_search/regex_match Jinja filters for ungrouped patterns (#65722)

### DIFF
--- a/changelog/65722.fixed.md
+++ b/changelog/65722.fixed.md
@@ -1,0 +1,1 @@
+Handle regular expressions which do not not use grouping

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -489,6 +489,9 @@ def regex_search(txt, rgx, ignorecase=False, multiline=False):
     obj = re.search(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 
@@ -516,6 +519,9 @@ def regex_match(txt, rgx, ignorecase=False, multiline=False):
     obj = re.match(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -497,6 +497,9 @@ def regex_search(txt, rgx, ignorecase=False, multiline=False):
     obj = re.search(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 
@@ -524,6 +527,9 @@ def regex_match(txt, rgx, ignorecase=False, multiline=False):
     obj = re.match(rgx, txt, flag)
     if not obj:
         return
+    # Handle regular expressions which do not use grouping
+    if obj and not obj.groups():
+        return (obj.group(),)
     return obj.groups()
 
 

--- a/tests/pytests/functional/modules/state/test_jinja_filters.py
+++ b/tests/pytests/functional/modules/state/test_jinja_filters.py
@@ -613,6 +613,17 @@ def _filter_id(value):
             """,
         ),
         Filter(
+            name="regex_match_ungrouped",
+            expected={"ret": "('1.abc',)"},
+            sls="""
+            {% set result = '1.abc' | regex_match('^1.abc$') %}
+            test:
+              module.run:
+                - name: test.echo
+                - text: {{ result }}
+            """,
+        ),
+        Filter(
             name="regex_match_no_match",
             expected={"ret": "None"},
             sls="""
@@ -694,6 +705,17 @@ def _filter_id(value):
             expected={"ret": "('a', 'd')"},
             sls="""
             {% set result = 'abcd' | regex_search('^(.*)bc(.*)$') %}
+            test:
+              module.run:
+                - name: test.echo
+                - text: {{ result }}
+            """,
+        ),
+        Filter(
+            name="regex_search_ungrouped",
+            expected={"ret": "('1.abc',)"},
+            sls="""
+            {% set result = '1.abc' | regex_search('^1.abc$') %}
             test:
               module.run:
                 - name: test.echo

--- a/tests/pytests/unit/utils/jinja/test_jinja_custom_filters.py
+++ b/tests/pytests/unit/utils/jinja/test_jinja_custom_filters.py
@@ -345,3 +345,42 @@ huh:
 def test_python():
     _render_fail(PYTHON_SLS_ERROR)
     assert _render(PYTHON_SLS) == PYTHON_SLS_RIGHT
+
+
+def test_regex_search_ungrouped():
+    """
+    Regression test for #65722: regex_search must return the whole match
+    when the pattern contains no capturing groups, not an empty tuple.
+    """
+    result = jinja.regex_search("1.abc", "^1.abc$")
+    assert result == ("1.abc",)
+    assert result
+
+
+def test_regex_search_grouped():
+    """
+    Ensure the ungrouped fix does not regress the grouped code path.
+    """
+    assert jinja.regex_search("1.abc", r"^(1)\.(.+)$") == ("1", "abc")
+
+
+def test_regex_search_no_match():
+    assert jinja.regex_search("1.abc", "^nope$") is None
+
+
+def test_regex_match_ungrouped():
+    """
+    Regression test for #65722: regex_match must return the whole match
+    when the pattern contains no capturing groups.
+    """
+    result = jinja.regex_match("1.abc", "^1.abc$")
+    assert result == ("1.abc",)
+    assert result
+
+
+def test_regex_match_grouped():
+    assert jinja.regex_match("1.abc", r"^(1)\.(.+)$") == ("1", "abc")
+
+
+def test_regex_match_no_match():
+    assert jinja.regex_match("1.abc", "^nope$") is None

--- a/tests/pytests/unit/utils/jinja/test_jinja_custom_filters.py
+++ b/tests/pytests/unit/utils/jinja/test_jinja_custom_filters.py
@@ -435,9 +435,9 @@ def test_regex_search_no_match_returns_none():
 
 
 def test_regex_search_no_group():
-    """The filter returns ``match.groups()``, so a successful match with no
-    capture groups yields an empty (falsy) tuple, not the matched text."""
-    assert jinja.regex_search("abcd", "bc") == ()
+    """When the pattern has no capture groups, the filter returns a tuple
+    containing the whole matched text (see #65722)."""
+    assert jinja.regex_search("abcd", "bc") == ("bc",)
 
 
 def test_regex_search_groups_ignorecase():
@@ -457,9 +457,9 @@ def test_regex_match_no_match_returns_none():
 
 
 def test_regex_match_no_group():
-    """Like regex_search, a match with no capture groups returns an empty
-    (falsy) tuple because the filter returns ``match.groups()``."""
-    assert jinja.regex_match("abcd", "ab") == ()
+    """Like regex_search, a match with no capture groups returns a tuple
+    containing the whole matched text (see #65722)."""
+    assert jinja.regex_match("abcd", "ab") == ("ab",)
 
 
 def test_regex_match_groups_ignorecase():
@@ -637,3 +637,42 @@ def test_skip_filter():
     assert jinja.skip_filter("foo") == ""
     assert jinja.skip_filter(None) == ""
     assert jinja.skip_filter([1, 2, 3]) == ""
+
+
+def test_regex_search_ungrouped():
+    """
+    Regression test for #65722: regex_search must return the whole match
+    when the pattern contains no capturing groups, not an empty tuple.
+    """
+    result = jinja.regex_search("1.abc", "^1.abc$")
+    assert result == ("1.abc",)
+    assert result
+
+
+def test_regex_search_grouped():
+    """
+    Ensure the ungrouped fix does not regress the grouped code path.
+    """
+    assert jinja.regex_search("1.abc", r"^(1)\.(.+)$") == ("1", "abc")
+
+
+def test_regex_search_no_match():
+    assert jinja.regex_search("1.abc", "^nope$") is None
+
+
+def test_regex_match_ungrouped():
+    """
+    Regression test for #65722: regex_match must return the whole match
+    when the pattern contains no capturing groups.
+    """
+    result = jinja.regex_match("1.abc", "^1.abc$")
+    assert result == ("1.abc",)
+    assert result
+
+
+def test_regex_match_grouped():
+    assert jinja.regex_match("1.abc", r"^(1)\.(.+)$") == ("1", "abc")
+
+
+def test_regex_match_no_match():
+    assert jinja.regex_match("1.abc", "^nope$") is None


### PR DESCRIPTION
### What does this PR do?

Backports the fix from PR #65708 to the `3006.x` branch. The
`regex_search` and `regex_match` Jinja filters returned an empty tuple
`()` when the regex pattern had no capturing groups. Since an empty
tuple is falsy in Jinja, `{% if my_text | regex_search('^1.abc$') %}`
evaluated false on a valid match. The filters now return
`(obj.group(),)` — a truthy single-element tuple containing the whole
match — when there are no groups. Grouped patterns are unchanged.

### What issues does this PR fix or reference?

Fixes #65722

The fix landed on `master` as commit ff28cd05b5b (PR #65708, merged
2025-06-25) and rode the merge-forward chain onto `3007.x` and
`3008.x`. It was never backported to `3006.x`, so the bug still
reproduces on the current LTS.

### Previous Behavior

```jinja
{% set my_text = '1.abc' %}
{{ my_text | regex_search('^1.abc$') }}
```

rendered as `()`, and `{% if my_text | regex_search('^1.abc$') %}`
was false even though the pattern matched.

### New Behavior

The same expression renders as `('1.abc',)` and evaluates truthy in
`if` statements. Patterns with groups (`^(.*)BC(.*)$`) still return
`obj.groups()` exactly as before.

### Merge requirements satisfied?
- [x] Docs (docstring examples still accurate; no user-visible
      contract change beyond making the ungrouped case work)
- [x] Changelog (`changelog/65722.fixed.md`)
- [x] Tests written/updated (unit tests in
      `tests/pytests/unit/utils/jinja/test_jinja_custom_filters.py`
      plus functional filters in
      `tests/pytests/functional/modules/state/test_jinja_filters.py`,
      backported from the master fix)

### Commits signed with GPG?

Yes
