### PR TITLE
Fix selinux.port_get_policy crash on unparseable semanage output (#64583)

### DIFF
--- a/changelog/64583.fixed.md
+++ b/changelog/64583.fixed.md
@@ -1,0 +1,1 @@
+Fixed `selinux.port_get_policy` raising `AttributeError: 'NoneType' object has no attribute 'group'` when `semanage port -l` output cannot be parsed (e.g. Fedora 38+); it now raises `CommandExecutionError` instead.

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -772,6 +772,10 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
         return None
 
     parts = re.match(r"^(\w+)[ ]+(\w+)[ ]+([\d\-, ]+)", port_policy)
+    if parts is None:
+        raise CommandExecutionError(
+            f"Port policy {port_policy!r} did not match expected format"
+        )
     return {
         "sel_type": parts.group(1).strip(),
         "protocol": parts.group(2).strip(),

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -3,7 +3,7 @@ import re
 import pytest
 
 import salt.modules.selinux as selinux
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from tests.support.mock import MagicMock, mock_open, patch
 
 pytestmark = [pytest.mark.skip_unless_on_linux]
@@ -217,6 +217,25 @@ def test_port_get_policy_parsing():
         ):
             ret = selinux.port_get_policy(case["name"])
             assert ret == case["expected"]
+
+
+def test_port_get_policy_unparseable_raises_command_execution_error_64583():
+    """
+    Regression test for #64583.
+
+    On Fedora 38+, `semanage port -l` output can change format so that the
+    grep pipeline in ``port_get_policy`` returns a non-empty line that does
+    not match the parsing regex. Previously ``re.match`` returned ``None``
+    and the code raised ``AttributeError: 'NoneType' object has no
+    attribute 'group'``. It should raise ``CommandExecutionError`` instead.
+    """
+    unparseable_output = "   \n"
+    with patch.dict(
+        selinux.__salt__,
+        {"cmd.shell": MagicMock(return_value=unparseable_output)},
+    ):
+        with pytest.raises(CommandExecutionError):
+            selinux.port_get_policy("tcp/22")
 
 
 def test_fcontext_policy_parsing_new():


### PR DESCRIPTION
### What does this PR do?

Guards `selinux.port_get_policy` against `re.match` returning `None` when
`semanage port -l` output cannot be parsed (e.g. on Fedora 38+). The
function now raises `CommandExecutionError` with the raw output instead of
crashing with `AttributeError: 'NoneType' object has no attribute 'group'`.

### What issues does this PR fix or reference?

Fixes #64583

### Previous Behavior

On Fedora 38+, `salt-call selinux.port_get_policy tcp/22` crashed with:

```
AttributeError: 'NoneType' object has no attribute 'group'
  File ".../salt/modules/selinux.py", line 776, in port_get_policy
    "sel_type": parts.group(1).strip(),
```

This happened because the `semanage port -l | grep ...` pipeline could
return a non-empty line that didn't match the parsing regex, and the code
dereferenced the `re.match` result unconditionally.

### New Behavior

`port_get_policy` now checks the `re.match` result and raises
`CommandExecutionError` with the offending output when it cannot be
parsed, surfacing the underlying `semanage` behavior to the caller
instead of dropping an unhelpful `AttributeError`.

### Notes

This is a minimal 3006.x-only backport of the fix already present on
3007.x / 3008.x / master (introduced by 990f25997ba as part of a broader
selinux refactor). Only the None-check is backported; the wider refactor
(1531 lines, type hints, `semanage port --list` flag change,
`mod_aggregate` for `selinux.boolean`, unrelated state refactors) is
intentionally out of scope for this LTS bug backport.

### Merge requirements satisfied?

- [x] Docs (no user-facing docs change; docstring behavior is unchanged
  aside from the raised exception)
- [x] Changelog (`changelog/64583.fixed.md`)
- [x] Tests written/updated
  (`tests/pytests/unit/modules/test_selinux.py::test_port_get_policy_unparseable_raises_command_execution_error_64583`)

### Commits signed with GPG?

No
