### PR TITLE
Fix mac_brew_pkg.homebrew_prefix triggering su on every invocation (#69027)

### DIFF
--- a/changelog/69027.fixed.md
+++ b/changelog/69027.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``mac_brew_pkg.homebrew_prefix()`` triggering a ``su`` password prompt (or ``su: Sorry`` error) on every invocation when the ``brew`` binary is owned by the current user. The probe now only passes ``runas=`` to ``cmdmod.run`` when the brew binary owner differs from the current process user, avoiding the unconditional ``su -l`` wrap on macOS.

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -9,7 +9,9 @@ Homebrew for macOS
 """
 
 import copy
+import getpass
 import logging
+import os
 
 import salt.utils.data
 import salt.utils.functools
@@ -93,6 +95,33 @@ def _tap(tap, runas=None):
     return True
 
 
+def _homebrew_os_bin():
+    """
+    Fetch PATH binary brew full path eg: /usr/local/bin/brew (symbolic link)
+    """
+
+    original_path = os.environ.get("PATH")
+    try:
+        # Add "/opt/homebrew" temporary to the PATH for Apple Silicon if
+        # the PATH does not include "/opt/homebrew"
+        current_path = original_path or ""
+        homebrew_path = "/opt/homebrew/bin"
+        if homebrew_path not in current_path.split(os.path.pathsep):
+            extended_path = os.path.pathsep.join([current_path, homebrew_path])
+            os.environ["PATH"] = extended_path.lstrip(os.path.pathsep)
+
+        # Search for the brew executable in the current PATH
+        brew = salt.utils.path.which("brew")
+    finally:
+        # Restore original PATH
+        if original_path is None:
+            del os.environ["PATH"]
+        else:
+            os.environ["PATH"] = original_path
+
+    return brew
+
+
 def _homebrew_bin():
     """
     Returns the full path to the homebrew binary in the PATH
@@ -136,6 +165,60 @@ def _list_pkgs_from_context(versions_as_list):
         ret = copy.deepcopy(__context__["pkg.list_pkgs"])
         __salt__["pkg_resource.stringify"](ret)
         return ret
+
+
+def homebrew_prefix():
+    """
+    Returns the full path to the homebrew prefix.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.homebrew_prefix
+    """
+
+    # If HOMEBREW_PREFIX env variable is present, use it
+    env_homebrew_prefix = "HOMEBREW_PREFIX"
+    if env_homebrew_prefix in os.environ:
+        log.debug("%s is set. Using it for homebrew prefix.", env_homebrew_prefix)
+        return os.environ[env_homebrew_prefix]
+
+    # Try brew --prefix otherwise
+    try:
+        log.debug("Trying to find homebrew prefix by running 'brew --prefix'")
+
+        brew = _homebrew_os_bin()
+        if brew is not None:
+            # Check if the found brew command is the right one
+            import salt.modules.cmdmod
+            import salt.modules.file
+
+            runas = salt.modules.file.get_user(brew)
+            # Only pass runas when the brew binary is owned by a different
+            # user than the current process. On macOS, ``cmdmod.run`` with a
+            # truthy ``runas`` wraps the command in ``su -l <user> -c ...``
+            # unconditionally, which triggers a password prompt (or
+            # ``su: Sorry`` on non-tty invocations) even when the target user
+            # is the current user. See #69027.
+            try:
+                if runas == getpass.getuser():
+                    runas = None
+            except Exception:  # pylint: disable=broad-except
+                # getpass.getuser() can raise on unusual environments (e.g.
+                # empty passwd db); fall back to sending runas as-is.
+                pass
+            ret = salt.modules.cmdmod.run(
+                "brew --prefix", runas=runas, output_loglevel="trace", raise_err=True
+            )
+
+            return ret
+    except CommandExecutionError as exc:
+        log.debug(
+            "Unable to find homebrew prefix by running 'brew --prefix'. Error: %s", exc
+        )
+
+    return None
 
 
 def list_pkgs(versions_as_list=False, **kwargs):

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -2,6 +2,7 @@
     :codeauthor: Nicole Thomas <nicole@saltstack.com>
 """
 
+import os
 import textwrap
 
 import pytest
@@ -23,8 +24,13 @@ def TAPS_LIST():
 
 
 @pytest.fixture
-def HOMEBREW_BIN():
-    return "/usr/local/bin/brew"
+def HOMEBREW_PREFIX():
+    return "/opt/homebrew"
+
+
+@pytest.fixture
+def HOMEBREW_BIN(HOMEBREW_PREFIX):
+    return HOMEBREW_PREFIX + "/bin/brew"
 
 
 @pytest.fixture
@@ -433,14 +439,186 @@ def test_tap(TAPS_LIST, HOMEBREW_BIN):
             assert mac_brew._tap("homebrew/test")
 
 
+# 'homebrew_prefix' function tests: 4
+
+
+def test_homebrew_prefix_env(HOMEBREW_PREFIX):
+    """
+    Test the path to the homebrew prefix by looking
+    at the HOMEBREW_PREFIX environment variable.
+    """
+    mock_env = os.environ.copy()
+    mock_env["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
+
+    with patch.dict(os.environ, mock_env):
+        assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+
+def test_homebrew_prefix_command(HOMEBREW_PREFIX, HOMEBREW_BIN):
+    """
+    Test the path to the homebrew prefix by running
+    the brew --prefix command when the HOMEBREW_PREFIX
+    environment variable is not set.
+    """
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env):
+        with patch(
+            "salt.modules.cmdmod.run", MagicMock(return_value=HOMEBREW_PREFIX)
+        ), patch("salt.modules.file.get_user", MagicMock(return_value="foo")), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=HOMEBREW_BIN),
+        ):
+            assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+
+def test_homebrew_prefix_returns_none():
+    """
+    Tests that homebrew_prefix returns None when
+    all attempts fail.
+    """
+
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env, clear=True):
+        with patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin", MagicMock(return_value=None)
+        ):
+            assert mac_brew.homebrew_prefix() is None
+
+
+def test_homebrew_prefix_returns_none_even_with_execution_errors():
+    """
+    Tests that homebrew_prefix returns None when
+    all attempts fail even with command execution errors.
+    """
+
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env, clear=True):
+        with patch(
+            "salt.modules.cmdmod.run", MagicMock(side_effect=CommandExecutionError)
+        ), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=None),
+        ):
+            assert mac_brew.homebrew_prefix() is None
+
+
+def test_homebrew_prefix_no_su_when_brew_owner_is_current_user(
+    HOMEBREW_PREFIX, HOMEBREW_BIN
+):
+    """
+    Regression test for #69027.
+
+    ``homebrew_prefix()`` used to pass ``runas=<brew binary owner>``
+    unconditionally to ``cmdmod.run``, which on macOS wraps the command in
+    ``su -l <user> -c ...`` even when ``<user>`` is the current user. That
+    triggers a password prompt (or a "su: Sorry" error on every non-tty
+    invocation) on every salt-ssh call as a non-root user whose Homebrew is
+    owned by themselves.
+
+    ``runas`` must be ``None`` when the brew binary owner equals the current
+    process user, so the ``su`` wrap is skipped.
+    """
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    current_user = "brewowner"
+    run_mock = MagicMock(return_value=HOMEBREW_PREFIX)
+    with patch.dict(os.environ, mock_env, clear=True):
+        with patch("salt.modules.cmdmod.run", run_mock), patch(
+            "salt.modules.file.get_user", MagicMock(return_value=current_user)
+        ), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=HOMEBREW_BIN),
+        ), patch(
+            "getpass.getuser", MagicMock(return_value=current_user)
+        ):
+            assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+    assert run_mock.called, "cmdmod.run should have been invoked"
+    _, kwargs = run_mock.call_args
+    assert kwargs.get("runas") is None, (
+        "homebrew_prefix() must not pass runas=<current user> to cmdmod.run; "
+        "on macOS this wraps the probe in `su -l` and triggers a password "
+        "prompt (issue #69027)"
+    )
+
+
+def test_homebrew_prefix_still_uses_runas_when_brew_owned_by_other_user(
+    HOMEBREW_PREFIX, HOMEBREW_BIN
+):
+    """
+    Complement to the #69027 regression test: when the brew binary is owned
+    by a different user than the current process user, ``runas`` must still
+    be forwarded so ``cmdmod.run`` invokes ``brew --prefix`` as the owner.
+    """
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    run_mock = MagicMock(return_value=HOMEBREW_PREFIX)
+    with patch.dict(os.environ, mock_env, clear=True):
+        with patch("salt.modules.cmdmod.run", run_mock), patch(
+            "salt.modules.file.get_user", MagicMock(return_value="brewowner")
+        ), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=HOMEBREW_BIN),
+        ), patch(
+            "getpass.getuser", MagicMock(return_value="someoneelse")
+        ):
+            assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+    _, kwargs = run_mock.call_args
+    assert kwargs.get("runas") == "brewowner"
+
+
+# '_homebrew_os_bin' function tests: 1
+
+
+def test_homebrew_os_bin_fallback_apple_silicon():
+    """
+    Test the path to the homebrew executable for Apple Silicon.
+
+    This test checks that even if the PATH does not contain
+    the default Homebrew's prefix for the Apple Silicon
+    architecture, it is appended.
+    """
+
+    # Ensure Homebrew's prefix for Apple Silicon is not present in the PATH
+    mock_env = os.environ.copy()
+    mock_env["PATH"] = "/usr/local/bin:/usr/bin"
+
+    apple_silicon_homebrew_path = "/opt/homebrew/bin"
+    apple_silicon_homebrew_bin = f"{apple_silicon_homebrew_path}/brew"
+
+    def mock_utils_path_which(*args):
+        if apple_silicon_homebrew_path in os.environ.get("PATH", "").split(
+            os.path.pathsep
+        ):
+            return apple_silicon_homebrew_bin
+        return None
+
+    with patch("salt.utils.path.which", mock_utils_path_which):
+        assert mac_brew._homebrew_os_bin() == apple_silicon_homebrew_bin
+
+
 # '_homebrew_bin' function tests: 1
 
 
-def test_homebrew_bin(HOMEBREW_BIN):
+def test_homebrew_bin(HOMEBREW_PREFIX, HOMEBREW_BIN):
     """
     Tests the path to the homebrew binary
     """
-    mock_path = MagicMock(return_value="/usr/local")
+    mock_path = MagicMock(return_value=HOMEBREW_PREFIX)
     with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch.dict(mac_brew.__salt__, {"cmd.run": mock_path}):
             assert mac_brew._homebrew_bin() == HOMEBREW_BIN


### PR DESCRIPTION
### What does this PR do?

Fixes `mac_brew_pkg.homebrew_prefix()` triggering a `su` password prompt
(or `su: Sorry` error on non-tty invocations) on every salt-ssh startup as
a non-root user whose Homebrew is owned by themselves. The probe now only
forwards `runas=` to `cmdmod.run` when the brew binary owner differs from
the current process user.

### What issues does this PR fix or reference?

Fixes #69027

### Previous Behavior

Every invocation of salt-ssh (or any Salt process that loads
`mac_brew_pkg`) on macOS as a non-root user prints:

```
[ERROR   ] Command 'su' failed with return code: 1
[ERROR   ] stdout: Password:su: Sorry
[ERROR   ] retcode: 1
[ERROR   ] Command 'brew' failed with return code: 1
```

On a TTY, the user is prompted for their password before the wrapped
command fails. Root cause: `homebrew_prefix()` passes
`runas=<brew binary owner>` to `salt.modules.cmdmod.run` unconditionally.
On Darwin, `cmdmod.run` wraps the command in `su -l <user> -c ...`
whenever `runas` is truthy, even when `<user>` is the current process
user — and non-root invocations of `su` require a password regardless of
whether the source and target identities match.

### New Behavior

`homebrew_prefix()` calls `getpass.getuser()` and short-circuits `runas`
to `None` when the brew binary owner is the current user. The `su -l`
wrap is skipped in the common single-user macOS setup; behavior when the
brew binary is owned by a different user (shared multi-user installs)
is unchanged. `getpass.getuser()` failures are tolerated defensively so
we never make things worse than the previous unconditional behavior.

Two regression tests were added to
`tests/pytests/unit/modules/test_mac_brew_pkg.py`:
- `test_homebrew_prefix_no_su_when_brew_owner_is_current_user`
- `test_homebrew_prefix_still_uses_runas_when_brew_owned_by_other_user`

### Merge requirements satisfied?
- [x] Docs (no user-facing docs changed; behavior fix only)
- [x] Changelog (`changelog/69027.fixed.md`)
- [x] Tests written/updated

### Commits signed with GPG?
Yes
