### PR TITLE
Fix managing users on NAPALM proxy minions (#62170)

### DIFF
--- a/changelog/62170.fixed.md
+++ b/changelog/62170.fixed.md
@@ -1,0 +1,10 @@
+Fixed managing users on NAPALM (proxy) minions. ``netusers.managed`` no longer
+raises ``AttributeError: 'NoneType' object has no attribute 'update'`` when the
+state declares no ``defaults``, and ``users.set_users`` / ``users.delete_users``
+no longer fail with ``Local file source set_users does not exist``. The bare
+template names these functions pass to ``net.load_template`` stopped resolving
+when native NAPALM template support was removed in the Sodium release (that
+removal was meant to spare the ``netusers`` state module); they now resolve the
+NAPALM-shipped per-driver template to an absolute path and render it through the
+Salt pipeline. ``netusers.managed`` also now refuses to proceed when it would
+manage an empty set of users, rather than removing every account on the device.

--- a/salt/modules/napalm_users.py
+++ b/salt/modules/napalm_users.py
@@ -19,7 +19,9 @@ Dependencies
 .. versionadded:: 2016.11.0
 """
 
+import inspect
 import logging
+import os.path
 
 # import NAPALM utils
 import salt.utils.napalm
@@ -52,6 +54,39 @@ def __virtual__():
 # ----------------------------------------------------------------------------------------------------------------------
 # helper functions -- will not be exported
 # ----------------------------------------------------------------------------------------------------------------------
+
+
+def _napalm_template_path(napalm_device, template_name):
+    """
+    Return the absolute path to a NAPALM-shipped Jinja template (e.g.
+    ``set_users``) for the driver backing this proxy, or ``None`` if the driver
+    does not ship one.
+
+    NAPALM keeps these config templates in a ``templates`` directory next to
+    each driver module and resolves them by walking the driver class MRO
+    (concrete driver first, then its bases). ``net.load_template`` used to route
+    bare template names into NAPALM's own renderer, but that path was removed in
+    the Sodium release; resolving the template to an absolute path lets the
+    still-supported Salt rendering pipeline render it instead.
+    """
+    driver = napalm_device.get("DRIVER") if napalm_device else None
+    if driver is None:
+        return None
+    for klass in type(driver).__mro__:
+        try:
+            module_file = inspect.getfile(klass)
+        except (TypeError, OSError):
+            # Built-in types (e.g. ``object``) raise TypeError; classes without
+            # an on-disk source (``__main__``, frozen) raise OSError. Neither
+            # can ship a template dir, so move on.
+            continue
+        candidate = os.path.join(
+            os.path.dirname(module_file), "templates", f"{template_name}.j2"
+        )
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # callable functions
@@ -132,8 +167,19 @@ def set_users(
     """
 
     # pylint: disable=undefined-variable
+    template_path = _napalm_template_path(napalm_device, "set_users")
+    if template_path is None:
+        driver_name = napalm_device.get("DRIVER_NAME") if napalm_device else None
+        return {
+            "result": False,
+            "out": None,
+            "comment": (
+                f"The 'set_users' template is not available for the"
+                f" '{driver_name}' driver."
+            ),
+        }
     return __salt__["net.load_template"](
-        "set_users",
+        template_path,
         users=users,
         test=test,
         commit=commit,
@@ -174,8 +220,19 @@ def delete_users(
     """
 
     # pylint: disable=undefined-variable
+    template_path = _napalm_template_path(napalm_device, "delete_users")
+    if template_path is None:
+        driver_name = napalm_device.get("DRIVER_NAME") if napalm_device else None
+        return {
+            "result": False,
+            "out": None,
+            "comment": (
+                f"The 'delete_users' template is not available for the"
+                f" '{driver_name}' driver."
+            ),
+        }
     return __salt__["net.load_template"](
-        "delete_users",
+        template_path,
         users=users,
         test=test,
         commit=commit,

--- a/salt/states/netusers.py
+++ b/salt/states/netusers.py
@@ -68,7 +68,10 @@ def _ordered_dict_to_dict(probes):
 def _expand_users(device_users, common_users):
     """Creates a longer list of accepted users on the device."""
 
-    expected_users = copy.deepcopy(common_users)
+    # ``common_users`` (the state's ``defaults`` argument) is optional, so it is
+    # ``None`` whenever the user does not declare any defaults. Treat that the
+    # same as an empty mapping rather than crashing on ``None.update()``.
+    expected_users = copy.deepcopy(common_users) if common_users else {}
     expected_users.update(device_users)
 
     return expected_users
@@ -319,6 +322,21 @@ def managed(name, users=None, defaults=None):
     defaults = _ordered_dict_to_dict(defaults)
 
     expected_users = _expand_users(users, defaults)
+
+    if not expected_users:
+        # Neither ``users`` nor ``defaults`` yielded anyone to manage. Because
+        # this is a declarative state, proceeding would remove *every* account
+        # configured on the device -- a likely lockout, e.g. when a pillar
+        # lookup renders to an empty mapping. Refuse rather than wipe. See
+        # #62170: previously an unset ``defaults`` crashed here, which happened
+        # to mask this case.
+        ret["comment"] = (
+            "No users were provided to manage. Refusing to proceed, as this"
+            " would remove every user configured on the device. Check the"
+            " state's 'users' and 'defaults' (and any pillar data behind them)."
+        )
+        return ret
+
     valid, message = _check_users(expected_users)
 
     if not valid:  # check and clean

--- a/tests/pytests/unit/modules/napalm/test_users.py
+++ b/tests/pytests/unit/modules/napalm/test_users.py
@@ -37,19 +37,152 @@ def test_config():
         assert ret["out"] == napalm_test_support.TEST_USERS.copy()
 
 
-def test_set_users():
+class _BaseDriver:
+    pass
+
+
+class _ConcreteDriver(_BaseDriver):
+    pass
+
+
+def _getfile_map(mapping):
+    """
+    Build an ``inspect.getfile`` replacement that returns a distinct path per
+    class and raises (like the real one) for anything not in the map -- notably
+    ``object``, so the loop's exception-continue is genuinely exercised.
+    """
+
+    def fake_getfile(klass):
+        try:
+            return mapping[klass]
+        except KeyError:
+            raise TypeError(f"{klass!r} is a built-in class")
+
+    return fake_getfile
+
+
+def test_napalm_template_path_walks_mro_to_base(tmp_path):
+    """
+    #62170: templates can be inherited -- the concrete driver ships none but a
+    base class does. The resolver must walk the MRO (concrete -> base) and skip
+    ``object`` (which raises from getfile) rather than stopping at the first
+    class.
+    """
+    concrete_dir = tmp_path / "concrete"
+    concrete_dir.mkdir()
+    base_tpl = tmp_path / "base" / "templates"
+    base_tpl.mkdir(parents=True)
+    (base_tpl / "set_users.j2").write_text("system { }")
+
+    device = {"DRIVER": _ConcreteDriver()}
+    getfile = _getfile_map(
+        {
+            _ConcreteDriver: str(concrete_dir / "driver.py"),
+            _BaseDriver: str(tmp_path / "base" / "base.py"),
+        }
+    )
+    with patch("salt.modules.napalm_users.inspect.getfile", side_effect=getfile):
+        resolved = napalm_users._napalm_template_path(device, "set_users")
+    assert resolved == str(base_tpl / "set_users.j2")
+
+
+def test_napalm_template_path_missing_returns_none(tmp_path):
+    """
+    Drivers that do not ship a given template anywhere in the MRO (e.g. ios has
+    no user templates) resolve to ``None`` rather than an unusable path -- and
+    the ``object`` -> exception step must not escape the helper.
+    """
+    (tmp_path / "concrete").mkdir()
+    (tmp_path / "base").mkdir()
+    device = {"DRIVER": _ConcreteDriver()}
+    getfile = _getfile_map(
+        {
+            _ConcreteDriver: str(tmp_path / "concrete" / "driver.py"),
+            _BaseDriver: str(tmp_path / "base" / "base.py"),
+        }
+    )
+    with patch("salt.modules.napalm_users.inspect.getfile", side_effect=getfile):
+        assert napalm_users._napalm_template_path(device, "set_users") is None
+    # No device / driver at all is handled too.
+    assert napalm_users._napalm_template_path({}, "set_users") is None
+    assert napalm_users._napalm_template_path(None, "set_users") is None
+
+
+def test_set_users_routes_resolved_template():
+    """
+    #62170: set_users must hand the resolved absolute template path (not the
+    bare "set_users" name, which no longer resolves) to net.load_template.
+    """
+    resolved = "/opt/napalm/junos/templates/set_users.j2"
+    load_template = MagicMock(return_value={"result": True, "comment": "", "out": None})
+    template_path = MagicMock(return_value=resolved)
     with patch(
         "salt.utils.napalm.get_device",
         MagicMock(return_value=napalm_test_support.MockNapalmDevice()),
+    ), patch.object(napalm_users, "_napalm_template_path", template_path), patch.dict(
+        napalm_users.__salt__, {"net.load_template": load_template}
     ):
-        ret = napalm_users.set_users({"mircea": {}})
-        assert ret["result"] is False
+        ret = napalm_users.set_users({"mircea": {"level": 1}}, test=True, commit=False)
+    assert ret == {"result": True, "comment": "", "out": None}
+    # It must ask for the "set_users" template, not "delete_users" (guards the
+    # copy-paste between the two near-identical functions).
+    assert template_path.call_args[0][1] == "set_users"
+    load_template.assert_called_once()
+    args, kwargs = load_template.call_args
+    assert args[0] == resolved
+    assert kwargs["users"] == {"mircea": {"level": 1}}
+    assert kwargs["test"] is True
+    assert kwargs["commit"] is False
+    # The open proxy device is threaded through so the load reuses the session.
+    assert "inherit_napalm_device" in kwargs
 
 
-def test_delete_users():
+def test_delete_users_routes_resolved_template():
+    """
+    #62170: delete_users resolves and uses delete_users.j2 the same way.
+    """
+    resolved = "/opt/napalm/junos/templates/delete_users.j2"
+    load_template = MagicMock(return_value={"result": True, "comment": "", "out": None})
+    template_path = MagicMock(return_value=resolved)
     with patch(
         "salt.utils.napalm.get_device",
         MagicMock(return_value=napalm_test_support.MockNapalmDevice()),
+    ), patch.object(napalm_users, "_napalm_template_path", template_path), patch.dict(
+        napalm_users.__salt__, {"net.load_template": load_template}
     ):
         ret = napalm_users.delete_users({"mircea": {}})
-        assert ret["result"] is False
+    assert ret == {"result": True, "comment": "", "out": None}
+    assert template_path.call_args[0][1] == "delete_users"
+    load_template.assert_called_once()
+    args, kwargs = load_template.call_args
+    assert args[0] == resolved
+    assert "inherit_napalm_device" in kwargs
+
+
+def test_set_users_no_template_for_driver():
+    """
+    When the driver ships no such template, set_users returns a clear error
+    instead of leaking the confusing "Local file source set_users does not
+    exist" message from the fileserver.
+    """
+    with patch(
+        "salt.utils.napalm.get_device",
+        MagicMock(return_value=napalm_test_support.MockNapalmDevice()),
+    ), patch.object(
+        napalm_users, "_napalm_template_path", MagicMock(return_value=None)
+    ):
+        ret = napalm_users.set_users({"mircea": {}})
+    assert ret["result"] is False
+    assert "not available" in ret["comment"]
+
+
+def test_delete_users_no_template_for_driver():
+    with patch(
+        "salt.utils.napalm.get_device",
+        MagicMock(return_value=napalm_test_support.MockNapalmDevice()),
+    ), patch.object(
+        napalm_users, "_napalm_template_path", MagicMock(return_value=None)
+    ):
+        ret = napalm_users.delete_users({"mircea": {}})
+    assert ret["result"] is False
+    assert "not available" in ret["comment"]

--- a/tests/pytests/unit/states/test_netusers.py
+++ b/tests/pytests/unit/states/test_netusers.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for the netusers state.
+"""
+
+import pytest
+
+import salt.states.netusers as netusers
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {netusers: {}}
+
+
+def test_expand_users_without_defaults():
+    """
+    Regression test for #62170.
+
+    ``netusers.managed`` passes its ``defaults`` argument through to
+    ``_expand_users`` as ``common_users``. That argument is optional, so it is
+    ``None`` whenever the SLS does not declare any defaults -- the common case.
+    ``_expand_users`` must treat that as "no defaults" instead of crashing with
+    ``AttributeError: 'NoneType' object has no attribute 'update'``.
+    """
+    users = {"admin": {"level": 15, "password": "$1$xyz", "sshkeys": []}}
+    assert netusers._expand_users(users, None) == users
+
+
+def test_managed_refuses_to_wipe_all_users():
+    """
+    #62170 safety guard: when neither ``users`` nor ``defaults`` yields anyone
+    to manage, ``managed`` must refuse instead of removing every account on the
+    device (which the declarative diff would otherwise do). It must bail out
+    before touching the device.
+    """
+    ret = netusers.managed("t", users={}, defaults=None)
+    assert ret["result"] is False
+    assert ret["changes"] == {}
+    assert "remove every user" in ret["comment"]
+
+
+def test_expand_users_merges_defaults():
+    """
+    When defaults are provided they are merged with the per-device users, and
+    the per-device definition wins on a key collision.
+    """
+    defaults = {"admin": {"level": 1}, "operator": {"level": 5}}
+    users = {"admin": {"level": 15}, "restricted": {"level": 1}}
+    assert netusers._expand_users(users, defaults) == {
+        "admin": {"level": 15},
+        "operator": {"level": 5},
+        "restricted": {"level": 1},
+    }


### PR DESCRIPTION
### What does this PR do?

Restores user management on NAPALM (proxy) minions, which has been broken since
the Sodium release. Two distinct failures are fixed:

**1. `netusers.managed` crash when no `defaults` are declared.**
`managed(name, users=None, defaults=None)` passes `defaults` to `_expand_users`
as `common_users`, then does `copy.deepcopy(common_users).update(...)`. With no
`defaults` (the common case, and the case in the issue's SLS), `common_users` is
`None`, so the state dies with:

```
File ".../salt/states/netusers.py", line 72, in _expand_users
    expected_users.update(device_users)
AttributeError: 'NoneType' object has no attribute 'update'
```

`_expand_users` now treats a missing `defaults` as an empty mapping.

Because that crash previously masked a hazard -- `netusers.managed` is
declarative, so an empty expanded user set means "remove every user" -- `managed`
now refuses to proceed when neither `users` nor `defaults` yields anyone to
manage, instead of silently wiping (and committing) every account on the device.
This closes an admin-lockout foot-gun, e.g. a pillar lookup that renders to `{}`.

**2. `users.set_users` / `users.delete_users` -> "Local file source set_users does not exist".**
These functions call `net.load_template("set_users", ...)` with a bare template
name. `net.load_template` used to route bare names into NAPALM's own renderer,
but that path was removed in Sodium (#57370). The bare name now falls through to
the fileserver, which reports it as a missing local file. Even after working
around bug 1, `netusers.managed` therefore fails with `Cannot configure new
users: Local file source set_users does not exist`.

### Why this is a regression, not a deprecation

The Sodium deprecation warning that preceded the removal said (emphasis added):

> Native NAPALM templates support will be removed in the Sodium release. Please
> consider using the Salt rendering pipeline instead. **If you are using the
> 'netntp', 'netsnmp', or 'netusers' Salt State modules, you can ignore this
> message.**

The `net<x>` state modules and their backing `set_*`/`delete_*` functions take
no template argument -- there is nowhere for a user to supply a `salt://`
template -- so the "use the Salt rendering pipeline" guidance was never aimed at
them, and the warning explicitly told their users to ignore it. But #57370
deleted the entire native-template branch, including the code path those
exempted modules relied on. This PR fixes the `netusers` half of that overshoot.

### Fix

`set_users`/`delete_users` now resolve the NAPALM-shipped per-driver template
(`set_users.j2` / `delete_users.j2`, which NAPALM still ships next to each driver
module) to an absolute path via a small `_napalm_template_path` helper that
mirrors NAPALM's own class-MRO template search, then hand that absolute path to
`net.load_template`. The template is rendered through the **Salt** pipeline --
which is what the deprecation nudged toward -- instead of NAPALM's removed native
path. If a driver ships no such template (e.g. `ios` has no user templates), the
functions now return a clear "template is not available for the '<driver>'
driver" message instead of the misleading fileserver error.

### Validation on real hardware

Reproduced both failures, then validated the fix end-to-end against a live
Juniper EX3400 (Junos 23.4R2) over NETCONF/SSH, driving a real `napalm`/`junos`
proxy minion (onedir 3006.x):

- `netusers.managed` with no `defaults`, `test=True`: crashes with the
  `AttributeError` before the fix; after the fix returns a proper diff and
  "Testing mode: configuration was not changed!".
- `users.set_users {'u': {'level': 1}}` (class-only) and
  `users.set_users {'u': {'level': 5, 'sshkeys': [...]}}` (ssh key): before the
  fix, "Local file source ... does not exist"; after the fix the user is
  rendered, committed, and confirmed present in the device config, then removed
  again with `users.delete_users`.

Note: NAPALM's shipped `set_users.j2` emits `plain-text-password`, which Junos
rejects over NETCONF (it is an interactive-only statement) -- so cleartext
passwords still fail, independent of this change and identically on NAPALM's own
renderer. SSH keys and class-only users work. That template-content limitation
is a NAPALM concern, not Salt's.

### Scope

Fixes the `netusers`/`napalm_users` path reported in the issue. `napalm_ntp` and
`napalm_snmp` (the other two modules the deprecation exempted) carry the
identical bare-name regression and could get the same treatment in a follow-up.

### What issues does this PR fix or reference?
Fixes #62170

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

Direct-altitude unit tests: `_expand_users(None)` no longer raises (and still
merges provided defaults); `managed` refuses an empty user set instead of
wiping the device; `_napalm_template_path` resolves a shipped template
(exercising the class-MRO walk and the `object` -> exception fall-through) and
returns `None` when absent; `set_users`/`delete_users` pass the resolved
absolute path -- and the correct template *name* -- to `net.load_template`, and
return a clear error when the driver ships no template. All fail against the
current code, and the routing/MRO tests are mutation-checked (a set/delete name
swap or a collapsed MRO walk makes them fail).

### Commits signed with GPG?
No
