### PR TITLE
Exit non-zero from batch mode when no minions match

### DIFF
--- a/changelog/57357.fixed.md
+++ b/changelog/57357.fixed.md
@@ -1,0 +1,1 @@
+Fixed the ``salt`` CLI exiting 0 in batch mode when the target matched no minions; it now exits 2 ("No return received"), matching the non-batch behavior.

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -292,6 +292,12 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
                 if job_retcode > retcode:
                     # Exit with the highest retcode we find
                     retcode = job_retcode
+            if not batch.minions:
+                # No minions matched the target. Mirror the non-batch CLI,
+                # which prints "No return received" and exits 2 rather than
+                # silently exiting 0 (#57357).
+                sys.stderr.write("ERROR: No return received\n")
+                sys.exit(2)
             sys.exit(retcode)
 
     def _print_errors_summary(self, errors):

--- a/tests/pytests/unit/cli/test_salt.py
+++ b/tests/pytests/unit/cli/test_salt.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for the salt CLI (salt.cli.salt.SaltCMD).
+"""
+
+import pytest
+
+from salt.cli.salt import SaltCMD
+from tests.support.mock import MagicMock, patch
+
+
+def _fake_saltcmd():
+    """
+    A stand-in SaltCMD self with just the attributes _run_batch's non-static
+    branch touches, so the method can be exercised without full CLI parsing.
+    """
+    fake = MagicMock()
+    fake.config = {}
+    fake.options.eauth = ""
+    fake.options.static = False
+    fake.options.batch = "100%"
+    return fake
+
+
+def _run_batch_exit_code(fake_batch):
+    fake = _fake_saltcmd()
+    with patch("salt.cli.batch.Batch", return_value=fake_batch):
+        with pytest.raises(SystemExit) as exc:
+            SaltCMD._run_batch(fake)
+    return exc.value.code
+
+
+def test_run_batch_no_minions_exits_nonzero():
+    """
+    Regression test for #57357.
+
+    When a batch run matches zero minions, ``batch.run()`` yields nothing. The
+    CLI must exit non-zero -- matching the non-batch path, which prints
+    "No return received" and exits 2 -- instead of silently exiting 0. Pins the
+    bug: before the fix the empty loop leaves ``retcode=0`` and the CLI exits 0.
+    """
+    fake_batch = MagicMock()
+    fake_batch.run.return_value = iter([])
+    fake_batch.minions = []
+    assert _run_batch_exit_code(fake_batch) == 2
+
+
+def test_run_batch_matched_minions_uses_highest_job_retcode():
+    """
+    Inverse of #57357: when minions match, the exit code is the highest job
+    retcode seen, and the no-return path is not taken.
+    """
+    fake_batch = MagicMock()
+    fake_batch.run.return_value = iter([({"m1": {}}, 0), ({"m2": {}}, 3)])
+    fake_batch.minions = ["m1", "m2"]
+    assert _run_batch_exit_code(fake_batch) == 3
+
+
+def test_run_batch_matched_minions_success_exits_zero():
+    """
+    A successful batch that matched minions still exits 0 -- the fix must not
+    regress the normal path.
+    """
+    fake_batch = MagicMock()
+    fake_batch.run.return_value = iter([({"m1": {}}, 0)])
+    fake_batch.minions = ["m1"]
+    assert _run_batch_exit_code(fake_batch) == 0


### PR DESCRIPTION
### What does this PR do?

Makes the `salt` CLI exit 2 ("No return received") in batch mode when the target matches no minions, matching the non-batch behavior instead of silently exiting 0.

### What issues does this PR fix or reference?

Fixes #57357

### Previous Behavior

In batch mode the CLI's exit code was derived by iterating `batch.run()`. When the target matches no minions, `Batch.run()` returns early on an empty minion list and yields nothing, so the loop never runs, `retcode` stays 0, and the CLI exits 0. The non-batch path instead reaches the "No return received" guard in `_output_ret` and exits 2, so the two modes disagree on a no-match run.

### New Behavior

After the batch loop, if no minions matched (`batch.minions` is empty), the CLI prints "No return received" and exits 2, matching non-batch. The `--static` batch branch already routes through `_output_ret` and was unaffected.

Note on the exit code: 2 was chosen to mirror the non-batch "No return received" path exactly (the reporter's stated expectation). If maintainers prefer a different code here I'm happy to adjust.

### Merge requirements satisfied?

- [ ] Docs - not applicable
- [x] Changelog - `changelog/57357.fixed.md`
- [x] Tests written/updated - `tests/pytests/unit/cli/test_salt.py`: no-match exits 2 (pins the bug), matched minions use the highest job retcode, matched-success exits 0

### Commits signed with GPG?

No
