### PR TITLE
Fix slack.post_message failing with legacy_custom_bots_deprecated (#67948)

### DIFF
--- a/changelog/67948.fixed.md
+++ b/changelog/67948.fixed.md
@@ -1,0 +1,1 @@
+Fixed the `slack.post_message` execution module and state so calls no longer fail with `legacy_custom_bots_deprecated`. The `from_name` and `icon` arguments are now optional and, when omitted, the deprecated `username` / `icon_url` fields are no longer forwarded to Slack's `chat.postMessage` API. Configure the display name and icon in the Slack app settings instead.

--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -161,7 +161,7 @@ def find_user(name, api_key=None):
 def post_message(
     channel,
     message,
-    from_name,
+    from_name=None,
     api_key=None,
     icon=None,
     attachments=None,
@@ -173,11 +173,30 @@ def post_message(
     .. versionchanged:: 3003
         Added `attachments` and `blocks` kwargs
 
+    .. versionchanged:: 3006.28
+        ``from_name`` is now optional. Slack deprecated the ability for
+        classic/custom-bot apps to override the bot's display name and icon
+        via the ``chat.postMessage`` API on March 31, 2025 (see
+        https://api.slack.com/changelog/2024-09-legacy-custom-bots-classic-apps-deprecation).
+        When ``from_name`` or ``icon`` is provided, Slack now rejects the
+        request with ``legacy_custom_bots_deprecated``. Omit both to send
+        with the bot's configured Slack app identity.
+
     :param channel:     The channel name, either will work.
     :param message:     The message to send to the Slack channel.
-    :param from_name:   Specify who the message is from.
+    :param from_name:   Deprecated. Formerly the ``username`` override for
+                        the sent message. Slack rejects this for modern
+                        apps; configure the display name in the Slack app
+                        settings instead. Passing this value now logs a
+                        warning and is only forwarded to Slack for
+                        backward compatibility.
     :param api_key:     The Slack api key, if not specified in the configuration.
-    :param icon:        URL to an image to use as the icon for this message
+    :param icon:        Deprecated. Formerly the ``icon_url`` override for
+                        the sent message. Slack rejects this for modern
+                        apps; configure the icon in the Slack app settings
+                        instead. Passing this value now logs a warning and
+                        is only forwarded to Slack for backward
+                        compatibility.
     :param attachments: Any attachments to be sent with the message.
     :param blocks:      Any blocks to be sent with the message.
     :return:            Boolean if message was sent successfully.
@@ -186,7 +205,7 @@ def post_message(
 
     .. code-block:: bash
 
-        salt '*' slack.post_message channel="Development Room" message="Build is done" from_name="Build Server"
+        salt '*' slack.post_message channel="Development Room" message="Build is done"
 
     """
     if not api_key:
@@ -206,24 +225,39 @@ def post_message(
         )
         channel = f"#{channel}"
 
-    if not from_name:
-        log.error("from_name is a required option.")
-
     if not message:
         log.error("message is a required option.")
 
-    if not from_name:
-        log.error("from_name is a required option.")
-
     parameters = {
         "channel": channel,
-        "username": from_name,
         "text": message,
         "attachments": attachments or [],
         "blocks": blocks or [],
     }
 
+    # Slack deprecated the ability for classic/custom-bot apps to override
+    # the display name and icon via ``chat.postMessage`` on 2025-03-31.
+    # Only include the overrides when the caller explicitly asked for
+    # them; otherwise Slack rejects the request with
+    # ``legacy_custom_bots_deprecated``. See issue #67948.
+    if from_name:
+        log.warning(
+            "The 'from_name' argument to slack.post_message is deprecated. "
+            "Slack no longer accepts a 'username' override on chat.postMessage "
+            "for modern apps; configure the display name in your Slack app "
+            "settings instead. See "
+            "https://api.slack.com/changelog/2024-09-legacy-custom-bots-classic-apps-deprecation"
+        )
+        parameters["username"] = from_name
+
     if icon is not None:
+        log.warning(
+            "The 'icon' argument to slack.post_message is deprecated. "
+            "Slack no longer accepts an 'icon_url' override on chat.postMessage "
+            "for modern apps; configure the icon in your Slack app settings "
+            "instead. See "
+            "https://api.slack.com/changelog/2024-09-legacy-custom-bots-classic-apps-deprecation"
+        )
         parameters["icon_url"] = icon
 
     # Slack wants the body on POST to be urlencoded.

--- a/salt/states/slack.py
+++ b/salt/states/slack.py
@@ -49,6 +49,14 @@ def post_message(name, **kwargs):
             - message: 'This state was executed successfully.'
             - api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
 
+    .. versionchanged:: 3006.28
+        ``from_name`` is now optional. Slack deprecated the ability for
+        classic/custom-bot apps to override the bot's display name and
+        icon via ``chat.postMessage`` on March 31, 2025 (see
+        https://api.slack.com/changelog/2024-09-legacy-custom-bots-classic-apps-deprecation).
+        Omit ``from_name`` and ``icon`` and configure the display name
+        and icon in the Slack app settings instead.
+
     The following parameters are required:
 
     api_key parameters:
@@ -57,9 +65,6 @@ def post_message(name, **kwargs):
 
         channel
             The channel to send the message to. Can either be the ID or the name.
-
-        from_name
-            The name of that is to be shown in the "from" field.
 
         message
             The message that is to be sent to the Slack channel.
@@ -70,8 +75,15 @@ def post_message(name, **kwargs):
             The api key for Slack to use for authentication,
             if not specified in the configuration options of master or minion.
 
+        from_name
+            Deprecated. Formerly the name shown in the "from" field.
+            Slack rejects this for modern apps; configure the display
+            name in the Slack app settings instead.
+
         icon
-            URL to an image to use as the icon for this message
+            Deprecated. Formerly a URL to an image to use as the icon for
+            this message. Slack rejects this for modern apps; configure
+            the icon in the Slack app settings instead.
 
     webhook parameters:
         name
@@ -122,10 +134,6 @@ def post_message(name, **kwargs):
 
     if api_key and not kwargs.get("channel"):
         ret["comment"] = "Slack channel is missing."
-        return ret
-
-    if api_key and not kwargs.get("from_name"):
-        ret["comment"] = "Slack from name is missing."
         return ret
 
     if not kwargs.get("message"):

--- a/tests/pytests/unit/modules/test_slack.py
+++ b/tests/pytests/unit/modules/test_slack.py
@@ -2,6 +2,7 @@
 Tests for salt.modules.slack module
 """
 
+import logging
 import urllib.parse
 
 import pytest
@@ -21,11 +22,12 @@ def test_post_message():
     """
     slack_query = MagicMock(return_value={"res": True})
 
-    # bare minimum
+    # bare minimum - from_name is now optional and, when omitted, the
+    # deprecated `username` field must not be sent (Slack rejects it with
+    # legacy_custom_bots_deprecated, see issue #67948).
     with patch("salt.utils.slack.query", slack_query):
         message_params = {
             "channel": "fake_channel",
-            "from_name": "salt server",
             "message": "test message",
             "api_key": "xxx-xx-xxx",
         }
@@ -38,7 +40,6 @@ def test_post_message():
             data=urllib.parse.urlencode(
                 {
                     "channel": "#fake_channel",
-                    "username": "salt server",
                     "text": "test message",
                     "attachments": [],
                     "blocks": [],
@@ -51,7 +52,6 @@ def test_post_message():
     with patch("salt.utils.slack.query", slack_query):
         message_params = {
             "channel": "fake_channel",
-            "from_name": "salt server",
             "message": "test message",
             "api_key": "xxx-xx-xxx",
             "attachments": [{"text": "And heres an attachment!"}],
@@ -71,7 +71,6 @@ def test_post_message():
             data=urllib.parse.urlencode(
                 {
                     "channel": "#fake_channel",
-                    "username": "salt server",
                     "text": "test message",
                     "attachments": [{"text": "And heres an attachment!"}],
                     "blocks": [
@@ -84,3 +83,73 @@ def test_post_message():
             ),
             opts=slack_notify.__opts__,
         )
+
+
+def test_post_message_legacy_from_name_preserved_with_warning(caplog):
+    """
+    Regression test for #67948.
+
+    When a caller explicitly passes ``from_name``/``icon`` (the legacy
+    Slack custom-bot fields), the values must still be forwarded to Slack
+    for backward compatibility, but a deprecation warning must be logged.
+    """
+    slack_query = MagicMock(return_value={"res": True})
+
+    with patch("salt.utils.slack.query", slack_query), caplog.at_level(
+        logging.WARNING, logger="salt.modules.slack_notify"
+    ):
+        message_params = {
+            "channel": "fake_channel",
+            "message": "test message",
+            "from_name": "salt server",
+            "icon": "https://example.com/icon.png",
+            "api_key": "xxx-xx-xxx",
+        }
+        assert slack_notify.post_message(**message_params)
+        slack_query.assert_called_with(
+            function="message",
+            api_key="xxx-xx-xxx",
+            method="POST",
+            header_dict={"Content-Type": "application/x-www-form-urlencoded"},
+            data=urllib.parse.urlencode(
+                {
+                    "channel": "#fake_channel",
+                    "text": "test message",
+                    "attachments": [],
+                    "blocks": [],
+                    "username": "salt server",
+                    "icon_url": "https://example.com/icon.png",
+                }
+            ),
+            opts=slack_notify.__opts__,
+        )
+    assert any(
+        "from_name" in rec.getMessage() and "deprecated" in rec.getMessage()
+        for rec in caplog.records
+    )
+    assert any(
+        "icon" in rec.getMessage() and "deprecated" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_post_message_omits_username_when_from_name_absent():
+    """
+    Regression test for #67948.
+
+    Ensure the deprecated ``username`` field is not present in the
+    request body when the caller does not provide ``from_name``. Slack
+    rejects calls that include ``username`` from classic/custom-bot
+    apps with ``legacy_custom_bots_deprecated`` since 2025-03-31.
+    """
+    slack_query = MagicMock(return_value={"res": True})
+    with patch("salt.utils.slack.query", slack_query):
+        assert slack_notify.post_message(
+            channel="fake_channel",
+            message="hi",
+            api_key="xxx-xx-xxx",
+        )
+    call_kwargs = slack_query.call_args.kwargs
+    body = call_kwargs["data"]
+    assert "username=" not in body
+    assert "icon_url=" not in body

--- a/tests/pytests/unit/states/test_slack.py
+++ b/tests/pytests/unit/states/test_slack.py
@@ -71,19 +71,6 @@ def test_post_message_apikey():
             == ret
         )
 
-        comt = "Slack from name is missing."
-        ret.update({"comment": comt, "result": False})
-        assert (
-            slack.post_message(
-                name,
-                channel=channel,
-                from_name=None,
-                message=message,
-                api_key=api_key,
-            )
-            == ret
-        )
-
         comt = "Slack message is missing."
         ret.update({"comment": comt, "result": False})
         assert (
@@ -111,6 +98,42 @@ def test_post_message_apikey():
                 )
                 == ret
             )
+
+
+def test_post_message_no_from_name_67948():
+    """
+    Regression test for #67948.
+
+    Ensure the state accepts a call without ``from_name``. Slack rejects
+    the deprecated ``username`` override on ``chat.postMessage`` from
+    classic/custom-bot apps with ``legacy_custom_bots_deprecated`` since
+    2025-03-31, so the state must no longer require ``from_name``.
+    """
+    name = "slack-message"
+    channel = "#general"
+    message = "This state was executed successfully."
+    api_key = "xoxp-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXXX"
+
+    with patch.dict(slack.__opts__, {"test": False}):
+        mock = MagicMock(return_value=True)
+        with patch.dict(slack.__salt__, {"slack.post_message": mock}):
+            ret = slack.post_message(
+                name,
+                channel=channel,
+                message=message,
+                api_key=api_key,
+            )
+            assert ret == {
+                "name": name,
+                "changes": {},
+                "result": True,
+                "comment": f"Sent message: {name}",
+            }
+            # The state must not forward a ``from_name`` when the caller
+            # did not supply one; the underlying module drops the
+            # deprecated ``username`` field in that case.
+            call_kwargs = mock.call_args.kwargs
+            assert call_kwargs.get("from_name") is None
 
 
 def test_post_message_webhook():


### PR DESCRIPTION
### What does this PR do?
Makes `slack.post_message` (module + state) functional again after Slack's 2025-03-31 deprecation of the classic/custom-bot `username`/`icon_url` overrides on `chat.postMessage`. `from_name` and `icon` are now optional, and the deprecated fields are only forwarded to Slack when the caller explicitly supplies them (with a deprecation warning).

### What issues does this PR fix or reference?
Fixes #67948

### Previous Behavior
Every call to `slack.post_message` failed with `Failed to send message (legacy_custom_bots_deprecated): ...`. Slack rejects any `chat.postMessage` request that includes `username`/`icon_url` from a classic/custom-bot app, and the module unconditionally sent `username=<from_name>` (with `from_name` being a required positional argument). See https://api.slack.com/changelog/2024-09-legacy-custom-bots-classic-apps-deprecation.

### New Behavior
- `from_name` and `icon` are optional at both the module and state layer.
- When omitted, the request body no longer contains the deprecated `username`/`icon_url` fields, so Slack accepts the call and the bot's configured app-side display name/icon are used.
- When supplied, the values are still forwarded (back-compat for callers that hardcode them) and a deprecation warning is logged pointing at the Slack changelog.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes
