### PR TITLE
Fix mysql.db_remove system-database guard checking a misspelled name

### DIFF
--- a/changelog/54938.fixed.md
+++ b/changelog/54938.fixed.md
@@ -1,0 +1,1 @@
+Fixed mysql.db_remove so it correctly refuses to drop the information_schema system database, which was previously misspelled as information_scheme.

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1364,7 +1364,7 @@ def db_remove(name, **connection_args):
         log.info("DB '%s' does not exist", name)
         return False
 
-    if name in ("mysql", "information_scheme"):
+    if name in ("mysql", "information_schema"):
         log.info("DB '%s' may not be removed", name)
         return False
 

--- a/tests/pytests/unit/modules/test_mysql.py
+++ b/tests/pytests/unit/modules/test_mysql.py
@@ -483,6 +483,21 @@ def test_db_remove():
         _test_call(mysql.db_remove, "DROP DATABASE `test``'\" db`;", "test`'\" db")
 
 
+def test_db_remove_system_db():
+    """
+    Test that MySQL db_remove refuses to drop the protected system databases
+    and never issues a DROP for them (regression test for #54938 where
+    "information_schema" was misspelled as "information_scheme").
+    """
+    for name in ("mysql", "information_schema"):
+        connect_mock = MagicMock()
+        with patch.object(
+            mysql, "db_exists", MagicMock(return_value=True)
+        ), patch.object(mysql, "_connect", connect_mock):
+            assert mysql.db_remove(name) is False
+            connect_mock.assert_not_called()
+
+
 def test_db_tables():
     """
     Test MySQL db_tables function in mysql exec module

--- a/tests/pytests/unit/modules/test_mysql.py
+++ b/tests/pytests/unit/modules/test_mysql.py
@@ -498,6 +498,33 @@ def test_db_remove_system_db():
             connect_mock.assert_not_called()
 
 
+def test_db_remove_allows_db_named_information_scheme_54938():
+    """
+    Test that db_remove issues DROP DATABASE for a user database literally
+    named "information_scheme" (the misspelling that used to sit in the
+    system-database guard before #54938 was fixed). Called the same way the
+    production caller mysql_database.absent() calls it: just the database
+    name, with connection_args empty.
+    """
+    with patch.object(mysql, "db_exists", MagicMock(return_value=True)):
+        _test_call(
+            mysql.db_remove, "DROP DATABASE `information_scheme`;", "information_scheme"
+        )
+
+
+def test_db_remove_does_not_block_similar_names_54938():
+    """
+    Guard against overcorrection of the #54938 fix: db_remove must still
+    issue DROP DATABASE for user databases whose names merely resemble the
+    protected system databases. This test passes with and without the fix
+    applied. Like the production caller mysql_database.absent(), db_remove
+    is called with just the database name (connection_args empty).
+    """
+    for name in ("mysql_backup", "information_schema_old"):
+        with patch.object(mysql, "db_exists", MagicMock(return_value=True)):
+            _test_call(mysql.db_remove, f"DROP DATABASE `{name}`;", name)
+
+
 def test_db_tables():
     """
     Test MySQL db_tables function in mysql exec module


### PR DESCRIPTION
### What does this PR do?

db_remove() in salt/modules/mysql.py guarded the system databases by comparing the name against the misspelled "information_scheme", so the guard never matched and the real information_schema database was not protected from a DROP. Changed the literal on line 1367 to "information_schema". Added test_db_remove_system_db which mocks db_exists=True and asserts db_remove returns False and never calls _connect for "mysql" and "information_schema"; verified it fails on the unpatched code and passes with the fix.

### What issues does this PR fix or reference?

Fixes #54938

### Previous Behavior

See #54938.

### New Behavior

Fix mysql.db_remove system-database guard checking a misspelled name. Validated by a unit test proven to fail on unpatched 3006.x and pass with the fix (confirmed by adversarial review).

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

### Commits signed with GPG?

No
