### PR TITLE
Fix grain PCRE/glob matching against dict-valued grains

### DIFF
--- a/changelog/35567.fixed.md
+++ b/changelog/35567.fixed.md
@@ -1,0 +1,1 @@
+Fixed grain_pcre and glob matching against dictionary-valued grains so patterns are applied to dict keys, not only list members.

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -925,6 +925,13 @@ def subdict_match(
         if not ret and pattern in target:
             # We might want to search for a key
             ret = True
+        if not ret and any(
+            _match(key, pattern, regex_match=regex_match, exact_match=exact_match)
+            for key in target
+        ):
+            # The pattern may be a regex/glob that matches one of the keys,
+            # just like list members are matched below
+            ret = True
         if not ret and subdict_match(
             target, pattern, regex_match=regex_match, exact_match=exact_match
         ):

--- a/tests/pytests/unit/utils/test_data.py
+++ b/tests/pytests/unit/utils/test_data.py
@@ -168,6 +168,45 @@ def test_subdict_match_regex_on_dict_keys():
     )
 
 
+def test_subdict_match_dict_keys_no_overcorrection_35567():
+    """
+    Guards against overcorrection of the issue #35567 fix. The new
+    key-matching branch in subdict_match runs for every caller, so it must
+    not loosen matching for the paths the fix was not meant to change.
+    These assertions hold both with and without the fix applied.
+    """
+    dict_grain = {
+        "roles": {"roleA": None, "roleB": ["envA", "envB"], "roleC": ["envA"]}
+    }
+
+    # exact_match=True is the production shape passed by
+    # salt/matchers/pillar_exact_match.py and the master-side cache check in
+    # salt/utils/minions.py. Glob/regex metacharacters must stay literal:
+    # the new branch must not start wildcard-matching dict keys here.
+    assert not salt.utils.data.subdict_match(
+        dict_grain, "roles:role*", exact_match=True
+    )
+    assert not salt.utils.data.subdict_match(
+        dict_grain, "roles:role.*", exact_match=True
+    )
+    # A literal key still matches under exact_match=True.
+    assert salt.utils.data.subdict_match(dict_grain, "roles:roleA", exact_match=True)
+
+    # Glob negative case (grain_match production shape, regex_match=False):
+    # a glob matching none of the keys must not match.
+    assert not salt.utils.data.subdict_match(dict_grain, "roles:bogus*")
+
+    # Deeper expressions must still require the deeper levels to match; a
+    # key-only match on 'roleC' must not satisfy 'roles:roleC:envB' when
+    # envB is not present under roleC.
+    assert not salt.utils.data.subdict_match(
+        dict_grain, "roles:roleC:envB", regex_match=True
+    )
+    assert salt.utils.data.subdict_match(
+        dict_grain, "roles:roleB:envB", regex_match=True
+    )
+
+
 @pytest.mark.parametrize(
     "wildcard",
     [

--- a/tests/pytests/unit/utils/test_data.py
+++ b/tests/pytests/unit/utils/test_data.py
@@ -142,6 +142,32 @@ def test_subdict_match():
     assert salt.utils.data.subdict_match(test_three_level_dict, "a:*:c:v")
 
 
+def test_subdict_match_regex_on_dict_keys():
+    """
+    Tests that regex/glob patterns are applied to dict keys, not only to
+    list members. Regression test for issue #35567.
+    """
+    dict_grain = {
+        "roles": {"roleA": None, "roleB": ["envA", "envB"], "roleC": ["envA"]}
+    }
+    list_grain = {"roles": ["roleA", "roleB", "roleC"]}
+
+    # The list-valued grain has always matched a regex alternation ...
+    assert salt.utils.data.subdict_match(
+        list_grain, "roles:(roleA|roleB|roleC)", regex_match=True
+    )
+    # ... and the dict-valued grain should behave the same way against its keys.
+    assert salt.utils.data.subdict_match(
+        dict_grain, "roles:(roleA|roleB|roleC)", regex_match=True
+    )
+    # Glob patterns should also match dict keys.
+    assert salt.utils.data.subdict_match(dict_grain, "roles:role*")
+    # Negative case: a pattern that matches none of the keys must fail.
+    assert not salt.utils.data.subdict_match(
+        dict_grain, "roles:(roleX|roleY)", regex_match=True
+    )
+
+
 @pytest.mark.parametrize(
     "wildcard",
     [


### PR DESCRIPTION
### What does this PR do?

subdict_match in salt/utils/data.py only applied regex/fnmatch to list members and to literal dict keys, so a PCRE/glob pattern like 'roles:(roleA|roleB|roleC)' matched a list-valued grain but returned False for the equivalent dict-valued grain (issue #35567, reproduced against 3006.x). The fix adds a key scan in _dict_match using the existing _match() helper so dict keys are matched consistently with list members. Verified the new unit test fails on unpatched code (stashed the source fix -> FAIL) and passes with the fix; existing subdict_match tests still pass. Note: pytest hangs unless the pytest-salt-factories plugins are disabled via -p no:..., which is why the test command lists them.

### What issues does this PR fix or reference?

Fixes #35567

### Previous Behavior

See #35567.

### New Behavior

Fix grain PCRE/glob matching against dict-valued grains. Validated by a unit test proven to fail on unpatched 3006.x and pass with the fix (confirmed by adversarial review).

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

### Commits signed with GPG?

No
