### PR TITLE
Fix metadata grain IMDSv2 token support (#65233)

### DIFF
--- a/changelog/65233.fixed.md
+++ b/changelog/65233.fixed.md
@@ -1,0 +1,1 @@
+Fixed the ``metadata`` grain module to send an ``X-aws-ec2-metadata-token`` header when the EC2 Instance Metadata Service requires IMDSv2, preventing silent grain-load failures on AMIs that enforce token-based metadata access.

--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -36,8 +36,28 @@ def __virtual__():
     if result != 0:
         return False
     if http.query(os.path.join(HOST, "latest/"), status=True).get("status") != 200:
-        return False
+        # Initial connection failed, might need a token
+        _refresh_token()
+        if (
+            http.query(
+                os.path.join(HOST, "latest/"),
+                status=True,
+                header_dict={
+                    "X-aws-ec2-metadata-token": __context__["metadata_aws_token"]
+                },
+            ).get("status")
+            != 200
+        ):
+            return False
     return True
+
+
+def _refresh_token():
+    __context__["metadata_aws_token"] = http.query(
+        os.path.join(HOST, "latest/api/token"),
+        method="PUT",
+        header_dict={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+    ).get("body")
 
 
 def _search(prefix="latest/"):
@@ -45,7 +65,26 @@ def _search(prefix="latest/"):
     Recursively look up all grains in the metadata server
     """
     ret = {}
-    linedata = http.query(os.path.join(HOST, prefix), headers=True)
+    if "metadata_aws_token" in __context__:
+        if (
+            http.query(
+                os.path.join(HOST, "latest/"),
+                status=True,
+                header_dict={
+                    "X-aws-ec2-metadata-token": __context__["metadata_aws_token"]
+                },
+            ).get("status")
+            != 200
+        ):
+            _refresh_token()
+
+        linedata = http.query(
+            os.path.join(HOST, prefix),
+            header_dict={"X-aws-ec2-metadata-token": __context__["metadata_aws_token"]},
+            headers=True,
+        )
+    else:
+        linedata = http.query(os.path.join(HOST, prefix), headers=True)
     if "body" not in linedata:
         return ret
     body = salt.utils.stringutils.to_unicode(linedata["body"])
@@ -76,7 +115,15 @@ def _search(prefix="latest/"):
             key, value = line.split("=")
             ret[value] = _search(prefix=os.path.join(prefix, key))
         else:
-            retdata = http.query(os.path.join(HOST, prefix, line)).get("body", None)
+            if "metadata_aws_token" in __context__:
+                retdata = http.query(
+                    os.path.join(HOST, prefix, line),
+                    header_dict={
+                        "X-aws-ec2-metadata-token": __context__["metadata_aws_token"]
+                    },
+                ).get("body", None)
+            else:
+                retdata = http.query(os.path.join(HOST, prefix, line)).get("body", None)
             # (gtmanfred) This try except block is slightly faster than
             # checking if the string starts with a curly brace
             if isinstance(retdata, bytes):

--- a/tests/pytests/unit/grains/test_metadata.py
+++ b/tests/pytests/unit/grains/test_metadata.py
@@ -17,6 +17,14 @@ metadata grain to fail to load with::
     [CRITICAL] Failed to load grains defined in grain file metadata.metadata
     ...
     KeyError: 'headers'
+
+Regression coverage for #65233: on AWS instances that enforce IMDSv2, the
+metadata service returns HTTP 401 for any request that does not carry an
+``X-aws-ec2-metadata-token`` header. The grain now PUTs to
+``latest/api/token`` on that 401, caches the token in ``__context__``, and
+sends it with every subsequent metadata query.
+
+:codeauthor: :email: `Gareth J. Greenaway <ggreenaway@vmware.com>`
 """
 
 import logging
@@ -25,9 +33,20 @@ import pytest
 
 import salt.grains.metadata as metadata
 import salt.utils.http as http
-from tests.support.mock import create_autospec, patch
+from tests.support.mock import MagicMock, create_autospec, patch
 
 log = logging.getLogger(__name__)
+
+
+class MockSocketClass:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def settimeout(self, *args, **kwargs):
+        pass
+
+    def connect_ex(self, *args, **kwargs):
+        return 0
 
 
 @pytest.fixture
@@ -94,7 +113,7 @@ def test_user_data_with_equals_is_returned_verbatim():
         result = metadata.metadata()
 
     assert "user-data" in result, result
-    # Verbatim — no splitting on "=", no key/value mangling.
+    # Verbatim - no splitting on "=", no key/value mangling.
     assert result["user-data"] == user_data_body
     # And specifically, the ``=`` characters in the payload must survive.
     assert "FOO=bar" in result["user-data"]
@@ -162,7 +181,7 @@ def test_equals_lines_other_than_user_data_still_parse_via_splitter():
             "headers": {"Content-Type": "text/plain"},
         },
         "http://169.254.169.254/latest/meta-data/iam/security-credentials/": {
-            # "alias=role" — the "=" branch must still fire for this.
+            # "alias=role" - the "=" branch must still fire for this.
             "body": "myrole-user-data=role-arn-suffix",
             "headers": {"Content-Type": "text/plain"},
         },
@@ -193,7 +212,7 @@ def test_equals_lines_other_than_user_data_still_parse_via_splitter():
 def test_search_handles_error_response_without_headers_65184():
     """
     Regression for #65184: a recursive ``http.query`` call that returns an
-    error-shaped response (``body`` present, ``headers`` absent — the shape
+    error-shaped response (``body`` present, ``headers`` absent - the shape
     produced by the tornado backend on HTTPError since 3006.3) must not
     crash ``_search()`` with ``KeyError: 'headers'``.
 
@@ -285,3 +304,148 @@ def test_search_octet_stream_still_returns_body_verbatim():
 
     # Body returned verbatim, not wrapped in a dict.
     assert result == "raw-octet-stream-payload"
+
+
+def test_metadata_search():
+    def mock_http(
+        url="",
+        method="GET",
+        headers=False,
+        header_list=None,
+        header_dict=None,
+        status=False,
+    ):
+        metadata_vals = {
+            "http://169.254.169.254/latest/api/token": {
+                "body": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==",
+                "status": 200,
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/": {
+                "body": "meta-data",
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/meta-data/": {
+                "body": "ami-id\nami-launch-index\nami-manifest-path\nhostname",
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/meta-data/ami-id": {
+                "body": "ami-xxxxxxxxxxxxxxxxx",
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/meta-data/ami-launch-index": {
+                "body": "0",
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/meta-data/ami-manifest-path": {
+                "body": "(unknown)",
+                "headers": {},
+            },
+            "http://169.254.169.254/latest/meta-data/hostname": {
+                "body": "ip-xx-x-xx-xx.us-west-2.compute.internal",
+                "headers": {},
+            },
+        }
+
+        return metadata_vals[url]
+
+    with patch(
+        "salt.utils.http.query",
+        create_autospec(http.query, autospec=True, side_effect=mock_http),
+    ):
+        ret = metadata.metadata()
+        assert ret == {
+            "meta-data": {
+                "ami-id": "ami-xxxxxxxxxxxxxxxxx",
+                "ami-launch-index": "0",
+                "ami-manifest-path": "(unknown)",
+                "hostname": "ip-xx-x-xx-xx.us-west-2.compute.internal",
+            }
+        }
+
+    with patch.dict(
+        metadata.__context__,
+        {
+            "metadata_aws_token": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=="
+        },
+    ):
+        with patch(
+            "salt.utils.http.query",
+            create_autospec(http.query, autospec=True, side_effect=mock_http),
+        ):
+            ret = metadata.metadata()
+            assert ret == {
+                "meta-data": {
+                    "ami-id": "ami-xxxxxxxxxxxxxxxxx",
+                    "ami-launch-index": "0",
+                    "ami-manifest-path": "(unknown)",
+                    "hostname": "ip-xx-x-xx-xx.us-west-2.compute.internal",
+                }
+            }
+
+
+def test_metadata_refresh_token():
+    with patch(
+        "salt.utils.http.query",
+        create_autospec(
+            http.query,
+            autospec=True,
+            return_value={
+                "body": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==",
+            },
+        ),
+    ):
+        metadata._refresh_token()
+        assert "metadata_aws_token" in metadata.__context__
+        assert (
+            metadata.__context__["metadata_aws_token"]
+            == "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=="
+        )
+
+
+def test_metadata_virtual():
+    with patch("socket.socket", MagicMock(return_value=MockSocketClass())):
+        with patch(
+            "salt.utils.http.query",
+            create_autospec(
+                http.query,
+                autospec=True,
+                return_value={"error": "[Errno -2] Name or service not known"},
+            ),
+        ):
+            assert metadata.__virtual__() is False
+
+        with patch(
+            "salt.utils.http.query",
+            create_autospec(
+                http.query,
+                autospec=True,
+                return_value={
+                    "body": "dynamic\nmeta-data\nuser-data",
+                    "status": 200,
+                },
+            ),
+        ):
+            assert metadata.__virtual__() is True
+
+        with patch(
+            "salt.utils.http.query",
+            create_autospec(
+                http.query,
+                autospec=True,
+                side_effect=[
+                    {
+                        "body": "",
+                        "status": 401,
+                    },
+                    {
+                        "body": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==",
+                    },
+                    {
+                        "body": "dynamic\nmeta-data\nuser-data",
+                        "status": 200,
+                    },
+                ],
+            ),
+        ):
+            assert metadata.__virtual__() is True


### PR DESCRIPTION
### What does this PR do?

Backports commit `f9fa9381efb` (PR #65512) from `master` to `3006.x`. The
`salt.grains.metadata` module now sends an `X-aws-ec2-metadata-token` header
when the EC2 Instance Metadata Service enforces IMDSv2, obtaining a token
via `PUT latest/api/token` on the first 401 and caching it in `__context__`
for subsequent queries.

The module was purged from `master`/`3007.x`/`3008.x` into the
community-extensions holding repo in commit `dc526dc2b17` (2024-01-31)
before this fix was ever backported, so `3006.x` is the only supported
branch that still ships the buggy code and thus the only branch that needs
this cherry-pick.

The test file resolution keeps the 3006.x-specific regression tests
covering #62061 (verbatim `user-data`) and #65184 (missing `headers` on
error responses) alongside the three new IMDSv2 tests from #65512.

### What issues does this PR fix or reference?

Fixes #65233
Backport of #65512 (commit f9fa9381efb).

### Previous Behavior

On AWS AMIs that enforce IMDSv2, every plain (unauthenticated) request to
`http://169.254.169.254/` returns HTTP 401. The grain silently produced
empty/bogus data (`{'': {'': ''}}`) instead of the expected metadata tree.

### New Behavior

`__virtual__()` probes the metadata service, retries with a PUT-obtained
token on the initial failure, and caches the token in `__context__`.
`_search()` sends the token with every recursive query and refreshes it
if the cached token is rejected.

### Merge requirements satisfied?
- [x] Docs (no user-facing docs change; behavior matches documented intent)
- [x] Changelog (`changelog/65233.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/grains/test_metadata.py`)

### Commits signed with GPG?

Yes
