### PR TITLE
Invalidate grains cache in saltutil.refresh_grains

### DIFF
--- a/changelog/55667.fixed.md
+++ b/changelog/55667.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``saltutil.refresh_grains`` being a no-op when ``grains_cache`` is enabled; it now invalidates the on-disk grains cache before reloading so refreshed grain values take effect.

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -99,6 +99,23 @@ def _get_top_file_envs():
         return envs
 
 
+def _clear_grains_cache():
+    """
+    Remove the on-disk grains cache (``grains.cache.p``) so the next grains
+    load regenerates it. No-op when grains caching is disabled or the cache
+    file is absent.
+    """
+    if not __opts__.get("grains_cache"):
+        return
+    cache_file = os.path.join(__opts__["cachedir"], "grains.cache.p")
+    if not os.path.isfile(cache_file):
+        return
+    try:
+        os.remove(cache_file)
+    except OSError:
+        log.error("Could not remove grains cache!")
+
+
 def _sync(form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None):
     """
     Sync the given directory in the given environment
@@ -119,15 +136,8 @@ def _sync(form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None):
         mod_file = os.path.join(__opts__["cachedir"], "module_refresh")
         with salt.utils.files.fopen(mod_file, "a"):
             pass
-    if (
-        form == "grains"
-        and __opts__.get("grains_cache")
-        and os.path.isfile(os.path.join(__opts__["cachedir"], "grains.cache.p"))
-    ):
-        try:
-            os.remove(os.path.join(__opts__["cachedir"], "grains.cache.p"))
-        except OSError:
-            log.error("Could not remove grains cache!")
+    if form == "grains":
+        _clear_grains_cache()
     return ret
 
 
@@ -401,6 +411,10 @@ def refresh_grains(**kwargs):
     clean_pillar_cache = kwargs.pop("clean_pillar_cache", False)
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
+    # Invalidate the on-disk grains cache so the reload below regenerates
+    # grains instead of re-reading stale cached values. Without this,
+    # saltutil.refresh_grains is a no-op when grains_cache is enabled (#55667).
+    _clear_grains_cache()
     # Modules and pillar need to be refreshed in case grains changes affected
     # them, and the module refresh process reloads the grains and assigns the
     # newly-reloaded grains to each execution module's __grains__ dunder.

--- a/tests/pytests/functional/modules/test_saltutil.py
+++ b/tests/pytests/functional/modules/test_saltutil.py
@@ -56,3 +56,52 @@ def test__get_top_file_envs(modules, get_top, destroy):
     assert get_top.called
     # Ensure destroy is getting called
     assert destroy.called
+
+
+def test_refresh_grains_regenerates_cached_grain_value(
+    minion_opts, tmp_path, monkeypatch
+):
+    """
+    Functional regression test for #55667.
+
+    With ``grains_cache`` enabled, ``salt.loader.grains`` serves grain values
+    from the on-disk cache without re-running the grain functions.
+    ``saltutil.refresh_grains`` must invalidate that cache so a changed grain
+    value actually takes effect on the next load -- the real end-to-end
+    behaviour the unit tests only approximate. Exercised through the real
+    ``minion_mods`` loader and the real grains loader; only the orthogonal
+    pillar refresh is mocked (it just avoids master auth and does not touch the
+    grains cache). Without the fix the cache survives, the stale value persists,
+    and the final assertion fails.
+    """
+    # A custom grain whose value we drive via an environment variable, so we can
+    # change "the source" between loads without touching the grains cache.
+    grains_dir = tmp_path / "grains"
+    grains_dir.mkdir()
+    (grains_dir / "refresh55667.py").write_text(
+        "import os\n\n\n"
+        "def refresh55667():\n"
+        '    return {"refresh55667_grain": os.environ.get("REFRESH55667_CTL", "")}\n'
+    )
+    minion_opts["cachedir"] = str(tmp_path)
+    minion_opts["grains_cache"] = True
+    minion_opts["grains_dirs"] = [str(grains_dir)]
+    cache_file = tmp_path / "grains.cache.p"
+
+    # First load runs the grain and writes the on-disk cache.
+    monkeypatch.setenv("REFRESH55667_CTL", "before")
+    assert salt.loader.grains(minion_opts)["refresh55667_grain"] == "before"
+    assert cache_file.is_file()
+
+    # The source changes, but a plain load still serves the stale cached value.
+    monkeypatch.setenv("REFRESH55667_CTL", "after")
+    assert salt.loader.grains(minion_opts)["refresh55667_grain"] == "before"
+
+    # refresh_grains (real module, real __opts__) invalidates the cache.
+    modules = salt.loader.minion_mods(minion_opts, context={})
+    with patch("salt.modules.saltutil.refresh_pillar"):
+        modules["saltutil.refresh_grains"]()
+    assert not cache_file.exists()
+
+    # The refreshed grain value now takes effect.
+    assert salt.loader.grains(minion_opts)["refresh55667_grain"] == "after"

--- a/tests/pytests/unit/modules/test_saltutil.py
+++ b/tests/pytests/unit/modules/test_saltutil.py
@@ -121,6 +121,66 @@ def test_refresh_grains_clean_pillar_cache_with_refresh_false():
         refresh_modules.assert_called()
 
 
+def test_refresh_grains_clears_grains_cache_when_enabled(minion_opts, tmp_path):
+    """
+    Regression test for #55667.
+
+    With ``grains_cache`` enabled, ``saltutil.refresh_grains`` must invalidate
+    the on-disk grains cache (``grains.cache.p``) so the subsequent reload
+    regenerates grains instead of re-reading the stale cached values. This pins
+    the bug: without the fix ``refresh_grains`` never touches the cache file, so
+    it survives and this assertion fails.
+    """
+    minion_opts["grains_cache"] = True
+    minion_opts["cachedir"] = str(tmp_path)
+    cache_file = tmp_path / "grains.cache.p"
+    cache_file.write_bytes(b"stale grains")
+    with patch("salt.modules.saltutil.refresh_pillar"):
+        saltutil.refresh_grains()
+    assert not cache_file.exists()
+
+
+def test_refresh_grains_keeps_grains_cache_when_disabled(minion_opts, tmp_path):
+    """
+    Inverse of #55667.
+
+    When ``grains_cache`` is disabled there is no cache to invalidate, so
+    ``refresh_grains`` must not remove a same-named file that happens to exist.
+    """
+    minion_opts["grains_cache"] = False
+    minion_opts["cachedir"] = str(tmp_path)
+    cache_file = tmp_path / "grains.cache.p"
+    cache_file.write_bytes(b"unrelated")
+    with patch("salt.modules.saltutil.refresh_pillar"):
+        saltutil.refresh_grains()
+    assert cache_file.exists()
+
+
+def test_clear_grains_cache_branches(minion_opts, tmp_path):
+    """
+    Guard the shared helper used by both refresh_grains and _sync: it removes
+    the cache only when grains_cache is enabled, and is a no-op when disabled or
+    when the cache file is absent.
+    """
+    minion_opts["cachedir"] = str(tmp_path)
+    cache_file = tmp_path / "grains.cache.p"
+
+    # disabled -> file preserved
+    minion_opts["grains_cache"] = False
+    cache_file.write_bytes(b"x")
+    saltutil._clear_grains_cache()
+    assert cache_file.exists()
+
+    # enabled -> file removed
+    minion_opts["grains_cache"] = True
+    saltutil._clear_grains_cache()
+    assert not cache_file.exists()
+
+    # enabled but no file -> no error
+    saltutil._clear_grains_cache()
+    assert not cache_file.exists()
+
+
 def test_sync_grains_default_clean_pillar_cache():
     with patch("salt.modules.saltutil._sync"):
         with patch("salt.modules.saltutil.refresh_pillar") as refresh_pillar:


### PR DESCRIPTION
### What does this PR do?

Makes `saltutil.refresh_grains` invalidate the on-disk grains cache
(`grains.cache.p`) before reloading, so refreshed grain values actually take
effect when `grains_cache: True` is configured. The grains-cache invalidation
that `sync_grains` already performed is factored into a small
`_clear_grains_cache` helper now shared by both `_sync` and `refresh_grains`.

### What issues does this PR fix or reference?

Fixes #55667

### Previous Behavior

With `grains_cache: True`, `saltutil.refresh_grains` reloaded grains through
`refresh_pillar`/`refresh_modules` without invalidating the on-disk cache. The
loader reads `grains.cache.p` when `grains_cache` is enabled and `force_refresh`
is not set, so the reload re-read the stale cached grains and the refresh was
effectively a no-op. The only workaround was `saltutil.clear_cache` (or
`sync_grains`, which already dropped the cache file on a grains sync).

### New Behavior

`refresh_grains` removes `grains.cache.p` before triggering the reload (when
`grains_cache` is enabled and the file exists). With no cache present, the
loader regenerates grains and rewrites a fresh cache, so updated grain values
are picked up. Behavior is unchanged when `grains_cache` is disabled.

### Merge requirements satisfied?

- [ ] Docs - not applicable (no doc-facing behavior change; brings `refresh_grains` in line with its documented purpose)
- [x] Changelog - `changelog/55667.fixed.md`
- [x] Tests written/updated - `tests/pytests/unit/modules/test_saltutil.py`: direct test (grains_cache enabled, cache removed - pins the bug), inverse test (disabled, file preserved), and a helper-branch guard

### Commits signed with GPG?

No
