### PR TITLE
Fix error handling on prep jid failure (#66457)

### DIFF
--- a/changelog/66457.fixed.md
+++ b/changelog/66457.fixed.md
@@ -1,0 +1,1 @@
+Fixed error handling when the returner configured as `master_job_cache` fails to load; the error dict returned by `_prep_jid` is now propagated back to `LocalClient` as a proper error instead of being passed through as the jid and blowing up in `fire_event` with `TypeError: expected str, bytes, or bytearray not <class 'dict'>`.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1934,6 +1934,9 @@ class LocalClient:
                 payload_kwargs["key"] = self.key
                 payload = channel.send(payload_kwargs)
 
+            if isinstance(payload, str):
+                payload = {"error": payload}
+
             error = payload.pop("error", None)
             if error is not None:
                 if isinstance(error, dict):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2368,8 +2368,12 @@ class ClearFuncs(TransportMethods):
                     },
                 }
         jid = self._prep_jid(clear_load, extra)
-        if jid is None:
-            return {"enc": "clear", "load": {"error": "Master failed to assign jid"}}
+        if jid is None or isinstance(jid, dict):
+            if jid and "error" in jid:
+                load = jid
+            else:
+                load = {"error": "Master failed to assign jid"}
+            return load
         payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
         if self.opts.get("order_masters"):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -587,3 +587,168 @@ def test_handle_presence(
         assert (
             set(new_presence_cache["present"]) == connected_ids
         ), "The presence cache on disk does not reflect the current connected set"
+
+
+@pytest.fixture
+def publish_clear_funcs(master_opts):
+    """
+    A ClearFuncs bound to a master_opts that will let ``publish`` reach
+    ``_prep_jid`` without touching auth, the ACL, or the returner loader.
+    """
+    clear_funcs = salt.master.ClearFuncs(master_opts, {})
+    try:
+        yield clear_funcs
+    finally:
+        clear_funcs.destroy()
+
+
+def test_publish_prep_jid_returns_error_dict(publish_clear_funcs):
+    """
+    Regression test for #66457.
+
+    When the returner configured as ``master_job_cache`` fails to load,
+    ``ClearFuncs._prep_jid`` returns ``{"error": <msg>}``. ``publish`` must
+    treat that dict the same as ``None`` and return the error load back to
+    the caller instead of passing the dict through as the jid, which would
+    later blow up in ``fire_event`` with
+    ``TypeError: expected str, bytes, or bytearray not <class 'dict'>``.
+    """
+    load = {
+        "user": "foo",
+        "fun": "test.ping",
+        "tgt": "test_minion",
+        "arg": [],
+    }
+    prep_jid_error = {
+        "error": (
+            "Failed to allocate a jid. The requested returner"
+            " 'not_a_real_returner' could not be loaded."
+        )
+    }
+    check_minions_ret = {
+        "minions": ["test_minion"],
+        "missing": [],
+        "ssh_minions": False,
+    }
+    with patch(
+        "salt.acl.PublisherACL.user_is_blacklisted", MagicMock(return_value=False)
+    ), patch(
+        "salt.acl.PublisherACL.cmd_is_blacklisted", MagicMock(return_value=False)
+    ), patch.object(
+        publish_clear_funcs.ckminions,
+        "check_minions",
+        MagicMock(return_value=check_minions_ret),
+    ), patch.object(
+        publish_clear_funcs.loadauth,
+        "check_authentication",
+        MagicMock(return_value={"auth_list": [], "error": None}),
+    ), patch.object(
+        publish_clear_funcs,
+        "_prep_jid",
+        MagicMock(return_value=prep_jid_error),
+    ):
+        # Before #66457 was fixed, ``publish`` would pass ``prep_jid_error``
+        # (a dict) through as the jid and then raise ``TypeError`` inside
+        # ``fire_event`` while converting it to bytes.
+        result = publish_clear_funcs.publish(load)
+
+    assert result == prep_jid_error, (
+        "publish() must return the error dict from _prep_jid unchanged when"
+        " the master_job_cache returner fails to load (#66457)."
+    )
+
+
+def test_publish_prep_jid_returns_none(publish_clear_funcs):
+    """
+    Companion to :func:`test_publish_prep_jid_returns_error_dict`: verify the
+    pre-existing ``jid is None`` path still returns the generic error load.
+    """
+    load = {
+        "user": "foo",
+        "fun": "test.ping",
+        "tgt": "test_minion",
+        "arg": [],
+    }
+    check_minions_ret = {
+        "minions": ["test_minion"],
+        "missing": [],
+        "ssh_minions": False,
+    }
+    with patch(
+        "salt.acl.PublisherACL.user_is_blacklisted", MagicMock(return_value=False)
+    ), patch(
+        "salt.acl.PublisherACL.cmd_is_blacklisted", MagicMock(return_value=False)
+    ), patch.object(
+        publish_clear_funcs.ckminions,
+        "check_minions",
+        MagicMock(return_value=check_minions_ret),
+    ), patch.object(
+        publish_clear_funcs.loadauth,
+        "check_authentication",
+        MagicMock(return_value={"auth_list": [], "error": None}),
+    ), patch.object(
+        publish_clear_funcs,
+        "_prep_jid",
+        MagicMock(return_value=None),
+    ):
+        result = publish_clear_funcs.publish(load)
+
+    assert result == {"error": "Master failed to assign jid"}
+
+
+def test_local_client_pub_handles_str_payload(tmp_path):
+    """
+    Regression test for #66457 (LocalClient side).
+
+    Before the fix, a bare-string payload returned by the master (e.g. an
+    error string that never got wrapped in an envelope) triggered
+    ``AttributeError: 'str' object has no attribute 'pop'`` when
+    ``LocalClient.pub`` tried to extract the error. The client now converts
+    a str payload into ``{"error": payload}`` so that ``payload.pop`` works
+    and the error propagates back to the CLI as a ``PublishError``.
+    """
+    import salt.client
+    from salt.exceptions import PublishError
+
+    sock_dir = tmp_path / "sock"
+    sock_dir.mkdir()
+    # LocalClient.pub bails out early with SaltClientError unless the
+    # publisher IPC socket exists (or ipc_mode is "tcp").
+    (sock_dir / "publish_pull.ipc").touch()
+
+    client = salt.client.LocalClient.__new__(salt.client.LocalClient)
+    client.opts = {
+        "transport": "zeromq",
+        "ipc_mode": "ipc",
+        "sock_dir": str(sock_dir),
+        "interface": "127.0.0.1",
+        "ret_port": 4506,
+        "publish_timeout": 5,
+        "extension_modules": str(tmp_path / "extmods"),
+    }
+    client.key = "fake-key"
+    client.mopts = None
+    # Populated so LocalClient.__del__/destroy don't emit an
+    # unraisable AttributeError when the test-only instance is torn down.
+    client.event = None
+    client.auto_reconnect = False
+
+    channel = MagicMock()
+    channel.send.return_value = "Failed to allocate a jid."
+
+    class _Ctx:
+        def __enter__(self):
+            return channel
+
+        def __exit__(self, *exc):
+            return False
+
+    with patch(
+        "salt.channel.client.ReqChannel.factory", MagicMock(return_value=_Ctx())
+    ), patch.object(
+        salt.client.LocalClient,
+        "_prep_pub",
+        MagicMock(return_value={"cmd": "publish"}),
+    ):
+        with pytest.raises(PublishError):
+            client.pub("test_minion", "test.ping", tgt_type="glob", timeout=5)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -230,8 +230,12 @@ class MasterACLTestCase(ModuleCase):
         # overwrite the _send_pub method so we don't have to serialize MagicMock
         self.clear._send_pub = lambda payload: True
 
-        # make sure to return a JID, instead of a mock
-        self.clear.mminion.returners = {".prep_jid": lambda x: 1}
+        # make sure to return a JID, instead of a mock. ``_prep_jid`` invokes
+        # the returner as ``returners[fstr](nocache=..., passed_jid=...)``, so
+        # the fake must accept those kwargs and return a string-shaped jid.
+        self.clear.mminion.returners = {
+            ".prep_jid": lambda nocache=False, passed_jid=None: "20260704000000000001"
+        }
 
         self.valid_clear_load = {
             "tgt_type": "glob",
@@ -778,8 +782,12 @@ class AuthACLTestCase(ModuleCase):
         # overwrite the _send_pub method so we don't have to serialize MagicMock
         self.clear._send_pub = lambda payload: True
 
-        # make sure to return a JID, instead of a mock
-        self.clear.mminion.returners = {".prep_jid": lambda x: 1}
+        # make sure to return a JID, instead of a mock. ``_prep_jid`` invokes
+        # the returner as ``returners[fstr](nocache=..., passed_jid=...)``, so
+        # the fake must accept those kwargs and return a string-shaped jid.
+        self.clear.mminion.returners = {
+            ".prep_jid": lambda nocache=False, passed_jid=None: "20260704000000000001"
+        }
 
         self.valid_clear_load = {
             "tgt_type": "glob",


### PR DESCRIPTION
### What does this PR do?

Backport of upstream commit `0b6f7e2f213` "fix error handling on prep jid
failure" (Matt Phillips, already on 3007.x, 3008.x, master) to 3006.x.

When the returner configured as `master_job_cache` fails to load,
`ClearFuncs._prep_jid` returns `{"error": <msg>}` (a dict). Before this
change, `ClearFuncs.publish` on 3006.x only guarded `if jid is None`, so
the dict flowed on as the jid and the next `fire_event` blew up with
`TypeError: expected str, bytes, or bytearray not <class 'dict'>`. The
client side saw the same bug as `AttributeError: 'str' object has no
attribute 'pop'`.

### What issues does this PR fix or reference?

Fixes #66457

### Previous Behavior

With a broken `master_job_cache` (e.g. `master_job_cache: postgres` and a
`psycopg2` that fails to import), `salt '*' test.ping` reported
`'str' object has no attribute 'pop'` on the CLI while the master log
showed `TypeError: expected str, bytes, or bytearray not <class 'dict'>`
inside `fire_event`.

### New Behavior

`publish` now treats a dict return from `_prep_jid` the same as `None` and
propagates the error load back to `LocalClient`. `LocalClient.pub` coerces
a bare-string payload into `{"error": payload}` so the CLI surfaces a
`PublishError` with the returner's real error message instead of an
`AttributeError`.

### Merge requirements satisfied?
- [x] Docs (no documented behavior change)
- [x] Changelog (`changelog/66457.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/test_master.py`
      regression tests for the master-side and client-side symptoms)

### Commits signed with GPG?
No
