### PR TITLE
Add Python 3.9 upper caps for deps that drop 3.9 on next release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,8 +29,12 @@ immutables>=0.21; python_version < '3.7'
 # py3.10, and let py>=3.11 use the existing 8.7+ floor.
 importlib-metadata>=3.3.0,<9.0.0; python_version < '3.10'
 importlib-metadata>=8.7.0; python_version >= '3.10'
-jaraco.functools>=4.4.0
-jaraco.context>=6.1.1
+# jaraco.functools 4.5.0 and jaraco.context 6.1.2 drop Python 3.9; keep the
+# last 3.9-compatible releases there and let py>=3.10 float forward.
+jaraco.functools>=4.4.0,<4.5.0; python_version < '3.10'
+jaraco.functools>=4.4.0; python_version >= '3.10'
+jaraco.context>=6.1.1,<6.1.2; python_version < '3.10'
+jaraco.context>=6.1.1; python_version >= '3.10'
 jaraco.text>=4.2.0
 Jinja2>=3.1.6
 jmespath>=1.1.0
@@ -40,17 +44,27 @@ MarkupSafe>=3.0.3; python_version < '3.14'
 MarkupSafe>=3.0.3,<4.0.0; python_version >= '3.14'
 more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
 more-itertools>=11.1.0; python_version >= '3.10'
-msgpack>=1.1.2 ; python_version < '3.13'
+# msgpack 1.2.1 drops Python 3.9; keep the last 3.9-compatible release there.
+msgpack>=1.1.2,<1.2.1 ; python_version < '3.10'
+msgpack>=1.1.2 ; python_version >= '3.10' and python_version < '3.13'
 msgpack>=1.1.0 ; python_version >= '3.13'
 # multidict 6.0.4 fails to source-build under clang 17+ with strict int/pointer
 # conversion checks (macOS 15 onedir builds compile from sdist via
 # --no-binary=:all:). 6.6+ fixed the C source compatibility.
 multidict>=6.6.0
-opentelemetry-api>=1.41.1
-opentelemetry-sdk>=1.41.1
-opentelemetry-exporter-otlp-proto-http>=1.41.1
-opentelemetry-exporter-prometheus>=0.62b1
-xxhash>=3.7.0
+# opentelemetry 1.43.0 (and exporter-prometheus 0.64b0) drop Python 3.9; keep
+# the last 3.9-compatible releases there and let py>=3.10 float forward.
+opentelemetry-api>=1.41.1,<1.43.0; python_version < '3.10'
+opentelemetry-api>=1.41.1; python_version >= '3.10'
+opentelemetry-sdk>=1.41.1,<1.43.0; python_version < '3.10'
+opentelemetry-sdk>=1.41.1; python_version >= '3.10'
+opentelemetry-exporter-otlp-proto-http>=1.41.1,<1.43.0; python_version < '3.10'
+opentelemetry-exporter-otlp-proto-http>=1.41.1; python_version >= '3.10'
+opentelemetry-exporter-prometheus>=0.62b1,<0.64b0; python_version < '3.10'
+opentelemetry-exporter-prometheus>=0.62b1; python_version >= '3.10'
+# xxhash 3.8.0 drops Python 3.9; keep the last 3.9-compatible release there.
+xxhash>=3.7.0,<3.8.0; python_version < '3.10'
+xxhash>=3.7.0; python_version >= '3.10'
 # Packaging 24.1 imports annotations from __future__ which breaks salt ssh
 # tests on target hosts with older python versions.
 packaging>=26.2; python_version < '3.11'
@@ -66,7 +80,10 @@ pycparser>=3.0; python_version >= '3.10'
 # ships cp3X-win32 wheels.
 pymssql>=2.2.1,<=2.3.11; sys_platform == 'win32' and python_version < '3.11'
 pymssql==2.3.11; sys_platform == 'win32' and python_version >= '3.11'
-pyopenssl>=26.2.0
+# pyopenssl 26.3.0 requires cryptography>=49 which drops Python 3.9; keep the
+# last 3.9-compatible release there and let py>=3.10 float forward.
+pyopenssl>=26.2.0,<26.3.0; python_version < '3.10'
+pyopenssl>=26.2.0; python_version >= '3.10'
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 pythonnet>=3.0.1; sys_platform == 'win32' and python_version < '3.11'
@@ -90,7 +107,9 @@ truststore>=0.10.0; python_version >= "3.10"
 # (CVE-2025-66418, CVE-2026-21441).
 urllib3>=1.26.20,<2.0.0; python_version < '3.10'
 urllib3>=2.7.0; python_version >= '3.10'
-virtualenv>=21.4.2
+# virtualenv 21.5.1 drops Python 3.9; keep the last 3.9-compatible release there.
+virtualenv>=21.4.2,<21.5.1; python_version < '3.10'
+virtualenv>=21.4.2; python_version >= '3.10'
 # Transitive of virtualenv; some uv resolver caches pin a stale 3.25
 # version that conflicts with the CI floor of 3.29.1 on Python 3.10+.
 filelock>=3.29.1; python_version >= '3.10'
@@ -98,4 +117,6 @@ filelock>=3.19.1,<3.29.0; python_version < '3.10'
 vultr>=1.0.1
 wmi>=1.5.1; sys_platform == 'win32'
 xmltodict>=1.0.4; sys_platform == 'win32'
-zipp>=3.23.1
+# zipp 4.1.0 drops Python 3.9; keep the last 3.9-compatible release there.
+zipp>=3.23.1,<4.1.0; python_version < '3.10'
+zipp>=3.23.1; python_version >= '3.10'

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -68,12 +68,14 @@ toml
 # vcert 0.18.x adds hard pins on cryptography, pynacl, and six that
 # conflict with every other CI requirement; stay on 0.9.x.
 vcert~=0.9.0; sys_platform != 'win32'
-virtualenv>=21.4.2
+virtualenv>=21.4.2,<21.5.1; python_version < '3.10'
+virtualenv>=21.4.2; python_version >= '3.10'
 watchdog>=6.0.0
 websocket-client>=1.9.0
 # werkzeug is a dependency of moto
 werkzeug>=3.1.8
-xmldiff>=2.7.0
+xmldiff>=2.7.0,<3.0; python_version < '3.10'
+xmldiff>=2.7.0; python_version >= '3.10'
 # Available template libraries that can be used
 genshi>=0.7.11
 cheetah3>=3.2.6.post1

--- a/requirements/static/pkg/freebsd.txt
+++ b/requirements/static/pkg/freebsd.txt
@@ -6,7 +6,8 @@ cryptography>=46.0.7,<48.0.0; python_version < '3.10'
 cryptography>=48.0.0; python_version >= '3.10'
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.2.0
+pyopenssl>=26.2.0,<26.3.0; python_version < '3.10'
+pyopenssl>=26.2.0; python_version >= '3.10'
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 setproctitle>=1.3.7

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -7,7 +7,8 @@ cherrypy>=18.10.0
 cheroot>=11.1.2
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.2.0
+pyopenssl>=26.2.0,<26.3.0; python_version < '3.10'
+pyopenssl>=26.2.0; python_version >= '3.10'
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 rpm-vercmp


### PR DESCRIPTION
## Summary
- Grouped pip-updates PRs keep failing pre-commit/lint/build because Dependabot raises the shared floor of several packages to a release that drops Python 3.9 support, leaving the py3.9 lock targets unresolvable.
- This splits each such package into a `python_version < '3.10'` branch capped at the last 3.9-compatible release plus an open `python_version >= '3.10'` branch, mirroring the existing `cryptography`/`aiohttp`/`urllib3` splits. Dependabot then only bumps the uncapped py>=3.10 line and 3.9 stays resolvable.
- Packages capped: `jaraco.functools` (<4.5.0), `jaraco.context` (<6.1.2), `msgpack` (<1.2.1), `opentelemetry-api/sdk/exporter-otlp-proto-http` (<1.43.0), `opentelemetry-exporter-prometheus` (<0.64b0), `pyopenssl` (<26.3.0), `virtualenv` (<21.5.1), `xmldiff` (<3.0), `xxhash` (<3.8.0), `zipp` (<4.1.0).
- Input `.txt` only; no lock changes are required now (uv already backtracks py3.9 to these versions). This only future-proofs the floors.

## Test plan
- [ ] Pre-commit `pip-compile` hooks pass unchanged (verified locally: all lock targets already consistent).
- [ ] Full CI green.