### PR TITLE
Paginate DigitalOcean destroy_dns_records and drop Py2 decode (Fixes #55143)

### DIFF
--- a/changelog/55143.fixed.md
+++ b/changelog/55143.fixed.md
@@ -1,0 +1,1 @@
+Fixed the DigitalOcean cloud driver so destroy_dns_records paginates through every page of DNS records instead of only the first page, and dropped a Python 2 ``.decode()`` call that crashed record matching on Python 3.

--- a/salt/cloud/clouds/digitalocean.py
+++ b/salt/cloud/clouds/digitalocean.py
@@ -966,16 +966,34 @@ def destroy_dns_records(fqdn):
     domain = ".".join(fqdn.split(".")[-2:])
     hostname = ".".join(fqdn.split(".")[:-2])
     # TODO: remove this when the todo on 754 is available
-    try:
-        response = query(method="domains", droplet_id=domain, command="records")
-    except SaltCloudSystemExit:
-        log.debug("Failed to find domains.")
-        return False
-    log.debug("found DNS records: %s", pprint.pformat(response))
-    records = response["domain_records"]
+    fetch = True
+    page = 1
+    records = []
+
+    # The DigitalOcean API paginates DNS records (20 per page by default), so
+    # walk every page and accumulate the results, otherwise records past the
+    # first page are never seen and their entries are never deleted.
+    while fetch:
+        try:
+            response = query(
+                method="domains",
+                droplet_id=domain,
+                command="records?page=" + str(page) + "&per_page=200",
+            )
+        except SaltCloudSystemExit:
+            log.debug("Failed to find domains.")
+            return False
+        log.debug("found DNS records: %s", pprint.pformat(response))
+        records.extend(response["domain_records"])
+
+        page += 1
+        try:
+            fetch = "next" in response["links"]["pages"]
+        except KeyError:
+            fetch = False
 
     if records:
-        record_ids = [r["id"] for r in records if r["name"].decode() == hostname]
+        record_ids = [r["id"] for r in records if r["name"] == hostname]
         log.debug("deleting DNS record IDs: %s", record_ids)
         for id_ in record_ids:
             try:

--- a/tests/pytests/unit/cloud/clouds/test_digitalocean.py
+++ b/tests/pytests/unit/cloud/clouds/test_digitalocean.py
@@ -11,6 +11,7 @@ import pytest
 
 from salt.cloud.clouds import digitalocean
 from salt.exceptions import SaltCloudSystemExit
+from tests.support.mock import MagicMock, patch
 
 log = logging.getLogger(__name__)
 
@@ -24,3 +25,105 @@ def test_reboot_no_call():
         digitalocean.reboot(name="fake_name")
 
     assert "The reboot action must be called with -a or --action." == str(excinfo.value)
+
+
+def test_destroy_dns_records_pagination_55143():
+    """
+    destroy_dns_records must walk every page of DNS records, not just the
+    first, so a matching record that lives past page 1 is still deleted.
+
+    Regression test for https://github.com/saltstack/salt/issues/55143: the
+    DigitalOcean API paginates records (20 per page by default), and the driver
+    only ever requested the first page, so records past it were never matched
+    or deleted. destroy() calls destroy_dns_records(name) with the minion name,
+    which splits into domain="example.com" / hostname="www" here.
+    """
+    # Page 1: 20 non-matching records plus a "next" link so the loop pages on.
+    page1 = {
+        "domain_records": [{"id": i, "name": "other"} for i in range(1, 21)],
+        "links": {
+            "pages": {
+                "next": "https://api.digitalocean.com/v2/domains/example.com/records?page=2",
+                "last": "https://api.digitalocean.com/v2/domains/example.com/records?page=2",
+            }
+        },
+        "meta": {"total": 21},
+    }
+    # Page 2: the matching record, with no further links so the loop stops.
+    page2 = {
+        "domain_records": [{"id": 42, "name": "www"}],
+        "meta": {"total": 21},
+    }
+
+    def fake_query(
+        method=None, droplet_id=None, command=None, http_method="get", args=None
+    ):
+        # command == "records" is the unpaginated call the buggy driver made.
+        if command == "records" or command.startswith("records?page=1"):
+            return page1
+        if command.startswith("records?page=2"):
+            return page2
+        if command.startswith("records/") and http_method == "delete":
+            return True
+        raise AssertionError(f"unexpected query command={command!r}")
+
+    query_mock = MagicMock(side_effect=fake_query)
+    with patch.object(digitalocean, "query", query_mock):
+        digitalocean.destroy_dns_records("www.example.com")
+
+    commands = [call.kwargs.get("command") for call in query_mock.call_args_list]
+    # The loop must have paged past page 1.
+    assert any(c and c.startswith("records?page=2") for c in commands)
+    # The page-2 record was matched and deleted.
+    query_mock.assert_any_call(
+        method="domains",
+        droplet_id="example.com",
+        command="records/42",
+        http_method="delete",
+    )
+    # Non-matching page-1 records must never be deleted.
+    for i in range(1, 21):
+        assert f"records/{i}" not in commands, f"non-matching record {i} was deleted"
+
+
+def test_destroy_dns_records_no_matching_records_55143():
+    """
+    Inverse of the pagination fix: a domain whose record set is empty must
+    result in zero deletions. This passes with and without the fix -- an empty
+    record set yields no deletions regardless of how many pages are walked --
+    so it guards against the paginated fix ever over-deleting.
+    """
+    empty_page = {"domain_records": [], "meta": {"total": 0}}
+
+    def fake_query(
+        method=None, droplet_id=None, command=None, http_method="get", args=None
+    ):
+        if command.startswith("records/"):
+            raise AssertionError("no record should be deleted")
+        return empty_page
+
+    query_mock = MagicMock(side_effect=fake_query)
+    with patch.object(digitalocean, "query", query_mock):
+        digitalocean.destroy_dns_records("www.example.com")
+
+    delete_calls = [
+        call
+        for call in query_mock.call_args_list
+        if call.kwargs.get("http_method") == "delete"
+    ]
+    assert delete_calls == []
+
+
+def test_destroy_dns_records_domain_lookup_failure_55143():
+    """
+    Peripheral coverage of the touched function: when the record lookup raises
+    SaltCloudSystemExit (e.g. the domain is not managed by DigitalOcean),
+    destroy_dns_records returns False and attempts no deletions.
+    """
+    query_mock = MagicMock(side_effect=SaltCloudSystemExit("boom"))
+    with patch.object(digitalocean, "query", query_mock):
+        result = digitalocean.destroy_dns_records("www.example.com")
+
+    assert result is False
+    for call in query_mock.call_args_list:
+        assert call.kwargs.get("http_method", "get") != "delete"


### PR DESCRIPTION
### What does this PR do?

Makes the DigitalOcean cloud driver's `destroy_dns_records()` walk every page of a domain's DNS records instead of requesting only the first page, and removes a leftover Python 2 `.decode()` call that crashed record matching on Python 3.

The pagination loop reuses the same `fetch`/`page` + `"next" in response["links"]["pages"]` idiom already used by `avail_images`, `list_keypairs`, `list_floating_ips`, and `_list_nodes` in this driver, requesting `records?page=<n>&per_page=200` until the API stops returning a `next` link.

### What issues does this PR fix or reference?

Fixes #55143

### Previous Behavior

`destroy_dns_records()` issued a single unpaginated request:

```python
response = query(method="domains", droplet_id=domain, command="records")
```

The DigitalOcean API returns at most 20 DNS records per page by default, so any record beyond the first page was never seen and therefore never deleted. In addition, the match used `r["name"].decode()`, a Python 2 leftover; on Python 3 `str` has no `.decode()`, so the comprehension raised `AttributeError` for any domain that has records (real domains always have SOA/NS), meaning the function crashed before deletion could even be attempted.

### New Behavior

`destroy_dns_records()` accumulates `domain_records` across every page before matching, so records past page 1 are found and their IDs deleted. Record names are compared directly (`r["name"] == hostname`), which works on Python 3. Non-matching records are still left untouched, and a failed domain lookup still returns `False` without attempting any deletion.

### Merge requirements satisfied?

- [ ] Docs -- N/A (internal bug fix, no doc-facing behaviour change)
- [x] Changelog -- `changelog/55143.fixed.md` added
- [x] Tests written/updated -- `tests/pytests/unit/cloud/clouds/test_digitalocean.py`:
  - `test_destroy_dns_records_pagination_55143` -- patches `query` with a paged side effect; the matching record lives on page 2, asserts the loop requested `records?page=2` and issued the `records/42` delete, and that no page-1 non-matching record was deleted.
  - `test_destroy_dns_records_no_matching_records_55143` -- inverse case: an empty record set produces zero deletions (passes with and without the fix; guards against over-deletion).
  - `test_destroy_dns_records_domain_lookup_failure_55143` -- a `SaltCloudSystemExit` from the lookup returns `False` with no delete attempted.

### Commits signed with GPG?

No