### PR TITLE
Fix pkg.installed with missing salt:// source (#68002)

### DIFF
--- a/changelog/68002.fixed.md
+++ b/changelog/68002.fixed.md
@@ -1,0 +1,1 @@
+Fixed `pkg.installed` with a `sources:` entry pointing at a missing `salt://` URL to raise a clear `CommandExecutionError` naming the source, rather than propagating a `False` from `cp.cache_file` that later crashed with a cryptic `TypeError` in `dpkg_lowpkg.bin_pkg_info`.

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -11,7 +11,7 @@ import pprint
 import salt.utils.data
 import salt.utils.versions
 import salt.utils.yaml
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 __SUFFIX_NOT_NEEDED = ("x86_64", "noarch")
@@ -155,7 +155,14 @@ def parse_targets(
             if __salt__["config.valid_fileproto"](pkg_src):
                 # Cache package from remote source (salt master, HTTP, FTP) and
                 # append the cached path.
-                srcinfo.append(__salt__["cp.cache_file"](pkg_src, saltenv))
+                cached_path = __salt__["cp.cache_file"](pkg_src, saltenv)
+                if not cached_path:
+                    raise CommandExecutionError(
+                        "Unable to cache source {} for package {}".format(
+                            pkg_src, pkg_name
+                        )
+                    )
+                srcinfo.append(cached_path)
             else:
                 # Package file local to the minion, just append the path to the
                 # package file.

--- a/tests/pytests/unit/modules/test_pkg_resource.py
+++ b/tests/pytests/unit/modules/test_pkg_resource.py
@@ -8,7 +8,7 @@ import yaml
 import salt.modules.pkg_resource as pkg_resource
 import salt.utils.data
 import salt.utils.yaml
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from tests.support.mock import MagicMock, patch
 
 
@@ -73,6 +73,36 @@ def test_parse_targets():
                 )
 
                 assert pkg_resource.parse_targets() == (None, None)
+
+
+def test_parse_targets_missing_salt_source():
+    """
+    Regression test for #68002.
+
+    When a ``salt://`` package source cannot be cached (e.g. the file does
+    not exist on the fileserver), ``cp.cache_file`` returns ``False``.
+    ``parse_targets`` must raise a ``CommandExecutionError`` that names the
+    offending source rather than silently propagating ``False`` into the
+    caller, which previously bubbled up as a cryptic ``TypeError`` from
+    ``dpkg_lowpkg.bin_pkg_info``.
+    """
+    with patch.dict(pkg_resource.__grains__, {"os": "Ubuntu"}):
+        with patch.object(
+            pkg_resource,
+            "pack_sources",
+            return_value={"my-package": "salt://this/does/not/exist.deb"},
+        ):
+            with patch.dict(
+                pkg_resource.__salt__,
+                {
+                    "config.valid_fileproto": MagicMock(return_value=True),
+                    "cp.cache_file": MagicMock(return_value=False),
+                },
+            ):
+                with pytest.raises(CommandExecutionError) as excinfo:
+                    pkg_resource.parse_targets(sources="s")
+                assert "salt://this/does/not/exist.deb" in str(excinfo.value)
+                assert "my-package" in str(excinfo.value)
 
 
 def test_version():


### PR DESCRIPTION
### What does this PR do?

`pkg.installed` with a `sources:` entry pointing at a missing `salt://`
URL now raises a clear `CommandExecutionError` naming the offending
source, instead of leaking a cryptic `TypeError` from `posixpath.isabs`.

### What issues does this PR fix or reference?

Fixes #68002

### Previous Behavior

```
TypeError: expected str, bytes or os.PathLike object, not bool
```
raised deep in `dpkg_lowpkg.bin_pkg_info` after `pkg_resource.parse_targets`
silently propagated a `False` returned by `cp.cache_file` into
`aptpkg.install`.

### New Behavior

A clean state failure:

```
Unable to cache source salt://this/does/not/exist.deb for package my-package
```

### Merge requirements satisfied?

- [x] Docs (no user-facing docs change; behavior change documented in
      changelog)
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?

Yes
