### PR TITLE
Skip sub events for non-dict job returns in the event tagger (#69730)

### DIFF
--- a/changelog/69730.fixed.md
+++ b/changelog/69730.fixed.md
@@ -1,0 +1,1 @@
+Fixed the master logging ``Event iteration failed with exception: 'list' object has no attribute 'items'`` for every failing state compilation: the return of a failed compile is a list of error strings, not a mapping of state results, and the event tagger assumed a dict.

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -937,6 +937,18 @@ class SaltEvent:
             ret = load.get("return", {})
             retcode = load["retcode"]
 
+        if not isinstance(ret, dict):
+            # A failing state compilation returns a list of error strings (or
+            # a plain string from some renderers) instead of a mapping of
+            # per-state results, so there are no state tags to fire sub
+            # events for.
+            log.debug(
+                "Skipping sub event for job %s: return is a %s, not a dict",
+                load.get("jid"),
+                type(ret).__name__,
+            )
+            return
+
         try:
             for tag, data in ret.items():
                 data["retcode"] = retcode

--- a/tests/pytests/unit/utils/event/test_event.py
+++ b/tests/pytests/unit/utils/event/test_event.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 import stat
 import time
@@ -340,3 +341,71 @@ def test_master_pub_permissions(sock_dir):
         assert bool(os.lstat(p).st_mode & stat.S_IRUSR)
         assert not bool(os.lstat(p).st_mode & stat.S_IRGRP)
         assert not bool(os.lstat(p).st_mode & stat.S_IROTH)
+
+
+@pytest.fixture
+def ret_load_event(sock_dir):
+    with salt.utils.event.SaltEvent(
+        "master", str(sock_dir), opts={"transport": "zeromq"}, listen=False
+    ) as event:
+        with patch.object(event, "fire_event") as fire_event:
+            yield event, fire_event
+
+
+def test_fire_ret_load_list_return_skips_quietly_69730(ret_load_event, caplog):
+    """
+    A failing state compilation returns a list of error strings rather than
+    a mapping of per-state results. fire_ret_load used to hand that list to
+    _fire_ret_load_specific_fun, which crashed on ret.items() and logged
+    "Event iteration failed with exception: 'list' object has no attribute
+    'items'" at ERROR for every failed compile. There are no state tags in
+    such a return, so it must be skipped without logging an error and
+    without firing sub events.
+    """
+    event, fire_event = ret_load_event
+    # The exact shape the master receives for a failed state.apply compile:
+    # fun in SUB_EVENT, a non-zero retcode, and a list-of-errors return.
+    load = {
+        "id": "minion",
+        "jid": "20260706000000000000",
+        "fun": "state.sls",
+        "retcode": 1,
+        "return": ["Rendering SLS 'base:broken' failed: Jinja error"],
+    }
+    with caplog.at_level(logging.ERROR, logger="salt.utils.event"):
+        event.fire_ret_load(load)
+    assert "Event iteration failed" not in caplog.text
+    fire_event.assert_not_called()
+
+
+def test_fire_ret_load_dict_return_still_fires_sub_events_69730(ret_load_event, caplog):
+    """
+    Guard against overcorrection: a dict-shaped failing state return (the
+    normal case) must keep firing the per-tag failure events exactly as
+    before the non-dict guard was added. This passes with and without the
+    fix.
+    """
+    event, fire_event = ret_load_event
+    tag = "file_|-broken_|-/etc/broken_|-managed"
+    load = {
+        "id": "minion",
+        "jid": "20260706000000000000",
+        "fun": "state.sls",
+        "retcode": 2,
+        "return": {tag: {"result": False, "comment": "no such file"}},
+    }
+    with caplog.at_level(logging.ERROR, logger="salt.utils.event"):
+        event.fire_ret_load(load)
+    assert "Event iteration failed" not in caplog.text
+    assert fire_event.call_count == 2
+    # old-style duplicate event: <state>.<func> tag
+    first_data, first_tag = fire_event.call_args_list[0][0]
+    assert first_tag == "file.managed"
+    assert first_data["retcode"] == 2
+    # namespaced job sub event, enriched with job metadata
+    second_data, second_tag = fire_event.call_args_list[1][0]
+    assert second_tag == "salt/job/20260706000000000000/sub/minion/error/state.sls"
+    assert second_data["jid"] == "20260706000000000000"
+    assert second_data["id"] == "minion"
+    assert second_data["success"] is False
+    assert second_data["fun"] == "state.sls"


### PR DESCRIPTION
### What does this PR do?

Stops the master's event tagger from crashing on non-dict job returns. A failing state compilation returns a list of error strings (or a plain string from some renderers) rather than a mapping of per-state results, and `_fire_ret_load_specific_fun` assumed a dict:

```
File "salt/utils/event.py", line 941, in _fire_ret_load_specific_fun
    for tag, data in ret.items():
AttributeError: 'list' object has no attribute 'items'
```

The broad `except` turned this into `Event iteration failed with exception: ...` logged at ERROR for every failed compile. The integration tests that assert that message never appears (`tests/pytests/integration/states/test_state_test.py`) fail whenever they share a run with a failing compile - this is the second failure cluster behind the "Rocky Linux 9 integration tcp/zeromq" noise on 3006.x PRs (12 occurrences in run 28764048341 job 85297152499; the first cluster, leaked minion keys, is addressed by #69729 and absent from that run).

A non-dict return has no state tags to fire sub events for, so it is now skipped at debug level after the return shape is resolved (the guard also covers the multi-function branches, where `ret.get(fun, {})` can produce a non-dict).

### What issues does this PR fix or reference?

Fixes #69730
Refs #69728

### Previous Behavior

Every failing state compilation made the master log `Event iteration failed with exception: 'list' object has no attribute 'items'`, and the test_state_test integration tests failed on the logged message.

### New Behavior

Non-dict returns are skipped quietly; dict-shaped returns fire the per-tag failure events exactly as before.

### Merge requirements satisfied?

- [x] Tests written/updated
- [x] Changelog

Two regression tests drive the production entry point `fire_ret_load` with a `SUB_EVENT` function and non-zero retcode: the list-return test reproduces the exact failed-compile load shape and fails on the previous code via the logged error; the dict-return test pins the two sub events (the old-style `<state>.<func>` duplicate tag and the namespaced `salt/job/<jid>/sub/<id>/error/<fun>` tag) with their enriched payload, guarding against overcorrection.

### Commits signed with GPG?

No
