### PR TITLE
Document master grains cache reorg requires refresh_grains after upgrade

### DIFF
--- a/changelog/68030.changed.md
+++ b/changelog/68030.changed.md
@@ -1,0 +1,1 @@
+Documented that upgrading a master from 3006.x/3007.x to 3008.x requires running ``saltutil.refresh_grains`` on minions due to the minion data cache reorganization (grains/pillar/mine split into dedicated cache banks).

--- a/doc/topics/releases/templates/3008.0.md.template
+++ b/doc/topics/releases/templates/3008.0.md.template
@@ -57,6 +57,18 @@ conceptual overview, the [tutorial](../resources/tutorial) for a
 guide](../resources/authoring/index) for shipping your own resource
 type.
 
+## Minion Data Cache Reorganized — Refresh Grains After Upgrading the Master
+> :warning: **Upgrade Notice**: <br>
+The master's on-disk minion data cache was reorganized in 3008.0: grains,
+pillar, and mine data now live in dedicated cache banks instead of a single
+combined per-minion blob. Cached data from a pre-3008 master is not migrated
+automatically. After upgrading the master, run
+``salt '*' saltutil.refresh_grains`` (or wait for minions' next scheduled
+pillar/highstate refresh) so minions repopulate the master's grains cache.
+Until then, grain-based targeting (``-G``), ``mine.get``, and cached
+pillar/grains lookups may return stale or empty results for minions that
+haven't re-synced since the upgrade.
+
 <!--
 Do not edit the changelog below.
 This is auto generated.

--- a/doc/topics/releases/templates/3008.3.md.template
+++ b/doc/topics/releases/templates/3008.3.md.template
@@ -1,0 +1,21 @@
+(release-3008.3)=
+# Salt 3008.3 release notes{{ unreleased }}
+{{ warning }}
+
+<!--
+Add release specific details below
+-->
+
+## Upgrading a Master to 3008.x
+> :warning: **Reminder**: <br>
+If your master is being upgraded from 3006.x/3007.x, see the
+[3008.0 release notes](3008.0.md#minion-data-cache-reorganized-refresh-grains-after-upgrading-the-master)
+about the minion data cache reorganization — run
+``salt '*' saltutil.refresh_grains`` on minions after the upgrade.
+
+<!--
+Do not edit the changelog below.
+This is auto generated.
+-->
+## Changelog
+{{ changelog }}


### PR DESCRIPTION
### What does this PR do?
3008.0 split the master's combined per-minion cache blob into dedicated `grains`/`pillar`/`mine` cache banks (#68030). Cached data from a pre-3008 master isn't migrated, so a minion's grains stay invisible to the master (breaking -G/grain targeting, mine.get, and cached pillar/grains lookups) until the minion re-syncs. This wasn't called out anywhere, so admins hit it blind on every 3006.x/3007.x -> 3008.x master upgrade.

Add a warning to the 3008.0 release notes explaining the cache reorganization and the saltutil.refresh_grains workaround, with a forward pointer from the upcoming 3008.3 notes so admins upgrading today also see it.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
