### PR TITLE
Fix poudriere jail functions for purely numeric jail names

### DIFF
--- a/changelog/61082.fixed.md
+++ b/changelog/61082.fixed.md
@@ -1,0 +1,1 @@
+Fixed poudriere jail functions failing on purely numeric jail names by coercing the name to a string in is_jail

--- a/salt/modules/poudriere.py
+++ b/salt/modules/poudriere.py
@@ -63,7 +63,7 @@ def is_jail(name):
     """
     jails = list_jails()
     for jail in jails:
-        if jail.split()[0] == name:
+        if jail.split()[0] == str(name):
             return True
     return False
 

--- a/tests/pytests/unit/modules/test_poudriere.py
+++ b/tests/pytests/unit/modules/test_poudriere.py
@@ -28,6 +28,71 @@ def test_is_jail():
         assert not poudriere.is_jail("SALT")
 
 
+def test_is_jail_numeric_61082():
+    """
+    A purely numeric jail name must be matched even though the salt CLI
+    YAML-parses the positional argument into an int before it reaches
+    is_jail (e.g. ``salt-call poudriere.is_jail 13`` passes int 13).
+
+    Regression test for #61082.
+    """
+    # Realistic ``poudriere jails -l`` output from the bug report.
+    jail_list = "\n".join(
+        [
+            "12              12.2-RELEASE-p9 amd64          ftp 2021-07-13 07:35:16 /var/poudriere/jails/12",
+            "13              13.0-RELEASE-p4 amd64          ftp 2021-10-20 08:10:06 /var/poudriere/jails/13",
+            "13-arm-oncourse 13.0-RELEASE-p4 arm64.aarch64 ftp 2021-10-20 08:11:59 /var/poudriere/jails/13-arm-oncourse",
+        ]
+    )
+    mock = MagicMock(return_value=jail_list)
+    with patch.dict(poudriere.__salt__, {"cmd.run": mock}), patch(
+        "salt.modules.poudriere._check_config_exists", MagicMock(return_value=True)
+    ):
+        # int 13, exactly as the CLI passes ``poudriere.is_jail 13``
+        assert poudriere.is_jail(13) is True
+
+
+def test_is_jail_numeric_absent_61082():
+    """
+    A numeric jail name that is not present must still return False. This
+    passes with and without the fix; it guards the str() coercion against
+    turning every numeric lookup into a false positive.
+    """
+    jail_list = "\n".join(
+        [
+            "12 12.2-RELEASE-p9 amd64 ftp 2021-07-13 07:35:16 /var/poudriere/jails/12",
+            "13 13.0-RELEASE-p4 amd64 ftp 2021-10-20 08:10:06 /var/poudriere/jails/13",
+        ]
+    )
+    mock = MagicMock(return_value=jail_list)
+    with patch.dict(poudriere.__salt__, {"cmd.run": mock}), patch(
+        "salt.modules.poudriere._check_config_exists", MagicMock(return_value=True)
+    ):
+        # int 99 is absent -> must not become a false positive
+        assert poudriere.is_jail(99) is False
+
+
+def test_is_jail_numeric_prefixed_string_61082():
+    """
+    A string jail name whose first token starts with digits (e.g.
+    ``13-arm-oncourse``) already worked before the fix and must keep working.
+    Peripheral coverage for the is_jail token comparison.
+    """
+    jail_list = "\n".join(
+        [
+            "13              13.0-RELEASE-p4 amd64          ftp 2021-10-20 08:10:06 /var/poudriere/jails/13",
+            "13-arm-oncourse 13.0-RELEASE-p4 arm64.aarch64 ftp 2021-10-20 08:11:59 /var/poudriere/jails/13-arm-oncourse",
+        ]
+    )
+    mock = MagicMock(return_value=jail_list)
+    with patch.dict(poudriere.__salt__, {"cmd.run": mock}), patch(
+        "salt.modules.poudriere._check_config_exists", MagicMock(return_value=True)
+    ):
+        assert poudriere.is_jail("13-arm-oncourse") is True
+        # a numeric name passed as a string also matches
+        assert poudriere.is_jail("13") is True
+
+
 def test_make_pkgng_aware():
     """
     Test if it make jail ``jname`` pkgng aware.


### PR DESCRIPTION
### What does this PR do?

`poudriere.is_jail` compared the parsed jail-name token (always a string) directly against the `name` argument. When a jail name is purely numeric, the salt CLI YAML-parses the positional argument into an `int`, so a `str == int` comparison is always `False` and the jail is never found. This coerces `name` to a string before the comparison.

Because `is_jail` gates `create_jail`, `update_jail`, `delete_jail`, `info_jail`, and `bulk_build`, this single fix repairs all of them for numeric jail names.

Note: the poudriere execution module lives in core only on the 3006.x branch (it was moved to a community saltext for 3008+), so this PR targets 3006.x.

### What issues does this PR fix or reference?

Fixes #61082

### Previous Behavior

A jail whose name is only digits could not be matched:

```
# salt-call poudriere.is_jail 13
local:
    False
# salt-call poudriere.delete_jail 12
local:
    Looks like jail 12 has not been created
```

while forcing the argument to a string worked:

```
# salt-call poudriere.is_jail "'13'"
local:
    True
```

### New Behavior

Numeric jail names are matched correctly, so `is_jail`, `delete_jail`, `create_jail`, `update_jail`, `info_jail`, and `bulk_build` work with digit-only jail names. Existing string names (including numeric-prefixed ones like `13-arm-oncourse`) are unaffected because `str()` is idempotent on strings.

### Merge requirements satisfied?

- [x] Docs: n/a (behavioural bugfix, no doc change needed)
- [x] Changelog entry added (`changelog/61082.fixed.md`)
- [x] Tests written and passing: `test_is_jail_numeric_61082` (int-input reproducer), `test_is_jail_numeric_absent_61082` (numeric non-match must-not-regress), and `test_is_jail_numeric_prefixed_string_61082` (string names still match)

[NOTICE] Bug fixes or features added to Salt require tests.

Commits signed with GPG: No