### PR TITLE
Fix NamedLoaderContext container-protocol when value() is None (#65504)

### DIFF
--- a/changelog/65504.fixed.md
+++ b/changelog/65504.fixed.md
@@ -1,0 +1,1 @@
+Fixed `AttributeError: 'NoneType' object has no attribute '__iter__'` when a `NamedLoaderContext` whose underlying value is `None` is serialized via `salt.payload.dumps` (for example when returning `__opts__` from `config.items`). The container-protocol dunder methods on `NamedLoaderContext` now degrade to empty-container semantics instead of crashing.

--- a/salt/loader/context.py
+++ b/salt/loader/context.py
@@ -85,28 +85,52 @@ class NamedLoaderContext(collections.abc.MutableMapping):
             )
 
     def get(self, key, default=None):
-        return self.value().get(key, default)
+        value = self.value()
+        if value is None:
+            return default
+        return value.get(key, default)
 
     def __getitem__(self, item):
-        return self.value()[item]
+        value = self.value()
+        if value is None:
+            raise KeyError(item)
+        return value[item]
 
     def __contains__(self, item):
-        return item in self.value()
+        value = self.value()
+        if value is None:
+            return False
+        return item in value
 
     def __setitem__(self, item, value):
-        self.value()[item] = value
+        underlying = self.value()
+        if underlying is None:
+            raise TypeError(
+                f"{type(self).__name__}({self.name!r}) has no underlying "
+                "mapping; cannot set items"
+            )
+        underlying[item] = value
 
     def __bool__(self):
         return bool(self.value())
 
     def __len__(self):
-        return self.value().__len__()
+        value = self.value()
+        if value is None:
+            return 0
+        return value.__len__()
 
     def __iter__(self):
-        return self.value().__iter__()
+        value = self.value()
+        if value is None:
+            return iter(())
+        return value.__iter__()
 
     def __delitem__(self, item):
-        return self.value().__delitem__(item)
+        value = self.value()
+        if value is None:
+            raise KeyError(item)
+        return value.__delitem__(item)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/tests/pytests/unit/loader/test_context.py
+++ b/tests/pytests/unit/loader/test_context.py
@@ -4,8 +4,11 @@ Tests for salt.loader.context
 
 import copy
 
+import pytest
+
 import salt.loader.context
 import salt.loader.lazy
+import salt.payload
 
 
 def test_named_loader_context():
@@ -55,3 +58,58 @@ def test_named_loader_context_opts():
     with salt.loader.context.loader_context(loader):
         assert "foo" in opts
         assert opts["foo"] == "bar"
+
+
+def test_named_loader_context_none_value_container_protocol():
+    """
+    Regression test for #65504.
+
+    When ``NamedLoaderContext.value()`` returns ``None`` (no loader in the
+    current context and ``default`` is ``None``), the container-protocol
+    dunder methods must not raise ``AttributeError``. They should return
+    sensible empty-container defaults so that consumers such as
+    ``salt.payload.dumps`` (which msgpack-encodes a
+    ``collections.abc.MutableMapping`` by calling ``dict(obj)``) do not
+    crash when a ``NamedLoaderContext`` slips into a returned payload.
+    """
+    loader_context = salt.loader.context.LoaderContext()
+    named_context = salt.loader.context.NamedLoaderContext(
+        "__some_dunder__", loader_context, default=None
+    )
+    # Sanity: value() really is None here.
+    assert named_context.value() is None
+
+    # Iteration protocol yields nothing.
+    assert list(iter(named_context)) == []
+
+    # Length is zero.
+    assert len(named_context) == 0
+
+    # Membership tests are False.
+    assert "anything" not in named_context
+
+    # Truthiness is False (empty container semantics).
+    assert bool(named_context) is False
+
+    # get() returns the requested default rather than crashing.
+    assert named_context.get("missing") is None
+    assert named_context.get("missing", "fallback") == "fallback"
+
+    # Indexed access raises KeyError, not AttributeError.
+    with pytest.raises(KeyError):
+        _ = named_context["missing"]
+
+    # Deletion raises KeyError, not AttributeError.
+    with pytest.raises(KeyError):
+        del named_context["missing"]
+
+    # Assignment raises TypeError (no underlying mapping to mutate),
+    # not AttributeError.
+    with pytest.raises(TypeError):
+        named_context["missing"] = "value"
+
+    # The load-bearing case from the issue: msgpack must be able to
+    # encode a payload that contains a NamedLoaderContext whose value
+    # is None without crashing on ``dict(obj)``.
+    packed = salt.payload.dumps({"foo": named_context}, use_bin_type=True)
+    assert salt.payload.loads(packed) == {"foo": {}}


### PR DESCRIPTION
### What does this PR do?

Guards the container-protocol dunder methods on
`salt.loader.context.NamedLoaderContext` so that a `None` underlying
value degrades to empty-container semantics instead of crashing with
`AttributeError`. Also adds a regression test that round-trips a
`NamedLoaderContext(default=None)` through `salt.payload.dumps`.

### What issues does this PR fix or reference?

Fixes #65504

### Previous Behavior

`salt '*' config.items` (or any function returning `__opts__` when
`__opts__` contains a packed `NamedLoaderContext` whose `value()` is
`None`) crashed the minion job with:

```
AttributeError: 'NoneType' object has no attribute '__iter__'
  File ".../salt/loader/context.py", line 106, in __iter__
    return self.value().__iter__()
```

The trace originates in `salt.payload.dumps` -> `ext_type_encoder` ->
`dict(obj)`, which invokes `NamedLoaderContext.__iter__`, which
dereferences `self.value()` unconditionally. Users saw "Minion did not
return" and the minion job never completed.

### New Behavior

`__iter__`, `__len__`, `__contains__`, `__getitem__`, `__setitem__`,
`__delitem__`, and `get` on `NamedLoaderContext` now short-circuit when
`value()` returns `None`:

- `__iter__` -> empty iterator
- `__len__` -> `0`
- `__contains__` -> `False`
- `__getitem__` / `__delitem__` -> raise `KeyError`
- `__setitem__` -> raise `TypeError` (no underlying mapping to mutate)
- `get(key, default)` -> return `default`

`__bool__` already returned `False` for a `None` value via `bool(None)`
and is left unchanged. `salt.payload.dumps` can now serialize a payload
containing a `NamedLoaderContext(default=None)` without crashing.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
