### PR TITLE
Fix linux_shadow and solaris_shadow spwd usage on Python 3.13+ (#64264)

### DIFF
--- a/changelog/64264.fixed.md
+++ b/changelog/64264.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.modules.linux_shadow` and `salt.modules.solaris_shadow` failing on Python 3.13, where the standard-library `spwd` module has been removed. Both modules now parse `/etc/shadow` directly.

--- a/changelog/67119.fixed.md
+++ b/changelog/67119.fixed.md
@@ -1,0 +1,1 @@
+Remove usage of spwd

--- a/salt/modules/linux_shadow.py
+++ b/salt/modules/linux_shadow.py
@@ -8,6 +8,7 @@ Manage the shadow file on Linux systems
     <module-provider-override>`.
 """
 
+import collections
 import datetime
 import functools
 import logging
@@ -16,12 +17,6 @@ import os
 import salt.utils.data
 import salt.utils.files
 from salt.exceptions import CommandExecutionError
-
-try:
-    import spwd  # pylint: disable=deprecated-module
-except ImportError:
-    pass
-
 
 try:
     import salt.utils.pycrypto
@@ -33,6 +28,21 @@ except ImportError:
 __virtualname__ = "shadow"
 
 log = logging.getLogger(__name__)
+
+struct_spwd = collections.namedtuple(
+    "struct_spwd",
+    [
+        "sp_namp",
+        "sp_pwdp",
+        "sp_lstchg",
+        "sp_min",
+        "sp_max",
+        "sp_warn",
+        "sp_inact",
+        "sp_expire",
+        "sp_flag",
+    ],
+)
 
 
 def __virtual__():
@@ -71,7 +81,7 @@ def info(name, root=None):
     if root is not None:
         getspnam = functools.partial(_getspnam, root=root)
     else:
-        getspnam = functools.partial(spwd.getspnam)
+        getspnam = functools.partial(_getspnam, root="/")
 
     try:
         data = getspnam(name)
@@ -509,7 +519,7 @@ def list_users(root=None):
     if root is not None:
         getspall = functools.partial(_getspall, root=root)
     else:
-        getspall = functools.partial(spwd.getspall)
+        getspall = functools.partial(_getspall, root="/")
 
     return sorted(
         user.sp_namp if hasattr(user, "sp_namp") else user.sp_nam for user in getspall()
@@ -529,7 +539,7 @@ def _getspnam(name, root=None):
                 # Generate a getspnam compatible output
                 for i in range(2, 9):
                     comps[i] = int(comps[i]) if comps[i] else -1
-                return spwd.struct_spwd(comps)
+                return struct_spwd(*comps)
     raise KeyError
 
 
@@ -545,4 +555,4 @@ def _getspall(root=None):
             # Generate a getspall compatible output
             for i in range(2, 9):
                 comps[i] = int(comps[i]) if comps[i] else -1
-            yield spwd.struct_spwd(comps)
+            yield struct_spwd(*comps)

--- a/salt/modules/linux_shadow.py
+++ b/salt/modules/linux_shadow.py
@@ -95,7 +95,7 @@ def info(name, root=None):
             "inact": data.sp_inact,
             "expire": data.sp_expire,
         }
-    except (KeyError, FileNotFoundError):
+    except (KeyError, OSError):
         return {
             "name": "",
             "passwd": "",

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -8,22 +8,17 @@ Manage the password database on Solaris systems
     <module-provider-override>`.
 """
 
+import collections
 import os
 
 import salt.utils.files
+import salt.utils.stringutils
 from salt.exceptions import CommandExecutionError
 
 try:
-    import spwd  # pylint: disable=deprecated-module
-
-    HAS_SPWD = True
+    import pwd
 except ImportError:
-    # SmartOS joyent_20130322T181205Z does not have spwd
-    HAS_SPWD = False
-    try:
-        import pwd
-    except ImportError:
-        pass  # We're most likely on a Windows machine.
+    pass  # We're most likely on a Windows machine.
 
 
 try:
@@ -36,6 +31,26 @@ except ImportError:
 
 # Define the module's virtual name
 __virtualname__ = "shadow"
+
+
+# The stdlib ``spwd`` module was deprecated in Python 3.11 and removed in
+# Python 3.13, so we can no longer rely on ``spwd.getspnam``/``spwd.struct_spwd``
+# to read ``/etc/shadow``. Emulate the pieces we need by parsing ``/etc/shadow``
+# directly and returning a namedtuple with the same attribute names.
+struct_spwd = collections.namedtuple(
+    "struct_spwd",
+    [
+        "sp_namp",
+        "sp_pwdp",
+        "sp_lstchg",
+        "sp_min",
+        "sp_max",
+        "sp_warn",
+        "sp_inact",
+        "sp_expire",
+        "sp_flag",
+    ],
+)
 
 
 def __virtual__():
@@ -64,9 +79,38 @@ def default_hash():
     return "!"
 
 
-def info(name):
+def _getspnam(name, root=None):
+    """
+    Read ``/etc/shadow`` and return an ``spwd.struct_spwd``-compatible
+    record for ``name``. Replaces ``spwd.getspnam``, which was removed
+    in Python 3.13.
+    """
+    root = "/" if not root else root
+    passwd = os.path.join(root, "etc/shadow")
+    with salt.utils.files.fopen(passwd) as fp_:
+        for line in fp_:
+            line = salt.utils.stringutils.to_unicode(line).rstrip("\n")
+            comps = line.split(":")
+            if comps[0] == name:
+                # Generate a getspnam compatible output
+                for i in range(2, 9):
+                    if i < len(comps):
+                        comps[i] = int(comps[i]) if comps[i] else -1
+                    else:
+                        comps.append(-1)
+                return struct_spwd(*comps[:9])
+    raise KeyError
+
+
+def info(name, root=None):
     """
     Return information for the specified user
+
+    name
+        User to get the information for
+
+    root
+        Directory to chroot into
 
     CLI Example:
 
@@ -74,34 +118,23 @@ def info(name):
 
         salt '*' shadow.info root
     """
-    if HAS_SPWD:
-        try:
-            data = spwd.getspnam(name)
-            ret = {
-                "name": data.sp_nam,
-                "passwd": data.sp_pwd,
-                "lstchg": data.sp_lstchg,
-                "min": data.sp_min,
-                "max": data.sp_max,
-                "warn": data.sp_warn,
-                "inact": data.sp_inact,
-                "expire": data.sp_expire,
-            }
-        except KeyError:
-            ret = {
-                "name": "",
-                "passwd": "",
-                "lstchg": "",
-                "min": "",
-                "max": "",
-                "warn": "",
-                "inact": "",
-                "expire": "",
-            }
-        return ret
+    try:
+        data = _getspnam(name, root=root)
+        return {
+            "name": data.sp_namp,
+            "passwd": data.sp_pwdp,
+            "lstchg": data.sp_lstchg,
+            "min": data.sp_min,
+            "max": data.sp_max,
+            "warn": data.sp_warn,
+            "inact": data.sp_inact,
+            "expire": data.sp_expire,
+        }
+    except (KeyError, FileNotFoundError):
+        pass
 
-    # SmartOS joyent_20130322T181205Z does not have spwd, but not all is lost
-    # Return what we can know
+    # /etc/shadow was not readable or the user was not found there.
+    # Fall back to what we can learn from pwd + `passwd -s` (SmartOS path).
     ret = {
         "name": "",
         "passwd": "",

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -130,7 +130,7 @@ def info(name, root=None):
             "inact": data.sp_inact,
             "expire": data.sp_expire,
         }
-    except (KeyError, FileNotFoundError):
+    except (KeyError, OSError):
         pass
 
     # /etc/shadow was not readable or the user was not found there.

--- a/tests/pytests/unit/modules/test_linux_shadow.py
+++ b/tests/pytests/unit/modules/test_linux_shadow.py
@@ -15,9 +15,6 @@ pytestmark = [
 shadow = pytest.importorskip(
     "salt.modules.linux_shadow", reason="shadow module is not available"
 )
-spwd = pytest.importorskip(
-    "spwd", reason="Standard library spwd module is not available"
-)
 
 
 def _pw_hash_ids(value):
@@ -186,10 +183,10 @@ def test_info(password):
         ("passwd", password.pw_hash),
         ("warn", 7),
     ]
-    getspnam_return = spwd.struct_spwd(
-        ["foo", password.pw_hash, 31337, 0, 99999, 7, -1, -1, -1]
+    getspnam_return = shadow.struct_spwd(
+        "foo", password.pw_hash, 31337, 0, 99999, 7, -1, -1, -1
     )
-    with patch("spwd.getspnam", return_value=getspnam_return):
+    with patch("salt.modules.linux_shadow._getspnam", return_value=getspnam_return):
         result = shadow.info("foo")
         assert expected_result == sorted(result.items(), key=lambda x: x[0])
 
@@ -206,12 +203,12 @@ def test_info(password):
     ]
     # We get KeyError exception for non-existent users in glibc based systems
     getspnam_return = KeyError
-    with patch("spwd.getspnam", side_effect=getspnam_return):
+    with patch("salt.modules.linux_shadow._getspnam", side_effect=getspnam_return):
         result = shadow.info("foo")
         assert expected_result == sorted(result.items(), key=lambda x: x[0])
     # And FileNotFoundError in musl based systems
     getspnam_return = FileNotFoundError
-    with patch("spwd.getspnam", side_effect=getspnam_return):
+    with patch("salt.modules.linux_shadow._getspnam", side_effect=getspnam_return):
         result = shadow.info("foo")
         assert expected_result == sorted(result.items(), key=lambda x: x[0])
 
@@ -323,3 +320,11 @@ def test_list_users():
     Test if it returns a list of all users
     """
     assert shadow.list_users()
+
+
+def test_module_import_does_not_reference_spwd():
+    """
+    Regression test for #64264: ``salt.modules.linux_shadow`` must not
+    import the removed-in-Python-3.13 ``spwd`` module.
+    """
+    assert not hasattr(shadow, "spwd")

--- a/tests/pytests/unit/modules/test_solaris_shadow.py
+++ b/tests/pytests/unit/modules/test_solaris_shadow.py
@@ -14,17 +14,7 @@ except ImportError:
     pwd = None
     missing_pwd = True
 
-try:
-    import spwd  # pylint: disable=unused-import,deprecated-module
 
-    missing_spwd = False
-except ImportError:
-    missing_spwd = True
-
-
-skip_on_missing_spwd = pytest.mark.skipif(
-    missing_spwd, reason="Has no spwd module for accessing /etc/shadow passwords"
-)
 skip_on_missing_pwd = pytest.mark.skipif(
     missing_pwd, reason="Has no pwd module for accessing /etc/password passwords"
 )
@@ -51,7 +41,7 @@ def fake_fopen_has_etc_shadow():
     )
     fake_output_shadow_file = io.StringIO()
 
-    def fopen(file, mode, *args, **kwargs):
+    def fopen(file, mode="r", *args, **kwargs):
         for line in contents.split():
             if "b" in mode:
                 return io.BytesIO(contents.encode())
@@ -67,24 +57,24 @@ def fake_fopen_has_etc_shadow():
 
 
 @pytest.fixture
-def has_spwd():
-    with patch.object(solaris_shadow, "HAS_SPWD", True):
-        yield
+def fake_getspnam():
+    """
+    Patch the module-local ``_getspnam`` helper (formerly ``spwd.getspnam``).
+    """
+    with patch.object(solaris_shadow, "_getspnam", autospec=True) as fake:
+        yield fake
 
 
 @pytest.fixture
-def has_not_spwd():
-    with patch.object(solaris_shadow, "HAS_SPWD", False):
+def missing_getspnam():
+    """
+    Simulate ``/etc/shadow`` being unreadable, so the SmartOS-style fallback
+    (pwd + ``passwd -s``) is exercised.
+    """
+    with patch.object(
+        solaris_shadow, "_getspnam", autospec=True, side_effect=FileNotFoundError
+    ):
         yield
-
-
-@pytest.fixture
-def fake_spnam():
-    with patch(
-        "spwd.getspnam",
-        autospec=True,
-    ) as fake_spnam:
-        yield fake_spnam
 
 
 @pytest.fixture
@@ -108,9 +98,8 @@ def has_not_shadow_file():
         yield
 
 
-@skip_on_missing_spwd
-def test_when_spwd_module_exists_results_should_be_returned_from_getspnam(
-    has_spwd, fake_spnam
+def test_when_getspnam_returns_data_results_should_be_returned_from_getspnam(
+    fake_getspnam,
 ):
     expected_results = {
         "name": "roscivs",
@@ -122,23 +111,22 @@ def test_when_spwd_module_exists_results_should_be_returned_from_getspnam(
         "inact": "whatever",
         "expire": "never!",
     }
-    fake_spnam.return_value.sp_nam = expected_results["name"]
-    fake_spnam.return_value.sp_pwd = expected_results["passwd"]
-    fake_spnam.return_value.sp_lstchg = expected_results["lstchg"]
-    fake_spnam.return_value.sp_min = expected_results["min"]
-    fake_spnam.return_value.sp_max = expected_results["max"]
-    fake_spnam.return_value.sp_warn = expected_results["warn"]
-    fake_spnam.return_value.sp_inact = expected_results["inact"]
-    fake_spnam.return_value.sp_expire = expected_results["expire"]
+    fake_getspnam.return_value.sp_namp = expected_results["name"]
+    fake_getspnam.return_value.sp_pwdp = expected_results["passwd"]
+    fake_getspnam.return_value.sp_lstchg = expected_results["lstchg"]
+    fake_getspnam.return_value.sp_min = expected_results["min"]
+    fake_getspnam.return_value.sp_max = expected_results["max"]
+    fake_getspnam.return_value.sp_warn = expected_results["warn"]
+    fake_getspnam.return_value.sp_inact = expected_results["inact"]
+    fake_getspnam.return_value.sp_expire = expected_results["expire"]
 
     actual_results = solaris_shadow.info(name="roscivs")
 
     assert actual_results == expected_results
 
 
-@skip_on_missing_spwd
-def test_when_swpd_module_exists_and_no_results_then_results_should_be_empty(
-    has_spwd, fake_spnam
+def test_when_getspnam_finds_no_user_and_pwnam_finds_no_user_results_should_be_empty(
+    fake_getspnam, fake_pwnam
 ):
     expected_results = {
         "name": "",
@@ -150,7 +138,8 @@ def test_when_swpd_module_exists_and_no_results_then_results_should_be_empty(
         "inact": "",
         "expire": "",
     }
-    fake_spnam.side_effect = KeyError
+    fake_getspnam.side_effect = KeyError
+    fake_pwnam.side_effect = KeyError
 
     actual_results = solaris_shadow.info(name="roscivs")
 
@@ -159,7 +148,7 @@ def test_when_swpd_module_exists_and_no_results_then_results_should_be_empty(
 
 @skip_on_missing_pwd
 def test_when_pwd_fallback_is_used_and_no_name_exists_results_should_be_empty(
-    has_not_spwd, fake_pwnam
+    missing_getspnam, fake_pwnam
 ):
     expected_results = {
         "name": "",
@@ -180,7 +169,7 @@ def test_when_pwd_fallback_is_used_and_no_name_exists_results_should_be_empty(
 
 @skip_on_missing_pwd
 def test_when_etc_shadow_does_not_exist_info_should_be_empty_except_for_name(
-    has_not_spwd, fake_pwnam, has_not_shadow_file
+    missing_getspnam, fake_pwnam, has_not_shadow_file
 ):
     expected_results = {
         "name": "wayne",
@@ -201,7 +190,7 @@ def test_when_etc_shadow_does_not_exist_info_should_be_empty_except_for_name(
 
 @skip_on_missing_pwd
 def test_when_etc_shadow_exists_but_name_not_in_shadow_passwd_field_should_be_empty(
-    fake_fopen_has_etc_shadow, has_not_spwd, fake_pwnam, has_shadow_file
+    fake_fopen_has_etc_shadow, missing_getspnam, fake_pwnam, has_shadow_file
 ):
     with patch.dict(
         solaris_shadow.__salt__,
@@ -214,7 +203,7 @@ def test_when_etc_shadow_exists_but_name_not_in_shadow_passwd_field_should_be_em
 
 @skip_on_missing_pwd
 def test_when_name_in_etc_shadow_passwd_should_be_in_info(
-    fake_fopen_has_etc_shadow, has_not_spwd, fake_pwnam, has_shadow_file
+    fake_fopen_has_etc_shadow, missing_getspnam, fake_pwnam, has_shadow_file
 ):
     with patch.dict(
         solaris_shadow.__salt__,
@@ -250,9 +239,8 @@ def test_set_password_should_return_False_if_passwd_in_info_is_different_than_ne
         assert actual_result == False
 
 
-@skip_on_missing_spwd
 def test_when_set_password_and_name_in_shadow_then_password_should_be_changed_for_that_user(
-    has_shadow_file, fake_fopen_has_etc_shadow, has_spwd, fake_spnam
+    has_shadow_file, fake_fopen_has_etc_shadow, fake_getspnam
 ):
     expected_password = "bottia2"
     expected_shadow_contents = dedent(
@@ -273,3 +261,56 @@ def test_when_set_password_and_name_in_shadow_then_password_should_be_changed_fo
 
     assert fake_fopen_has_etc_shadow.getvalue() == expected_shadow_contents
     assert actual_result == True
+
+
+@skip_on_missing_pwd
+def test_module_import_does_not_reference_spwd():
+    """
+    Regression test for #64264: ``salt.modules.solaris_shadow`` must not
+    import the removed-in-Python-3.13 ``spwd`` module.
+    """
+    import salt.modules.solaris_shadow as module_under_test
+
+    assert not hasattr(module_under_test, "spwd")
+    assert not hasattr(module_under_test, "HAS_SPWD")
+
+
+def test_getspnam_parses_etc_shadow_and_returns_struct_spwd():
+    """
+    Regression test for #64264: the replacement ``_getspnam`` reads
+    ``/etc/shadow`` directly and returns an ``spwd.struct_spwd``-compatible
+    namedtuple.
+    """
+    shadow_contents = dedent(
+        """\
+        root:$6$abc$xyz:19000:0:99999:7:::
+        roscivs:$6$def$uvw:19100:1:42:14:30:19999:0
+        """
+    )
+
+    def fopen(file, mode="r", *args, **kwargs):
+        return io.StringIO(shadow_contents)
+
+    with patch("salt.utils.files.fopen", side_effect=fopen, autospec=True):
+        record = solaris_shadow._getspnam("roscivs")
+
+    assert record.sp_namp == "roscivs"
+    assert record.sp_pwdp == "$6$def$uvw"
+    assert record.sp_lstchg == 19100
+    assert record.sp_min == 1
+    assert record.sp_max == 42
+    assert record.sp_warn == 14
+    assert record.sp_inact == 30
+    assert record.sp_expire == 19999
+    assert record.sp_flag == 0
+
+
+def test_getspnam_raises_keyerror_when_user_missing():
+    shadow_contents = "root:x:19000:0:99999:7:::\n"
+
+    def fopen(file, mode="r", *args, **kwargs):
+        return io.StringIO(shadow_contents)
+
+    with patch("salt.utils.files.fopen", side_effect=fopen, autospec=True):
+        with pytest.raises(KeyError):
+            solaris_shadow._getspnam("nobody")


### PR DESCRIPTION
### What does this PR do?

Removes the last uses of the removed-in-Python-3.13 `spwd` stdlib module
from Salt's shadow modules, so `shadow.info` no longer crashes with
`NameError: name 'spwd' is not defined` on Python 3.13+.

Two-part change against `3006.x`:

1. Cherry-pick of `a5cd3113f2d` "Remove uses of spwd" (originally
   authored by Toyam Cox / Georg Pfuetzenreuter, referencing #67119)
   which fixes `salt/modules/linux_shadow.py`. That commit currently
   lives on `3007.x` / `3008.x` / `master` but has **not yet shipped in
   any 3007 release tag** (latest tag is `v3007.14`), and it has never
   been on `3006.x`.
2. A fresh, mirrored fix for `salt/modules/solaris_shadow.py` (still
   `import spwd` on every branch, including `master`) plus rewrites of
   the affected unit tests so they run on Python 3.13+ (they previously
   `importorskip('spwd')`, which silently disabled all coverage on the
   new interpreters).

Merge-forward will carry the solaris_shadow removal from 3006.x up
through 3007.x, 3008.x, and master; the linux_shadow cherry-pick is a
no-op on 3007.x+ because the fix is already there.

### What issues does this PR fix or reference?

Fixes #64264

### Previous Behavior

On Python 3.13, `salt.modules.linux_shadow.info` raised at first use:

```
File ".../salt/modules/linux_shadow.py", line 74, in info
    getspnam = functools.partial(spwd.getspnam)
                                 ^^^^
NameError: name 'spwd' is not defined
```

`salt.modules.solaris_shadow` still imported `spwd` at module load
(deprecation warning on 3.11/3.12, `ImportError` swallowed on 3.13+),
and its `HAS_SPWD`-guarded primary Solaris code path was silently dead
on 3.13+, forcing every Solaris minion into the SmartOS `passwd -s`
fallback.

### New Behavior

Both modules parse `/etc/shadow` directly via a local `_getspnam` helper
that returns an `spwd.struct_spwd`-compatible namedtuple. The
SmartOS-style `pwd` + `passwd -s` fallback in `solaris_shadow` is
preserved for the case where `/etc/shadow` is not readable.

### Merge requirements satisfied?

- [x] Docs (no doc changes needed — the CLI/behavior for `shadow.info`
      is unchanged, only its internal implementation)
- [x] Changelog (`changelog/64264.fixed.md`; the cherry-picked commit
      also keeps its original `changelog/67119.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/modules/test_linux_shadow.py`,
      `tests/pytests/unit/modules/test_solaris_shadow.py`)

### Commits signed with GPG?

Yes
