### PR TITLE
Fix postgres.privileges_list crashing on an empty ACL

### DIFF
--- a/changelog/51450.fixed.md
+++ b/changelog/51450.fixed.md
@@ -1,0 +1,1 @@
+Fixed postgres.privileges_list raising ValueError on an emptied ACL so postgres_privileges.present can re-grant privileges after they were revoked

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -3149,8 +3149,15 @@ def privileges_list(
             result = result.strip("{}")
             parts = result.split(",")
             for part in parts:
-                perms_part, _ = part.split("/")
-                rolename, perms = perms_part.split("=")
+                if not part:
+                    # Empty ACL (e.g. after all privileges were revoked)
+                    continue
+                perms_part, _, _grantor = part.partition("/")
+                if "=" not in perms_part:
+                    # Malformed ACL entry; skip instead of crashing
+                    log.debug("Skipping malformed ACL entry: %s", part)
+                    continue
+                rolename, _, perms = perms_part.partition("=")
                 if rolename == "":
                     rolename = "public"
                 _tmp = _process_priv_part(perms)

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -1674,6 +1674,31 @@ def test_privileges_list_table(get_test_privileges_list_table_csv):
         )
 
 
+def test_privileges_list_table_empty_acl():
+    """
+    Test privilege listing on a table whose ACL has been emptied by REVOKE.
+
+    Regression test for #51450: an empty relacl ('{}') or an entry lacking
+    the '=' assignment must not raise ValueError but yield no privileges.
+    """
+    empty_acl_csv = 'name\n"{}"\n'
+    with patch(
+        "salt.modules.postgres._run_psql",
+        Mock(return_value={"retcode": 0, "stdout": empty_acl_csv}),
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
+        ret = postgres.privileges_list(
+            "awl",
+            "table",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+        assert ret == {}
+
+
 def test_privileges_list_group(get_test_privileges_list_group_csv):
     """
     Test privilege listing on a group

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -1699,6 +1699,88 @@ def test_privileges_list_table_empty_acl():
         assert ret == {}
 
 
+def test_privileges_list_table_mixed_malformed_acl_51450():
+    """
+    Test that valid ACL entries are still returned when the relacl also
+    contains entries the #51450 fix skips (no '=' assignment).
+
+    Skipping must be per-entry: junk entries may not take the valid ones
+    down with them, and may not raise ValueError as before the fix.
+    """
+    # object_type "table" (anything but "group") is the decisive argument:
+    # it is what postgres.has_privileges / the postgres_privileges state
+    # pass through, and it routes into the relacl-parsing branch that
+    # #51450 changed. prepend="public" matches has_privileges' default.
+    mixed_acl_csv = 'name\n"{baruwatest=arwdDxtm/baruwatest,garbage,junk/postgres}"\n'
+    with patch(
+        "salt.modules.postgres._run_psql",
+        Mock(return_value={"retcode": 0, "stdout": mixed_acl_csv}),
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
+        ret = postgres.privileges_list(
+            "awl",
+            "table",
+            prepend="public",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+        assert ret == {
+            "baruwatest": {
+                "INSERT": False,
+                "SELECT": False,
+                "UPDATE": False,
+                "DELETE": False,
+                "TRUNCATE": False,
+                "REFERENCES": False,
+                "TRIGGER": False,
+                "MAINTAIN": False,
+            }
+        }
+
+
+def test_privileges_list_table_public_grant_51450():
+    """
+    Test that a PUBLIC grant (empty rolename, e.g. '=r/postgres') is still
+    reported under the 'public' key and not skipped as malformed.
+
+    Guards against overcorrection of the #51450 fix: an entry with an empty
+    rolename contains '=' and is well-formed, so the malformed-entry skip
+    must not touch it. This passes with and without the fix.
+    """
+    public_acl_csv = 'name\n"{baruwatest=arwdDxtm/baruwatest,=r/baruwatest}"\n'
+    with patch(
+        "salt.modules.postgres._run_psql",
+        Mock(return_value={"retcode": 0, "stdout": public_acl_csv}),
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
+        ret = postgres.privileges_list(
+            "awl",
+            "table",
+            prepend="public",
+            maintenance_db="db_name",
+            runas="user",
+            host="testhost",
+            port="testport",
+            user="testuser",
+            password="testpassword",
+        )
+        assert ret == {
+            "baruwatest": {
+                "INSERT": False,
+                "SELECT": False,
+                "UPDATE": False,
+                "DELETE": False,
+                "TRUNCATE": False,
+                "REFERENCES": False,
+                "TRIGGER": False,
+                "MAINTAIN": False,
+            },
+            "public": {"SELECT": False},
+        }
+
+
 def test_privileges_list_group(get_test_privileges_list_group_csv):
     """
     Test privilege listing on a group


### PR DESCRIPTION
### What does this PR do?

In salt/modules/postgres.py, privileges_list parsed each relacl entry with unguarded part.split("/") and perms_part.split("="); once all privileges are revoked the relacl is emptied to '{}', so the split raised ValueError('not enough values to unpack') and crashed postgres_privileges.present when re-granting. The fix skips empty parts, uses str.partition() and requires '=' before unpacking (logging and skipping malformed entries), so an emptied ACL yields no privileges and the state proceeds to re-grant while well-formed ACLs are unchanged. Added a unit test that returns an empty '{}' ACL and asserts privileges_list returns {}; verified it fails with the exact ValueError on the unpatched code and passes with the fix (control test_privileges_list_table still passes).

### What issues does this PR fix or reference?

Fixes #51450

### Previous Behavior

See #51450.

### New Behavior

Fix postgres.privileges_list crashing on an empty ACL. Validated by a unit test (proven to fail on unpatched 3006.x) plus a live PostgreSQL 16 container check confirming the underlying DROP/ACL behaviour the fix relies on.

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

### Commits signed with GPG?

No
