### PR TITLE
Auto-restart salt-minion.service on crash (#69182)

### DIFF
--- a/changelog/69182.fixed.md
+++ b/changelog/69182.fixed.md
@@ -1,0 +1,1 @@
+Fixed the shipped `salt-minion.service` systemd unit so a crashed minion is restarted by systemd instead of being left in the failed state until manual intervention.

--- a/pkg/common/salt-minion.service
+++ b/pkg/common/salt-minion.service
@@ -2,6 +2,8 @@
 Description=The Salt Minion
 Documentation=man:salt-minion(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltproject.io/en/latest/contents.html
 After=network.target salt-master.service
+StartLimitBurst=3
+StartLimitIntervalSec=300
 
 [Service]
 KillMode=mixed
@@ -9,6 +11,8 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+Restart=on-failure
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/pytests/unit/test_pkg_systemd_units.py
+++ b/tests/pytests/unit/test_pkg_systemd_units.py
@@ -51,3 +51,55 @@ def test_salt_minion_service_killmode_is_mixed():
     """
     parser = _read_unit("salt-minion.service")
     assert parser.get("Service", "KillMode", fallback=None) == "mixed"
+
+
+def test_salt_minion_service_restarts_on_failure():
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69182.
+
+    An unhandled exception (or worker OOM) in ``salt-minion`` leaves the
+    unit in the ``failed`` state until manual intervention. The shipped
+    unit must ask systemd to restart on failure, with a ``RestartSec`` gap
+    and ``StartLimit*`` bounds so a persistent crash cannot hammer the
+    box in a tight restart loop.
+    """
+    parser = _read_unit("salt-minion.service")
+
+    restart = parser.get("Service", "Restart", fallback=None)
+    assert restart in ("on-failure", "on-abnormal", "always"), (
+        "salt-minion.service must set Restart= so systemd revives the "
+        "minion after a crash. See issue #69182."
+    )
+
+    restart_sec = parser.get("Service", "RestartSec", fallback=None)
+    assert restart_sec is not None, (
+        "salt-minion.service must set RestartSec= to avoid an immediate "
+        "restart storm. See issue #69182."
+    )
+    # RestartSec may carry a systemd time-unit suffix (e.g. "15s"); accept
+    # any leading positive integer.
+    restart_sec_int = int("".join(c for c in restart_sec if c.isdigit()) or 0)
+    assert restart_sec_int > 0, (
+        f"salt-minion.service RestartSec must be a positive interval; "
+        f"got {restart_sec!r}. See issue #69182."
+    )
+
+    burst = parser.get("Service", "StartLimitBurst", fallback=None)
+    interval = parser.get(
+        "Service", "StartLimitIntervalSec", fallback=None
+    ) or parser.get("Service", "StartLimitInterval", fallback=None)
+    # systemd accepts both StartLimitIntervalSec (modern) and
+    # StartLimitInterval (legacy alias) in either [Service] or [Unit].
+    if burst is None:
+        burst = parser.get("Unit", "StartLimitBurst", fallback=None)
+    if interval is None:
+        interval = parser.get(
+            "Unit", "StartLimitIntervalSec", fallback=None
+        ) or parser.get("Unit", "StartLimitInterval", fallback=None)
+    assert burst is not None and interval is not None, (
+        "salt-minion.service must bound restart attempts with "
+        "StartLimitBurst and StartLimitIntervalSec (or the legacy "
+        "StartLimitInterval alias) so a persistent crash cannot hammer "
+        "the box. See issue #69182."
+    )
+    assert int(burst) > 0, f"StartLimitBurst must be positive; got {burst!r}."


### PR DESCRIPTION
### What does this PR do?

Adds `Restart=on-failure`, `RestartSec=15`, `StartLimitBurst=3`, and
`StartLimitIntervalSec=300` to the shipped `pkg/common/salt-minion.service`
systemd unit so that a crashed minion (unhandled exception, worker OOM,
etc.) is revived by systemd instead of being left in the failed state.

### What issues does this PR fix or reference?

Fixes #69182

Related: #68406 (the recent `KillMode=mixed` fix on the same file — this
PR extends the `tests/pytests/unit/test_pkg_systemd_units.py` static
audit added there).

### Previous Behavior

The shipped unit had no `Restart=`/`RestartSec=`/`StartLimit*` directives.
When the `salt-minion` process crashed the unit went to `failed` and
stayed there until someone ran `systemctl start salt-minion` by hand. As
the reporter observed on 3008.0rc4 (Ubuntu 22.04) and a second contributor
confirmed on 3007.14 (Rocky 9), an unhandled exception took the minion
offline from the master's point of view until the next manual intervention.

### New Behavior

`Restart=on-failure` + `RestartSec=15` in `[Service]` cause systemd to
restart the minion 15 seconds after a non-clean exit. `StartLimitBurst=3`
+ `StartLimitIntervalSec=300` in `[Unit]` cap the loop at three restart
attempts per five minutes so a persistent crash cannot hammer the box.

`StartLimitBurst` / `StartLimitIntervalSec` are intentionally placed in
`[Unit]` — `systemd-analyze verify` rejects them in `[Service]` with
`Unknown key 'StartLimitIntervalSec' in section [Service], ignoring.`,
and `[Unit]` is systemd's canonical section for these directives.

### Merge requirements satisfied?

- [x] Tests written/updated (extends the audit added by #68406)
- [x] Changelog (`changelog/69182.fixed.md`)
- [x] Commits signed with GPG

### Commits signed with GPG?

Yes
