### PR TITLE
Fix grains.append leaking defaultdict into persisted grain state (#64017)

### DIFF
--- a/changelog/64017.fixed.md
+++ b/changelog/64017.fixed.md
@@ -1,0 +1,1 @@
+Fixed `grains.append` (and by extension `grains.list_present`) leaking a `collections.defaultdict` into persisted grain state, which caused sibling `list_present` calls under a shared nested path to fail with "not a valid list".

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -371,7 +371,14 @@ def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):
 
     while delimiter in key:
         key, rest = key.rsplit(delimiter, 1)
-        _grain = get(key, _infinitedict(), delimiter)
+        # NOTE: default must be a plain dict, not `_infinitedict()`. A
+        # `collections.defaultdict` returned here (when `key` does not yet
+        # exist) is later persisted via `setval` and, on subsequent lookups
+        # through `salt.utils.data.traverse_dict_and_list`, auto-materializes
+        # empty children instead of raising `KeyError`. That silent-insert
+        # made sibling nested `grains.append`/`grains.list_present` calls
+        # fail with "not a valid list". See #64017.
+        _grain = get(key, {}, delimiter)
         if isinstance(_grain, dict):
             _grain.update({rest: grains})
         grains = _grain

--- a/tests/pytests/unit/states/test_grains.py
+++ b/tests/pytests/unit/states/test_grains.py
@@ -734,6 +734,47 @@ def test_list_present_unknown_failure():
             assert_grain_file_content("a: aval\nfoo:\n- bar\n")
 
 
+def test_list_present_multiple_nested_siblings_64017():
+    """
+    Regression test for #64017.
+
+    Successive ``grains.list_present`` calls that create nested keys sharing
+    a common parent path should all succeed. Previously the first call left a
+    ``collections.defaultdict`` (from ``_infinitedict``) in ``__grains__``,
+    which auto-materialized empty children when the second call traversed
+    the shared parent -- so ``grains.append`` was handed an empty
+    ``defaultdict`` instead of ``[]`` and rejected it as "not a valid list".
+    """
+    with set_grains({}):
+        ret = grains.list_present(name="core-services:monitored", value="basic")
+        assert ret["result"] is True, ret["comment"]
+
+        ret = grains.list_present(name="core-services:mon-config:rules", value="rules1")
+        assert ret["result"] is True, ret["comment"]
+
+        ret = grains.list_present(
+            name="core-services:mon-config:store-servers", value="1.1.1.1"
+        )
+        assert ret["result"] is True, ret["comment"]
+
+        ret = grains.list_present(name="core-services:mon-config:rules", value="rules2")
+        assert ret["result"] is True, ret["comment"]
+
+        assert grains.__grains__ == {
+            "core-services": {
+                "monitored": ["basic"],
+                "mon-config": {
+                    "rules": ["rules1", "rules2"],
+                    "store-servers": ["1.1.1.1"],
+                },
+            },
+        }
+        # The persisted grain state must contain only plain dicts, not
+        # defaultdicts that would leak the same bug forward.
+        assert type(grains.__grains__["core-services"]) is dict
+        assert type(grains.__grains__["core-services"]["mon-config"]) is dict
+
+
 # 'list_absent' function tests: 6
 
 


### PR DESCRIPTION
### What does this PR do?
Prevents `grains.append` (and by extension `grains.list_present`) from persisting a
`collections.defaultdict` into the minion's grain state. That leaked defaultdict caused
subsequent lookups to silently auto-materialize empty children instead of raising
`KeyError`, so sibling nested `grains.list_present` calls under a shared parent path
failed with "not a valid list".

### What issues does this PR fix or reference?
Fixes #64017

Related history: #47912 (original umbrella report) and closed-for-inactivity #64018
(reporter's traverse-layer patch). This PR takes the narrower grains-layer approach
so `salt.utils.data.traverse_dict_and_list` semantics are unchanged.

### Previous Behavior
Applying two `grains.list_present` states with keys under a common nested parent -- e.g.
```yaml
core-services:monitored:
  grains.list_present:
    - value: basic
core-services:mon-config:rules:
  grains.list_present:
    - value: rules1
```
resulted in the second state failing with:
```
Failed append value rules1 to grain core-services:mon-config:rules
```
because the first `list_present` had left an `_infinitedict` (a self-nesting
`collections.defaultdict`) at `__grains__["core-services"]`. `traverse_dict_and_list`
walked into it, and `defaultdict.__getitem__` silently inserted empty children --
so `grains.append` was handed an empty `defaultdict` where it expected `[]`.

### New Behavior
Both states succeed. `__grains__["core-services"]` and its children are plain
`dict` instances after either call, so `traverse_dict_and_list` raises `KeyError`
for absent paths and callers see the correct `default` (or `[]`).

### Merge requirements satisfied?
- [x] Docs (no user-facing docs affected; the buggy behavior was never documented)
- [x] Changelog (`changelog/64017.fixed.md`)
- [x] Tests written/updated (`test_list_present_multiple_nested_siblings_64017`)

### Commits signed with GPG?
Yes
