### PR TITLE
Fix crash/mutation/log bugs in the shared napalm utils and proxy

### DIFF
--- a/changelog/69796.fixed.md
+++ b/changelog/69796.fixed.md
@@ -1,0 +1,5 @@
+Fixed three bugs in the shared NAPALM support code. ``salt.utils.napalm.get_device_opts``
+no longer crashes on ``optional_args: null`` and no longer mutates the caller's
+opts/pillar; ``force_reconnect`` no longer raises ``KeyError: 'proxy'`` on a
+straight (non-proxy) NAPALM minion; and the NAPALM proxy's shutdown error log no
+longer renders the port as a tuple.

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -292,7 +292,7 @@ def shutdown(opts):
         port = (
             __context__["napalm_device"]["network_device"]
             .get("OPTIONAL_ARGS", {})
-            .get("port"),
+            .get("port")
         )
         log.error(
             "Cannot close connection with %s%s! Please check error: %s",

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -354,7 +354,13 @@ def get_device_opts(opts, salt_obj=None):
         or ""
     )
     network_device["TIMEOUT"] = device_dict.get("timeout", 60)
-    network_device["OPTIONAL_ARGS"] = device_dict.get("optional_args", {})
+    # ``or {}`` (not a ``get`` default) so an explicit ``optional_args: null`` in
+    # the config yields a dict rather than None; deepcopy so the config_lock /
+    # keepalive injected below are not written back into the caller's live
+    # opts / pillar structure.
+    network_device["OPTIONAL_ARGS"] = copy.deepcopy(
+        device_dict.get("optional_args") or {}
+    )
     network_device["ALWAYS_ALIVE"] = device_dict.get("always_alive", True)
     network_device["PROVIDER"] = device_dict.get("provider")
     network_device["UP"] = False
@@ -445,11 +451,16 @@ def proxy_napalm_wrap(func):
         force_reconnect = kwargs.get("force_reconnect", False)
         if force_reconnect:
             log.debug("Usage of reconnect force detected")
-            log.debug("Opts before merging")
-            log.debug(opts["proxy"])
-            opts["proxy"].update(**kwargs)
-            log.debug("Opts after merging")
-            log.debug(opts["proxy"])
+            # The credential override is merged into opts['proxy'] for the
+            # always-alive proxy path below. A straight minion has no 'proxy'
+            # key (this raised KeyError) and picks the override up from
+            # clean_kwargs further down, so only touch opts['proxy'] for a proxy.
+            if is_proxy(opts):
+                log.debug("Opts before merging")
+                log.debug(opts["proxy"])
+                opts["proxy"].update(**kwargs)
+                log.debug("Opts after merging")
+                log.debug(opts["proxy"])
         if is_proxy(opts) and always_alive:
             # if it is running in a NAPALM Proxy and it's using the default
             # always alive behaviour, will get the cached copy of the network

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -291,7 +291,13 @@ def get_device_opts(opts, salt_obj=None):
         or ""
     )
     network_device["TIMEOUT"] = device_dict.get("timeout", 60)
-    network_device["OPTIONAL_ARGS"] = device_dict.get("optional_args", {})
+    # ``or {}`` (not a ``get`` default) so an explicit ``optional_args: null`` in
+    # the config yields a dict rather than None; deepcopy so the config_lock /
+    # keepalive injected below are not written back into the caller's live
+    # opts / pillar structure.
+    network_device["OPTIONAL_ARGS"] = copy.deepcopy(
+        device_dict.get("optional_args") or {}
+    )
     network_device["ALWAYS_ALIVE"] = device_dict.get("always_alive", True)
     network_device["PROVIDER"] = device_dict.get("provider")
     network_device["UP"] = False
@@ -382,11 +388,16 @@ def proxy_napalm_wrap(func):
         force_reconnect = kwargs.get("force_reconnect", False)
         if force_reconnect:
             log.debug("Usage of reconnect force detected")
-            log.debug("Opts before merging")
-            log.debug(opts["proxy"])
-            opts["proxy"].update(**kwargs)
-            log.debug("Opts after merging")
-            log.debug(opts["proxy"])
+            # The credential override is merged into opts['proxy'] for the
+            # always-alive proxy path below. A straight minion has no 'proxy'
+            # key (this raised KeyError) and picks the override up from
+            # clean_kwargs further down, so only touch opts['proxy'] for a proxy.
+            if is_proxy(opts):
+                log.debug("Opts before merging")
+                log.debug(opts["proxy"])
+                opts["proxy"].update(**kwargs)
+                log.debug("Opts after merging")
+                log.debug(opts["proxy"])
         if is_proxy(opts) and always_alive:
             # if it is running in a NAPALM Proxy and it's using the default
             # always alive behaviour, will get the cached copy of the network

--- a/tests/pytests/unit/proxy/test_napalm.py
+++ b/tests/pytests/unit/proxy/test_napalm.py
@@ -311,3 +311,30 @@ def test_call(test_opts):
     with patch.dict(napalm_proxy.__context__, mock_context):
         ret = napalm_proxy.call("get_arp_table")
         assert ret == {"result": False, "comment": "Not initialised yet", "out": None}
+
+
+def _shutdown_port_log(optional_args):
+    """Run shutdown() with a failing close() and return the port fragment that
+    was passed to the error log (index 2 of the log.error args)."""
+    driver = MagicMock()
+    driver.close.side_effect = Exception("boom")
+    network_device = {
+        "DRIVER": driver,
+        "UP": True,
+        "HOSTNAME": "core05.nrt02",
+        "OPTIONAL_ARGS": optional_args,
+    }
+    mock_context = {"napalm_device": {"network_device": network_device}}
+    with patch.dict(napalm_proxy.__context__, mock_context), patch(
+        "salt.proxy.napalm.log"
+    ) as mock_log:
+        ret = napalm_proxy.shutdown({})
+    assert ret is True
+    return mock_log.error.call_args[0][2]
+
+
+def test_shutdown_logs_scalar_port_on_close_failure():
+    # The trailing comma made ``port`` a 1-tuple, so the error log rendered
+    # ``:(830,)`` / ``:(None,)`` instead of ``:830`` / ``""``.
+    assert _shutdown_port_log({"port": 830}) == ":830"
+    assert _shutdown_port_log({}) == ""

--- a/tests/pytests/unit/utils/test_napalm.py
+++ b/tests/pytests/unit/utils/test_napalm.py
@@ -2,6 +2,8 @@
 Unit tests for salt.utils.napalm helpers.
 """
 
+import types
+
 import salt.utils.napalm as napalm_utils
 from tests.support.mock import MagicMock, patch
 
@@ -161,3 +163,52 @@ def test_template_not_available_leaves_always_alive_open():
             {"DRIVER": driver, "__opts__": {"id": "sw01"}, "CLOSE": False},
         )
     driver.close.assert_not_called()
+
+
+def test_get_device_opts_null_optional_args():
+    # ``optional_args: null`` in the config yields None from ``.get(..., {})``
+    # (the default only applies to a missing key), which then crashed the
+    # ``"config_lock" not in ...`` membership test.
+    opts = {"napalm": {"driver": "junos", "optional_args": None}}
+    device = napalm_utils.get_device_opts(opts)
+    assert isinstance(device["OPTIONAL_ARGS"], dict)
+    assert device["OPTIONAL_ARGS"]["config_lock"] is False
+
+
+def test_get_device_opts_does_not_mutate_caller():
+    # The injected config_lock / keepalive must land in a copy, not in the
+    # caller's live opts / pillar ``optional_args`` dict.
+    optional_args = {"port": 830}
+    opts = {"napalm": {"driver": "junos", "optional_args": optional_args}}
+    napalm_utils.get_device_opts(opts)
+    assert optional_args == {"port": 830}
+
+
+def _wrapped_with_opts(opts):
+    """A ``proxy_napalm_wrap``-decorated function whose module globals carry the
+    given ``__opts__`` (so we can drive the wrapper without a real minion)."""
+
+    def _fn(*args, **kwargs):
+        return "ok"
+
+    func_globals = {
+        "__opts__": opts,
+        "__proxy__": {},
+        "__salt__": {"config.get": MagicMock(return_value={"driver": "junos"})},
+    }
+    fn = types.FunctionType(_fn.__code__, func_globals, "_fn")
+    return napalm_utils.proxy_napalm_wrap(fn)
+
+
+def test_proxy_napalm_wrap_force_reconnect_straight_minion():
+    # force_reconnect on a straight (non-proxy) minion has no ``opts['proxy']``;
+    # the wrapper must not blindly do ``opts['proxy'].update(...)`` (KeyError).
+    # The override reaches the device through clean_kwargs on the straight path.
+    opts = {"napalm": {"driver": "junos"}}
+    wrapped = _wrapped_with_opts(opts)
+    get_device = MagicMock(return_value={"DRIVER": MagicMock()})
+    with patch("salt.utils.napalm.get_device", get_device):
+        result = wrapped(force_reconnect=True)
+    assert result == "ok"
+    get_device.assert_called_once()
+    assert get_device.call_args[0][0]["napalm"].get("force_reconnect") is True

--- a/tests/pytests/unit/utils/test_napalm.py
+++ b/tests/pytests/unit/utils/test_napalm.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for salt.utils.napalm.
+"""
+
+import types
+
+import salt.utils.napalm as napalm_utils
+from tests.support.mock import MagicMock, patch
+
+
+def test_get_device_opts_null_optional_args():
+    # ``optional_args: null`` in the config yields None from ``.get(..., {})``
+    # (the default only applies to a missing key), which then crashed the
+    # ``"config_lock" not in ...`` membership test.
+    opts = {"napalm": {"driver": "junos", "optional_args": None}}
+    device = napalm_utils.get_device_opts(opts)
+    assert isinstance(device["OPTIONAL_ARGS"], dict)
+    assert device["OPTIONAL_ARGS"]["config_lock"] is False
+
+
+def test_get_device_opts_does_not_mutate_caller():
+    # The injected config_lock / keepalive must land in a copy, not in the
+    # caller's live opts / pillar ``optional_args`` dict.
+    optional_args = {"port": 830}
+    opts = {"napalm": {"driver": "junos", "optional_args": optional_args}}
+    napalm_utils.get_device_opts(opts)
+    assert optional_args == {"port": 830}
+
+
+def _wrapped_with_opts(opts):
+    """A ``proxy_napalm_wrap``-decorated function whose module globals carry the
+    given ``__opts__`` (so we can drive the wrapper without a real minion)."""
+
+    def _fn(*args, **kwargs):
+        return "ok"
+
+    func_globals = {
+        "__opts__": opts,
+        "__proxy__": {},
+        "__salt__": {"config.get": MagicMock(return_value={"driver": "junos"})},
+    }
+    fn = types.FunctionType(_fn.__code__, func_globals, "_fn")
+    return napalm_utils.proxy_napalm_wrap(fn)
+
+
+def test_proxy_napalm_wrap_force_reconnect_straight_minion():
+    # force_reconnect on a straight (non-proxy) minion has no ``opts['proxy']``;
+    # the wrapper must not blindly do ``opts['proxy'].update(...)`` (KeyError).
+    # The override reaches the device through clean_kwargs on the straight path.
+    opts = {"napalm": {"driver": "junos"}}
+    wrapped = _wrapped_with_opts(opts)
+    get_device = MagicMock(return_value={"DRIVER": MagicMock()})
+    with patch("salt.utils.napalm.get_device", get_device):
+        result = wrapped(force_reconnect=True)
+    assert result == "ok"
+    get_device.assert_called_once()
+    assert get_device.call_args[0][0]["napalm"].get("force_reconnect") is True


### PR DESCRIPTION
### What does this PR do?

Fixes three bugs in the shared NAPALM machinery (`salt/utils/napalm.py` and
`salt/proxy/napalm.py`) that every NAPALM module and proxy sits on top of.

1. **`get_device_opts` crashes on `optional_args: null` and mutates the caller's
   config.** `device_dict.get("optional_args", {})` returns `None` when the key is
   present but null (the default only applies to a *missing* key), so the
   `"config_lock" not in ...` membership test raised `TypeError`. And when
   `optional_args` was a dict, it was used by reference -- the `config_lock` /
   `keepalive` defaults injected below were written straight back into the user's
   live opts/pillar structure. Now `copy.deepcopy(... or {})`.

2. **`force_reconnect` raises `KeyError: 'proxy'` on a straight minion.**
   `proxy_napalm_wrap` did `opts["proxy"].update(**kwargs)` unconditionally, but a
   straight (non-proxy) NAPALM minion has no `proxy` key. That merge is only
   needed for the always-alive proxy path; a straight minion already picks the
   override up from `clean_kwargs` further down, so it's now guarded by
   `is_proxy(opts)`.

3. **`proxy.shutdown` logs a malformed port.** A trailing comma made `port` a
   1-tuple, so a failed `close()` logged `:(830,)` / `:(None,)` (and the
   `if port` guard never suppressed the empty case). Comma removed.

### What issues does this PR fix or reference?

Found by an audit of the NAPALM modules (same series as #69793 / #69794 /
#69795).

### Note

The audit also found a `salt.utils.napalm.call()` reconnect issue -- in
not-always-alive mode, the inner `open()` during a `ConnectionClosedException`
retry is closed by its own `finally` before the command re-runs. It needs a more
careful fix plus a reconnect test harness, so it is intentionally left for a
follow-up rather than shipped unvalidated here.

This PR adds `tests/pytests/unit/utils/test_napalm.py`; #69793 also adds that
file (different test functions), so whichever merges second needs a trivial
combine.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog
- [x] Tests written/updated

`test_get_device_opts_null_optional_args`, `test_get_device_opts_does_not_mutate_caller`,
`test_proxy_napalm_wrap_force_reconnect_straight_minion` (new
`utils/test_napalm.py`) and `test_shutdown_logs_scalar_port_on_close_failure`
(added to `proxy/test_napalm.py`). All fail against the current code.

### Commits signed with GPG?
No



Also fixes #62902 (`secret`/`optional_args` dropped on `status.proxy_reconnect`, because the shared `OPTIONAL_ARGS` dict was mutated in place across reconnects).
