### PR TITLE
Add Python 3.9 upper caps for 3.9-dropping deps and fix pip-compile hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -747,9 +747,10 @@ repos:
           - -c=requirements/static/pkg/py3.14/linux.lock
           - -o=requirements/static/ci/py3.14/linux.lock
 
+      - id: pip-compile
         alias: compile-ci-linux-3.13-zmq-requirements
         name: Linux CI Py3.13 ZeroMQ Requirements
-        files: ^requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(linux\.txt|common\.txt)|py3\.14/linux\.txt))$
+        files: ^requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(linux\.txt|common\.txt)|py3\.13/linux\.txt))$
         pass_filenames: false
         additional_dependencies: ["pip<26.0"]
         args:
@@ -970,9 +971,10 @@ repos:
           - -c=requirements/static/pkg/py3.14/freebsd.lock
           - -o=requirements/static/ci/py3.14/freebsd.lock
 
+      - id: pip-compile
         alias: compile-ci-freebsd-3.13-zmq-requirements
         name: FreeBSD CI Py3.13 ZeroMQ Requirements
-        files: ^requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(freebsd|common)\.txt|py3\.14/freebsd\.txt))$
+        files: ^requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(freebsd|common)\.txt|py3\.13/freebsd\.txt))$
         pass_filenames: false
         additional_dependencies: ["pip<26.0"]
         args:
@@ -1195,9 +1197,10 @@ repos:
           - -c=requirements/static/pkg/py3.14/darwin.lock
           - -o=requirements/static/ci/py3.14/darwin.lock
 
+      - id: pip-compile
         alias: compile-ci-darwin-3.13-zmq-requirements
         name: Darwin CI Py3.13 ZeroMQ Requirements
-        files: ^(requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(darwin|common)\.txt|py3\.14/darwin\.txt)))$
+        files: ^(requirements/(constraints\.txt|(base|zeromq|pytest)\.txt|static/((ci|pkg)/(darwin|common)\.txt|py3\.13/darwin\.txt)))$
         pass_filenames: false
         additional_dependencies: ["pip<26.0"]
         args:
@@ -1418,9 +1421,10 @@ repos:
           - -c=requirements/static/pkg/py3.14/windows.lock
           - -o=requirements/static/ci/py3.14/windows.lock
 
+      - id: pip-compile
         alias: compile-ci-windows-3.13-zmq-requirements
         name: Windows CI Py3.13 ZeroMQ Requirements
-        files: requirements/((base|zeromq|pytest)\.txt|static/((ci|pkg)/(windows|common)\.txt|py3\.14/windows\.txt))$
+        files: requirements/((base|zeromq|pytest)\.txt|static/((ci|pkg)/(windows|common)\.txt|py3\.13/windows\.txt))$
         pass_filenames: false
         additional_dependencies: ["pip<26.0"]
         args:
@@ -1777,6 +1781,7 @@ repos:
           - -c=requirements/static/ci/py3.14/linux.lock
           - -o=requirements/static/ci/py3.14/docs.lock
 
+      - id: pip-compile
         alias: compile-doc-requirements
         name: Docs CI Py3.13 Requirements
         files: ^requirements/(constraints\.txt|(base|zeromq|pytest|crypto)\.txt|static/ci/(docs|common|linux)\.txt|static/pkg/linux\.txt|static/pkg/.*/linux\.txt)$

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,8 +24,12 @@ frozenlist>=1.5.0; python_version >= '3.11'
 gitpython>=3.1.50
 immutables>=0.21
 importlib-metadata>=8.7.0
-jaraco.functools>=4.4.0
-jaraco.context>=6.1.1
+# jaraco.functools 4.5.0 and jaraco.context 6.1.2 drop Python 3.9; keep the
+# last 3.9-compatible releases there and let py>=3.10 float forward.
+jaraco.functools>=4.4.0,<4.5.0; python_version < '3.10'
+jaraco.functools>=4.4.0; python_version >= '3.10'
+jaraco.context>=6.1.1,<6.1.2; python_version < '3.10'
+jaraco.context>=6.1.1; python_version >= '3.10'
 jaraco.text>=4.2.0
 Jinja2>=3.1.6
 jmespath>=1.1.0
@@ -36,7 +40,9 @@ MarkupSafe<4.0.0
 # conversion checks (macOS 15 onedir builds compile from sdist via
 # --no-binary=:all:). 6.6+ fixed the C source compatibility.
 multidict>=6.6.0
-msgpack>=1.1.2
+# msgpack 1.2.1 drops Python 3.9; keep the last 3.9-compatible release there.
+msgpack>=1.1.2,<1.2.1; python_version < '3.10'
+msgpack>=1.1.2; python_version >= '3.10'
 # Packaging 24.1+ imports annotations from __future__ which breaks
 # salt-ssh on target hosts with older Python versions (Amazon Linux 2
 # still ships Python 3.7). 26.x additionally uses positional-only
@@ -54,7 +60,9 @@ pymysql>=1.2.0; sys_platform == 'win32'
 pyopenssl>=26.0.0,<26.2.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
-pythonnet>=3.0.5; sys_platform == 'win32'
+# pythonnet 3.1.0 drops Python 3.9; keep the last 3.9-compatible release there.
+pythonnet>=3.0.5,<3.1.0; sys_platform == 'win32' and python_version < '3.10'
+pythonnet>=3.0.5; sys_platform == 'win32' and python_version >= '3.10'
 tzdata; sys_platform == 'win32'
 pywin32>=312; sys_platform == 'win32'
 pycryptodomex>=3.23.0
@@ -72,17 +80,25 @@ tornado>=6.5.5
 # (CVE-2025-66418, CVE-2026-21441).
 urllib3>=1.26.20,<2.0.0; python_version < '3.10'
 urllib3>=2.7.0; python_version >= '3.10'
-virtualenv>=21.4.2
+# virtualenv 21.5.1 drops Python 3.9; keep the last 3.9-compatible release there.
+virtualenv>=21.4.2,<21.5.1; python_version < '3.10'
+virtualenv>=21.4.2; python_version >= '3.10'
 # Transitive of virtualenv; some uv resolver caches pin a stale 3.25
 # version that conflicts with the CI floor of 3.29.1 on Python 3.10+.
 filelock>=3.29.1; python_version >= '3.10'
 filelock>=3.19.1,<3.29.0; python_version < '3.10'
 wmi>=1.5.1; sys_platform == 'win32'
 xmltodict>=1.0.4; sys_platform == 'win32'
-zipp>=3.23.1
+# zipp 4.1.0 drops Python 3.9; keep the last 3.9-compatible release there.
+zipp>=3.23.1,<4.1.0; python_version < '3.10'
+zipp>=3.23.1; python_version >= '3.10'
 apache-libcloud>=3.8.0,<3.9.1; python_version < '3.10'
 apache-libcloud>=3.9.1; python_version >= '3.10'
 idna>=3.18
-more-itertools>=10.8.0
+# more-itertools 11.0.0 drops Python 3.9; keep the last 3.9-compatible release there.
+more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
+more-itertools>=10.8.0; python_version >= '3.10'
 pyasn1>=0.6.3
-pycparser>=2.23
+# pycparser 3.0 drops Python 3.9; keep the last 3.9-compatible release there.
+pycparser>=2.23,<3.0; python_version < '3.10'
+pycparser>=2.23; python_version >= '3.10'

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -59,12 +59,14 @@ toml
 # vcert 0.18.x adds hard pins on cryptography, pynacl, and six that
 # conflict with every other CI requirement; stay on 0.9.x.
 vcert~=0.9.0; sys_platform != 'win32'
-virtualenv>=21.4.2
+virtualenv>=21.4.2,<21.5.1; python_version < '3.10'
+virtualenv>=21.4.2; python_version >= '3.10'
 watchdog>=6.0.0
 websocket-client>=1.9.0
 # werkzeug is a dependency of moto
 werkzeug>=3.1.8
-xmldiff>=2.7.0
+xmldiff>=2.7.0,<3.0; python_version < '3.10'
+xmldiff>=2.7.0; python_version >= '3.10'
 # Available template libraries that can be used
 genshi>=0.7.11
 cheetah3>=3.2.6.post1

--- a/requirements/static/ci/py3.14/cloud.lock
+++ b/requirements/static/ci/py3.14/cloud.lock
@@ -727,6 +727,7 @@ toml==0.10.2
     #   -r requirements/static/ci/common.txt
 tornado==6.5.7
     # via
+    #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
 transitions==0.9.3

--- a/requirements/static/ci/py3.14/darwin.lock
+++ b/requirements/static/ci/py3.14/darwin.lock
@@ -4,17 +4,22 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   etcd3-py
+    #   kubernetes
 aiosignal==1.4.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   aiohttp
-apache-libcloud==3.9.0
+annotated-doc==0.0.4
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   typer
+apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -34,26 +39,22 @@ attrs==25.4.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   referencing
-autocommand==2.2.2
-    # via
-    #   -c requirements/static/pkg/py3.14/darwin.lock
-    #   jaraco-text
 bcrypt==5.0.0
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.42.33
+boto3==1.43.48
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.42.33
+botocore==1.43.48
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.1.4
+certifi==2026.5.20
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -91,11 +92,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
-croniter==6.0.0
+croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -125,10 +126,12 @@ durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.20.3
+filelock==3.29.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
+    #   python-discovery
     #   virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
@@ -138,7 +141,7 @@ frozenlist==1.8.0
     #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
-genshi==0.7.10
+genshi==0.7.11
     # via -r requirements/static/ci/common.txt
 gitdb==4.0.12
     # via
@@ -152,7 +155,7 @@ gitpython==3.1.50
     #   -r requirements/static/ci/darwin.txt
 hglib==2.6.2
     # via -r requirements/static/ci/darwin.txt
-idna==3.11
+idna==3.18
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -173,23 +176,27 @@ iniconfig==2.3.0
     # via pytest
 invoke==2.2.1
     # via paramiko
+jaraco-classes==3.4.0
+    # via keyring
 jaraco-collections==5.2.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
     #   jaraco-text
+    #   keyring
 jaraco-functools==4.4.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
+    #   keyring
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -199,7 +206,6 @@ jinja2==3.1.6
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
     #   junos-eznc
-    #   moto
 jmespath==1.1.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
@@ -217,9 +223,9 @@ junos-eznc==2.7.6
     # via -r requirements/static/ci/common.txt
 jxmlease==1.0.3
     # via -r requirements/static/ci/common.txt
-keyring==5.7.1
+keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==35.0.0
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -232,6 +238,10 @@ lxml==6.0.2
     #   xmldiff
 mako==1.3.10
     # via -r requirements/static/ci/common.txt
+markdown-it-py==4.2.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   rich
 markupsafe==2.1.5
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
@@ -239,7 +249,11 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   werkzeug
-mercurial==7.1.2
+mdurl==0.1.2
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   markdown-it-py
+mercurial==7.2.3
     # via -r requirements/static/ci/darwin.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -250,9 +264,10 @@ more-itertools==10.8.0
     #   -r requirements/pytest.txt
     #   cheroot
     #   cherrypy
+    #   jaraco-classes
     #   jaraco-functools
     #   jaraco-text
-moto==5.1.20
+moto==5.2.2
     # via -r requirements/static/ci/common.txt
 msgpack==1.1.2
     # via
@@ -262,6 +277,7 @@ msgpack==1.1.2
 multidict==6.7.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 ncclient==0.7.0
@@ -287,6 +303,7 @@ pathspec==1.0.3
 platformdirs==4.5.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   python-discovery
     #   virtualenv
 pluggy==1.6.0
     # via pytest
@@ -322,15 +339,18 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygit2==1.19.1
+pygit2==1.19.3
     # via -r requirements/static/ci/darwin.txt
-pygments==2.19.2
-    # via pytest
+pygments==2.20.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   pytest
+    #   rich
 pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.0.0
+pyopenssl==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -384,19 +404,18 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   croniter
     #   kubernetes
-    #   moto
     #   tempora
     #   vcert
+python-discovery==1.4.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   virtualenv
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.txt
 python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
-pytz==2025.2
-    # via
-    #   -c requirements/static/pkg/py3.14/darwin.lock
-    #   croniter
 pyvmomi==9.0.0.0
     # via -r requirements/static/ci/common.txt
 pyyaml==6.0.3
@@ -410,7 +429,7 @@ pyyaml==6.0.3
     #   responses
     #   yamllint
     #   yamlloader
-pyzmq==25.1.2
+pyzmq==27.1.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/zeromq.txt
@@ -437,11 +456,15 @@ responses==0.25.8
     # via moto
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.txt
+rich==15.0.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   typer
 rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.16.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -451,6 +474,10 @@ setproctitle==1.3.7
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
+shellingham==1.5.4
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   typer
 six==1.17.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
@@ -477,10 +504,22 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
+tornado==6.5.7
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   -r requirements/base.txt
 transitions==0.9.3
     # via junos-eznc
 trustme==1.2.1
     # via -r requirements/pytest.txt
+typer==0.26.7
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   typer-slim
+typer-slim==0.24.0
+    # via
+    #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   jaraco-text
 typing-extensions==4.14.1
     # via pytest-system-statistics
 urllib3==2.7.0
@@ -495,7 +534,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==20.36.1
+virtualenv==21.4.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -509,7 +548,7 @@ websocket-client==1.9.0
     #   kubernetes
 wempy==0.2.1
     # via -r requirements/static/ci/common.txt
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
@@ -530,7 +569,7 @@ zc-lockfile==4.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/docs.lock
+++ b/requirements/static/ci/py3.14/docs.lock
@@ -6,7 +6,7 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -16,7 +16,11 @@ aiosignal==1.4.0
     #   aiohttp
 alabaster==1.0.0
     # via sphinx
-apache-libcloud==3.9.0
+annotated-doc==0.0.4
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   typer
+apache-libcloud==3.9.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -24,17 +28,13 @@ attrs==25.4.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   aiohttp
-autocommand==2.2.2
-    # via
-    #   -c requirements/static/ci/py3.14/linux.lock
-    #   jaraco-text
 babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.1.4
+certifi==2026.5.20
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -62,11 +62,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-croniter==6.0.0
+croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -83,9 +83,11 @@ docutils==0.22.4
     # via
     #   pydata-sphinx-theme
     #   sphinx
-filelock==3.20.3
+filelock==3.29.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
+    #   -r requirements/base.txt
+    #   python-discovery
     #   virtualenv
 frozenlist==1.8.0
     # via
@@ -101,7 +103,7 @@ gitpython==3.1.50
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-idna==3.11
+idna==3.18
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -114,7 +116,7 @@ immutables==0.21
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
     #   contextvars
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -122,7 +124,7 @@ jaraco-collections==5.2.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -134,7 +136,7 @@ jaraco-functools==4.4.0
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -156,10 +158,12 @@ looseversion==1.3.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via
+    #   -c requirements/static/ci/py3.14/linux.lock
     #   mdit-py-plugins
     #   myst-docutils
+    #   rich
 markupsafe==2.1.5
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
@@ -169,8 +173,10 @@ markupsafe==2.1.5
 mdit-py-plugins==0.5.0
     # via myst-docutils
 mdurl==0.1.2
-    # via markdown-it-py
-more-itertools==10.8.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   markdown-it-py
+more-itertools==11.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -185,6 +191,7 @@ msgpack==1.1.2
 multidict==6.7.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 myst-docutils==5.0.0
@@ -197,6 +204,7 @@ packaging==24.0
 platformdirs==4.5.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
+    #   python-discovery
     #   virtualenv
 portend==3.2.1
     # via
@@ -229,13 +237,14 @@ pydata-sphinx-theme==0.18.0
     # via -r requirements/static/ci/docs.txt
 pyenchant==3.3.0
     # via sphinxcontrib-spelling
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   accessible-pygments
     #   pydata-sphinx-theme
+    #   rich
     #   sphinx
-pyopenssl==26.0.0
+pyopenssl==26.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -245,14 +254,14 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   croniter
     #   tempora
+python-discovery==1.4.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   virtualenv
 python-gnupg==0.5.6
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-pytz==2025.2
-    # via
-    #   -c requirements/static/ci/py3.14/linux.lock
-    #   croniter
 pyyaml==6.0.3
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
@@ -269,17 +278,24 @@ requests==2.33.1
     #   apache-libcloud
     #   sphinx
     #   sphinxcontrib-spelling
+rich==15.0.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   typer
 roman-numerals==4.1.0
     # via sphinx
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
+shellingham==1.5.4
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   typer
 six==1.17.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   python-dateutil
-    #   sphinxcontrib-httpdomain
 smmap==5.0.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
@@ -300,7 +316,7 @@ sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
-sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-httpdomain==2.0.0
     # via -r requirements/static/ci/docs.txt
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -314,6 +330,18 @@ tempora==5.8.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   portend
+tornado==6.5.7
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   -r requirements/base.txt
+typer==0.26.7
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   typer-slim
+typer-slim==0.24.0
+    # via
+    #   -c requirements/static/ci/py3.14/linux.lock
+    #   jaraco-text
 typing-extensions==4.15.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
@@ -326,7 +354,7 @@ urllib3==2.7.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.36.1
+virtualenv==21.4.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -338,7 +366,7 @@ zc-lockfile==4.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/freebsd.lock
+++ b/requirements/static/ci/py3.14/freebsd.lock
@@ -4,17 +4,22 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   etcd3-py
+    #   kubernetes
 aiosignal==1.4.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   aiohttp
-apache-libcloud==3.9.0
+annotated-doc==0.0.4
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   typer
+apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -34,26 +39,23 @@ attrs==25.4.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   referencing
-autocommand==2.2.2
-    # via
-    #   -c requirements/static/pkg/py3.14/freebsd.lock
-    #   jaraco-text
 bcrypt==5.0.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/static/ci/common.txt
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.42.33
+boto3==1.43.48
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.42.33
+botocore==1.43.48
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.1.4
+certifi==2026.5.20
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -95,16 +97,19 @@ clr-loader==0.2.10 ; sys_platform == 'win32'
 clustershell==1.9.3
     # via -r requirements/static/ci/common.txt
 colorama==0.4.6 ; sys_platform == 'win32'
-    # via pytest
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   pytest
+    #   typer
 contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-croniter==6.0.0 ; sys_platform != 'win32'
+croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -114,6 +119,7 @@ cryptography==46.0.7
     #   moto
     #   paramiko
     #   pyopenssl
+    #   secretstorage
     #   trustme
     #   vcert
 distlib==0.4.0
@@ -136,10 +142,12 @@ durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.20.3
+filelock==3.29.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
+    #   python-discovery
     #   virtualenv
 flaky==3.8.1
     # via -r requirements/pytest.txt
@@ -149,7 +157,7 @@ frozenlist==1.8.0
     #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
-genshi==0.7.10
+genshi==0.7.11
     # via -r requirements/static/ci/common.txt
 gitdb==4.0.12
     # via
@@ -162,7 +170,7 @@ gitpython==3.1.50
     #   -r requirements/static/ci/common.txt
 hglib==2.6.2
     # via -r requirements/static/ci/freebsd.txt
-idna==3.11
+idna==3.18
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -175,7 +183,7 @@ immutables==0.21
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   contextvars
-importlib-metadata==8.7.1
+importlib-metadata==9.0.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -184,33 +192,40 @@ iniconfig==2.3.0
     # via pytest
 invoke==2.2.1 ; sys_platform != 'win32'
     # via paramiko
+jaraco-classes==3.4.0
+    # via keyring
 jaraco-collections==5.2.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   jaraco-text
+    #   keyring
 jaraco-functools==4.4.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
+    #   keyring
     #   tempora
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   jaraco-collections
+jeepney==0.9.0 ; sys_platform == 'linux'
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   junos-eznc
-    #   moto
 jmespath==1.1.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -219,20 +234,24 @@ jmespath==1.1.0
     #   boto3
     #   botocore
 jsonschema==4.26.0
-    # via -r requirements/static/ci/common.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/static/ci/common.txt
 jsonschema-specifications==2025.9.1
     # via jsonschema
 junit-xml==1.9
     # via -r requirements/static/ci/common.txt
 junos-eznc==2.7.6 ; sys_platform != 'win32'
-    # via -r requirements/static/ci/common.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/static/ci/common.txt
 jxmlease==1.0.3 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 kazoo==2.10.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-keyring==5.7.1
+keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==35.0.0
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
@@ -240,7 +259,7 @@ looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-lxml==6.0.2
+lxml==6.1.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -249,6 +268,12 @@ lxml==6.0.2
     #   xmldiff
 mako==1.3.10
     # via -r requirements/static/ci/common.txt
+markdown-it-py==4.2.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/static/ci/common.txt
+    #   rich
 markupsafe==2.1.5
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -256,7 +281,11 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   werkzeug
-mercurial==7.1.2
+mdurl==0.1.2
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   markdown-it-py
+mercurial==7.2.3
     # via -r requirements/static/ci/freebsd.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -267,9 +296,10 @@ more-itertools==10.8.0
     #   -r requirements/pytest.txt
     #   cheroot
     #   cherrypy
+    #   jaraco-classes
     #   jaraco-functools
     #   jaraco-text
-moto==5.1.20
+moto==5.2.2
     # via -r requirements/static/ci/common.txt
 msgpack==1.1.2
     # via
@@ -279,6 +309,7 @@ msgpack==1.1.2
 multidict==6.7.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 ncclient==0.7.0 ; sys_platform != 'win32'
@@ -292,7 +323,7 @@ packaging==24.0
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   pytest
-paramiko==4.0.0 ; sys_platform != 'win32'
+paramiko==5.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/static/ci/common.txt
     #   junos-eznc
@@ -305,6 +336,7 @@ pathspec==1.0.3
 platformdirs==4.5.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   python-discovery
     #   virtualenv
 pluggy==1.6.0
     # via pytest
@@ -341,15 +373,18 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygments==2.19.2
-    # via pytest
+pygments==2.20.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   pytest
+    #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 pymssql==2.3.11 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-pymysql==1.1.2 ; sys_platform == 'win32'
+pymysql==1.2.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -357,7 +392,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.0.0
+pyopenssl==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -413,9 +448,12 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   croniter
     #   kubernetes
-    #   moto
     #   tempora
     #   vcert
+python-discovery==1.4.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   virtualenv
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.txt
 python-gnupg==0.5.6
@@ -427,19 +465,17 @@ pythonnet==3.0.5 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-pytz==2025.2 ; sys_platform != 'win32'
-    # via
-    #   -c requirements/static/pkg/py3.14/freebsd.lock
-    #   croniter
 pyvmomi==9.0.0.0
     # via -r requirements/static/ci/common.txt
-pywin32==311 ; sys_platform == 'win32'
+pywin32==312 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   docker
     #   pytest-skip-markers
     #   wmi
+pywin32-ctypes==0.2.3 ; sys_platform == 'win32'
+    # via keyring
 pyyaml==6.0.3
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -478,14 +514,20 @@ responses==0.25.8
     # via moto
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.txt
+rich==15.0.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   typer
 rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.16.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'
     # via junos-eznc
+secretstorage==3.5.0 ; sys_platform == 'linux'
+    # via keyring
 semantic-version==2.10.0
     # via etcd3-py
 setproctitle==1.3.7
@@ -493,6 +535,10 @@ setproctitle==1.3.7
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
+shellingham==1.5.4
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   typer
 six==1.17.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -523,12 +569,28 @@ timelib==0.3.0
     #   -r requirements/static/pkg/freebsd.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
+tornado==6.5.7
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
 transitions==0.9.3 ; sys_platform != 'win32'
     # via junos-eznc
 trustme==1.2.1
     # via -r requirements/pytest.txt
+typer==0.26.7
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   typer-slim
+typer-slim==0.24.0
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   jaraco-text
 typing-extensions==4.15.0
     # via pytest-system-statistics
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -541,7 +603,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-virtualenv==20.36.1
+virtualenv==21.4.2
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -555,7 +617,7 @@ websocket-client==1.9.0
     #   kubernetes
 wempy==0.2.1
     # via -r requirements/static/ci/common.txt
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
@@ -583,7 +645,7 @@ zc-lockfile==4.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/lint.lock
+++ b/requirements/static/ci/py3.14/lint.lock
@@ -727,6 +727,7 @@ tomlkit==0.14.0
     # via pylint
 tornado==6.5.7
     # via
+    #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
 transitions==0.9.3

--- a/requirements/static/ci/py3.14/linux.lock
+++ b/requirements/static/ci/py3.14/linux.lock
@@ -309,6 +309,7 @@ msgpack==1.1.2
 multidict==6.7.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 ncclient==0.7.0
@@ -565,6 +566,10 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
+tornado==6.5.7
+    # via
+    #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
 transitions==0.9.3
     # via junos-eznc
 trustme==1.2.1

--- a/requirements/static/ci/py3.14/windows.lock
+++ b/requirements/static/ci/py3.14/windows.lock
@@ -4,12 +4,13 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   aiohttp
-aiohttp==3.13.5
+aiohttp==3.14.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   etcd3-py
+    #   kubernetes
 aiosignal==1.4.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
@@ -18,7 +19,7 @@ annotated-doc==0.0.4
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   typer
-apache-libcloud==3.9.0
+apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -37,16 +38,16 @@ bcrypt==5.0.0
     # via -r requirements/static/ci/common.txt
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.42.33
+boto3==1.43.48
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.42.33
+botocore==1.43.48
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.2.25
+certifi==2026.5.20
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -96,7 +97,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -128,9 +129,10 @@ durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.25.0
+filelock==3.29.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   python-discovery
     #   virtualenv
@@ -142,7 +144,7 @@ frozenlist==1.8.0
     #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
-genshi==0.7.10
+genshi==0.7.11
     # via -r requirements/static/ci/common.txt
 gitdb==4.0.12
     # via
@@ -153,7 +155,7 @@ gitpython==3.1.50
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
-idna==3.11
+idna==3.18
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -172,21 +174,25 @@ importlib-metadata==8.7.1
     #   -r requirements/base.txt
 iniconfig==2.3.0
     # via pytest
+jaraco-classes==3.4.0
+    # via keyring
 jaraco-collections==5.2.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   cherrypy
-jaraco-context==6.1.0
+jaraco-context==6.1.2
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
     #   jaraco-text
+    #   keyring
 jaraco-functools==4.4.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
+    #   keyring
     #   tempora
 jaraco-text==4.2.0
     # via
@@ -197,7 +203,6 @@ jinja2==3.1.6
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-    #   moto
 jmespath==1.1.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
@@ -211,15 +216,15 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 junit-xml==1.9
     # via -r requirements/static/ci/common.txt
-keyring==5.7.1
+keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==35.0.0
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-lxml==6.0.2
+lxml==6.1.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -250,9 +255,10 @@ more-itertools==10.8.0
     #   -r requirements/pytest.txt
     #   cheroot
     #   cherrypy
+    #   jaraco-classes
     #   jaraco-functools
     #   jaraco-text
-moto==5.1.20
+moto==5.2.2
     # via -r requirements/static/ci/common.txt
 msgpack==1.1.2
     # via
@@ -262,6 +268,7 @@ msgpack==1.1.2
 multidict==6.7.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 oauthlib==3.3.1
@@ -316,7 +323,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygit2==1.19.1
+pygit2==1.19.3
     # via -r requirements/static/ci/windows.txt
 pygments==2.19.2
     # via
@@ -327,13 +334,13 @@ pymssql==2.3.11
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-pymysql==1.1.2
+pymysql==1.2.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.0.0
+pyopenssl==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -384,9 +391,8 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   botocore
     #   kubernetes
-    #   moto
     #   tempora
-python-discovery==1.1.0
+python-discovery==1.4.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   virtualenv
@@ -402,13 +408,15 @@ pythonnet==3.0.5
     #   -r requirements/base.txt
 pyvmomi==9.0.0.0
     # via -r requirements/static/ci/common.txt
-pywin32==311
+pywin32==312
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
     #   docker
     #   pytest-skip-markers
     #   wmi
+pywin32-ctypes==0.2.3
+    # via keyring
 pywinrm==0.5.0
     # via -r requirements/static/ci/windows.txt
 pyyaml==6.0.3
@@ -458,7 +466,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.16.0
+s3transfer==0.19.1
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.txt
@@ -497,6 +505,10 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
+tornado==6.5.6
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
 trustme==1.2.1
     # via -r requirements/pytest.txt
 typer==0.24.1
@@ -509,6 +521,10 @@ typer-slim==0.24.0
     #   jaraco-text
 typing-extensions==4.15.0
     # via pytest-system-statistics
+tzdata==2026.2
+    # via
+    #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
 urllib3==2.7.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
@@ -519,7 +535,7 @@ urllib3==2.7.0
     #   python-etcd
     #   requests
     #   responses
-virtualenv==21.1.0
+virtualenv==21.4.2
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -533,7 +549,7 @@ websocket-client==1.9.0
     #   kubernetes
 wempy==0.2.1
     # via -r requirements/static/ci/common.txt
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
@@ -560,7 +576,7 @@ zc-lockfile==4.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   cherrypy
-zipp==3.23.0
+zipp==4.1.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt


### PR DESCRIPTION
## Summary
Two coupled fixes that stop grouped pip-updates PRs from failing on 3006.x:

1. **Python 3.9 caps.** Dependabot raises the shared floor of several packages to a release that no longer supports Python 3.9, leaving the py3.9 lock targets unresolvable. Each is split into a `python_version < '3.10'` branch capped at the last 3.9-compatible release plus an open `python_version >= '3.10'` branch, mirroring the existing `cryptography`/`aiohttp`/`urllib3` splits. Packages capped: `jaraco.functools` (<4.5.0), `jaraco.context` (<6.1.2), `msgpack` (<1.2.1), `more-itertools` (<11.0.0), `pycparser` (<3.0), `pythonnet` (<3.1.0), `virtualenv` (<21.5.1), `xmldiff` (<3.0), `zipp` (<4.1.0). `cryptography` and `pyopenssl` already carry all-Python caps here, so they need no split.
2. **Malformed `pip-compile` hooks.** The Py3.13 ZeroMQ hooks (linux/freebsd/darwin/windows) and the docs hook were missing their `- id: pip-compile` line, so YAML folded them into the preceding Py3.14 blocks as duplicate keys and the Py3.14 CI locks never regenerated. This restores the missing ids, corrects the `py3.14`->`py3.13` file globs, and regenerates the affected Py3.14 locks.

## Test plan
- [ ] Pre-commit `pip-compile` hooks pass and converge.
- [ ] Full CI green (note: any pre-existing docs `Inconsistent title style` failure in `highstate.rst` is unrelated to this change).