### PR TITLE
fix: ensure pkgrepo key files are world-readable regardless of umask

### DIFF
--- a/changelog/66731.fixed.md
+++ b/changelog/66731.fixed.md
@@ -1,0 +1,1 @@
+Ensure pkgrepo managed key files are world-readable (0o644) regardless of the process umask, preventing NO_PUBKEY errors on hardened systems.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2244,6 +2244,7 @@ def add_repo_key(
                 if keyfile.endswith(".decrypted"):
                     keyfile = keyfile[:-10]
             shutil.copyfile(str(key), str(keydir / keyfile))
+            os.chmod(str(keydir / keyfile), 0o644)
             return True
         else:
             cmd.extend(["add", cached_source_path])
@@ -2286,6 +2287,8 @@ def add_repo_key(
     cmd_ret = _call_apt(cmd, **kwargs)
 
     if cmd_ret["retcode"] == 0:
+        if not aptkey and keyserver and keyfile:
+            os.chmod(str(keydir / keyfile), 0o644)
         return True
     log.error("Unable to add repo key: %s", cmd_ret["stderr"])
     return False

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -624,7 +624,9 @@ def test_add_repo_key_key_url_sets_world_readable_permissions(tmp_path):
     keydir = tmp_path / "keyrings"
     keydir.mkdir()
     cached = tmp_path / "microsoft.asc"
-    cached.write_text("-----BEGIN PGP PUBLIC KEY BLOCK-----\nFAKEKEYDATA\n-----END PGP PUBLIC KEY BLOCK-----\n")
+    cached.write_text(
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\nFAKEKEYDATA\n-----END PGP PUBLIC KEY BLOCK-----\n"
+    )
 
     with patch.dict(
         aptpkg.__salt__,
@@ -664,7 +666,10 @@ def test_add_repo_key_keyserver_sets_world_readable_permissions(tmp_path):
         },
     ), patch("salt.modules.aptpkg.get_repo_keys", MagicMock(return_value={})), patch(
         "salt.utils.path.which", MagicMock(return_value="/usr/bin/gpg")
-    ), patch("salt.modules.aptpkg._call_apt", MagicMock(return_value={"retcode": 0, "stdout": ""})), patch(
+    ), patch(
+        "salt.modules.aptpkg._call_apt",
+        MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    ), patch(
         "salt.modules.aptpkg.os.chmod", MagicMock()
     ) as mock_chmod:
         ret = aptpkg.add_repo_key(

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -615,6 +615,70 @@ def test_decrypt_key_skips_dearmor_for_asc_destination_68464(tmp_path):
     assert not cmd_run_all.called
 
 
+def test_add_repo_key_key_url_sets_world_readable_permissions(tmp_path):
+    """
+    Test that a key imported via key_url with aptkey=False is saved
+    with world-readable permissions (0o644) regardless of the process
+    umask.
+    """
+    keydir = tmp_path / "keyrings"
+    keydir.mkdir()
+    cached = tmp_path / "microsoft.asc"
+    cached.write_text("-----BEGIN PGP PUBLIC KEY BLOCK-----\nFAKEKEYDATA\n-----END PGP PUBLIC KEY BLOCK-----\n")
+
+    with patch.dict(
+        aptpkg.__salt__,
+        {
+            "cp.cache_file": MagicMock(return_value=str(cached)),
+            "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": "OK"}),
+        },
+    ), patch("salt.modules.aptpkg.get_repo_keys", MagicMock(return_value={})), patch(
+        "salt.utils.path.which", MagicMock(return_value=None)
+    ):
+        ret = aptpkg.add_repo_key(
+            path="salt://files/microsoft.asc",
+            aptkey=False,
+            keydir=keydir,
+        )
+
+    assert ret is True
+    dest = keydir / "microsoft.asc"
+    assert dest.is_file()
+    assert dest.stat().st_mode & 0o777 == 0o644
+
+
+def test_add_repo_key_keyserver_sets_world_readable_permissions(tmp_path):
+    """
+    Test that a key imported via keyserver with aptkey=False gets its
+    permissions set to world-readable (0o644) after the gpg command
+    completes successfully.
+    """
+    keydir = tmp_path / "keyrings"
+    keydir.mkdir()
+    dest = keydir / "test-key.gpg"
+
+    with patch.dict(
+        aptpkg.__salt__,
+        {
+            "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": "OK"}),
+        },
+    ), patch("salt.modules.aptpkg.get_repo_keys", MagicMock(return_value={})), patch(
+        "salt.utils.path.which", MagicMock(return_value="/usr/bin/gpg")
+    ), patch("salt.modules.aptpkg._call_apt", MagicMock(return_value={"retcode": 0, "stdout": ""})), patch(
+        "salt.modules.aptpkg.os.chmod", MagicMock()
+    ) as mock_chmod:
+        ret = aptpkg.add_repo_key(
+            keyserver="keyserver.ubuntu.com",
+            keyid="FBB75451",
+            keyfile="test-key.gpg",
+            aptkey=False,
+            keydir=keydir,
+        )
+
+    assert ret is True
+    mock_chmod.assert_called_once_with(str(dest), 0o644)
+
+
 def test_get_repo_keys(repo_keys_var):
     """
     Test - List known repo key details.


### PR DESCRIPTION
Fixes #66731

When `pkgrepo.managed` saves GPG key files via `add_repo_key` with `aptkey=False`, the destination file inherits permissions from the process umask. On hardened systems with umask 077, this produces mode 0o700 files that the `_apt` user cannot read, causing `apt-get update` to fail with `NO_PUBKEY` errors.

**Changes:**
1. `salt/modules/aptpkg.py`: Added `os.chmod(0o644)` after `shutil.copyfile` in the `key_url`/`path` branch, and after the gpg command succeeds in the `keyserver` branch. This matches the pattern used elsewhere in the salt codebase (e.g., `tls.py`, `cron.py`, `ssh.py`).

2. `tests/pytests/unit/modules/test_aptpkg.py`: Added two tests:
   - `test_add_repo_key_key_url_sets_world_readable_permissions` - verifies the key file from `key_url` gets 0o644
   - `test_add_repo_key_keyserver_sets_world_readable_permissions` - verifies chmod is called after gpg import