### PR TITLE
Fix LazyLoader.__init__ crash on undeepcopyable opts values (#64549)

### DIFF
--- a/changelog/64549.fixed.md
+++ b/changelog/64549.fixed.md
@@ -1,0 +1,1 @@
+Fixed a crash in ``LazyLoader.__init__`` when ``opts`` contained a value that ``copy.deepcopy`` could not handle (e.g. an ``ssl.SSLContext`` reachable via the napalm-ros HTTPS driver stashed into ``__context__["napalm_device"]``). The loader now falls back to a shallow copy instead of raising ``TypeError: cannot pickle 'SSLContext' object``.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -274,7 +274,23 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 self.pack[i] = self.pack[i].value()
         if opts is None:
             opts = {}
-        opts = copy.deepcopy(opts)
+        try:
+            opts = copy.deepcopy(opts)
+        except TypeError:
+            # Issue #64549: some proxies (e.g. napalm-ros HTTPS) stash live
+            # driver objects into ``__context__`` whose reachable object
+            # graphs contain unpicklable values (e.g. ``ssl.SSLContext``).
+            # A deepcopy of ``opts`` walks into those objects via bound
+            # methods and blows up with ``TypeError: cannot pickle ...``.
+            # Fall back to a shallow copy so LazyLoader can still start;
+            # the loader only mutates top-level opts keys itself, so
+            # reference-sharing nested values is safe here.
+            log.debug(
+                "LazyLoader opts contained an undeepcopyable value; "
+                "falling back to a shallow copy",
+                exc_info=True,
+            )
+            opts = copy.copy(opts)
         for i in ["pillar", "grains"]:
             if i in opts and isinstance(
                 opts[i], salt.loader.context.NamedLoaderContext

--- a/tests/pytests/unit/loader/test_lazy.py
+++ b/tests/pytests/unit/loader/test_lazy.py
@@ -2,6 +2,7 @@
 Tests for salt.loader.lazy
 """
 
+import ssl
 import sys
 import textwrap
 
@@ -216,3 +217,47 @@ def test_virtualname_collision_surfaces_all_reasons(tmp_path):
     msg = loader.missing_fun_string("x509.expires")
     assert "Superseded, using x509_v2" in msg
     assert "Could not load cryptography" in msg
+
+
+def test_lazyloader_init_survives_undeepcopyable_opts_value(loader_dir):
+    """
+    LazyLoader.__init__ must not crash when ``opts`` contains a value that
+    ``copy.deepcopy`` cannot handle.
+
+    Regression test for #64549: ``salt-call --proxyid=<napalm-ros-https>``
+    crashed with ``TypeError: cannot pickle 'SSLContext' object`` because the
+    napalm-ros HTTPS driver (stashed by the napalm proxy into
+    ``__context__["napalm_device"]``) transitively surfaced a bound method
+    whose ``__self__`` holds an ``ssl.SSLContext``. That object was pulled
+    into the deepcopy walk of ``opts`` in ``LazyLoader.__init__`` and blew up.
+
+    Rather than depending on napalm being installed, we synthesize the same
+    class of shape: an object in ``opts`` (here a bound method) whose
+    reachable object graph includes an ``ssl.SSLContext``, which
+    ``copy.deepcopy`` cannot pickle.
+    """
+
+    class _DriverWithSSLContext:
+        def __init__(self):
+            # SSLContext is the concrete deepcopy-hostile object surfaced by
+            # napalm-ros HTTPS transport in the original crash.
+            self.ctx = ssl.create_default_context()
+
+        def is_alive(self):
+            return {"is_alive": True}
+
+    driver = _DriverWithSSLContext()
+    opts = {
+        "optimization_order": [0, 1, 2],
+        # A bound method whose __self__ carries an SSLContext — the exact
+        # shape napalm-ros presents via __context__["napalm_device"].
+        "ssl_check": driver.is_alive,
+    }
+
+    # Must not raise TypeError. Before the fix this raised
+    # ``TypeError: cannot pickle 'SSLContext' object``.
+    loader = salt.loader.lazy.LazyLoader([loader_dir], opts)
+
+    # The undeepcopyable value should still be accessible on the loader's
+    # opts (fallback path preserves the reference).
+    assert "ssl_check" in loader.opts


### PR DESCRIPTION
### What does this PR do?

Guards ``copy.deepcopy(opts)`` in ``salt/loader/lazy.py::LazyLoader.__init__``
with a ``try/except TypeError`` that falls back to a shallow copy when
``opts`` contains an undeepcopyable value. This stops ``salt-call
--proxyid=<napalm-ros-https-proxy>`` from crashing at loader initialization
before any grains can run.

### What issues does this PR fix or reference?

Fixes #64549

### Previous Behavior

On 3006.x, ``salt-call --proxyid=<napalm-ros-https-proxy>`` crashed with:

```
TypeError: cannot pickle 'SSLContext' object
```

The napalm proxy stashes a live napalm-ros driver into
``__context__["napalm_device"]``. napalm-ros over HTTPS carries an
``ssl.SSLContext`` on its transport, reachable through a bound method
inside the driver. When ``salt.loader.grains`` later builds a
``LazyLoader`` for utils, ``copy.deepcopy(opts)`` walked into the bound
method's ``__self__``, hit the ``SSLContext``, and raised. No output
was produced by the CLI.

### New Behavior

``LazyLoader.__init__`` catches the ``TypeError`` from ``copy.deepcopy``
and falls back to ``copy.copy(opts)``. The loader only mutates top-level
opts keys itself, so reference-sharing nested values is safe. Proxies
whose ``__context__`` holds unpicklable driver objects can now finish
loading grains and produce output.

### Approach note

Newer branches (3007.x/3008.x/master) replaced ``copy.deepcopy(opts)`` with
``salt.utils.optsdict.safe_opts_copy`` in
``d4241347d53`` "Add copy on write opts handling". That is the authoritative
fix, but it introduces ~1200 lines of new code (``salt/utils/optsdict.py``
plus tests). Backporting that refactor to the LTS branch is out of
proportion for a single crash; this PR takes the localized-guard route,
consistent with the style of the parallel-state fix
``fd7b0dcea2b`` "Filter unpicklable objects from the context dict when necessary".

### Merge requirements satisfied?

- [x] Docs (no documented-behavior change)
- [x] Changelog (``changelog/64549.fixed.md``)
- [x] Tests written/updated (``tests/pytests/unit/loader/test_lazy.py::test_lazyloader_init_survives_undeepcopyable_opts_value``)

### Commits signed with GPG?

Yes
