### PR TITLE
Fix bare except: use except ValueError for datetime.strptime in x509 module

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1537,7 +1537,7 @@ def create_certificate(path=None, text=False, overwrite=True, ca_server=None, **
     if "not_before" in kwargs:
         try:
             time = datetime.datetime.strptime(kwargs["not_before"], fmt)
-        except:
+        except ValueError:
             raise salt.exceptions.SaltInvocationError(
                 "not_before: {} is not in required format {}".format(
                     kwargs["not_before"], fmt
@@ -1555,7 +1555,7 @@ def create_certificate(path=None, text=False, overwrite=True, ca_server=None, **
     if "not_after" in kwargs:
         try:
             time = datetime.datetime.strptime(kwargs["not_after"], fmt)
-        except:
+        except ValueError:
             raise salt.exceptions.SaltInvocationError(
                 "not_after: {} is not in required format {}".format(
                     kwargs["not_after"], fmt


### PR DESCRIPTION
Replace bare `except:` with `except ValueError:` in `salt/modules/x509.py`.

Two bare `except:` clauses wrap `datetime.datetime.strptime()` calls for validating `not_before` and `not_after` certificate date parameters. `strptime` raises `ValueError` when the format doesn't match, so `except ValueError:` is the correct specific exception type here.