### PR TITLE
Fix byte conversion factors off by a power of 10 in disk._parse_numbers

### DIFF
--- a/changelog/65490.fixed.md
+++ b/changelog/65490.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``disk._parse_numbers`` (used internally by ``disk.iostat`` on AIX) returning values that were off by a factor of 10 for byte counts with a K/M/G/T/P/E/Z/Y postfix, e.g. ``1.0K`` was parsed as ``10000.0`` instead of ``1000.0``.

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -40,14 +40,14 @@ def _parse_numbers(text):
 
     try:
         postPrefixes = {
-            "K": "10E3",
-            "M": "10E6",
-            "G": "10E9",
-            "T": "10E12",
-            "P": "10E15",
-            "E": "10E18",
-            "Z": "10E21",
-            "Y": "10E24",
+            "K": "1e3",
+            "M": "1e6",
+            "G": "1e9",
+            "T": "1e12",
+            "P": "1e15",
+            "E": "1e18",
+            "Z": "1e21",
+            "Y": "1e24",
         }
         if text[-1] in postPrefixes:
             v = decimal.Decimal(text[:-1])

--- a/tests/pytests/unit/modules/test_disk.py
+++ b/tests/pytests/unit/modules/test_disk.py
@@ -2,6 +2,8 @@
 :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
+import decimal
+
 import pytest
 
 import salt.modules.disk as disk
@@ -408,6 +410,25 @@ def test_format__nodiscard_xfs():
     with patch.dict(disk.__salt__, {"cmd.retcode": mock}):
         disk.format_(device=device, fs_type="xfs", discard=False)
         mock.assert_any_call(["mkfs", "-t", "xfs", "-K", device], ignore_retcode=True)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("1.0K", decimal.Decimal("1000.0")),
+        ("32.8K", decimal.Decimal("32800.0")),
+        ("1.0M", decimal.Decimal("1000000.0")),
+        ("1.0G", decimal.Decimal("1000000000.0")),
+        ("100", decimal.Decimal("100")),
+    ],
+)
+def test_parse_numbers_issue_65490(text, expected):
+    """
+    Test for issue #65490 where postfixed values returned by
+    _parse_numbers were off by a factor of 10 (e.g. "1.0K" was
+    parsed as 10000.0 instead of 1000.0)
+    """
+    assert disk._parse_numbers(text) == expected
 
 
 @pytest.mark.skip_on_windows(reason="Skip on Windows")


### PR DESCRIPTION
## What does this PR do

Fixes #65490.

`_parse_numbers` in `salt/modules/disk.py` (used internally by `disk.iostat` on AIX to parse `iostat` output) defines its K/M/G/T/P/E/Z/Y postfix multipliers as `"10E3"`, `"10E6"`, `"10E9"`, etc, which is ten times the actual SI value. This made every postfixed value ten times too large, e.g.:

```python
>>> float(_parse_numbers("1.0K"))
10000.0   # expected 1000.0
>>> float(_parse_numbers("32.8K"))
328000.0  # expected 32800.0
```

Changed the multipliers to `1e3`, `1e6`, `1e9`, `1e12`, `1e15`, `1e18`, `1e21`, `1e24` so the values match the standard SI prefixes.

## What issues does this PR fix or reference

Fixes #65490

## Test plan

Added `test_parse_numbers_issue_65490`, a parametrized test covering the two examples from the issue plus the M and G postfixes and a plain digit string. Ran the full `tests/pytests/unit/modules/test_disk.py` suite: 25 passed, 6 skipped (pre-existing, platform related). Formatted with `black` per the project's pre-commit config.

## Changelog

Added `changelog/65490.fixed.md`.