### PR TITLE
Fix napalm.junos_rpc get-config filter leaking the __kwarg__ marker (#65867)

### DIFF
--- a/changelog/65867.fixed.md
+++ b/changelog/65867.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``junos.rpc`` (used by ``napalm.junos_rpc``) so the reserved ``__kwarg__`` marker carried in through ``__pub_arg`` is stripped before the request is sent to the device. Previously a ``get-config`` call with a ``filter`` would fail after upgrading from 3004, because the marker leaked into the RPC options.

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -346,6 +346,11 @@ def rpc(cmd=None, dest=None, **kwargs):
     else:
         op.update(kwargs)
 
+    # Reserved kwargs such as __kwarg__ can be carried in via __pub_arg. Strip
+    # them so they are not forwarded to the device as RPC options/arguments,
+    # which would otherwise raise (e.g. the get-config filter reply below).
+    op = salt.utils.args.clean_kwargs(**op)
+
     if cmd is None:
         ret["message"] = "Please provide the rpc to execute."
         ret["out"] = False

--- a/tests/pytests/unit/modules/test_junos.py
+++ b/tests/pytests/unit/modules/test_junos.py
@@ -2322,6 +2322,58 @@ def test_rpc_get_config_filter():
         assert etree.tostring(exec_args[0][0]) == expected_rpc
 
 
+def test_rpc_get_config_filter_ignores_kwarg_marker():
+    # The CLI and napalm.junos_rpc carry the reserved __kwarg__ marker in via
+    # __pub_arg. It must be stripped, otherwise it leaks into the get-config
+    # options and the request fails (issue #65867).
+    with patch("jnpr.junos.device.Device.execute") as mock_execute:
+        mock_execute.return_value = etree.XML("<reply><rpc/></reply>")
+        args = {
+            "__pub_user": "root",
+            "__pub_arg": [
+                "get-config",
+                {
+                    "filter": "<configuration><system/></configuration>",
+                    "__kwarg__": True,
+                },
+            ],
+            "__pub_fun": "napalm.junos_rpc",
+            "__pub_jid": "20170314162715866528",
+            "__pub_tgt": "mac_min",
+            "__pub_tgt_type": "glob",
+            "filter": "<configuration><system/></configuration>",
+            "__pub_ret": "",
+        }
+        ret = junos.rpc("get-config", **args)
+        assert ret["out"] is True
+        rendered = etree.tostring(mock_execute.call_args[0][0])
+        expected_rpc = b'<get-configuration format="xml"><configuration><system/></configuration></get-configuration>'
+        assert rendered == expected_rpc
+        assert b"__kwarg__" not in rendered
+
+
+def test_rpc_non_get_config_ignores_kwarg_marker():
+    # The __kwarg__ marker must also be stripped on the non get-config path,
+    # where op is forwarded as RPC arguments rather than options (issue #65867).
+    with patch("jnpr.junos.device.Device.execute") as mock_execute:
+        mock_execute.return_value = etree.XML("<rpc-reply/>")
+        args = {
+            "__pub_arg": [
+                "get-interface-information",
+                {"terse": True, "interface_name": "lo0", "__kwarg__": True},
+            ],
+            "terse": True,
+            "interface_name": "lo0",
+            "__pub_fun": "junos.rpc",
+        }
+        ret = junos.rpc("get-interface-information", **args)
+        assert ret["out"] is True
+        rendered = etree.tostring(mock_execute.call_args[0][0])
+        expected_rpc = b'<get-interface-information format="xml"><terse/><interface-name>lo0</interface-name></get-interface-information>'
+        assert rendered == expected_rpc
+        assert b"__kwarg__" not in rendered
+
+
 def test_rpc_get_interface_information():
     with patch("jnpr.junos.device.Device.execute") as mock_execute:
         junos.rpc("get-interface-information", format="json")


### PR DESCRIPTION
### What does this PR do?

Fixes `junos.rpc` (used by `napalm.junos_rpc`) so a `get-config` call with a `filter` works again.

`junos.rpc` builds its RPC options (`op`) from `__pub_arg`, which carries the reserved `__kwarg__` marker that the Salt CLI appends to keyword arguments. That marker leaked into the RPC options; on the `get-config` path junos-eznc's `ElementMaker` then tried to render the `True` value as an XML attribute and raised `KeyError: <class 'bool'>`, so the `filter` option stopped working after upgrading from 3004 to 3006.

The fix strips dunder keys from `op` with `salt.utils.args.clean_kwargs` (already used by `junos.diff`) right after `op` is assembled, so reserved markers are dropped on both the `get-config` and the generic RPC branch.

### Fixes

Fixes #65867

### Tests

Adds two regression tests in `tests/pytests/unit/modules/test_junos.py`:

- `test_rpc_get_config_filter_ignores_kwarg_marker` - the reported case: `__pub_arg` carries `{'filter': ..., '__kwarg__': True}` and the rendered RPC must be the clean `<get-configuration format="xml">...</get-configuration>`.
- `test_rpc_non_get_config_ignores_kwarg_marker` - the generic path, where `op` is forwarded as RPC arguments rather than options.

Both fail without the fix (the `get-config` case raises `KeyError: <class 'bool'>` in junos-eznc's `ElementMaker`) and pass with it, verified against real junos-eznc (2.8.2) rendering with only `Device.execute` mocked.

### Notes

The same `__pub_arg` handling block is repeated in several other `junos` functions (e.g. `cli`, `commit`, `install_config`). This PR is scoped to the reported `get-config` regression; applying the same marker stripping to the other functions can follow separately.