### PR TITLE
Document the rest_cherrypy /token and /app endpoints (#69726)

### DIFF
--- a/changelog/69726.fixed.md
+++ b/changelog/69726.fixed.md
@@ -1,0 +1,1 @@
+Added the missing ``POST /token`` and ``GET /app`` sections to the rest_cherrypy REST API reference; their docstrings were never rendered because the page lacked autoclass entries for the Token and App handlers.

--- a/doc/ref/netapi/all/salt.netapi.rest_cherrypy.rst
+++ b/doc/ref/netapi/all/salt.netapi.rest_cherrypy.rst
@@ -33,6 +33,12 @@ REST URI Reference
 .. autoclass:: Logout
     :members: POST
 
+``/token``
+----------
+
+.. autoclass:: Token
+    :members: POST
+
 ``/minions``
 ------------
 
@@ -79,4 +85,10 @@ REST URI Reference
 ----------
 
 .. autoclass:: Stats
+    :members: GET
+
+``/app``
+--------
+
+.. autoclass:: App
     :members: GET


### PR DESCRIPTION
### What does this PR do?

Adds the two missing sections to the rest_cherrypy REST URI Reference: `POST /token` (`Token` handler) and `GET /app` (`App` handler). Every other handler class on the page has an `.. autoclass::` entry; these two were never included, so their endpoint docstrings (complete with request/response examples in Token's case) have never been rendered anywhere, and both endpoints are absent from the API reference and the HTTP routing table even though the running API routes them.

### What issues does this PR fix or reference?

Fixes #69726

### Previous Behavior

`POST /token` and `GET /app` were undocumented in the rendered docs.

### New Behavior

Both endpoints appear in the REST URI Reference in the existing page style and are listed in the HTTP routing table.

Verified with the pinned docs toolchain (sphinx 7.0.1, sphinxcontrib-httpdomain 2.0.0): `make html` and `make man` build clean with `-W -j auto --keep-going`; both new sections render with properly transformed field lists and anchors (`#post--token`, `#get--app`); each route registers exactly once in the http domain, so this does not interact with the duplicate-route cleanup in #69725.

### Merge requirements satisfied?

- [x] Changelog

Docs-only change; no runtime code paths affected.

### Commits signed with GPG?

No
