### PR TITLE
fix(cp): fall back to __opts__ when __file_client__ is not packed

### DIFF
--- a/changelog/69734.fixed.md
+++ b/changelog/69734.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``cp._client`` raising ``LoaderError`` (surfaced as ``KeyError: '__file_client__'``) when the executing loader has not packed a ``__file_client__`` context. It now falls back to building a file client from ``__opts__``, so ``cp.cache_file`` and other ``salt://`` fetches work under loaders that do not pack a file client.

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -19,7 +19,7 @@ import salt.utils.gzip_util
 import salt.utils.path
 import salt.utils.templates
 import salt.utils.url
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, LoaderError
 from salt.loader.dunder import (
     __context__,
     __file_client__,
@@ -171,8 +171,20 @@ def _client():
     If the __file_client__ context is set return it, otherwize create a new
     file client using __opts__.
     """
-    if __file_client__:
-        return __file_client__.value()
+    # ``__file_client__`` is a NamedLoaderContext. When the loader executing
+    # this module has not packed a file client (e.g. loaders other than
+    # minion_mods, such as the resource module loader), evaluating the context
+    # raises ``LoaderError`` instead of yielding a falsey value -- so the
+    # ``__opts__`` fallback below was never reached and callers such as
+    # ``cp.cache_file`` (and therefore every ``salt://`` fetch) failed with
+    # ``KeyError: '__file_client__'``. Guard the lookup so a missing/None
+    # context falls back to building a client from ``__opts__``.
+    try:
+        file_client = __file_client__.value()
+    except LoaderError:
+        file_client = None
+    if file_client:
+        return file_client
     return salt.fileclient.get_file_client(__opts__.value())
 
 

--- a/tests/pytests/unit/modules/test_cp.py
+++ b/tests/pytests/unit/modules/test_cp.py
@@ -9,13 +9,48 @@ import salt.modules.cp as cp
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.templates as templates
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, LoaderError
 from tests.support.mock import MagicMock, Mock, mock_open, patch
 
 
 @pytest.fixture()
 def configure_loader_modules():
     return {cp: {"__opts__": {"saltenv": None}}}
+
+
+def test__client_returns_packed_file_client():
+    """
+    _client() returns the file client from the __file_client__ context when
+    one is packed.
+    """
+    packed_client = Mock()
+    ctx = MagicMock()
+    ctx.value.return_value = packed_client
+    with patch.object(cp, "__file_client__", ctx, create=True):
+        with patch("salt.fileclient.get_file_client") as get_file_client:
+            assert cp._client() is packed_client
+            get_file_client.assert_not_called()
+
+
+def test__client_falls_back_when_file_client_not_packed():
+    """
+    When the executing loader has not packed __file_client__, evaluating the
+    context raises LoaderError. _client() must fall back to building a client
+    from __opts__ instead of propagating the error.
+    """
+    opts = {"saltenv": None}
+    opts_ctx = MagicMock()
+    opts_ctx.value.return_value = opts
+    file_client_ctx = MagicMock()
+    file_client_ctx.value.side_effect = LoaderError("__file_client__ not packed")
+    built_client = Mock()
+    with patch.object(cp, "__file_client__", file_client_ctx, create=True):
+        with patch.object(cp, "__opts__", opts_ctx, create=True):
+            with patch(
+                "salt.fileclient.get_file_client", return_value=built_client
+            ) as get_file_client:
+                assert cp._client() is built_client
+                get_file_client.assert_called_once_with(opts)
 
 
 def test__render_filenames_undefined_template():


### PR DESCRIPTION
### What does this PR do?

`salt.modules.cp._client()` did:

```python
if __file_client__:
    return __file_client__.value()
return salt.fileclient.get_file_client(__opts__.value())
```

`__file_client__` is a `NamedLoaderContext`. When the loader executing the `cp`
module has **not** packed a `__file_client__` (any loader other than
`minion_mods` that omits a file client — e.g. the resource module loader),
evaluating `if __file_client__:` raises `LoaderError` rather than returning a
falsey value. That raise short-circuits the intended `__opts__` fallback, so
`cp.cache_file` — and therefore **every `salt://` fetch a state performs** —
fails with `KeyError: '__file_client__'`.

This guards the context lookup and falls back to building a file client from
`__opts__` when the context is missing/None.

### What issues does this PR fix or reference?

Fixes #69734

### Previous Behavior

`cp._client()` raised `LoaderError`/`KeyError: '__file_client__'` on any loader
that did not pack a file client, breaking `salt://` fetches.

### New Behavior

`cp._client()` returns the packed file client when present, otherwise builds one
from `__opts__` — no exception.

### Tests written?

Yes — `tests/pytests/unit/modules/test_cp.py`:
- `test__client_returns_packed_file_client`
- `test__client_falls_back_when_file_client_not_packed`

### Commits signed with GPG?

No