### PR TITLE
Fix mod_aggregate for pkg state module when a version is specified in a pkgs argument

### DIFF
--- a/changelog/69736.fixed.md
+++ b/changelog/69736.fixed.md
@@ -1,0 +1,1 @@
+Fixed mod_aggregate for pkg state when an item in pkgs argument list contains a name: version dict

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -3655,7 +3655,7 @@ def mod_aggregate(low, chunks, running):
         return low
     is_sources = "sources" in low
     # use a dict instead of a set to maintain insertion order
-    pkgs = {}
+    pkgs: dict[str, set[str | None]] = {}
     for chunk in chunks:
         tag = __utils__["state.gen_tag"](chunk)
         if tag in running:
@@ -3692,10 +3692,10 @@ def mod_aggregate(low, chunks, running):
                     chunk["__agg__"] = True
     if pkgs:
         pkg_type = "sources" if is_sources else "pkgs"
-        low_pkgs = {}
+        low_pkgs: dict[str, set[str | None]] = {}
         _combine_pkgs(low_pkgs, low.get(pkg_type, []))
         for pkg, values in pkgs.items():
-            low_pkgs.setdefault(pkg, {None}).update(values)
+            low_pkgs.setdefault(pkg, set()).update(values)
         # the value is the version for pkgs and
         # the URI for sources
         low_pkgs_list = [
@@ -3707,13 +3707,13 @@ def mod_aggregate(low, chunks, running):
     return low
 
 
-def _combine_pkgs(pkgs_dict, additional_pkgs_list):
+def _combine_pkgs(pkgs_dict: dict[str, set[str | None]], additional_pkgs_list):
     for item in additional_pkgs_list:
         if isinstance(item, str):
             pkgs_dict.setdefault(item, {None})
         else:
-            for pkg, version in item:
-                pkgs_dict.setdefault(pkg, {None}).add(version)
+            for pkg, version in item.items():
+                pkgs_dict.setdefault(pkg, set()).add(version)
 
 
 def mod_watch(name, **kwargs):

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -467,7 +467,7 @@ def test_mod_aggregate():
             "__sls__": "47628",
             "__env __": "base",
             "__id__": "other_pkgs",
-            "pkgs": ["byobu"],
+            "pkgs": ["byobu", {"tput": "1.0.1"}],
             "aggregate": True,
             "order": 10002,
             "fun": "installed",
@@ -552,7 +552,7 @@ def test_mod_aggregate():
     }
 
     expected = {
-        "pkgs": ["byobu", "vim", "tmux", "google-cloud-sdk"],
+        "pkgs": ["byobu", {"tput": "1.0.1"}, "vim", "tmux", "google-cloud-sdk"],
         "name": "other_pkgs",
         "fun": "installed",
         "aggregate": True,

--- a/tests/pytests/unit/utils/requisite/test_dependency_graph.py
+++ b/tests/pytests/unit/utils/requisite/test_dependency_graph.py
@@ -312,7 +312,7 @@ def test_get_aggregate_chunks():
             "name": "packages-2",
             "state": "pkg",
             "fun": "installed",
-            "pkgs": ["cowsay", "fortune-mod"],
+            "pkgs": ["cowsay", "fortune-mod", {"tput": "1.0.1"}],
             "require": ["requirement"],
         },
         {
@@ -388,7 +388,7 @@ def test_get_dependencies():
             "name": "packages-2",
             "state": "pkg",
             "fun": "installed",
-            "pkgs": ["cowsay", "fortune-mod"],
+            "pkgs": ["cowsay", "fortune-mod", {"tput": "1.0.1"}],
             "require": ["requirement"],
         },
         {
@@ -465,7 +465,7 @@ def test_get_dependencies_when_aggregated():
             "name": "packages-2",
             "state": "pkg",
             "fun": "installed",
-            "pkgs": ["cowsay", "fortune-mod"],
+            "pkgs": ["cowsay", "fortune-mod", {"tput": "1.0.1"}],
             "require": ["requirement"],
         },
         {


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #69736

### Previous Behavior
Raised an exception

### New Behavior
Correctly aggregates the packages for multiple states even when a version is specified

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
