### PR TITLE
Fix grafana4_datasource.present spurious update under test=True (#54122)

### DIFF
--- a/changelog/54122.fixed.md
+++ b/changelog/54122.fixed.md
@@ -1,0 +1,1 @@
+Fixed grafana4_datasource.present reporting a spurious update under test=True for an unchanged existing data source

--- a/salt/states/grafana4_datasource.py
+++ b/salt/states/grafana4_datasource.py
@@ -167,16 +167,25 @@ def present(
         if key not in datasource:
             datasource[key] = None
 
-    if data == datasource:
+    # Grafana returns server-managed keys (id, orgId, readOnly) that our "data"
+    # dict never contains, so a plain "data == datasource" comparison is never
+    # True for an existing datasource. Decide with the same diff the update path
+    # uses, ignoring those server-managed keys, so test mode agrees with a live
+    # run instead of always reporting a spurious update.
+    changes = deep_diff(datasource, data, ignore=["id", "orgId", "readOnly"])
+
+    if not changes:
+        ret["result"] = True
         ret["comment"] = f"Data source {name} already up-to-date"
         return ret
 
     if __opts__["test"]:
         ret["comment"] = f"Datasource {name} will be updated"
+        ret["changes"] = changes
         return ret
     __salt__["grafana4.update_datasource"](datasource["id"], profile=profile, **data)
     ret["result"] = True
-    ret["changes"] = deep_diff(datasource, data, ignore=["id", "orgId", "readOnly"])
+    ret["changes"] = changes
     ret["comment"] = f"Data source {name} updated"
     return ret
 

--- a/tests/pytests/unit/states/test_grafana4_datasource.py
+++ b/tests/pytests/unit/states/test_grafana4_datasource.py
@@ -1,0 +1,200 @@
+import pytest
+
+import salt.states.grafana4_datasource as grafana4_datasource
+from tests.support.mock import MagicMock, patch
+
+profile = {
+    "grafana_url": "http://grafana",
+    "grafana_token": "token",
+    "grafana_timeout": 3,
+}
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {grafana4_datasource: {"__opts__": {"test": False}}}
+
+
+def _desired():
+    """
+    Build the datasource body exactly as present() does via _get_json_data,
+    with all the keyword arguments present() forwards (Nones included).
+    """
+    return grafana4_datasource._get_json_data(
+        name="test",
+        type="prometheus",
+        url="http://localhost:8080",
+        access="proxy",
+        user=None,
+        password=None,
+        database=None,
+        basicAuth=None,
+        basicAuthUser=None,
+        basicAuthPassword=None,
+        tlsAuth=None,
+        jsonData=None,
+        isDefault=False,
+        withCredentials=None,
+        typeLogoUrl=None,
+    )
+
+
+def _stored(**overrides):
+    """
+    Simulate what grafana4.get_datasource returns: the desired body plus the
+    server-managed keys Grafana always adds (id, orgId, readOnly).
+    """
+    stored = _desired()
+    stored.update({"id": 1, "orgId": 1, "readOnly": False})
+    stored.update(overrides)
+    return stored
+
+
+def test_present_unchanged_test_mode_54122():
+    """
+    test=True must not report an update for an existing, unchanged datasource.
+
+    Regression test for issue #54122: get_datasource returns server-managed
+    keys (id, orgId, readOnly) that the desired body never carries, so the old
+    "data == datasource" check was never True and test mode always claimed the
+    datasource "will be updated" even though a live run made no changes.
+    """
+    stored = _stored()
+    update = MagicMock()
+    with patch.dict(
+        grafana4_datasource.__salt__,
+        {
+            "grafana4.get_datasource": MagicMock(return_value=stored),
+            "grafana4.update_datasource": update,
+        },
+    ), patch.dict(grafana4_datasource.__opts__, {"test": True}):
+        ret = grafana4_datasource.present(
+            "test",
+            "prometheus",
+            "http://localhost:8080",
+            access="proxy",
+            is_default=False,
+            profile=profile,
+        )
+    assert ret["result"] is True
+    assert ret["comment"] == "Data source test already up-to-date"
+    assert ret["changes"] == {}
+    update.assert_not_called()
+
+
+def test_present_changed_test_mode():
+    """
+    Inverse / must-not-regress: a real change (url differs) must still be
+    reported as pending under test=True, with result left as None and no
+    live update performed. Passes with and without the #54122 fix.
+    """
+    stored = _stored(url="http://OLD:8080")
+    update = MagicMock()
+    with patch.dict(
+        grafana4_datasource.__salt__,
+        {
+            "grafana4.get_datasource": MagicMock(return_value=stored),
+            "grafana4.update_datasource": update,
+        },
+    ), patch.dict(grafana4_datasource.__opts__, {"test": True}):
+        ret = grafana4_datasource.present(
+            "test",
+            "prometheus",
+            "http://NEW:8080",
+            access="proxy",
+            is_default=False,
+            profile=profile,
+        )
+    assert ret["result"] is None
+    assert ret["comment"] == "Datasource test will be updated"
+    update.assert_not_called()
+
+
+def test_present_unchanged_live():
+    """
+    Live run (test=False) on an unchanged datasource must be a no-op: result
+    True, empty changes, and update_datasource never invoked.
+    """
+    stored = _stored()
+    update = MagicMock()
+    with patch.dict(
+        grafana4_datasource.__salt__,
+        {
+            "grafana4.get_datasource": MagicMock(return_value=stored),
+            "grafana4.update_datasource": update,
+        },
+    ), patch.dict(grafana4_datasource.__opts__, {"test": False}):
+        ret = grafana4_datasource.present(
+            "test",
+            "prometheus",
+            "http://localhost:8080",
+            access="proxy",
+            is_default=False,
+            profile=profile,
+        )
+    assert ret["result"] is True
+    assert ret["comment"] == "Data source test already up-to-date"
+    assert ret["changes"] == {}
+    update.assert_not_called()
+
+
+def test_present_changed_live():
+    """
+    Live run (test=False) with a real change updates the datasource: it calls
+    update_datasource with the stored id, reports the diff in changes, and
+    returns result True.
+    """
+    stored = _stored(url="http://OLD:8080")
+    update = MagicMock()
+    with patch.dict(
+        grafana4_datasource.__salt__,
+        {
+            "grafana4.get_datasource": MagicMock(return_value=stored),
+            "grafana4.update_datasource": update,
+        },
+    ), patch.dict(grafana4_datasource.__opts__, {"test": False}):
+        ret = grafana4_datasource.present(
+            "test",
+            "prometheus",
+            "http://NEW:8080",
+            access="proxy",
+            is_default=False,
+            profile=profile,
+        )
+    assert ret["result"] is True
+    assert ret["comment"] == "Data source test updated"
+    assert ret["changes"] == {
+        "old": {"url": "http://OLD:8080"},
+        "new": {"url": "http://NEW:8080"},
+    }
+    update.assert_called_once()
+    assert update.call_args[0][0] == 1
+
+
+def test_present_absent_creates_in_test_mode():
+    """
+    Peripheral coverage: when the datasource does not exist yet, test mode
+    reports creation and does not touch update_datasource.
+    """
+    create = MagicMock()
+    update = MagicMock()
+    with patch.dict(
+        grafana4_datasource.__salt__,
+        {
+            "grafana4.get_datasource": MagicMock(return_value={}),
+            "grafana4.create_datasource": create,
+            "grafana4.update_datasource": update,
+        },
+    ), patch.dict(grafana4_datasource.__opts__, {"test": True}):
+        ret = grafana4_datasource.present(
+            "test",
+            "prometheus",
+            "http://localhost:8080",
+            access="proxy",
+            is_default=False,
+            profile=profile,
+        )
+    assert ret["result"] is None
+    assert ret["comment"] == "Datasource test will be created"
+    create.assert_not_called()
+    update.assert_not_called()


### PR DESCRIPTION
### What does this PR do?

`grafana4_datasource.present` decided the up-to-date vs update case with a plain dict equality, `if data == datasource:`. The datasource returned by `grafana4.get_datasource` always carries server-managed keys (`id`, `orgId`, `readOnly`) that the desired body built by `_get_json_data` never contains, so that comparison was never True for an existing data source. As a result the function always fell through: under `test=True` it reported "Datasource X will be updated", while a live run computed the real diff with `deep_diff(..., ignore=["id","orgId","readOnly"])` (empty for an unchanged source) and effectively did nothing. The two paths disagreed.

This computes the diff once, up front, with that same ignore list and branches on it, so test mode predicts exactly what a live run does. It also makes the now-reachable up-to-date branch return `result=True` (it previously left `result=None`, matching the `absent()` "already absent" convention in the same file).

Note: this module (and the grafana4 execution modules) was moved out of core into the `saltext.grafana` community extension for 3008+, so it now exists in-tree only on 3006.x and this fix cannot forward-merge. The same bug very likely exists in `saltext.grafana`; the identical patch should port trivially there.

### What issues does this PR fix or reference?

Fixes #54122

### Previous Behavior

For an existing, unchanged data source, `present` under `test=True` reported `Result: None` / `Comment: Datasource X will be updated`, even though a subsequent non-test run made no changes. In a live run the up-to-date path was unreachable, so `present` issued a no-op update every time and returned an empty `changes` dict (hidden by `--state-verbose false`).

### New Behavior

An existing, unchanged data source is correctly reported as already up-to-date (`result=True`, empty `changes`) in both test and live runs, and no update call is made. When a real change is present, test mode reports the pending diff in `changes` and the live run applies exactly that diff.

### Merge requirements satisfied?

- [ ] Docs: N/A (behaviour fix, no doc changes)
- [x] Changelog entry: `changelog/54122.fixed.md`
- [x] Tests written and passing: new `tests/pytests/unit/states/test_grafana4_datasource.py` with a direct regression test for #54122, an inverse (real-change-still-reported) test, and peripheral coverage for the live unchanged/changed and test-mode create paths.

### Commits signed with GPG?

No