### PR TITLE
Add ability to disable pillar masking globally

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -563,6 +563,10 @@
 # to 'False', the failed attempt returns an empty string. Default is 'False'.
 #pillar_raise_on_missing: False
 #
+# Set this option to 'False' to globally disable masking of pillar values
+# (e.g. passwords, keys) in logs and CLI output. Default is 'True'.
+#pillar_masking: True
+#
 # If using the local file directory, then the state top file name needs to be
 # defined, by default this is top.sls.
 #state_top: top.sls

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2901,6 +2901,27 @@ Set this option to ``True`` to force a ``KeyError`` to be raised whenever an
 attempt to retrieve a named value from pillar fails. When this option is set
 to ``False``, the failed attempt returns an empty string.
 
+.. conf_minion:: pillar_masking
+
+``pillar_masking``
+-------------------
+
+.. versionadded:: 3008.2
+
+Default: ``True``
+
+By default, pillar values (e.g. passwords, keys) are redacted with
+``**********`` whenever pillar data is logged or displayed, such as in
+``salt '*' pillar.items`` output or in state execution logs. Set this option
+to ``False`` to disable this masking globally, so pillar functions return and
+display plain, unmasked values by default. This is equivalent to always
+passing ``unmask=True`` to the :py:mod:`pillar <salt.modules.pillar>`
+execution module functions.
+
+.. code-block:: yaml
+
+    pillar_masking: False
+
 .. conf_minion:: minion_pillar_cache
 
 ``minion_pillar_cache``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -693,6 +693,8 @@ VALID_OPTS = immutabletypes.freeze(
         # GPG data cache backend. Defaults to `disk` which stores caches in the master cache
         "gpg_cache_backend": str,
         "pillar_safe_render_error": bool,
+        # Global switch to disable redaction of pillar values in logs/output
+        "pillar_masking": bool,
         # When creating a pillar, there are several strategies to choose from when
         # encountering duplicate values
         "pillar_source_merging_strategy": str,
@@ -1170,6 +1172,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "pillarenv": None,
         "pillarenv_from_saltenv": False,
         "pillar_opts": False,
+        "pillar_masking": True,
         "pillar_source_merging_strategy": "smart",
         "pillar_merge_lists": False,
         "pillar_includes_override_sls": False,

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -146,7 +146,7 @@ def get(
     )
 
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        unmask = not salt.utils.secret.masking_active(__opts__)
 
     if merge:
         if isinstance(default, dict):
@@ -297,7 +297,7 @@ def items(
     )
     ret = pillar.compile_pillar()
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        unmask = not salt.utils.secret.masking_active(__opts__)
     if unmask:
         return salt.utils.secret.expose(ret)
     else:
@@ -579,7 +579,7 @@ def item(
     )
 
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        unmask = not salt.utils.secret.masking_active(__opts__)
 
     try:
         for arg in args:
@@ -682,7 +682,9 @@ def ext(external, pillar=None, unmask=None):
         to ``False``, masked values are returned. The default of ``None``
         auto-detects from the :func:`salt.utils.secret.mask_pillar` context
         variable so direct user invocations see plain values while invocations
-        from inside the renderer/state pipeline stay masked.
+        from inside the renderer/state pipeline stay masked. Masking can also
+        be disabled globally with the :conf_minion:`pillar_masking` config
+        option.
 
         .. versionadded:: 3008.2
 
@@ -708,7 +710,7 @@ def ext(external, pillar=None, unmask=None):
     ret = pillar_obj.compile_pillar()
 
     if unmask is None:
-        unmask = not salt.utils.secret.mask_pillar.get()
+        unmask = not salt.utils.secret.masking_active(__opts__)
 
     if unmask:
         return salt.utils.secret.expose(ret)

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -279,7 +279,7 @@ class AsyncRemotePillar(RemotePillarMixin):
             log.exception("Exception getting pillar:")
             raise SaltClientError("Exception getting pillar.")
         self.validate_return(ret_pillar)
-        ret_pillar = salt.utils.secret.hide(ret_pillar)
+        ret_pillar = salt.utils.secret.hide(ret_pillar, self.opts)
         return ret_pillar
 
     def destroy(self):
@@ -371,7 +371,7 @@ class RemotePillar(RemotePillarMixin):
             log.exception("Exception getting pillar:")
             raise SaltClientError("Exception getting pillar.")
         self.validate_return(ret_pillar)
-        return salt.utils.secret.hide(ret_pillar)
+        return salt.utils.secret.hide(ret_pillar, self.opts)
 
     def destroy(self):
         if hasattr(self, "_closing") and self._closing:

--- a/salt/utils/secret.py
+++ b/salt/utils/secret.py
@@ -26,6 +26,10 @@ Usage::
 
     # Safety net for general output (output/__init__.py)
     mask_output(state_return_data)              # no-op for plain data
+
+    # Global override via the ``pillar_masking`` minion config option: when
+    # set to False, hide() skips wrapping and masking_active() reports False,
+    # so pillar data is never redacted regardless of context.
 """
 
 from __future__ import annotations
@@ -202,13 +206,32 @@ class MaskedList(list):
 # ---------------------------------------------------------------------------
 
 
-def hide(value):
+def masking_active(opts=None):
+    """Return whether pillar masking should currently be applied.
+
+    Combines the ``pillar_masking`` config option (a global on/off switch,
+    default ``True``) with the ``mask_pillar`` context var (used to disable
+    masking for the duration of renderer/template execution regardless of
+    config). If ``opts`` disables ``pillar_masking``, masking is off
+    unconditionally.
+    """
+    if opts is not None and not opts.get("pillar_masking", True):
+        return False
+    return mask_pillar.get()
+
+
+def hide(value, opts=None):
     """Wrap a pillar dict/list in MaskedDict/MaskedList for display masking.
 
     Scalar values (str, int, bool, None …) are returned unchanged — they are
     stored plain inside the container and only redacted in the container's repr.
     Already-wrapped values are returned as-is (idempotent).
+
+    If ``opts`` has ``pillar_masking`` set to ``False``, masking is disabled
+    globally and *value* is returned unwrapped.
     """
+    if opts is not None and not opts.get("pillar_masking", True):
+        return value
     return _mask_wrap(value)
 
 

--- a/tests/pytests/unit/modules/test_pillar.py
+++ b/tests/pytests/unit/modules/test_pillar.py
@@ -278,6 +278,32 @@ def test_raw_unmask_false_returns_masked_values():
         assert "*" in masked_key
 
 
+def test_get_default_masks_when_unmask_not_passed():
+    """``pillar.get`` masks by default when ``unmask`` is not passed."""
+    with patch.dict(pillarmod.__pillar__, {"secret": "swordfish"}):
+        result = pillarmod.get("secret")
+        assert result != "swordfish"
+        assert "*" in result
+
+
+def test_get_pillar_masking_false_disables_masking_by_default():
+    """``pillar_masking: False`` in opts makes ``pillar.get`` unmask by default."""
+    with patch.dict(pillarmod.__pillar__, {"secret": "swordfish"}), patch.dict(
+        pillarmod.__opts__, {"pillar_masking": False}
+    ):
+        assert pillarmod.get("secret") == "swordfish"
+
+
+def test_get_pillar_masking_false_explicit_unmask_false_still_wins():
+    """An explicit ``unmask=False`` still masks even if pillar_masking is False."""
+    with patch.dict(pillarmod.__pillar__, {"secret": "swordfish"}), patch.dict(
+        pillarmod.__opts__, {"pillar_masking": False}
+    ):
+        result = pillarmod.get("secret", unmask=False)
+        assert result != "swordfish"
+        assert "*" in result
+
+
 def test_ext_forwards_unmask_to_expose():
     """``pillar.ext(unmask=True)`` returns unmasked compiled pillar."""
     compiled = {"a": "plain", "b": "secret"}

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -7,6 +7,7 @@ import pytest
 import salt.loader
 import salt.pillar
 import salt.utils.cache
+import salt.utils.secret
 from tests.support.mock import MagicMock, patch
 
 
@@ -260,6 +261,43 @@ def test_remote_pillar_timeout(temp_salt_minion, tmp_path):
     msg = r"^Pillar timed out after \d{1,4} seconds$"
     with pytest.raises(salt.exceptions.SaltClientError):
         pillar.compile_pillar()
+
+
+def test_remote_pillar_compile_pillar_masks_by_default(temp_salt_minion):
+    opts = temp_salt_minion.config.copy()
+    opts["master_uri"] = "tcp://127.0.0.1:12323"
+    grains = salt.loader.grains(opts)
+    pillar = salt.pillar.RemotePillar(
+        opts,
+        grains,
+        temp_salt_minion.id,
+        "base",
+    )
+    pillar.channel.crypted_transfer_decode_dictentry = MagicMock(
+        return_value={"secret": "hunter2"}
+    )
+    ret = pillar.compile_pillar()
+    assert isinstance(ret, salt.utils.secret.MaskedDict)
+    assert salt.utils.secret.REDACT_PLACEHOLDER in repr(ret)
+
+
+def test_remote_pillar_compile_pillar_pillar_masking_false(temp_salt_minion):
+    opts = temp_salt_minion.config.copy()
+    opts["master_uri"] = "tcp://127.0.0.1:12323"
+    opts["pillar_masking"] = False
+    grains = salt.loader.grains(opts)
+    pillar = salt.pillar.RemotePillar(
+        opts,
+        grains,
+        temp_salt_minion.id,
+        "base",
+    )
+    pillar.channel.crypted_transfer_decode_dictentry = MagicMock(
+        return_value={"secret": "hunter2"}
+    )
+    ret = pillar.compile_pillar()
+    assert not isinstance(ret, salt.utils.secret.MaskedDict)
+    assert ret == {"secret": "hunter2"}
 
 
 def test_ext_pillar_dunder_in_modules_in_pillar(temp_salt_minion):

--- a/tests/pytests/unit/utils/test_secret.py
+++ b/tests/pytests/unit/utils/test_secret.py
@@ -197,6 +197,66 @@ def test_hide_already_masked_list_is_idempotent():
     assert lst2 is lst
 
 
+def test_hide_without_opts_masks_by_default():
+    d = secret.hide({"k": "v"})
+    assert isinstance(d, secret.MaskedDict)
+
+
+def test_hide_respects_pillar_masking_true():
+    d = secret.hide({"k": "v"}, {"pillar_masking": True})
+    assert isinstance(d, secret.MaskedDict)
+
+
+def test_hide_respects_pillar_masking_false():
+    value = {"k": "v"}
+    result = secret.hide(value, {"pillar_masking": False})
+    assert result is value
+    assert not isinstance(result, secret.MaskedDict)
+
+
+def test_hide_opts_without_pillar_masking_key_defaults_true():
+    d = secret.hide({"k": "v"}, {})
+    assert isinstance(d, secret.MaskedDict)
+
+
+# ---------------------------------------------------------------------------
+# masking_active()
+# ---------------------------------------------------------------------------
+
+
+def test_masking_active_default_true():
+    assert secret.masking_active() is True
+
+
+def test_masking_active_with_opts_true():
+    assert secret.masking_active({"pillar_masking": True}) is True
+
+
+def test_masking_active_with_opts_false():
+    assert secret.masking_active({"pillar_masking": False}) is False
+
+
+def test_masking_active_opts_missing_key_defaults_true():
+    assert secret.masking_active({}) is True
+
+
+def test_masking_active_opts_false_overrides_context_var():
+    """pillar_masking: False disables masking even inside renderer context."""
+    token = secret.mask_pillar.set(False)
+    try:
+        assert secret.masking_active({"pillar_masking": False}) is False
+    finally:
+        secret.mask_pillar.reset(token)
+
+
+def test_masking_active_opts_true_still_respects_context_var():
+    token = secret.mask_pillar.set(False)
+    try:
+        assert secret.masking_active({"pillar_masking": True}) is False
+    finally:
+        secret.mask_pillar.reset(token)
+
+
 # ---------------------------------------------------------------------------
 # expose()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

adds ability to disable pillar masking from minion config file

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/69599


### Previous Behavior
by default, salt masks all pillar returns to stdout and log unless passing unmask=true

ie default pillar return

```
salt devsaltmaster pillar.items
devsaltmaster:
    ----------
    accounts:
        - **********
        - **********
        - **********
    disabled_services:
        - **********
        - **********
        - **********
 ```

this breaks a lot of default behavior and workflows, especially if certain states use salt['pillar.get'] < this returns ***** asterisks and breaks formulas

### New Behavior
by default, pillar return will be masked, but you can now globally override this in salt minion cfg file with

```
pillar_masking: False 
```


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
