### PR TITLE
Fix vt.setwinsize passing negative ioctl request on Python 3.14 (#69705)

### DIFF
--- a/changelog/69705.fixed.md
+++ b/changelog/69705.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.utils.vt.setwinsize` and `getwinsize` to pass `termios.TIOCSWINSZ`/`TIOCGWINSZ` through to `fcntl.ioctl` unchanged, instead of sign-flipping the macOS value to a negative literal. Python 3.14 rejects negative ioctl request values with `Errno 25`, which broke `salt-ssh` on the 3008.x macOS onedir because `setwinsize` runs inside every spawned pty child's `preexec_fn`.

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -74,13 +74,18 @@ def setwinsize(child, rows=80, cols=80):
     Thank you for the shortcut PEXPECT
     """
     # pylint: disable=used-before-assignment
-    TIOCSWINSZ = getattr(termios, "TIOCSWINSZ", -2146929561)
-    if TIOCSWINSZ == 2148037735:
-        # Same bits, but with sign.
-        TIOCSWINSZ = -2146929561
     # Note, assume ws_xpixel and ws_ypixel are zero.
+    #
+    # Historical note: this used to fall back to a negative literal
+    # (-2146929561) when ``termios.TIOCSWINSZ`` compared equal to the
+    # unsigned macOS value 2148037735, working around an old CPython
+    # signed-cast quirk in ``fcntl.ioctl``. Python 3.14 rejects negative
+    # ``request`` values outright (Errno 25 "Inappropriate ioctl for
+    # device"), which broke salt-ssh on the 3008.x macOS onedir. The
+    # ``termios`` constant is authoritative on every supported platform,
+    # so pass it through unchanged.
     packed = struct.pack(b"HHHH", rows, cols, 0, 0)
-    fcntl.ioctl(child, TIOCSWINSZ, packed)
+    fcntl.ioctl(child, termios.TIOCSWINSZ, packed)
 
 
 def getwinsize(child):
@@ -90,9 +95,9 @@ def getwinsize(child):
 
     Thank you for the shortcut PEXPECT
     """
-    TIOCGWINSZ = getattr(termios, "TIOCGWINSZ", 1074295912)
+    # pylint: disable=used-before-assignment
     packed = struct.pack(b"HHHH", 0, 0, 0, 0)
-    ioctl = fcntl.ioctl(child, TIOCGWINSZ, packed)
+    ioctl = fcntl.ioctl(child, termios.TIOCGWINSZ, packed)
     return struct.unpack(b"HHHH", ioctl)[0:2]
 
 

--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -5,6 +5,7 @@ import signal
 import pytest
 
 import salt.utils.vt as vt
+from tests.support.mock import patch
 
 
 @pytest.mark.skip_on_windows(reason="salt.utils.vt.Terminal doesn't have _spawn.")
@@ -28,6 +29,74 @@ def test_isalive_no_child():
     aliveness = term.isalive()
     assert term.exitstatus == 0
     assert aliveness is False
+
+
+@pytest.mark.skip_on_windows(reason="setwinsize/getwinsize are POSIX-only.")
+def test_setwinsize_passes_termios_constant_unchanged():
+    """
+    Regression test for #69705.
+
+    ``setwinsize`` used to sign-flip the macOS value of ``TIOCSWINSZ``
+    (``2148037735``) to a negative int (``-2146929561``) as a workaround
+    for an old CPython signed-cast quirk. Python 3.14 rejects negative
+    ``request`` arguments to ``fcntl.ioctl`` outright, which broke
+    ``salt-ssh`` on the 3008.x macOS onedir because ``setwinsize`` runs
+    inside the ``preexec_fn`` of every spawned pty child.
+
+    The fix is to pass ``termios.TIOCSWINSZ`` through untouched. This
+    test simulates the macOS constant and asserts the value handed to
+    ``fcntl.ioctl`` matches ``termios.TIOCSWINSZ`` exactly (and is not
+    negative).
+    """
+    mac_tiocswinsz = 2148037735
+    captured = []
+
+    def fake_ioctl(fd, req, packed):
+        captured.append(req)
+        return b"\x00" * 8
+
+    with patch.object(
+        vt.termios, "TIOCSWINSZ", mac_tiocswinsz, create=True
+    ), patch.object(vt.fcntl, "ioctl", side_effect=fake_ioctl):
+        vt.setwinsize(0, 24, 80)
+
+    assert captured, "fcntl.ioctl was not called"
+    assert captured[0] == mac_tiocswinsz, (
+        f"setwinsize passed {captured[0]!r} to fcntl.ioctl; expected "
+        f"{mac_tiocswinsz!r} (termios.TIOCSWINSZ, unchanged). Python 3.14 "
+        "rejects negative ioctl request values."
+    )
+    assert captured[0] > 0, "ioctl request must not be negative on Python 3.14+"
+
+
+@pytest.mark.skip_on_windows(reason="setwinsize/getwinsize are POSIX-only.")
+def test_getwinsize_passes_termios_constant_unchanged():
+    """
+    Regression test for #69705 (``getwinsize`` companion).
+
+    ``getwinsize`` had a similar hard-coded negative fallback for
+    ``TIOCGWINSZ``. Make sure the ``termios`` constant is passed to
+    ``fcntl.ioctl`` unchanged, so no negative value can reach the kernel
+    on Python 3.14+.
+    """
+    import struct as _struct
+    import termios as _termios
+
+    captured = []
+
+    def fake_ioctl(fd, req, packed):
+        captured.append(req)
+        return _struct.pack(b"HHHH", 24, 80, 0, 0)
+
+    with patch.object(vt.fcntl, "ioctl", side_effect=fake_ioctl):
+        vt.getwinsize(0)
+
+    assert captured, "fcntl.ioctl was not called"
+    assert captured[0] == _termios.TIOCGWINSZ, (
+        f"getwinsize passed {captured[0]!r} to fcntl.ioctl; expected "
+        f"{_termios.TIOCGWINSZ!r} (termios.TIOCGWINSZ, unchanged)."
+    )
+    assert captured[0] > 0, "ioctl request must not be negative on Python 3.14+"
 
 
 @pytest.mark.parametrize("test_cmd", ["echo", "ls"])


### PR DESCRIPTION
### What does this PR do?

`salt.utils.vt.setwinsize` (and its sibling `getwinsize`) carried a
pexpect-era workaround that sign-flipped the macOS `TIOCSWINSZ`
constant (`2148037735`) to a negative literal (`-2146929561`) as a
work-around for an old CPython signed-cast quirk in `fcntl.ioctl`.
Python 3.14 rejects negative `ioctl` `request` values outright
(`[Errno 25] Inappropriate ioctl for device`), which breaks `salt-ssh`
on the 3008.x macOS onedir because `setwinsize` runs inside every
spawned pty child's `preexec_fn`.

`termios.TIOCSWINSZ` / `TIOCGWINSZ` exist on every POSIX platform this
code path reaches (the surrounding `try/except ImportError` only
excludes Windows, which never calls into `setwinsize`/`getwinsize`).
Pass the `termios` constants through unchanged.

### What issues does this PR fix or reference?

Fixes #69705

### Previous Behavior

On the 3008.x macOS onedir (bundled Python 3.14), every `salt-ssh`
invocation fails immediately with:

```
[WARNING ] Failed to spawn the VT: Exception occurred in preexec_fn.
[ERROR   ] Error while parsing the command output: Failed to spawn the
VT. Error: Exception occurred in preexec_fn.
```

The real child-side exception (swallowed by `subprocess`) is:

```
File ".../salt/utils/vt.py", line 452, in _preexec
    setwinsize(tty_fd, rows, cols)
File ".../salt/utils/vt.py", line 83, in setwinsize
    fcntl.ioctl(child, TIOCSWINSZ, packed)
OSError: [Errno 25] Inappropriate ioctl for device
```

3007.x is unaffected because its bundled Python (3.12) still cast the
negative request through to unsigned inside `fcntl.ioctl`.

### New Behavior

`salt-ssh` runs normally on 3008.x macOS. `setwinsize`/`getwinsize`
pass `termios.TIOCSWINSZ` / `TIOCGWINSZ` unchanged, so no negative
value ever reaches `fcntl.ioctl`.

### Regression test

`tests/pytests/unit/utils/test_vt.py::test_setwinsize_passes_termios_constant_unchanged`
patches `termios.TIOCSWINSZ` to the macOS unsigned value and asserts
`setwinsize` hands that value to `fcntl.ioctl` unchanged (and
positive). Fails on the unmodified 3006.x tree:

```
AssertionError: setwinsize passed -2146929561 to fcntl.ioctl;
expected 2148037735 (termios.TIOCSWINSZ, unchanged). Python 3.14
rejects negative ioctl request values.
```

Passes with the fix.

### Merge requirements satisfied?

- [x] Docs (no doc changes needed; historical rationale captured in
  the code comment)
- [x] Changelog (`changelog/69705.fixed.md`)
- [x] Tests written/updated

### Commits signed with GPG?

No (local key not configured in this environment; happy to re-sign if
required for merge).
