### PR TITLE
Fix Codecov CLI installation: keybase.io PGP key gone (404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,7 +571,7 @@ jobs:
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -569,7 +569,7 @@ jobs:
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -355,7 +355,7 @@
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/changelog/69800.fixed.md
+++ b/changelog/69800.fixed.md
@@ -1,0 +1,1 @@
+Fix Codecov CLI installation step by replacing dead keybase.io PGP key URL.


### PR DESCRIPTION
## What's broken

The `Install Codecov CLI` step in the `Combine Code Coverage` job (`.github/workflows/ci.yml`) and the equivalent step in `.github/workflows/depcheck.yml` fail on every push and PR:

```
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
Process completed with exit code 2.
```

Reference failing run: https://github.com/saltstack/salt/actions/runs/29173817946

## Why

The step fetches the Codecov signing key from `https://keybase.io/codecovsecurity/pgp_keys.asc`, which now returns HTTP 404. Keybase is effectively dead post-Zoom acquisition.

## Fix

Swap the dead Keybase URL for `https://uploader.codecov.io/verification.gpg` -- the Codecov Uploader Verification Key (keyid `27034E7FDB850E0BBC2C62FF806BB28AED779869`), which is the same key that signs the `codecov.SHA256SUM.sig` file the workflow already downloads and verifies. Minimum-blast-radius change: one URL, no new action pins, coverage semantics unchanged.

I also considered switching to `codecov/codecov-action@v5`; deferred because it's a broader refactor and would need to be re-evaluated for tokenless/token semantics. The URL swap unblocks CI now.

## Verification

```
$ curl -sI https://uploader.codecov.io/verification.gpg
HTTP/2 200
content-type: text/plain; charset=utf-8
content-length: 3187
last-modified: Tue, 11 Oct 2022 16:54:26 GMT
...

$ curl -s https://uploader.codecov.io/verification.gpg | gpg --show-keys
pub   rsa4096 2021-05-24 [SC]
      27034E7FDB850E0BBC2C62FF806BB28AED779869
uid                      Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>
sub   rsa4096 2021-05-24 [E]
```

Confirmed valid OpenPGP data (not HTML).

## Scope / merge-forward

Same broken block exists on `3007.x`, `3008.x`, and `master`. This PR targets `3006.x`; the maintainer merge-forward pipeline will carry it to the newer branches. No sibling PRs.

Fixes #69800