### PR TITLE
Fix postgres_database.absent reporting success when the drop fails

### DIFF
--- a/changelog/37506.fixed.md
+++ b/changelog/37506.fixed.md
@@ -1,0 +1,1 @@
+Report a failure when a PostgreSQL database exists but cannot be removed instead of claiming it is not present.

--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -225,6 +225,10 @@ def absent(
             ret["comment"] = f"Database {name} has been removed"
             ret["changes"][name] = "Absent"
             return ret
+        else:
+            ret["result"] = False
+            ret["comment"] = f"Database {name} failed to be removed"
+            return ret
 
     # fallback
     ret["comment"] = f"Database {name} is not present, so it cannot be removed"

--- a/tests/pytests/unit/states/postgresql/test_database.py
+++ b/tests/pytests/unit/states/postgresql/test_database.py
@@ -80,3 +80,24 @@ def test_absent():
             comt = f"Database {name} is not present, so it cannot be removed"
             ret.update({"comment": comt, "result": True, "changes": {}})
             assert postgres_database.absent(name) == ret
+
+
+def test_absent_removal_failure():
+    """
+    Test that a database which exists but cannot be removed (e.g. it is
+    still in use) is reported as a failure rather than as "not present".
+    """
+    name = "frank"
+
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    mock_exists = MagicMock(return_value=True)
+    mock_remove = MagicMock(return_value=False)
+    with patch.dict(
+        postgres_database.__salt__,
+        {"postgres.db_exists": mock_exists, "postgres.db_remove": mock_remove},
+    ):
+        with patch.dict(postgres_database.__opts__, {"test": False}):
+            comt = f"Database {name} failed to be removed"
+            ret.update({"comment": comt, "result": False, "changes": {}})
+            assert postgres_database.absent(name) == ret


### PR DESCRIPTION
### What does this PR do?

postgres_database.absent() reported result=True with the comment "Database X is not present, so it cannot be removed" whenever postgres.db_exists() was True but postgres.db_remove() failed (e.g. DROP DATABASE refused because the DB is in use), because control fell through to the fallback branch. The fix adds an else branch mirroring postgres_user.absent that sets result=False and comment "Database X failed to be removed". Verified the test fails on unpatched code (result=True, "not present" comment) and passes with the fix via direct-import exercise of absent(); the pytest harness itself hangs in this environment during salt-factories collection, so the identical code path was driven through a direct module import instead.

### What issues does this PR fix or reference?

Fixes #37506

### Previous Behavior

See #37506.

### New Behavior

Fix postgres_database.absent reporting success when the drop fails. Validated by a unit test (proven to fail on unpatched 3006.x) plus a live PostgreSQL 16 container check confirming the underlying DROP/ACL behaviour the fix relies on.

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

### Commits signed with GPG?

No
