### PR TITLE
Fix salt.utils.systemd for Python 3.6 salt-ssh targets (#68778)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2244,6 +2244,11 @@ repos:
       - id: pyupgrade
         name: Upgrade code to Py3.10+
         args: [--py310-plus, --keep-mock]
+        # salt/utils/systemd.py is bundled in the salt-ssh thin (which
+        # advertises 3.0+ target Pythons via salt/utils/thin.py py3:3:0),
+        # so it must stay importable/callable on Python 3.6 targets.
+        # pyupgrade's --py310-plus rewrites stdout=/stderr=PIPE to
+        # capture_output=True, which is 3.7+; exclude it here. See #68778.
         exclude: >
           (?x)^(
             salt/client/ssh/ssh_py_shim.py
@@ -2251,6 +2256,8 @@ repos:
             salt/client/ssh/wrapper/pillar.py
             |
             salt/ext/.*\.py
+            |
+            salt/utils/systemd.py
           )$
 
   - repo: https://github.com/saltstack/pre-commit-remove-import-headers

--- a/changelog/68778.fixed.md
+++ b/changelog/68778.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.utils.systemd` using `subprocess.run(capture_output=True)`, which is Python 3.7+, so the module remains importable and callable on the Python 3.6 targets that salt-ssh's thin still advertises support for. Replaced with the equivalent `stdout=subprocess.PIPE`/`stderr=subprocess.PIPE` form in `status()` and `_pid_to_service_systemctl()`.

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -90,10 +90,17 @@ def status(context=None):
             return context[contextkey]
     elif context is not None:
         raise SaltInvocationError("context must be a dictionary if passed")
+    # Use stdout=/stderr=PIPE rather than capture_output so this module
+    # remains importable/callable on the Python 3.6 interpreters that
+    # salt-ssh still advertises as supported target Pythons (see
+    # salt/utils/thin.py py3:3:0 and #68778). capture_output is 3.7+.
+    # NOTE: this file is excluded from pyupgrade in .pre-commit-config.yaml
+    # so that the rewrite back to capture_output=True is suppressed.
     proc = subprocess.run(
         ["systemctl", "status"],
         check=False,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     ret = (
         b"Failed to get D-Bus connection: No such file or directory" not in proc.stderr
@@ -175,7 +182,10 @@ def _pid_to_service_systemctl(pid):
             systemd_cmd,
             check=True,
             text=True,
-            capture_output=True,
+            # See status() above: capture_output is 3.7+, but salt-ssh's
+            # thin advertises 3.0+ as a supported target Python (#68778).
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         status_json = salt.utils.json.find_json(systemd_output.stdout)
     except (ValueError, subprocess.CalledProcessError):

--- a/tests/unit/utils/test_systemd.py
+++ b/tests/unit/utils/test_systemd.py
@@ -362,3 +362,48 @@ class SystemdTestCase(TestCase):
         dbus_mock.GetUnitByPID = Mock(site_effect=dbus_mock.DBusException)
         with patch("salt.utils.systemd.dbus", dbus_mock):
             assert _systemd.pid_to_service(99999) is None
+
+    def test_status_does_not_use_capture_output_kwarg(self):
+        """
+        Regression test for #68778.
+
+        salt-ssh's thin advertises Python 3.0+ as a supported target
+        interpreter (see ``salt/utils/thin.py`` ``py3:3:0``), which means
+        ``salt.utils.systemd`` must import and run on Python 3.6 targets
+        (e.g. stock RHEL 8 system Python). ``subprocess.run``'s
+        ``capture_output`` keyword was added in Python 3.7, so any call
+        site that passes it raises ``TypeError`` on 3.6.  Assert that
+        ``status()`` uses the equivalent ``stdout=PIPE, stderr=PIPE``
+        form instead of ``capture_output=True``.
+        """
+        run_mock = Mock(return_value=Mock(stderr=b""))
+        with patch("salt.utils.systemd.subprocess.run", run_mock):
+            _systemd.status({})
+        run_mock.assert_called_once()
+        _, kwargs = run_mock.call_args
+        assert "capture_output" not in kwargs, (
+            "salt.utils.systemd.status() must not use capture_output=; "
+            "it is Python 3.7+ only and salt-ssh targets can run 3.6."
+        )
+        assert kwargs.get("stdout") is subprocess.PIPE
+        assert kwargs.get("stderr") is subprocess.PIPE
+
+    @patch("salt.utils.systemd.dbus", False)
+    def test_pid_to_service_systemctl_does_not_use_capture_output_kwarg(self):
+        """
+        Regression test for #68778. See ``test_status_does_not_use_capture_output_kwarg``
+        for background — the same constraint applies to
+        ``_pid_to_service_systemctl``.
+        """
+        run_mock = Mock(return_value=Mock(stdout='{"_SYSTEMD_UNIT":"foo.service"}'))
+        with patch("salt.utils.systemd.subprocess.run", run_mock):
+            _systemd.pid_to_service(1234)
+        run_mock.assert_called_once()
+        _, kwargs = run_mock.call_args
+        assert "capture_output" not in kwargs, (
+            "salt.utils.systemd._pid_to_service_systemctl() must not use "
+            "capture_output=; it is Python 3.7+ only and salt-ssh targets "
+            "can run 3.6."
+        )
+        assert kwargs.get("stdout") is subprocess.PIPE
+        assert kwargs.get("stderr") is subprocess.PIPE


### PR DESCRIPTION
### What does this PR do?

Rewrites the two `subprocess.run(..., capture_output=True)` calls in `salt/utils/systemd.py` to use the equivalent `stdout=subprocess.PIPE, stderr=subprocess.PIPE` form so the module remains importable and callable on Python 3.6 targets.

`salt/utils/systemd.py` is bundled into the salt-ssh thin, and the thin's `supported-versions` manifest (built by `salt/utils/thin.py._get_supported_py_config`) advertises **`py3:3:0`** — i.e. any Python 3 interpreter is a supported target. `capture_output` is a Python 3.7+ keyword; on a stock RHEL 8 salt-ssh target (system Python 3.6), both call sites raise `TypeError` the moment they execute.

### What issues does this PR fix or reference?

Fixes #68778

### Previous Behavior

On salt-ssh runs whose remote is Python 3.6 (e.g. stock RHEL 8), any code path that reaches `salt.utils.systemd.status()` or `_pid_to_service_systemctl()` raised:

    TypeError: __init__() got an unexpected keyword argument 'capture_output'

### New Behavior

Both helpers now build the pipes explicitly:

    subprocess.run(
        ["systemctl", "status"],
        check=False,
        stdout=subprocess.PIPE,
        stderr=subprocess.PIPE,
    )

Behavior on Python 3.7+ is unchanged.

### Notes

- `pyupgrade` with `--py310-plus` unconditionally rewrites `stdout=/stderr=PIPE` back to `capture_output=True`, so `salt/utils/systemd.py` is added to the `pyupgrade` exclude list in `.pre-commit-config.yaml` (alongside the existing `salt/client/ssh/ssh_py_shim.py` entry). Without that exclude, the fix silently reverts on the first pre-commit run.
- Two regression tests in `tests/unit/utils/test_systemd.py` assert both call sites are invoked without the `capture_output` kwarg and with explicit `stdout=`/`stderr=PIPE`.
- Salt's `pyproject.toml` `requires-python = ">=3.8"` gates the master/minion install; it does not gate the thin's target-Python contract, which is what this issue is about. A prior attempt to fix this same bug (#68970) was closed on the strength of that mistake — this PR keeps the fix scoped to the thin-target constraint only.

### Merge requirements satisfied?
- [x] Docs (no user-facing docs change; behavior unchanged on all supported Pythons ≥3.7)
- [x] Changelog (`changelog/68778.fixed.md`)
- [x] Tests written (`tests/unit/utils/test_systemd.py::SystemdTestCase::test_status_does_not_use_capture_output_kwarg`, `::test_pid_to_service_systemctl_does_not_use_capture_output_kwarg`)

### Commits signed with GPG?
No — local commit signing key unavailable in this environment; DCO-equivalent authorship on the commit.
