### PR TITLE
Unmask pillar values in file.serialize and file.decode (#69709)

### DIFF
--- a/changelog/69709.fixed.md
+++ b/changelog/69709.fixed.md
@@ -1,0 +1,1 @@
+Fixed file.serialize (dataset_pillar) and file.decode (contents_pillar) writing the pillar redaction placeholder (``**********``) into the managed file instead of the real values on 3008 and later, where pillar.get masks by default.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -8762,7 +8762,10 @@ def serialize(
         return _error(ret, "Only one of 'dataset' and 'dataset_pillar' is permitted")
 
     if dataset_pillar:
-        dataset = __salt__["pillar.get"](dataset_pillar)
+        # Since 3008, pillar.get masks scalar string values by default; pass
+        # unmask=True so the real values are serialized into the file instead
+        # of the redaction placeholder, matching file.managed contents_pillar.
+        dataset = __salt__["pillar.get"](dataset_pillar, unmask=True)
 
     if dataset is None:
         return _error(ret, "Neither 'dataset' nor 'dataset_pillar' was defined")
@@ -9255,7 +9258,10 @@ def decode(
     elif encoded_data:
         content = encoded_data
     elif contents_pillar:
-        content = __salt__["pillar.get"](contents_pillar, False)
+        # Since 3008, pillar.get masks scalar string values by default; pass
+        # unmask=True so the decoded data written to the file is the real
+        # value rather than the redaction placeholder.
+        content = __salt__["pillar.get"](contents_pillar, False, unmask=True)
         if content is False:
             raise CommandExecutionError("Pillar data not found.")
     else:

--- a/tests/pytests/unit/states/file/test_filestate.py
+++ b/tests/pytests/unit/states/file/test_filestate.py
@@ -11,6 +11,7 @@ import salt.states.file as filestate
 import salt.utils.files
 import salt.utils.json
 import salt.utils.platform
+import salt.utils.secret
 import salt.utils.win_functions
 import salt.utils.yaml
 from salt.exceptions import CommandExecutionError
@@ -617,3 +618,46 @@ def test_recurse_test_mode_user_group_not_present():
         )
         assert ret["result"] is not False
         assert "is not available" not in ret["comment"]
+
+
+def _masking_pillar_get(masked_pillar):
+    """A fake pillar.get that masks scalar strings unless unmask=True."""
+
+    def _get(key, default=None, unmask=None, **kwargs):
+        value = masked_pillar.get(key, default)
+        if value is default:
+            return default
+        if unmask:
+            return salt.utils.secret.expose(value)
+        return salt.utils.secret.serial(value)
+
+    return _get
+
+
+def test_decode_contents_pillar_unmasks_pillar_values(tmp_path):
+    """
+    Regression test for issue #69709: file.decode with contents_pillar must
+    request unmasked pillar values, otherwise the redaction placeholder is
+    decoded and written to the file instead of the real data.
+    """
+    secret = "c3VwZXItc2VjcmV0LWtleQ=="  # base64, a scalar string in pillar
+    masked_pillar = salt.utils.secret.hide({"encoded_blob": secret})
+    captured = {}
+
+    def fake_decodefile(content, name, *args, **kwargs):
+        captured["content"] = content
+        return True
+
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "pillar.get": _masking_pillar_get(masked_pillar),
+            "file.file_exists": MagicMock(return_value=False),
+            "hashutil.base64_decodefile": fake_decodefile,
+            "hashutil.digest_file": MagicMock(return_value="deadbeef"),
+        },
+    ):
+        filestate.decode(str(tmp_path / "out.bin"), contents_pillar="encoded_blob")
+
+    assert captured["content"] == secret
+    assert captured["content"] != salt.utils.secret.REDACT_PLACEHOLDER

--- a/tests/pytests/unit/states/file/test_filestate.py
+++ b/tests/pytests/unit/states/file/test_filestate.py
@@ -661,3 +661,28 @@ def test_decode_contents_pillar_unmasks_pillar_values(tmp_path):
 
     assert captured["content"] == secret
     assert captured["content"] != salt.utils.secret.REDACT_PLACEHOLDER
+
+
+def test_decode_contents_pillar_missing_key_still_errors_69709(tmp_path):
+    """
+    Guard against overcorrection of the issue #69709 fix: file.decode passes
+    False as the positional default to pillar.get (now alongside unmask=True),
+    and a missing pillar key must still return that default untouched so the
+    'Pillar data not found.' error is raised instead of writing anything to
+    disk. This test passes both with and without the fix applied.
+    """
+    masked_pillar = salt.utils.secret.hide({})  # pillar key does not exist
+    decodefile = MagicMock()
+
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "pillar.get": _masking_pillar_get(masked_pillar),
+            "file.file_exists": MagicMock(return_value=False),
+            "hashutil.base64_decodefile": decodefile,
+        },
+    ):
+        with pytest.raises(CommandExecutionError, match="Pillar data not found."):
+            filestate.decode(str(tmp_path / "out.bin"), contents_pillar="missing_blob")
+
+    decodefile.assert_not_called()

--- a/tests/pytests/unit/states/file/test_serialize.py
+++ b/tests/pytests/unit/states/file/test_serialize.py
@@ -4,6 +4,7 @@ import salt.serializers.json as jsonserializer
 import salt.serializers.msgpack as msgpackserializer
 import salt.serializers.yaml as yamlserializer
 import salt.states.file as filestate
+import salt.utils.secret
 from tests.support.mock import MagicMock, patch
 
 
@@ -40,3 +41,50 @@ def test_file_serialize_tmp_dir_system_temp(tmp_path):
     ):
         filestate.serialize(str(tmp_file), dataset={"wollo": "herld"}, check_cmd="true")
         mock_mkstemp.assert_called_with(suffix="", dir=None)
+
+
+def _pillar_get(masked_pillar):
+    """
+    A fake pillar.get that mirrors salt.modules.pillar.get masking: it hands
+    back redacted values unless the caller passes unmask=True.
+    """
+
+    def _get(key, default=None, unmask=None, **kwargs):
+        value = masked_pillar.get(key, default if default is not None else {})
+        if unmask:
+            return salt.utils.secret.expose(value)
+        return salt.utils.secret.serial(value)
+
+    return _get
+
+
+def test_serialize_dataset_pillar_unmasks_pillar_values(tmp_path):
+    """
+    Regression test for issue #69709: file.serialize with dataset_pillar must
+    request unmasked pillar values, otherwise scalar string values are written
+    to the managed file as the redaction placeholder instead of the real data.
+    """
+    dataset = {"db_password": "hunter2", "api_key": "abcdef123456", "port": 5432}
+    masked_pillar = salt.utils.secret.hide({"app_config": dataset})
+
+    captured = {}
+
+    def fake_manage_file(name, **kwargs):
+        # contents is the serialized payload the state would write to disk
+        captured["contents"] = kwargs.get("contents")
+        return {"result": True, "changes": {}, "comment": "", "name": name}
+
+    target = tmp_path / "config.yaml"
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "pillar.get": _pillar_get(masked_pillar),
+            "file.manage_file": fake_manage_file,
+        },
+    ):
+        filestate.serialize(str(target), dataset_pillar="app_config", serializer="yaml")
+
+    written = captured["contents"]
+    assert salt.utils.secret.REDACT_PLACEHOLDER not in written
+    assert "hunter2" in written
+    assert "abcdef123456" in written

--- a/tests/pytests/unit/states/file/test_serialize.py
+++ b/tests/pytests/unit/states/file/test_serialize.py
@@ -88,3 +88,36 @@ def test_serialize_dataset_pillar_unmasks_pillar_values(tmp_path):
     assert salt.utils.secret.REDACT_PLACEHOLDER not in written
     assert "hunter2" in written
     assert "abcdef123456" in written
+
+
+def test_serialize_direct_dataset_bypasses_pillar_get_69709(tmp_path):
+    """
+    Guard against overcorrection of the issue #69709 fix: when a 'dataset'
+    argument is supplied directly (the non-pillar path), file.serialize must
+    not start routing the data through pillar.get at all, with or without
+    unmask=True. The dataset must be serialized exactly as given. This test
+    passes both with and without the fix applied.
+    """
+    dataset = {"db_password": "hunter2", "port": 5432}
+    captured = {}
+
+    def fake_manage_file(name, **kwargs):
+        captured["contents"] = kwargs.get("contents")
+        return {"result": True, "changes": {}, "comment": "", "name": name}
+
+    # pillar.get is a strict mock so any call to it is detectable
+    pillar_get = MagicMock()
+
+    target = tmp_path / "config.yaml"
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "pillar.get": pillar_get,
+            "file.manage_file": fake_manage_file,
+        },
+    ):
+        filestate.serialize(str(target), dataset=dataset, serializer="yaml")
+
+    pillar_get.assert_not_called()
+    assert "hunter2" in captured["contents"]
+    assert salt.utils.secret.REDACT_PLACEHOLDER not in captured["contents"]


### PR DESCRIPTION
### What does this PR do?

Passes `unmask=True` when `file.serialize` resolves `dataset_pillar` and when `file.decode` resolves `contents_pillar`. Since 3008, `pillar.get` masks scalar string values by default, so both states were reading redacted values and writing the placeholder (`**********`) into the managed file instead of the real data. This mirrors the `file.managed` `contents_pillar` path (already fixed) and the `_get_signing_policy` fix in #69636.

### What issues does this PR fix or reference?

Fixes #69709

### Previous Behavior

`file.serialize` with `dataset_pillar` and `file.decode` with `contents_pillar` wrote `**********` in place of every scalar string pulled from pillar, silently corrupting the managed file. Note this is distinct from #69160 (the pillar SLS renderer, fixed in 3008.1): the compiled pillar is intact, but these two consumer call sites re-mask the values on read.

### New Behavior

Both states write the real pillar values, consistent with `file.managed` `contents_pillar`.

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

Each fix has a unit test that drives the state with a masking-aware fake `pillar.get` and asserts the real value is written, not the redaction placeholder. Both were confirmed to fail on unpatched 3008.x and pass with the fix. The masking behaviour is pure-Python and platform independent, so no container/OS matrix is relevant.

### Commits signed with GPG?

No
