### PR TITLE
Fix AsyncAuth AttributeError on _creds race with creds_map (#67947)

### DIFF
--- a/changelog/67947.fixed.md
+++ b/changelog/67947.fixed.md
@@ -1,0 +1,1 @@
+Fixed a race in the minion's `AsyncAuth._authenticate` that raised `AttributeError: 'AsyncAuth' object has no attribute '_creds'` and silently severed master communication when a sibling `AsyncAuth` populated `creds_map` between construction and the coroutine's `key not in creds_map` check.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -689,6 +689,14 @@ class AsyncAuth:
         self.pub_path = os.path.join(self.opts["pki_dir"], "minion.pub")
         self.rsa_path = os.path.join(self.opts["pki_dir"], "minion.pem")
         self._private_key = None
+        # Initialize ``_creds`` so ``_authenticate`` can safely check it even
+        # when a sibling ``AsyncAuth`` populates ``creds_map`` between our
+        # construction and the ``key not in AsyncAuth.creds_map`` check in
+        # the coroutine.  Without this pre-assignment the else-branch below
+        # falls through to ``self.authenticate()`` and ``_authenticate``
+        # later raises ``AttributeError`` on ``self._creds["aes"]`` (see
+        # issue #67947).
+        self._creds = None
         if self.opts["__role"] == "syndic":
             self.mpub = "syndic_master.pub"
         else:
@@ -878,7 +886,10 @@ class AsyncAuth:
             else:
                 key = self.__key(self.opts)
                 new_aes, changed_aes, changed_session = False, False, False
-                if key not in AsyncAuth.creds_map:
+                # ``self._creds is None`` covers the first-authentication case
+                # even when a sibling ``AsyncAuth`` for the same key raced us
+                # into ``creds_map``. See issue #67947.
+                if key not in AsyncAuth.creds_map or self._creds is None:
                     new_aes = True
                     log.debug("%s Got new master aes key.", self)
                 else:

--- a/tests/pytests/unit/test_crypt.py
+++ b/tests/pytests/unit/test_crypt.py
@@ -523,3 +523,83 @@ async def test_authenticate_default_does_not_cap_retry_loop_69442(minion_root, i
         exc_info.value
     )
     assert "Attempt to authenticate with the salt master failed" in str(exc_info.value)
+
+
+async def test_authenticate_missing_creds_attribute_67947(minion_root, io_loop, caplog):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/67947
+
+    ``AsyncAuth.__singleton_init__`` only assigned ``self._creds`` when the
+    minion's ``creds_map`` already contained the key for this auth instance.
+    In the not-in-cache branch it fell through to ``self.authenticate()`` and
+    left ``_creds`` unset.
+
+    ``_authenticate`` then runs on the io_loop and checks ``if key not in
+    AsyncAuth.creds_map:`` after the round-trip to the master. If a *sibling*
+    ``AsyncAuth`` instance for the same key (same pki_dir + id + master_uri +
+    key-mtime tuple) completed its own sign_in between our construction and
+    our ``_authenticate`` running, ``creds_map`` now contains the key and the
+    check goes into the ``else`` branch that dereferences ``self._creds``.
+    That raises ``AttributeError: 'AsyncAuth' object has no attribute
+    '_creds'`` on the reporter's Windows minion, aborts the authenticate
+    coroutine, and silently disconnects the minion until manual restart.
+
+    The fix initializes ``self._creds = None`` in the constructor (matching
+    the sibling ``SAuth`` class) and updates the else-branch to treat
+    ``self._creds is None`` as the first-time case rather than the
+    key-changed case.
+    """
+    pki_dir = minion_root / "etc" / "salt" / "pki"
+    opts = {
+        "id": "minion",
+        "__role": "minion",
+        "pki_dir": str(pki_dir),
+        "master_uri": "tcp://127.0.0.1:4505",
+        "keysize": 4096,
+        "acceptance_wait_time": 0,
+        "acceptance_wait_time_max": 0,
+    }
+    crypt.gen_keys(pki_dir, "minion", opts["keysize"])
+    credskey = (
+        opts["pki_dir"],
+        opts["id"],
+        opts["master_uri"],
+        str(os.path.getmtime(os.path.join(opts["pki_dir"], "minion.pem"))),
+    )
+
+    # Make sure any leftover mapping from prior tests in this session does not
+    # mask the bug: the constructor's short-circuit branch would otherwise set
+    # ``_creds`` for us.
+    crypt.AsyncAuth.creds_map.pop(credskey, None)
+
+    auth = crypt.AsyncAuth(opts, io_loop)
+
+    aes = crypt.Crypticle.generate_key_string()
+    session = crypt.Crypticle.generate_key_string()
+
+    async def mock_sign_in(*args, **kwargs):
+        # Simulate a sibling ``AsyncAuth`` for the same key winning the race
+        # and populating ``creds_map`` after our constructor ran but before
+        # our ``_authenticate`` reaches the ``key not in creds_map`` check.
+        crypt.AsyncAuth.creds_map[credskey] = {
+            "aes": aes,
+            "session": session,
+        }
+        return {"enc": "pub", "aes": aes, "session": session}
+
+    auth.sign_in = mock_sign_in
+
+    try:
+        with caplog.at_level(logging.DEBUG):
+            await auth.authenticate()
+    finally:
+        crypt.AsyncAuth.creds_map.pop(credskey, None)
+
+    # Before the fix, ``_authenticate`` raised ``AttributeError: 'AsyncAuth'
+    # object has no attribute '_creds'`` from the else branch that compared
+    # ``self._creds["aes"]`` against the freshly signed-in creds. After the
+    # fix, the constructor initializes ``_creds`` to ``None`` and the else
+    # branch treats that as the first-authentication case.
+    assert isinstance(auth._creds, dict)
+    assert auth._creds["aes"] == aes
+    assert auth._creds["session"] == session


### PR DESCRIPTION
### What does this PR do?

Initializes `AsyncAuth._creds` in `__singleton_init__` (matching the
sibling `SAuth.__init__`) and treats `self._creds is None` as the
first-authentication case in `_authenticate`, closing a race that could
raise `AttributeError: 'AsyncAuth' object has no attribute '_creds'` and
silently sever a minion's master connection.

### What issues does this PR fix or reference?

Fixes #67947

### Previous Behavior

When `AsyncAuth.__singleton_init__` ran with the auth key absent from the
class-wide `creds_map`, it fell through to `self.authenticate()` and left
`self._creds` unset. If a sibling `AsyncAuth` for the same key (same
`pki_dir` + `id` + `master_uri` + key-mtime tuple) completed its own
sign_in between our construction and our `_authenticate` reaching the
`if key not in AsyncAuth.creds_map:` check, the coroutine took the else
branch and dereferenced `self._creds["aes"]`:

```
File "salt/crypt.py", line 712, in _authenticate
    elif self._creds["aes"] != creds["aes"]:
AttributeError: 'AsyncAuth' object has no attribute '_creds'
```

The exception aborted the coroutine mid-flight, `_authenticate_future`
never resolved, and the minion's channel to the master silently died.
Running jobs kept publishing results that went nowhere until the minion
was restarted. Reproduced by the reporter on Windows 3006.8 multi-master
failover minions.

### New Behavior

`self._creds = None` is set at the top of `__singleton_init__` so
`_authenticate` can safely inspect it, and the else-branch guard becomes
`if key not in AsyncAuth.creds_map or self._creds is None:` — a raced
`creds_map` insert during our sign_in is now handled as a normal
first-authentication rather than crashing.

### Merge requirements satisfied?

- [x] Docs (no documented behavior change)
- [x] Changelog (`changelog/67947.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/test_crypt.py::test_authenticate_missing_creds_attribute_67947`)

### Commits signed with GPG?

No (matching the rest of 3006.x history).
