### PR TITLE
Remove temporary Fedora 40 test skips (#66540, #66539)

### DIFF
--- a/changelog/66540.fixed.md
+++ b/changelog/66540.fixed.md
@@ -1,0 +1,1 @@
+Removed the temporary Fedora 40 skips from ``tests/pytests/integration/master/test_peer.py::test_peer_communication`` and ``tests/pytests/integration/modules/grains/test_append.py::test_grains_remove_add``. Fedora 40 reached end-of-life on 2025-05-13 and the tests now pass without the workaround.

--- a/tests/pytests/integration/master/test_peer.py
+++ b/tests/pytests/integration/master/test_peer.py
@@ -110,9 +110,7 @@ def peer_salt_minion_3(peer_salt_master):
 @pytest.mark.parametrize(
     "source,target", ((x, y) for x in range(1, 4) for y in range(1, 4) if x != y)
 )
-def test_peer_communication(source, target, request, grains):
-    if grains["os"] == "Fedora" and grains["osmajorrelease"] >= 40:
-        pytest.skip(f"Temporary skip on {grains['osfinger']}")
+def test_peer_communication(source, target, request):
     cli = request.getfixturevalue(f"peer_salt_minion_{source}").salt_call_cli()
     tgt = request.getfixturevalue(f"peer_salt_minion_{target}").id
     ret = cli.run("publish.publish", tgt, "test.ping")

--- a/tests/pytests/integration/modules/grains/test_append.py
+++ b/tests/pytests/integration/modules/grains/test_append.py
@@ -108,10 +108,8 @@ def test_grains_append_val_is_list(salt_call_cli, append_grain):
 
 @pytest.mark.timeout_unless_on_windows(300)
 def test_grains_remove_add(
-    salt_call_cli, append_grain, wait_for_pillar_refresh_complete, grains
+    salt_call_cli, append_grain, wait_for_pillar_refresh_complete
 ):
-    if grains["os"] == "Fedora" and grains["osmajorrelease"] >= 40:
-        pytest.skip(f"Temporary skip on {grains['osfinger']}")
     second_grain = append_grain.value + "-2"
     ret = salt_call_cli.run("grains.get", append_grain.key)
     assert ret.returncode == 0


### PR DESCRIPTION
### What does this PR do?

Removes the temporary Fedora 40 skips added in 5a85699c8b4 (2024-05-17) on:

- `tests/pytests/integration/master/test_peer.py::test_peer_communication`
- `tests/pytests/integration/modules/grains/test_append.py::test_grains_remove_add`

Fedora 40 reached upstream EOL on 2025-05-13 and a repro run against 3007.x
and master confirms the tests now pass without the skip. Fedora 40 remains
in the CI matrix (`cicd/shared-gh-workflows-context.yml`); dropping it there
is a separate housekeeping change.

### What issues does this PR fix or reference?

Fixes #66540
Fixes #66539

### Previous Behavior

`test_peer_communication` and `test_grains_remove_add` skipped unconditionally
on Fedora >= 40 with the message "Temporary skip on {osfinger}". The original
commit landed as a workaround with no root cause captured, and the skips have
persisted on 3007.x, 3008.x, and master.

### New Behavior

Both tests run on Fedora 40 (and any future Fedora >= 40 image that lands in
CI). No product code changes; only test-suite skip removal plus the required
changelog entry.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
