### PR TITLE
Fix get_returner_options ignoring defaults for unset attributes (#69654)

### DIFF
--- a/changelog/69654.fixed.md
+++ b/changelog/69654.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt.returners.get_returner_options`` so that attributes not present in the config now fall through to the supplied ``defaults`` value instead of being returned as ``None``.

--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -164,7 +164,7 @@ def _options_browser(cfg, ret_config, defaults, virtualname, options):
         # default place for the option in the config
         value = _fetch_option(cfg, ret_config, virtualname, options[option])
 
-        if value != "":
+        if value is not None and value != "":
             yield option, value
             continue
 

--- a/tests/pytests/unit/returners/test_returners_init.py
+++ b/tests/pytests/unit/returners/test_returners_init.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for salt.returners package helpers (``get_returner_options`` /
+``_options_browser``).
+"""
+
+import pytest
+
+import salt.returners
+from tests.support.mock import patch
+
+
+@pytest.mark.parametrize(
+    "configured_value",
+    [0, 0.0, False, []],
+    ids=["int-zero", "float-zero", "bool-false", "empty-list"],
+)
+def test_options_browser_yields_falsy_configured_value(configured_value):
+    """
+    Regression coverage for https://github.com/saltstack/salt/issues/63980:
+    a falsy-but-set configuration value must be returned as-is instead of
+    being masked by the returner's default value.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=configured_value):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": configured_value}
+
+
+def test_options_browser_falls_back_to_default_when_unset():
+    """
+    When ``_fetch_option`` returns the empty-string sentinel (i.e. the
+    option is not configured), the default value should be yielded.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=""):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": 42}
+
+
+def test_options_browser_yields_configured_truthy_value():
+    """
+    A configured, truthy value should be yielded unchanged.
+    """
+    defaults = {"my_option": 42}
+    options = {"my_option": "my_option"}
+
+    with patch.object(salt.returners, "_fetch_option", return_value="hello"):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="custom_returner",
+                options=options,
+            )
+        )
+
+    assert result == {"my_option": "hello"}
+
+
+def test_options_browser_falls_back_to_default_when_none():
+    """
+    Regression coverage for https://github.com/saltstack/salt/issues/69654:
+    when ``_fetch_option`` returns ``None`` (for example because the config
+    source is a plain ``__opts__`` dict without a value for the attribute),
+    the default value must be yielded instead of a bare ``None``.
+    """
+    defaults = {
+        "filename": "/tmp/prometheus.prom",
+        "uid": -1,
+        "gid": -1,
+        "match_exe": False,
+        "proc_name": "salt-minion",
+    }
+    options = {k: k for k in defaults}
+
+    with patch.object(salt.returners, "_fetch_option", return_value=None):
+        result = dict(
+            salt.returners._options_browser(
+                cfg=None,
+                ret_config=None,
+                defaults=defaults,
+                virtualname="prometheus_textfile",
+                options=options,
+            )
+        )
+
+    assert result == defaults
+
+
+def test_get_returner_options_defaults_with_plain_opts_dict():
+    """
+    Regression coverage for https://github.com/saltstack/salt/issues/69654:
+    when ``get_returner_options`` is called with ``__opts__`` that does not
+    contain the returner's attributes (and ``__salt__`` has no
+    ``config.option``), each unset attribute should fall through to its
+    ``defaults`` value rather than being yielded as ``None``.
+    """
+    opts = {"cachedir": "/tmp"}
+    defaults = {
+        "exe": None,
+        "filename": "/tmp/prometheus.prom",
+        "uid": -1,
+        "gid": -1,
+        "mode": None,
+        "match_exe": False,
+        "proc_name": "salt-minion",
+        "add_state_name": False,
+    }
+    attrs = {k: k for k in defaults}
+
+    result = salt.returners.get_returner_options(
+        "prometheus_textfile",
+        ret=None,
+        attrs=attrs,
+        __salt__={},
+        __opts__=opts,
+        defaults=defaults,
+    )
+
+    assert result == defaults


### PR DESCRIPTION
### What does this PR do?

Fixes `salt.returners._options_browser` so that attributes not present in
the config source fall through to the supplied `defaults` value instead of
being yielded as `None`. This restores the behavior returners rely on when
they pass `defaults=` to `get_returner_options`.

### What issues does this PR fix or reference?

Fixes #69654

Related: #66828 (introduced the regression on 3007.x / 3008.x / master),
#66816 / #63980 (the original falsy-values bug that #66828 was fixing).

### Previous Behavior

PR #66828 changed the check in `_options_browser` from `if value:` to
`if value != "":`. That fixes the falsy-values bug on the `config.option`
code path where `_fetch_option` returns the empty-string sentinel `""` for
a missing key. But on the plain-dict code path (`__salt__` does not contain
`config.option`, so `cfg = __opts__`), `_fetch_option` returns `None` for a
missing attribute — see `salt/returners/__init__.py:132`. `None != ""` is
true, so the buggy check yielded `(option, None)` and skipped the defaults
branch entirely. Every unset attribute came back as `None` instead of its
supplied default.

Reporter's example (via `saltext-prometheus`'s test suite):

```python
_options = salt.returners.get_returner_options(
    "prometheus_textfile",
    ret,
    attrs,
    __salt__=__salt__,
    __opts__=__opts__,
    defaults=defaults,  # rich, non-None defaults dict
)
# Actual: every value is None
# Expected: the supplied defaults dict
```

### New Behavior

`_options_browser` now excludes `None` explicitly:

```python
if value is not None and value != "":
    yield option, value
    continue
```

`None` falls through to the defaults branch; legitimately-falsy configured
values (`0`, `0.0`, `False`, `[]`, …) — the fix from #66828 — continue to
round-trip unchanged.

### Merge requirements satisfied?

- [x] Docs (no documented behavior changes; the fix restores the intended
  fallback semantics)
- [x] Changelog (`changelog/69654.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/returners/test_returners_init.py`)

### Commits signed with GPG?

Yes
