### PR TITLE
Fix HighState/State leaking fileclient on init failure (#69637)

### DIFF
--- a/changelog/69637.fixed.md
+++ b/changelog/69637.fixed.md
@@ -1,0 +1,1 @@
+Fixed `HighState` and `State` init leaking their fileclient (and its ZeroMQ transport) when a later step in the constructor raises, which produced `TransportWarning: Unclosed transport!` messages during `salt-call state.apply`.

--- a/salt/state.py
+++ b/salt/state.py
@@ -791,36 +791,45 @@ class State:
         else:
             self.file_client = salt.fileclient.get_file_client(self.opts)
             self.preserve_file_client = False
-        self.proxy = proxy
-        self._pillar_override = pillar_override
-        if pillar_enc is not None:
-            try:
-                pillar_enc = pillar_enc.lower()
-            except AttributeError:
-                pillar_enc = str(pillar_enc).lower()
-        self._pillar_enc = pillar_enc
-        log.debug("Gathering pillar data for state run")
-        if initial_pillar and not self._pillar_override:
-            self.opts["pillar"] = initial_pillar
-        else:
-            # Compile pillar data
-            self.opts["pillar"] = self._gather_pillar()
-            # Reapply overrides on top of compiled pillar
-            if self._pillar_override:
-                self.opts["pillar"] = salt.utils.dictupdate.merge(
-                    self.opts["pillar"],
-                    self._pillar_override,
-                    self.opts.get("pillar_source_merging_strategy", "smart"),
-                    self.opts.get("renderer", "yaml"),
-                    self.opts.get("pillar_merge_lists", False),
-                )
-        log.debug("Finished gathering pillar data for state run")
-        if context is None:
-            self.state_con = {}
-        else:
-            self.state_con = context
-        self.state_con["fileclient"] = self.file_client
-        self.load_modules()
+        # If any of the calls below raise, destroy the file client we just
+        # allocated so its transport doesn't get finalized without close()
+        # (issue #69637 -- ``Unclosed transport!`` TransportWarning during
+        # interpreter shutdown).
+        try:
+            self.proxy = proxy
+            self._pillar_override = pillar_override
+            if pillar_enc is not None:
+                try:
+                    pillar_enc = pillar_enc.lower()
+                except AttributeError:
+                    pillar_enc = str(pillar_enc).lower()
+            self._pillar_enc = pillar_enc
+            log.debug("Gathering pillar data for state run")
+            if initial_pillar and not self._pillar_override:
+                self.opts["pillar"] = initial_pillar
+            else:
+                # Compile pillar data
+                self.opts["pillar"] = self._gather_pillar()
+                # Reapply overrides on top of compiled pillar
+                if self._pillar_override:
+                    self.opts["pillar"] = salt.utils.dictupdate.merge(
+                        self.opts["pillar"],
+                        self._pillar_override,
+                        self.opts.get("pillar_source_merging_strategy", "smart"),
+                        self.opts.get("renderer", "yaml"),
+                        self.opts.get("pillar_merge_lists", False),
+                    )
+            log.debug("Finished gathering pillar data for state run")
+            if context is None:
+                self.state_con = {}
+            else:
+                self.state_con = context
+            self.state_con["fileclient"] = self.file_client
+            self.load_modules()
+        except Exception:
+            if not self.preserve_file_client:
+                self._destroy_fileclient_on_init_failure()
+            raise
         self.active = set()
         self.mod_init = set()
         self.pre = {}
@@ -833,6 +842,31 @@ class State:
         self.global_state_conditions = None
         # Fix for Issue #30971: Track processed SLS files to handle empty SLS files
         self._processed_sls_files = set()
+
+    def _destroy_fileclient_on_init_failure(self):
+        """
+        Best-effort teardown for ``self.file_client`` when the constructor is
+        unwinding due to an exception (issue #69637).
+
+        ``RemoteClient`` exposes ``destroy()``; ``FSChan`` / older fileclients
+        expose ``close()``.  Swallow errors -- the caller re-raises the
+        original exception.
+        """
+        try:
+            file_client = self.file_client
+        except AttributeError:
+            return
+        try:
+            teardown = getattr(file_client, "destroy", None)
+            if teardown is None:
+                teardown = getattr(file_client, "close", None)
+            if teardown is not None:
+                teardown()
+        except Exception:  # pylint: disable=broad-except
+            log.debug(
+                "Error while destroying State file client after failed init",
+                exc_info=True,
+            )
 
     def _match_global_state_conditions(self, full, state, name):
         """
@@ -914,7 +948,19 @@ class State:
             pillar_override=self._pillar_override,
             pillarenv=self.opts.get("pillarenv"),
         )
-        return pillar.compile_pillar()
+        try:
+            return pillar.compile_pillar()
+        finally:
+            # Explicitly release the pillar's channel/transport.  Relying on
+            # ``__del__`` for cleanup during interpreter shutdown can trip
+            # ``Unclosed transport!`` warnings (see #69637) because the
+            # transport may be finalized before the pillar or its channel.
+            destroy = getattr(pillar, "destroy", None)
+            if destroy is not None:
+                try:
+                    destroy()
+                except Exception:  # pylint: disable=broad-except
+                    log.debug("Error while destroying pillar", exc_info=True)
 
     def _mod_init(self, low):
         """
@@ -5067,19 +5113,35 @@ class HighState(BaseHighState):
         else:
             self.client = salt.fileclient.get_file_client(self.opts)
             self.preserve_client = False
-        BaseHighState.__init__(self, opts)
-        self.state = State(
-            self.opts,
-            pillar_override,
-            jid,
-            pillar_enc,
-            proxy=proxy,
-            context=context,
-            mocked=mocked,
-            loader=loader,
-            initial_pillar=initial_pillar,
-            file_client=self.client,
-        )
+        # If any of the calls below raise, destroy the file client we just
+        # allocated so its transport doesn't get finalized without close()
+        # (issue #69637 -- ``Unclosed transport!`` TransportWarning during
+        # interpreter shutdown).
+        try:
+            BaseHighState.__init__(self, opts)
+            self.state = State(
+                self.opts,
+                pillar_override,
+                jid,
+                pillar_enc,
+                proxy=proxy,
+                context=context,
+                mocked=mocked,
+                loader=loader,
+                initial_pillar=initial_pillar,
+                file_client=self.client,
+            )
+        except Exception:
+            if not self.preserve_client:
+                try:
+                    self.client.destroy()
+                except Exception:  # pylint: disable=broad-except
+                    log.debug(
+                        "Error while destroying HighState file client after "
+                        "failed init",
+                        exc_info=True,
+                    )
+            raise
         self.matchers = salt.loader.matchers(self.opts)
         self.proxy = proxy
 

--- a/tests/pytests/unit/state/test_highstate_transport_cleanup.py
+++ b/tests/pytests/unit/state/test_highstate_transport_cleanup.py
@@ -1,0 +1,119 @@
+"""
+Regression tests for issue #69637.
+
+If ``HighState.__init__`` (or ``State.__init__``) allocates a fileclient and
+then a later step in the same constructor raises, the caller never gets the
+``HighState``/``State`` instance and therefore never calls ``destroy()``.  The
+allocated fileclient's transport is finalized during garbage collection with
+``_closing = False``, which trips the ``TransportWarning: Unclosed
+transport!`` warning added by PR #65559.
+
+These tests exercise the failure path and assert that the fileclient's
+``destroy()`` is invoked before the exception propagates.
+"""
+
+import pytest
+
+import salt.state
+from tests.support import mock
+
+pytestmark = [
+    pytest.mark.core_test,
+]
+
+
+@pytest.fixture
+def minimal_opts(tmp_path):
+    return {
+        "id": "test-minion",
+        "__role": "minion",
+        "cachedir": str(tmp_path / "cache"),
+        "extension_modules": str(tmp_path / "ext_mods"),
+        "file_client": "remote",
+        "file_roots": {"base": []},
+        "pillar_roots": {"base": []},
+        "state_top": "salt://top.sls",
+        "renderer": "yaml_jinja",
+        "renderer_whitelist": [],
+        "renderer_blacklist": [],
+        "grains": {},
+        "pillar": {},
+        "pillarenv": None,
+        "saltenv": "base",
+        "state_events": False,
+        "state_verbose": True,
+        "pillar_cache": False,
+        "master_type": "str",
+        "master": "127.0.0.1",
+        "master_uri": "tcp://127.0.0.1:44506",
+        "transport": "zeromq",
+    }
+
+
+def test_highstate_init_failure_destroys_fileclient(minimal_opts):
+    """
+    If ``BaseHighState.__init__`` (called from ``HighState.__init__``) raises,
+    the fileclient allocated seconds earlier must be destroyed rather than
+    leaked to garbage collection.
+
+    Regression test for issue #69637.
+    """
+    mock_client = mock.MagicMock()
+    with mock.patch(
+        "salt.fileclient.get_file_client", return_value=mock_client
+    ), mock.patch.object(
+        salt.state.BaseHighState, "__init__", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            salt.state.HighState(minimal_opts)
+    mock_client.destroy.assert_called_once()
+
+
+def test_highstate_init_success_does_not_destroy_fileclient(minimal_opts):
+    """
+    In the success case the fileclient must remain owned by the HighState so
+    that ``HighState.destroy()`` can close it later.  This test guards the
+    happy path so the exception-safety change doesn't accidentally double-
+    destroy.
+    """
+    mock_client = mock.MagicMock()
+    with mock.patch(
+        "salt.fileclient.get_file_client", return_value=mock_client
+    ), mock.patch.object(
+        salt.state.BaseHighState, "__init__", return_value=None
+    ), mock.patch.object(
+        salt.state, "State", return_value=mock.MagicMock()
+    ), mock.patch(
+        "salt.loader.matchers"
+    ):
+        hs = salt.state.HighState(minimal_opts)
+        # Constructor succeeded — the client is now owned by hs.
+        assert hs.client is mock_client
+        assert hs.preserve_client is False
+        mock_client.destroy.assert_not_called()
+        # Explicit destroy still works.
+        hs.destroy()
+        mock_client.destroy.assert_called_once()
+
+
+def test_state_init_failure_destroys_fileclient(minimal_opts):
+    """
+    If ``State.__init__`` raises after allocating a fileclient (e.g. during
+    pillar rendering), that fileclient must be destroyed.
+
+    Regression test for issue #69637.
+    """
+    mock_client = mock.MagicMock()
+    with mock.patch(
+        "salt.fileclient.get_file_client", return_value=mock_client
+    ), mock.patch.object(
+        salt.state.State,
+        "_gather_pillar",
+        side_effect=RuntimeError("pillar boom"),
+    ):
+        with pytest.raises(RuntimeError, match="pillar boom"):
+            salt.state.State(minimal_opts)
+    # State prefers destroy() but falls back to close() if not available.
+    assert (
+        mock_client.destroy.called or mock_client.close.called
+    ), "State did not tear down its fileclient after init failure"


### PR DESCRIPTION
### What does this PR do?

Fix `HighState.__init__` and `State.__init__` leaking their fileclient (and its ZeroMQ transport) when a later step in the constructor raises. The salt-call flow that hits the failure now shuts down cleanly instead of emitting `TransportWarning: Unclosed transport!` at interpreter exit.

### What issues does this PR fix or reference?

Fixes #69637

### Previous Behavior

`salt-call state.apply` on 3006.26/3006.27 prints repeated `TransportWarning: Unclosed transport! <salt.transport.zeromq.RequestClient>` messages, with a stack pointing at `HighState.__init__` -> `get_file_client` -> `RemoteClient.__init__`. This is the warning added by PR #65559.

### New Behavior

Both `HighState.__init__` and `State.__init__` wrap their post-`get_file_client` bodies in `try/except` and call `.destroy()` on the freshly-allocated fileclient before re-raising, so the ZeroMQ transport is torn down cleanly and `Transport.__del__` no longer trips the warning. `State._gather_pillar()` also destroys the temporary `Pillar` in a `try/finally` so its channel doesn't rely on `__del__` ordering at shutdown.

### Merge requirements satisfied?

- [x] Docs (no user-facing docs change; behavior fix only)
- [x] Changelog (`changelog/69637.fixed.md`)
- [x] Tests written/updated (`tests/pytests/unit/state/test_highstate_transport_cleanup.py`)

### Commits signed with GPG?

Yes
