### PR TITLE
Remove rpm-vercmp leftover requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -61,7 +61,6 @@ pycryptodomex>=3.23.0
 PyYAML>=6.0.3
 requests>=2.32.5 ; python_version < '3.10'
 requests>=2.33.1 ; python_version >= '3.10'
-rpm-vercmp; sys_platform == 'linux'
 setproctitle>=1.3.7
 # pyzmq 27 dropped its tornado runtime dep; pyzmq.eventloop submodules
 # (zmqstream, future) still import tornado.ioloop at module load. Pin

--- a/requirements/static/ci/py3.10/cloud.lock
+++ b/requirements/static/ci/py3.10/cloud.lock
@@ -669,12 +669,6 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.10/linux.lock
-    #   -c requirements/static/pkg/py3.10/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/docs.lock
+++ b/requirements/static/ci/py3.10/docs.lock
@@ -294,10 +294,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.10/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -538,10 +538,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.10/freebsd.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.14.5 ; sys_platform != 'win32'

--- a/requirements/static/ci/py3.10/lint.lock
+++ b/requirements/static/ci/py3.10/lint.lock
@@ -660,12 +660,6 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.10/linux.lock
-    #   -c requirements/static/pkg/py3.10/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/linux.lock
+++ b/requirements/static/ci/py3.10/linux.lock
@@ -530,10 +530,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.10/linux.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.14.5

--- a/requirements/static/ci/py3.11/cloud.lock
+++ b/requirements/static/ci/py3.11/cloud.lock
@@ -654,12 +654,6 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.11/linux.lock
-    #   -c requirements/static/pkg/py3.11/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/docs.lock
+++ b/requirements/static/ci/py3.11/docs.lock
@@ -289,10 +289,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.11/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -548,10 +548,6 @@ rpds-py==0.30.0 ; python_full_version >= '3.12'
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.11/freebsd.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'

--- a/requirements/static/ci/py3.11/lint.lock
+++ b/requirements/static/ci/py3.11/lint.lock
@@ -645,12 +645,6 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.11/linux.lock
-    #   -c requirements/static/pkg/py3.11/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/linux.lock
+++ b/requirements/static/ci/py3.11/linux.lock
@@ -521,10 +521,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.11/linux.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0

--- a/requirements/static/ci/py3.12/cloud.lock
+++ b/requirements/static/ci/py3.12/cloud.lock
@@ -656,12 +656,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.12/linux.lock
-    #   -c requirements/static/pkg/py3.12/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/docs.lock
+++ b/requirements/static/ci/py3.12/docs.lock
@@ -287,10 +287,6 @@ rich==15.0.0
     #   typer
 roman-numerals==4.1.0
     # via sphinx
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.12/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -525,10 +525,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.12/freebsd.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'

--- a/requirements/static/ci/py3.12/lint.lock
+++ b/requirements/static/ci/py3.12/lint.lock
@@ -647,12 +647,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.12/linux.lock
-    #   -c requirements/static/pkg/py3.12/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/linux.lock
+++ b/requirements/static/ci/py3.12/linux.lock
@@ -520,10 +520,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.12/linux.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0

--- a/requirements/static/ci/py3.13/cloud.lock
+++ b/requirements/static/ci/py3.13/cloud.lock
@@ -653,12 +653,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.13/linux.lock
-    #   -c requirements/static/pkg/py3.13/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/docs.lock
+++ b/requirements/static/ci/py3.13/docs.lock
@@ -285,10 +285,6 @@ rich==15.0.0
     #   typer
 roman-numerals==4.1.0
     # via sphinx
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.13/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -523,10 +523,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.13/freebsd.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'

--- a/requirements/static/ci/py3.13/lint.lock
+++ b/requirements/static/ci/py3.13/lint.lock
@@ -643,12 +643,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.13/linux.lock
-    #   -c requirements/static/pkg/py3.13/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/linux.lock
+++ b/requirements/static/ci/py3.13/linux.lock
@@ -518,10 +518,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.13/linux.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0

--- a/requirements/static/ci/py3.14/cloud.lock
+++ b/requirements/static/ci/py3.14/cloud.lock
@@ -653,12 +653,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.14/linux.lock
-    #   -c requirements/static/pkg/py3.14/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/docs.lock
+++ b/requirements/static/ci/py3.14/docs.lock
@@ -272,10 +272,6 @@ requests==2.33.1
     #   vultr
 roman-numerals==4.1.0
     # via sphinx
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.14/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/freebsd.lock
+++ b/requirements/static/ci/py3.14/freebsd.lock
@@ -483,10 +483,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.14/freebsd.lock
-    #   -r requirements/base.txt
 s3transfer==0.16.0
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'

--- a/requirements/static/ci/py3.14/lint.lock
+++ b/requirements/static/ci/py3.14/lint.lock
@@ -644,12 +644,6 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.14/linux.lock
-    #   -c requirements/static/pkg/py3.14/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 s3transfer==0.18.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/linux.lock
+++ b/requirements/static/ci/py3.14/linux.lock
@@ -519,10 +519,6 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.14/linux.lock
-    #   -r requirements/base.txt
 s3transfer==0.18.0
     # via boto3
 scp==0.15.0

--- a/requirements/static/ci/py3.9/cloud.lock
+++ b/requirements/static/ci/py3.9/cloud.lock
@@ -730,12 +730,6 @@ rpds-py==0.27.1
     #   -c requirements/static/ci/py3.9/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.9/linux.lock
-    #   -c requirements/static/pkg/py3.9/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 rsa==4.9.1
     # via
     #   -c requirements/static/ci/py3.9/linux.lock

--- a/requirements/static/ci/py3.9/docs.lock
+++ b/requirements/static/ci/py3.9/docs.lock
@@ -299,10 +299,6 @@ rich==15.0.0
     # via
     #   -c requirements/static/ci/py3.9/linux.lock
     #   typer
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.9/linux.lock
-    #   -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -c requirements/static/ci/py3.9/linux.lock

--- a/requirements/static/ci/py3.9/freebsd.lock
+++ b/requirements/static/ci/py3.9/freebsd.lock
@@ -715,10 +715,6 @@ rpds-py==0.27.1 ; python_full_version != '3.11.*'
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via
-    #   -c requirements/static/pkg/py3.9/freebsd.lock
-    #   -r requirements/base.txt
 rsa==4.9.1 ; python_full_version < '3.10'
     # via google-auth
 ruamel-yaml==0.19.1 ; python_full_version < '3.10' and sys_platform != 'win32'

--- a/requirements/static/ci/py3.9/lint.lock
+++ b/requirements/static/ci/py3.9/lint.lock
@@ -705,12 +705,6 @@ rpds-py==0.27.1
     #   -c requirements/static/ci/py3.9/linux.lock
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/ci/py3.9/linux.lock
-    #   -c requirements/static/pkg/py3.9/linux.lock
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 rsa==4.9.1
     # via
     #   -c requirements/static/ci/py3.9/linux.lock

--- a/requirements/static/ci/py3.9/linux.lock
+++ b/requirements/static/ci/py3.9/linux.lock
@@ -568,10 +568,6 @@ rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
-rpm-vercmp==0.1.2
-    # via
-    #   -c requirements/static/pkg/py3.9/linux.lock
-    #   -r requirements/base.txt
 rsa==4.9.1
     # via google-auth
 ruamel-yaml==0.19.1

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -10,7 +10,6 @@ pycparser>=3.0; python_version >= '3.10'
 pyopenssl>=26.0.0,<26.2.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
-rpm-vercmp
 setproctitle>=1.3.7
 timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -200,8 +200,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.lock
+++ b/requirements/static/pkg/py3.10/linux.lock
@@ -177,10 +177,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -194,8 +194,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.lock
+++ b/requirements/static/pkg/py3.11/linux.lock
@@ -173,10 +173,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -192,8 +192,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.lock
+++ b/requirements/static/pkg/py3.12/linux.lock
@@ -171,10 +171,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -191,8 +191,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/linux.lock
+++ b/requirements/static/pkg/py3.13/linux.lock
@@ -170,10 +170,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -191,8 +191,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/linux.lock
+++ b/requirements/static/pkg/py3.14/linux.lock
@@ -170,10 +170,6 @@ requests==2.33.1
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/freebsd.lock
+++ b/requirements/static/pkg/py3.9/freebsd.lock
@@ -251,8 +251,6 @@ requests==2.33.1 ; python_full_version >= '3.10'
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2 ; sys_platform == 'linux'
-    # via -r requirements/base.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.lock
+++ b/requirements/static/pkg/py3.9/linux.lock
@@ -179,10 +179,6 @@ requests==2.32.5
     #   vultr
 rich==15.0.0
     # via typer
-rpm-vercmp==0.1.2
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/static/pkg/linux.txt
 setproctitle==1.3.7
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
### What does this PR do?

This PR removes the leftover of https://github.com/saltstack/salt/pull/67806 and later https://github.com/saltstack/salt/pull/68342

It just removes unused requirement.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29488

### Previous Behavior
Nothing wrong, but just unused requirement listed.

### New Behavior
The unused requirement removed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
