### PR TITLE
Fix PrintableDict folding long multi-line strings across YAML lines (#69658)

### DIFF
--- a/changelog/69658.fixed.md
+++ b/changelog/69658.fixed.md
@@ -1,0 +1,4 @@
+Fixed SLS rendering failure when a Jinja-interpolated ``PrintableDict`` value
+contained a multi-line string longer than ~80 columns inside a YAML block
+scalar. The YAML double-quoted scalar emitted for such values is no longer
+folded across physical lines.

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -245,9 +245,17 @@ def _yaml_safe_repr(value):
         # safe_dump always emits a trailing newline; strip it. default_style='"'
         # forces a double-quoted scalar which encodes newlines as the YAML \n
         # escape sequence that the YAML parser will decode back to a real
-        # newline.
+        # newline. width=2**31-1 disables PyYAML's default line-folding at
+        # ~80 columns; folding would introduce real newlines inside the
+        # scalar, which breaks YAML block-scalar interpolation via Jinja
+        # (see issue #69658).
         return (
-            salt.utils.yaml.safe_dump(value, default_style='"', default_flow_style=True)
+            salt.utils.yaml.safe_dump(
+                value,
+                default_style='"',
+                default_flow_style=True,
+                width=2**31 - 1,
+            )
             .rstrip("\n")
             .rstrip("...")
             .rstrip("\n")

--- a/tests/pytests/unit/utils/jinja/test_jinja.py
+++ b/tests/pytests/unit/utils/jinja/test_jinja.py
@@ -3,7 +3,7 @@ Tests for salt.utils.jinja
 """
 
 import salt.utils.dateutils  # pylint: disable=unused-import
-from salt.utils.jinja import Markup, indent, tojson
+from salt.utils.jinja import Markup, PrintableDict, indent, tojson
 
 
 def test_tojson():
@@ -38,3 +38,31 @@ def test_tojson_should_ascii_sort_keys_when_told():
 
     actual = tojson(data, sort_keys=True)
     assert actual == expected
+
+
+def test_printabledict_long_multiline_str_not_folded_issue_69658():
+    """
+    Regression test for issue #69658.
+
+    ``PrintableDict.__str__`` emits string values containing newlines as
+    YAML double-quoted scalars via ``yaml.safe_dump()`` (see #30690).
+    ``safe_dump()`` folds double-quoted scalars at ~80 columns by default,
+    which inserts real newlines into the emitted scalar. When the resulting
+    representation is interpolated into a YAML state file via Jinja inside
+    a ``|``/``|-`` block scalar, the folded continuation lines break the
+    document and rendering fails with ``could not find expected ':'``.
+
+    The emitted representation must therefore stay on a single physical
+    line even for long strings so it can be safely interpolated inside a
+    block scalar.
+    """
+    long_value = (
+        "ServerName my-very-long-hostname.example.com and more words "
+        "to exceed eighty columns\n"
+        "ServerAlias alias.example.com\n"
+    )
+    rendered = str(PrintableDict({"conf": long_value}))
+    # The rendered dict must be a single physical line: any newline
+    # inside it would be a fold-point that breaks YAML block-scalar
+    # interpolation.
+    assert "\n" not in rendered, rendered


### PR DESCRIPTION
### What does this PR do?

`_yaml_safe_repr` (used by `PrintableDict.__str__` / `__repr__`) called
`salt.utils.yaml.safe_dump()` without a `width` argument, so PyYAML folded
double-quoted scalars at ~80 columns. Any multi-line string longer than
that got real newlines inserted mid-scalar. Once the folded representation
was Jinja-interpolated inside a YAML block scalar (`|`/`|-`), rendering
failed with `could not find expected ':'`.

Pass `width=2**31 - 1` to `safe_dump()` so the emitted scalar always stays
on a single physical line, preserving the intent of the #30690 fix.

### What issues does this PR fix or reference?

Fixes #69658

### Previous Behavior

```
{% load_yaml as data %}
conf: |
  ServerName my-very-long-hostname.example.com and more words to exceed eighty columns
  ServerAlias alias.example.com
{% endload %}

repro:
  file.managed:
    - name: /tmp/repro
    - contents: |
        {{ data }}
```

Renders as:

```
[CRITICAL] Rendering SLS 'base:repro' failed: could not find expected ':'; line 9
```

### New Behavior

The SLS renders successfully; the interpolated `PrintableDict` sits on a
single physical line, and the YAML parser round-trips the embedded newlines
back to real newlines as intended by #30690.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
