### PR TITLE
Terminate at.at() stdin with a trailing newline

### DIFF
--- a/changelog/58510.fixed.md
+++ b/changelog/58510.fixed.md
@@ -1,0 +1,1 @@
+Terminate the stdin piped to `at` with a trailing newline so distro-patched `at` (Fedora/RHEL) no longer concatenates its job delimiter onto the last command

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -261,6 +261,11 @@ def at(*args, **kwargs):  # pylint: disable=C0103
         stdin = "### SALT: {}\n{}".format(kwargs["tag"], " ".join(args[1:]))
     else:
         stdin = " ".join(args[1:])
+    # Ensure the command is terminated with a newline. Distro-patched at
+    # (Fedora/RHEL, BZ 486844) appends its job delimiter immediately after the
+    # last stdin byte; without a trailing newline the marker concatenates onto
+    # the final command and produces a job that never executes.
+    stdin += "\n"
     cmd = [binary, args[0]]
 
     cmd_kwargs = {"stdin": stdin, "python_shell": False}

--- a/tests/pytests/unit/modules/test_at.py
+++ b/tests/pytests/unit/modules/test_at.py
@@ -230,3 +230,77 @@ def test_atc():
 
     with patch.object(at, "_cmd", return_value="101\tThu Dec 11 19:48:47 2014 A B"):
         assert at.atc(101) == "101\tThu Dec 11 19:48:47 2014 A B"
+
+
+def test_at_stdin_trailing_newline_58510(atq_output):
+    """
+    at.at() must terminate the stdin piped to ``at`` with a trailing newline
+    for both the tagged (``tag=`` kwarg) and untagged branches.
+
+    Distro-patched at (Fedora/RHEL, BZ 486844) appends its job delimiter
+    immediately after the last stdin byte, so without a trailing newline the
+    marker concatenates onto the final command and produces a job that never
+    executes. Regression test for issue #58510.
+    """
+    with patch("salt.modules.at.atq", MagicMock(return_value=atq_output)):
+        with patch.object(salt.utils.path, "which", return_value=True):
+            with patch.dict(at.__grains__, {"os_family": "RedHat", "os": "Linux"}):
+                # Tagged branch, production-exact:
+                #   salt '*' at.at 12:05am '/sbin/reboot' tag=reboot
+                tag_mock = MagicMock(return_value="job 101")
+                with patch.dict(at.__salt__, {"cmd.run": tag_mock}):
+                    at.at("12:05am", "/sbin/reboot", tag="reboot")
+                assert tag_mock.call_args.kwargs["stdin"].endswith("\n")
+
+                # Untagged branch:
+                #   salt '*' at.at 12:05am '/sbin/reboot'
+                notag_mock = MagicMock(return_value="job 101")
+                with patch.dict(at.__salt__, {"cmd.run": notag_mock}):
+                    at.at("12:05am", "/sbin/reboot")
+                assert notag_mock.call_args.kwargs["stdin"].endswith("\n")
+
+
+def test_at_stdin_payload_preserved_58510(atq_output):
+    """
+    Inverse guard for issue #58510: appending the trailing newline must not
+    alter or duplicate the command payload. With trailing newlines stripped the
+    stdin must equal exactly what at.at() built before the fix, and a single
+    newline must not become a double newline. This passes with and without the
+    fix, so it fails a fix that mangles the payload instead of only appending a
+    newline.
+    """
+    with patch("salt.modules.at.atq", MagicMock(return_value=atq_output)):
+        with patch.object(salt.utils.path, "which", return_value=True):
+            with patch.dict(at.__grains__, {"os_family": "RedHat", "os": "Linux"}):
+                tag_mock = MagicMock(return_value="job 101")
+                with patch.dict(at.__salt__, {"cmd.run": tag_mock}):
+                    at.at("12:05am", "/sbin/reboot", tag="reboot")
+                tag_stdin = tag_mock.call_args.kwargs["stdin"]
+                assert tag_stdin.rstrip("\n") == "### SALT: reboot\n/sbin/reboot"
+                assert not tag_stdin.endswith("\n\n")
+
+                notag_mock = MagicMock(return_value="job 101")
+                with patch.dict(at.__salt__, {"cmd.run": notag_mock}):
+                    at.at("12:05am", "/sbin/reboot")
+                notag_stdin = notag_mock.call_args.kwargs["stdin"]
+                assert notag_stdin.rstrip("\n") == "/sbin/reboot"
+                assert not notag_stdin.endswith("\n\n")
+
+
+def test_at_passes_cmd_and_runas_58510(atq_output):
+    """
+    Peripheral coverage of the command construction in at.at() around the
+    touched stdin assembly: the timespec is passed as the second element of the
+    command list, cmd.run is invoked with python_shell=False, and an explicit
+    runas is forwarded.
+    """
+    with patch("salt.modules.at.atq", MagicMock(return_value=atq_output)):
+        with patch.object(salt.utils.path, "which", return_value=True):
+            with patch.dict(at.__grains__, {"os_family": "RedHat", "os": "Linux"}):
+                mock = MagicMock(return_value="job 101")
+                with patch.dict(at.__salt__, {"cmd.run": mock}):
+                    at.at("12:05am", "/sbin/reboot", tag="reboot", runas="jim")
+                cmd_arg = mock.call_args.args[0]
+                assert cmd_arg[1] == "12:05am"
+                assert mock.call_args.kwargs["python_shell"] is False
+                assert mock.call_args.kwargs["runas"] == "jim"


### PR DESCRIPTION
### What does this PR do?

`at.at()` builds the command string it pipes to `at` via `cmd.run(..., stdin=stdin, python_shell=False)` but never terminates it with a newline. This PR appends a single trailing newline after the stdin is assembled, covering both the tagged (`tag=`) and untagged branches in one place.

### What issues does this PR fix or reference?

Fixes #58510

### Previous Behavior

On distributions that ship the Fedora-patched `at` (Fedora/RHEL/CentOS; Fedora `at-3.2.2-shell.patch`, Red Hat BZ 486844 / BZ 2070450), `at` writes its job delimiter with `fprintf(fp, "marcinDELIMITER%08lx\n", i)` immediately after the last byte of stdin. Because Salt sent no trailing newline, the delimiter concatenated onto the final command, e.g. `shutdown -r nowmarcinDELIMITER7f94e9f4`, producing an invalid job that silently never executed. Reproduced by the maintainer and by a bare `subprocess` repro in the issue thread.

### New Behavior

A trailing newline is appended to the stdin, so the delimiter lands on its own line and the command runs. This matches the newline a normal `echo cmd | at now` shell pipe already sends, so behaviour is unchanged on Debian/Ubuntu/BSD and on any non-patched `at`.

### Merge requirements satisfied?

- [x] Docs (not applicable - no user-facing doc change)
- [x] Changelog entry (`changelog/58510.fixed.md`)
- [x] Tests written and described - added a direct-altitude test asserting the piped stdin ends with a newline for both the tagged and untagged branches (production-exact `at.at('12:05am', '/sbin/reboot', tag='reboot')`), an inverse test asserting the command payload is preserved and not double-newlined (passes with and without the fix), and peripheral coverage of the command-list and `runas`/`python_shell` handling.

[NOTE] Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

Commits signed with GPG?: No