### PR TITLE
Fix pymssql pin for win32: revert 2.3.13 back to 2.3.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,11 @@ croniter!=0.3.22,>=6.2.4; sys_platform != 'win32'
 # last 46.x release for Python 3.9 so uv pip compile can still resolve.
 # Furthermore, pyOpenSSL 26.2 dropped X509Extension and add_extensions()
 # which breaks salt/modules/tls.py. pyOpenSSL < 26.2 requires cryptography < 48.0.0.
-cryptography>=49.0.0,<50.0.0
+# cryptography 49.0.0+ dropped win32 (32-bit Windows) wheels; salt 3006.x
+# still builds a Windows x86 onedir, so pin to the last release that
+# ships cp3X-win32 wheels.
+cryptography==48.0.0; sys_platform == 'win32'
+cryptography>=49.0.0,<50.0.0; sys_platform != 'win32'
 distro>=1.9.0
 frozenlist>=1.8.0; python_version < '3.11'
 frozenlist>=1.5.0; python_version >= '3.11'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,30 +3,30 @@
 
 aiohttp>=3.13.5,<3.14.0; python_version < '3.10'
 aiohttp>=3.14.1; python_version >= '3.10'
-certifi>=2026.5.20
-cffi>=2.0.0
+certifi>=2026.6.17
+cffi>=2.1.0
 # cheroot 8.5.2 fails to build with modern setuptools due to setuptools_scm_git_archive dependency
 cheroot>=11.1.2
 cherrypy>=18.10.0
 # We need contextvars for salt-ssh
 contextvars
-croniter!=0.3.22,>=6.2.2; sys_platform != 'win32'
+croniter!=0.3.22,>=6.2.4; sys_platform != 'win32'
 # cryptography 48.0.0 drops support for Python 3.9.0 and 3.9.1
 # (only >3.9.1 is accepted), but the py3.9 lock files are compiled
 # with --python-version=3.9 which includes those releases. Cap at the
 # last 46.x release for Python 3.9 so uv pip compile can still resolve.
 # Furthermore, pyOpenSSL 26.2 dropped X509Extension and add_extensions()
 # which breaks salt/modules/tls.py. pyOpenSSL < 26.2 requires cryptography < 48.0.0.
-cryptography>=46.0.7,<48.0.0
+cryptography>=49.0.0,<50.0.0
 distro>=1.9.0
 frozenlist>=1.8.0; python_version < '3.11'
 frozenlist>=1.5.0; python_version >= '3.11'
-gitpython>=3.1.50
+gitpython>=3.1.52
 immutables>=0.21
 importlib-metadata>=8.7.0
-jaraco.functools>=4.4.0
-jaraco.context>=6.1.1
-jaraco.text>=4.2.0
+jaraco.functools>=4.6.0
+jaraco.context>=6.1.2
+jaraco.text>=4.3.0
 Jinja2>=3.1.6
 jmespath>=1.1.0
 looseversion
@@ -35,54 +35,54 @@ MarkupSafe<4.0.0
 # multidict 6.0.4 fails to source-build under clang 17+ with strict int/pointer
 # conversion checks (macOS 15 onedir builds compile from sdist via
 # --no-binary=:all:). 6.6+ fixed the C source compatibility.
-multidict>=6.6.0
-msgpack>=1.1.2
+multidict>=6.7.1
+msgpack>=1.2.1
 # Packaging 24.1+ imports annotations from __future__ which breaks
 # salt-ssh on target hosts with older Python versions (Amazon Linux 2
 # still ships Python 3.7). 26.x additionally uses positional-only
 # `/` parameter syntax which is a SyntaxError on Python <3.8. Keep at
 # 24.0 to preserve salt-ssh compatibility against legacy target
 # Pythons; salt 3006.x still promises this matrix.
-packaging==24.0
+packaging==26.2
 psutil<6.0.0; python_version <= '3.9'
-psutil>=5.0.0; python_version >= '3.10'
+psutil>=7.2.2; python_version >= '3.10'
 # pymssql 2.3.12+ dropped win32 (32-bit Windows) wheels; salt 3006.x
 # still builds a Windows x86 onedir, so pin to the last release that
 # ships cp3X-win32 wheels.
-pymssql==2.3.11; sys_platform == 'win32'
+pymssql==2.3.13; sys_platform == 'win32'
 pymysql>=1.2.0; sys_platform == 'win32'
-pyopenssl>=26.0.0,<26.2.0
+pyopenssl>=26.3.0,<26.4.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
-pythonnet>=3.0.5; sys_platform == 'win32'
+pythonnet>=3.1.0; sys_platform == 'win32'
 tzdata; sys_platform == 'win32'
 pywin32>=312; sys_platform == 'win32'
 pycryptodomex>=3.23.0
 PyYAML>=6.0.3
 requests>=2.32.5 ; python_version < '3.10'
-requests>=2.33.1 ; python_version >= '3.10'
+requests>=2.34.2 ; python_version >= '3.10'
 setproctitle>=1.3.7
 # pyzmq 27 dropped its tornado runtime dep; pyzmq.eventloop submodules
 # (zmqstream, future) still import tornado.ioloop at module load. Pin
 # tornado explicitly so onedir lockfiles keep shipping it.
-tornado>=6.5.5
+tornado>=6.5.7
 # Python 3.9 stays on urllib3 1.26.x because botocore on py3.9 hard
 # requires urllib3 < 2 and Salt 3006.x still builds a py3.9 onedir.
 # The Python 3.10+ floor carries the urllib3 2.6.3 CVE backports
 # (CVE-2025-66418, CVE-2026-21441).
 urllib3>=1.26.20,<2.0.0; python_version < '3.10'
 urllib3>=2.7.0; python_version >= '3.10'
-virtualenv>=21.4.2
+virtualenv>=21.6.1
 # Transitive of virtualenv; some uv resolver caches pin a stale 3.25
 # version that conflicts with the CI floor of 3.29.1 on Python 3.10+.
-filelock>=3.29.1; python_version >= '3.10'
+filelock>=3.31.0; python_version >= '3.10'
 filelock>=3.19.1,<3.29.0; python_version < '3.10'
 wmi>=1.5.1; sys_platform == 'win32'
 xmltodict>=1.0.4; sys_platform == 'win32'
-zipp>=3.23.1
+zipp>=4.1.0
 apache-libcloud>=3.8.0,<3.9.1; python_version < '3.10'
 apache-libcloud>=3.9.1; python_version >= '3.10'
 idna>=3.18
-more-itertools>=10.8.0
-pyasn1>=0.6.3
-pycparser>=2.23
+more-itertools>=11.1.0
+pyasn1>=0.6.4
+pycparser>=3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ psutil>=7.2.2; python_version >= '3.10'
 # pymssql 2.3.12+ dropped win32 (32-bit Windows) wheels; salt 3006.x
 # still builds a Windows x86 onedir, so pin to the last release that
 # ships cp3X-win32 wheels.
-pymssql==2.3.13; sys_platform == 'win32'
+pymssql==2.3.11; sys_platform == 'win32'
 pymysql>=1.2.0; sys_platform == 'win32'
 pyopenssl>=26.3.0,<26.4.0
 python-dateutil>=2.9.0.post0

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,2 @@
 twine
-build>=1.4.4
+build>=1.5.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,7 @@ wheel >= 0.47.0
 # setuptools; this floor only relaxes what the onedir-bundled pip is
 # allowed to use.
 setuptools >= 78.1.1
-pip == 26.0.1
+pip == 26.1.2
 markdown-it-py < 3.0.0; python_version == "3.9"
 # myst-docutils 4.x (the latest supporting Python 3.10) requires
 # markdown-it-py ~=3.0; the 5.x line that pairs with markdown-it-py 4.x

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,8 +1,8 @@
 mock >= 5.2.0
 # PyTest
-docker >= 7.1.0; python_version >= '3.8'
+docker >= 7.2.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'
-pytest >= 8.4.2
+pytest >= 9.1.1
 pytest-salt-factories >= 1.0.5
 pytest-helpers-namespace >= 2021.12.29
 pytest-subtests

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -14,17 +14,17 @@ bcrypt
 # our urllib3 floor is 2.6.3 so we skip the boto3 cloud module tests on
 # 3.9 by not pinning it here. The bare `boto3` package is still
 # available transitively for any tool that needs it.
-boto3>=1.43.24; python_version >= '3.10'
+boto3>=1.43.51; python_version >= '3.10'
 boto>=2.49.0
-cryptography>=46.0.7,<48.0.0
-cffi>=2.0.0
+cryptography>=49.0.0,<50.0.0
+cffi>=2.1.0
 cherrypy>=18.10.0
 clustershell
 dnspython
 etcd3-py==0.1.6
 filelock>=3.19.1 ; python_version < '3.10'
-filelock>=3.29.1 ; python_version >= '3.10'
-gitpython>=3.1.50
+filelock>=3.31.0 ; python_version >= '3.10'
+gitpython>=3.1.52
 google-auth==2.35.0; python_version == '3.9'
 jmespath>=1.1.0
 jsonschema
@@ -35,7 +35,7 @@ kazoo; sys_platform != 'win32' and sys_platform != 'darwin'
 keyring==25.7.0
 pyasn1-modules==0.4.0; python_version == '3.9'
 kubernetes>=35.0.0,<36.0.0; python_version < '3.10'
-kubernetes>=36.0.2; python_version >= '3.10'
+kubernetes>=36.0.3; python_version >= '3.10'
 libnacl>=2.1.0; sys_platform != 'win32' and sys_platform != 'darwin'
 # markdown-it-py constraint for py3.9: myst-docutils (docs requirement) needs <3.0.0,
 # but netmiko (from napalm, only in py3.9) pulls in rich which wants 3.0.0+
@@ -47,7 +47,7 @@ napalm; sys_platform != 'win32' and python_version < '3.10'
 paramiko>=5.0.0; sys_platform != 'win32' and sys_platform != 'darwin'
 passlib>=1.7.4
 pycryptodomex
-pynacl>=1.5.0
+pynacl>=1.6.2
 pyinotify>=0.9.6; sys_platform != 'win32' and sys_platform != 'darwin' and platform_system != "openbsd"
 python-etcd>=0.4.5
 pyvmomi
@@ -58,13 +58,13 @@ textfsm
 toml
 # vcert 0.18.x adds hard pins on cryptography, pynacl, and six that
 # conflict with every other CI requirement; stay on 0.9.x.
-vcert~=0.9.0; sys_platform != 'win32'
-virtualenv>=21.4.2
+vcert~=0.9.1; sys_platform != 'win32'
+virtualenv>=21.6.1
 watchdog>=6.0.0
 websocket-client>=1.9.0
 # werkzeug is a dependency of moto
 werkzeug>=3.1.8
-xmldiff>=2.7.0
+xmldiff>=3.0
 # Available template libraries that can be used
 genshi>=0.7.11
 cheetah3>=3.2.6.post1

--- a/requirements/static/ci/darwin.txt
+++ b/requirements/static/ci/darwin.txt
@@ -1,6 +1,6 @@
 pygit2>=1.13.1,<1.18.0; python_version < '3.11'
-pygit2>=1.19.2; python_version >= '3.11'
+pygit2>=1.19.3; python_version >= '3.11'
 yamllint
-mercurial>=7.2.2
+mercurial>=7.2.3
 hglib
-gitpython>=3.1.50
+gitpython>=3.1.52

--- a/requirements/static/ci/freebsd.txt
+++ b/requirements/static/ci/freebsd.txt
@@ -1,5 +1,5 @@
 # FreeBSD static CI requirements
 
 yamllint
-mercurial>=7.2.2
+mercurial>=7.2.3
 hglib

--- a/requirements/static/ci/lint.txt
+++ b/requirements/static/ci/lint.txt
@@ -1,11 +1,11 @@
 # Lint requirements
 
-docker >= 7.1.0; python_version >= '3.8'
+docker >= 7.2.0; python_version >= '3.8'
 docker < 7.1.0; python_version < '3.8'
 # pylint 4 introduces new default-on E0606/E0601/E0602 checks that the
 # Salt 3006.x codebase has not been audited for; the lint job logs are
 # full of pre-existing possibly-used-before-assignment warnings now
 # turning into errors. Stay on the 3.1.x line for 3006.x.
-pylint~=3.1.0
+pylint~=3.3.9
 SaltPyLint>=2024.2.5
 toml

--- a/requirements/static/ci/linux.txt
+++ b/requirements/static/ci/linux.txt
@@ -1,7 +1,7 @@
 # Linux static CI requirements
 pyiface
 pygit2>=1.13.1,<1.18.0; python_version < '3.11'
-pygit2>=1.19.2; python_version >= '3.11'
+pygit2>=1.19.3; python_version >= '3.11'
 pymysql>=1.2.0
 # ansible release lines support different Python versions:
 #   ansible-core / ansible 10.x — Python 3.10+ (controller and managed)
@@ -17,12 +17,12 @@ pymysql>=1.2.0
 # Python 3.10+ as a controller and installs cleanly on the py3.11 onedir.
 # See PR #69527 / issue #69526.
 ansible>=10.7.0,<11.0.0; python_version >= '3.10' and python_version < '3.12'
-ansible>=14.0.0; python_version >= '3.12'
+ansible>=14.2.0; python_version >= '3.12'
 twilio>=9.10.9
 python-telegram-bot>=20.3,<22.0; python_version < '3.10'
-python-telegram-bot>=22.7; python_version >= '3.10'
+python-telegram-bot>=22.8; python_version >= '3.10'
 yamllint
-mercurial>=7.2.2
+mercurial>=7.2.3
 hglib
 redis-py-cluster
 python-consul

--- a/requirements/static/ci/py3.10/changelog.lock
+++ b/requirements/static/ci/py3.10/changelog.lock
@@ -14,7 +14,7 @@ markupsafe==2.1.5
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   jinja2
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/changelog.txt

--- a/requirements/static/ci/py3.10/cloud.lock
+++ b/requirements/static/ci/py3.10/cloud.lock
@@ -65,18 +65,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -87,7 +87,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -127,12 +127,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -165,7 +165,7 @@ dnspython==2.6.1
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/pytest.txt
@@ -181,7 +181,7 @@ exceptiongroup==1.1.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   pytest
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -213,7 +213,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -265,7 +265,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -274,7 +274,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -323,7 +323,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -385,7 +385,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -415,7 +415,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -463,7 +463,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -495,12 +495,12 @@ pyinotify==0.9.6
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -526,7 +526,7 @@ pyspnego==0.9.0
     #   -r requirements/static/ci/cloud.txt
     #   requests-ntlm
     #   smbprotocol
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/pytest.txt
@@ -590,7 +590,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -633,7 +633,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -668,7 +668,7 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   boto3
@@ -804,7 +804,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -830,7 +830,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.10/darwin.lock
+++ b/requirements/static/ci/py3.10/darwin.lock
@@ -52,16 +52,16 @@ bcrypt==4.0.1
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -69,7 +69,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -99,11 +99,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -127,7 +127,7 @@ dnspython==2.6.1
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
@@ -135,7 +135,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
 exceptiongroup==1.1.1
     # via pytest
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -158,7 +158,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -198,7 +198,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -206,7 +206,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -233,7 +233,7 @@ jxmlease==1.0.3
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -262,7 +262,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/darwin.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -278,7 +278,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -297,7 +297,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -334,7 +334,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -357,11 +357,11 @@ pygments==2.20.0
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   pytest
     #   rich
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -372,7 +372,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -418,7 +418,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   virtualenv
@@ -450,7 +450,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -472,7 +472,7 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.14.5
     # via junos-eznc
@@ -558,7 +558,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -577,7 +577,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==0.13.0
     # via moto

--- a/requirements/static/ci/py3.10/docs.lock
+++ b/requirements/static/ci/py3.10/docs.lock
@@ -42,12 +42,12 @@ backports-tarfile==1.2.0
     #   jaraco-context
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -70,11 +70,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -91,7 +91,7 @@ docutils==0.20.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -107,7 +107,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -137,14 +137,14 @@ jaraco-context==6.1.2
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -193,7 +193,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -205,7 +205,7 @@ multidict==6.7.1
     #   yarl
 myst-docutils==4.0.1
     # via -r requirements/static/ci/docs.txt
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -228,7 +228,7 @@ psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -253,7 +253,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -262,7 +262,7 @@ python-dateutil==2.9.0.post0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   virtualenv
@@ -283,7 +283,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -369,7 +369,7 @@ urllib3==2.7.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -53,16 +53,16 @@ bcrypt==4.0.1
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -70,7 +70,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1 ; sys_platform != 'win32'
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -97,7 +97,7 @@ cherrypy==18.10.0
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   pythonnet
@@ -112,11 +112,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -143,7 +143,7 @@ dnspython==2.6.1
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
@@ -151,7 +151,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
 exceptiongroup==1.1.1 ; python_full_version < '3.11'
     # via pytest
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -174,7 +174,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -216,7 +216,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -224,7 +224,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -261,7 +261,7 @@ kazoo==2.9.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
@@ -301,7 +301,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/freebsd.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -317,7 +317,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -336,7 +336,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -374,7 +374,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -398,7 +398,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -406,11 +406,11 @@ pymysql==1.2.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -422,7 +422,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyserial==3.5 ; sys_platform != 'win32'
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -469,7 +469,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   virtualenv
@@ -480,7 +480,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -515,7 +515,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -537,7 +537,7 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.14.5 ; sys_platform != 'win32'
     # via junos-eznc
@@ -635,7 +635,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -658,7 +658,7 @@ wmi==1.5.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -398,7 +398,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/lint.lock
+++ b/requirements/static/ci/py3.10/lint.lock
@@ -52,7 +52,7 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.10/linux.lock
     #   certvalidator
     #   oscrypto
-astroid==3.1.0
+astroid==3.3.11
     # via pylint
 async-timeout==4.0.3
     # via
@@ -79,18 +79,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -103,7 +103,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -144,12 +144,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -180,7 +180,7 @@ dnspython==2.6.1
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/lint.txt
@@ -196,7 +196,7 @@ exceptiongroup==1.1.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   anyio
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -224,7 +224,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -291,7 +291,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -300,7 +300,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -350,7 +350,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -394,7 +394,7 @@ mdurl==0.1.2
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -413,7 +413,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -441,7 +441,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -485,7 +485,7 @@ psutil==7.2.2
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -524,7 +524,7 @@ pyjwt==2.12.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   twilio
-pylint==3.1.1
+pylint==3.3.9
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
@@ -532,12 +532,12 @@ pymysql==1.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/linux.txt
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -570,7 +570,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -585,7 +585,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -623,7 +623,7 @@ redis-py-cluster==2.1.3
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -659,7 +659,7 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   boto3
@@ -808,7 +808,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -832,7 +832,7 @@ werkzeug==3.1.8
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.10/linux.lock
+++ b/requirements/static/ci/py3.10/linux.lock
@@ -62,16 +62,16 @@ bcrypt==4.0.1
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -81,7 +81,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -111,11 +111,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -141,7 +141,7 @@ dnspython==2.6.1
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
@@ -151,7 +151,7 @@ exceptiongroup==1.1.1
     # via
     #   anyio
     #   pytest
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -174,7 +174,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -223,7 +223,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -231,7 +231,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -265,7 +265,7 @@ kazoo==2.9.0
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0
     # via -r requirements/static/ci/common.txt
@@ -296,7 +296,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/linux.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -312,7 +312,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -331,7 +331,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -370,7 +370,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -401,11 +401,11 @@ pyjwt==2.12.1
     # via twilio
 pymysql==1.2.0
     # via -r requirements/static/ci/linux.txt
-pynacl==1.5.0
+pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -416,7 +416,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -464,7 +464,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   virtualenv
@@ -474,7 +474,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via -r requirements/static/ci/linux.txt
 pytz==2024.1
     # via
@@ -503,7 +503,7 @@ redis==3.5.3
     # via redis-py-cluster
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -529,7 +529,7 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.14.5
     # via junos-eznc
@@ -628,7 +628,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -647,7 +647,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==0.13.0
     # via moto

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -104,7 +104,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -45,22 +45,22 @@ bcrypt==4.0.1
     # via -r requirements/static/ci/common.txt
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -89,7 +89,7 @@ click==8.3.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   pythonnet
@@ -104,7 +104,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -130,7 +130,7 @@ dnspython==2.6.1
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
@@ -138,7 +138,7 @@ etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
 exceptiongroup==1.1.1
     # via pytest
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -161,7 +161,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -198,7 +198,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -206,7 +206,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -228,7 +228,7 @@ junit-xml==1.9
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -259,7 +259,7 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -271,7 +271,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -284,7 +284,7 @@ multidict==6.7.1
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -318,7 +318,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -341,7 +341,7 @@ pygments==2.19.2
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -349,9 +349,9 @@ pymysql==1.2.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-pynacl==1.5.0
+pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -360,7 +360,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyspnego==0.12.0
     # via requests-ntlm
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -405,7 +405,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   kubernetes
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   virtualenv
@@ -415,7 +415,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -446,7 +446,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -471,7 +471,7 @@ rich==14.3.3
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.txt
@@ -515,7 +515,7 @@ toml==0.10.2
     # via -r requirements/static/ci/common.txt
 tomli==2.2.1
     # via pytest
-tornado==6.5.6
+tornado==6.5.7
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -555,7 +555,7 @@ urllib3==2.7.0
     #   python-etcd
     #   requests
     #   responses
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -578,7 +578,7 @@ wmi==1.5.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -341,7 +341,7 @@ pygments==2.19.2
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/changelog.lock
+++ b/requirements/static/ci/py3.11/changelog.lock
@@ -14,7 +14,7 @@ markupsafe==2.1.5
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   jinja2
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/changelog.txt

--- a/requirements/static/ci/py3.11/cloud.lock
+++ b/requirements/static/ci/py3.11/cloud.lock
@@ -60,18 +60,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -82,7 +82,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -122,12 +122,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -160,7 +160,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/pytest.txt
@@ -172,7 +172,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -200,7 +200,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -252,7 +252,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -261,7 +261,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -312,7 +312,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -373,7 +373,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -400,7 +400,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -448,7 +448,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -485,7 +485,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -511,7 +511,7 @@ pyspnego==0.9.0
     #   -r requirements/static/ci/cloud.txt
     #   requests-ntlm
     #   smbprotocol
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/pytest.txt
@@ -575,7 +575,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -618,7 +618,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -653,7 +653,7 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   boto3
@@ -775,7 +775,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -801,7 +801,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.11/darwin.lock
+++ b/requirements/static/ci/py3.11/darwin.lock
@@ -48,16 +48,16 @@ bcrypt==4.3.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -65,7 +65,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -95,11 +95,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -123,13 +123,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -150,7 +150,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -192,7 +192,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -200,7 +200,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -231,7 +231,7 @@ jxmlease==1.0.3
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -259,11 +259,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/darwin.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -275,7 +275,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -292,7 +292,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -329,7 +329,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -345,7 +345,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/darwin.txt
 pygments==2.20.0
     # via
@@ -356,7 +356,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -367,7 +367,7 @@ pyrsistent==0.20.0
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -413,7 +413,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   virtualenv
@@ -445,7 +445,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -467,7 +467,7 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -544,7 +544,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -563,7 +563,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.11/docs.lock
+++ b/requirements/static/ci/py3.11/docs.lock
@@ -38,12 +38,12 @@ backports-tarfile==1.2.0
     #   jaraco-context
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -66,11 +66,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -87,7 +87,7 @@ docutils==0.20.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -103,7 +103,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -133,14 +133,14 @@ jaraco-context==6.1.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -188,7 +188,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -200,7 +200,7 @@ multidict==6.7.1
     #   yarl
 myst-docutils==5.1.0
     # via -r requirements/static/ci/docs.txt
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -223,7 +223,7 @@ psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -248,7 +248,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -257,7 +257,7 @@ python-dateutil==2.9.0.post0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   virtualenv
@@ -278,7 +278,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -361,7 +361,7 @@ urllib3==2.7.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -54,16 +54,16 @@ bcrypt==5.0.0 ; python_full_version >= '3.12'
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -71,7 +71,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1 ; sys_platform != 'win32'
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -98,7 +98,7 @@ cherrypy==18.10.0
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   pythonnet
@@ -113,11 +113,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -144,13 +144,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -171,7 +171,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -213,7 +213,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -221,7 +221,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -268,7 +268,7 @@ kazoo==2.10.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
@@ -302,11 +302,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/freebsd.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -318,7 +318,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -337,7 +337,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -375,7 +375,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -399,7 +399,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -411,7 +411,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -423,7 +423,7 @@ pyrsistent==0.20.0 ; python_full_version < '3.12'
     # via jsonschema
 pyserial==3.5 ; sys_platform != 'win32'
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -470,7 +470,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   virtualenv
@@ -481,7 +481,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -521,7 +521,7 @@ referencing==0.37.0 ; python_full_version >= '3.12'
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -547,7 +547,7 @@ rpds-py==0.30.0 ; python_full_version >= '3.12'
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'
     # via junos-eznc
@@ -636,7 +636,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -659,7 +659,7 @@ wmi==1.5.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -399,7 +399,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/lint.lock
+++ b/requirements/static/ci/py3.11/lint.lock
@@ -52,7 +52,7 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.11/linux.lock
     #   certvalidator
     #   oscrypto
-astroid==3.1.0
+astroid==3.3.11
     # via pylint
 attrs==23.2.0
     # via
@@ -75,18 +75,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -99,7 +99,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -140,12 +140,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -176,7 +176,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/lint.txt
@@ -188,7 +188,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -212,7 +212,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -279,7 +279,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -288,7 +288,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -340,7 +340,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -383,7 +383,7 @@ mdurl==0.1.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -402,7 +402,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -426,7 +426,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -470,7 +470,7 @@ psutil==7.2.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -488,7 +488,7 @@ pycryptodomex==3.23.0
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -509,7 +509,7 @@ pyjwt==2.12.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   twilio
-pylint==3.1.1
+pylint==3.3.9
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
@@ -522,7 +522,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -555,7 +555,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -570,7 +570,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -608,7 +608,7 @@ redis-py-cluster==2.1.3
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -644,7 +644,7 @@ rich==15.0.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   boto3
@@ -777,7 +777,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -801,7 +801,7 @@ werkzeug==3.1.8
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.11/linux.lock
+++ b/requirements/static/ci/py3.11/linux.lock
@@ -58,16 +58,16 @@ bcrypt==4.3.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -77,7 +77,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -107,11 +107,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -137,13 +137,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -164,7 +164,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -213,7 +213,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -221,7 +221,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -259,7 +259,7 @@ kazoo==2.10.0
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0
     # via -r requirements/static/ci/common.txt
@@ -289,7 +289,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/linux.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -305,7 +305,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -322,7 +322,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -361,7 +361,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -377,7 +377,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/linux.txt
 pygments==2.20.0
     # via
@@ -396,7 +396,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -407,7 +407,7 @@ pyrsistent==0.20.0
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -455,7 +455,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   virtualenv
@@ -465,7 +465,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via -r requirements/static/ci/linux.txt
 pytz==2024.1
     # via
@@ -494,7 +494,7 @@ redis==3.5.3
     # via redis-py-cluster
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -520,7 +520,7 @@ rich==15.0.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -608,7 +608,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -627,7 +627,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -42,22 +42,22 @@ bcrypt==4.3.0
     #   -r requirements/static/ci/common.txt
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -86,7 +86,7 @@ click==8.3.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   pythonnet
@@ -101,7 +101,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -127,13 +127,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -154,7 +154,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -191,7 +191,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -199,7 +199,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -223,7 +223,7 @@ junit-xml==1.9
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -253,7 +253,7 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -265,7 +265,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -278,7 +278,7 @@ multidict==6.7.1
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -312,7 +312,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -328,14 +328,14 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/windows.txt
 pygments==2.19.2
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -345,7 +345,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -354,7 +354,7 @@ pyrsistent==0.20.0
     # via jsonschema
 pyspnego==0.12.0
     # via requests-ntlm
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -399,7 +399,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   kubernetes
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   virtualenv
@@ -409,7 +409,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -440,7 +440,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -465,7 +465,7 @@ rich==14.3.3
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   typer
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.txt
@@ -505,7 +505,7 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
-tornado==6.5.6
+tornado==6.5.7
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -540,7 +540,7 @@ urllib3==2.7.0
     #   python-etcd
     #   requests
     #   responses
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -563,7 +563,7 @@ wmi==1.5.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -101,7 +101,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -335,7 +335,7 @@ pygments==2.19.2
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/changelog.lock
+++ b/requirements/static/ci/py3.12/changelog.lock
@@ -14,7 +14,7 @@ markupsafe==2.1.5
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jinja2
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/changelog.txt

--- a/requirements/static/ci/py3.12/cloud.lock
+++ b/requirements/static/ci/py3.12/cloud.lock
@@ -55,18 +55,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -77,7 +77,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -117,12 +117,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -155,7 +155,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/pytest.txt
@@ -167,7 +167,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -195,7 +195,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -246,7 +246,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -255,7 +255,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -308,7 +308,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -369,7 +369,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -396,7 +396,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -444,7 +444,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -481,7 +481,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -503,7 +503,7 @@ pyspnego==0.9.0
     #   -r requirements/static/ci/cloud.txt
     #   requests-ntlm
     #   smbprotocol
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/pytest.txt
@@ -567,7 +567,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -615,7 +615,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -655,7 +655,7 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   boto3
@@ -776,7 +776,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -802,7 +802,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.12/darwin.lock
+++ b/requirements/static/ci/py3.12/darwin.lock
@@ -44,16 +44,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -61,7 +61,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -91,11 +91,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -119,13 +119,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -146,7 +146,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -187,7 +187,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -195,7 +195,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -224,7 +224,7 @@ jxmlease==1.0.3
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -252,11 +252,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/darwin.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -268,7 +268,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -285,7 +285,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -322,7 +322,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -338,7 +338,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/darwin.txt
 pygments==2.20.0
     # via
@@ -349,7 +349,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -358,7 +358,7 @@ pyparsing==3.3.2
     # via junos-eznc
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -404,7 +404,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   virtualenv
@@ -440,7 +440,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -466,7 +466,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -542,7 +542,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -561,7 +561,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.12/docs.lock
+++ b/requirements/static/ci/py3.12/docs.lock
@@ -34,12 +34,12 @@ babel==2.18.0
     #   sphinx
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -62,11 +62,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -83,7 +83,7 @@ docutils==0.22.4
     # via
     #   pydata-sphinx-theme
     #   sphinx
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -99,7 +99,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -129,14 +129,14 @@ jaraco-context==6.1.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -184,7 +184,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -196,7 +196,7 @@ multidict==6.7.1
     #   yarl
 myst-docutils==5.1.0
     # via -r requirements/static/ci/docs.txt
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -219,7 +219,7 @@ psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -244,7 +244,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -253,7 +253,7 @@ python-dateutil==2.9.0.post0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   virtualenv
@@ -274,7 +274,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -359,7 +359,7 @@ urllib3==2.7.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -379,7 +379,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -45,16 +45,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -62,7 +62,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1 ; sys_platform != 'win32'
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -89,7 +89,7 @@ cherrypy==18.10.0
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   pythonnet
@@ -104,11 +104,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -135,13 +135,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -162,7 +162,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -203,7 +203,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -211,7 +211,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -250,7 +250,7 @@ kazoo==2.10.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
@@ -284,11 +284,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/freebsd.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -300,7 +300,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -317,7 +317,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -355,7 +355,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -379,7 +379,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -391,7 +391,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -401,7 +401,7 @@ pyparsing==3.3.2 ; sys_platform != 'win32'
     # via junos-eznc
 pyserial==3.5 ; sys_platform != 'win32'
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -448,7 +448,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   virtualenv
@@ -459,7 +459,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -498,7 +498,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -524,7 +524,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'
     # via junos-eznc
@@ -611,7 +611,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -634,7 +634,7 @@ wmi==1.5.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.12/lint.lock
+++ b/requirements/static/ci/py3.12/lint.lock
@@ -29,11 +29,11 @@ annotated-doc==0.0.4
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   typer
-ansible==14.0.0
+ansible==14.2.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/linux.txt
-ansible-core==2.21.0
+ansible-core==2.21.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   ansible
@@ -52,7 +52,7 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.12/linux.lock
     #   certvalidator
     #   oscrypto
-astroid==3.1.0
+astroid==3.3.11
     # via pylint
 attrs==23.2.0
     # via
@@ -70,18 +70,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -94,7 +94,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -135,12 +135,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -171,7 +171,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/lint.txt
@@ -183,7 +183,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -207,7 +207,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -273,7 +273,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -282,7 +282,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -336,7 +336,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -379,7 +379,7 @@ mdurl==0.1.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -398,7 +398,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -422,7 +422,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -466,7 +466,7 @@ psutil==7.2.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -484,7 +484,7 @@ pycryptodomex==3.23.0
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -505,7 +505,7 @@ pyjwt==2.12.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   twilio
-pylint==3.1.1
+pylint==3.3.9
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
@@ -518,7 +518,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -547,7 +547,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -562,7 +562,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -605,7 +605,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -646,7 +646,7 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   boto3
@@ -778,7 +778,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -802,7 +802,7 @@ werkzeug==3.1.8
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.12/linux.lock
+++ b/requirements/static/ci/py3.12/linux.lock
@@ -23,9 +23,9 @@ annotated-doc==0.0.4
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   typer
-ansible==14.0.0
+ansible==14.2.0
     # via -r requirements/static/ci/linux.txt
-ansible-core==2.21.0
+ansible-core==2.21.2
     # via ansible
 anyio==4.1.0
     # via httpx
@@ -54,16 +54,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -73,7 +73,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -103,11 +103,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -133,13 +133,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -160,7 +160,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -208,7 +208,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -216,7 +216,7 @@ jaraco-functools==4.5.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -252,7 +252,7 @@ kazoo==2.10.0
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0
     # via -r requirements/static/ci/common.txt
@@ -282,7 +282,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/linux.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -298,7 +298,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -315,7 +315,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -354,7 +354,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -370,7 +370,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/linux.txt
 pygments==2.20.0
     # via
@@ -389,7 +389,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -398,7 +398,7 @@ pyparsing==3.3.2
     # via junos-eznc
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -446,7 +446,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   virtualenv
@@ -456,7 +456,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via -r requirements/static/ci/linux.txt
 pytz==2024.1
     # via
@@ -489,7 +489,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -519,7 +519,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -606,7 +606,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -625,7 +625,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -329,7 +329,7 @@ pygments==2.19.2
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -96,7 +96,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -37,22 +37,22 @@ bcrypt==5.0.0
     # via -r requirements/static/ci/common.txt
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -81,7 +81,7 @@ click==8.3.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   pythonnet
@@ -96,7 +96,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -122,13 +122,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -149,7 +149,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -185,7 +185,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -193,7 +193,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -217,7 +217,7 @@ junit-xml==1.9
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -247,7 +247,7 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -259,7 +259,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -272,7 +272,7 @@ multidict==6.7.1
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -306,7 +306,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -322,14 +322,14 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==5.3.1
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/windows.txt
 pygments==2.19.2
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -339,14 +339,14 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
     #   etcd3-py
 pyspnego==0.12.0
     # via requests-ntlm
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -391,7 +391,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   kubernetes
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   virtualenv
@@ -401,7 +401,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -436,7 +436,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -465,7 +465,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.txt
@@ -504,7 +504,7 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
-tornado==6.5.6
+tornado==6.5.7
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -540,7 +540,7 @@ urllib3==2.7.0
     #   python-etcd
     #   requests
     #   responses
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -563,7 +563,7 @@ wmi==1.5.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.13/changelog.lock
+++ b/requirements/static/ci/py3.13/changelog.lock
@@ -14,7 +14,7 @@ markupsafe==2.1.5
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jinja2
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/changelog.txt

--- a/requirements/static/ci/py3.13/cloud.lock
+++ b/requirements/static/ci/py3.13/cloud.lock
@@ -56,18 +56,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -78,7 +78,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -118,12 +118,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -156,7 +156,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/pytest.txt
@@ -168,7 +168,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -196,7 +196,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -247,7 +247,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -256,7 +256,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -309,7 +309,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -370,13 +370,13 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
     #   pytest-salt-factories
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -397,7 +397,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -445,7 +445,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -482,7 +482,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -504,7 +504,7 @@ pyspnego==0.12.0
     #   -r requirements/static/ci/cloud.txt
     #   requests-ntlm
     #   smbprotocol
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/pytest.txt
@@ -569,7 +569,7 @@ python-dateutil==2.9.0.post0
     #   kubernetes
     #   tempora
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -612,7 +612,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -652,7 +652,7 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   boto3
@@ -767,7 +767,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -793,7 +793,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.13/darwin.lock
+++ b/requirements/static/ci/py3.13/darwin.lock
@@ -45,16 +45,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -62,7 +62,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -92,11 +92,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -120,13 +120,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -147,7 +147,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -188,7 +188,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -196,7 +196,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -225,7 +225,7 @@ jxmlease==1.0.3
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -253,11 +253,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/darwin.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -269,12 +269,12 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
     #   pytest-salt-factories
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -286,7 +286,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -323,7 +323,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -339,7 +339,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/darwin.txt
 pygments==2.20.0
     # via
@@ -350,7 +350,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -359,7 +359,7 @@ pyparsing==3.3.2
     # via junos-eznc
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -406,7 +406,7 @@ python-dateutil==2.9.0.post0
     #   kubernetes
     #   tempora
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   virtualenv
@@ -438,7 +438,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -464,7 +464,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -534,7 +534,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -553,7 +553,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.13/docs.lock
+++ b/requirements/static/ci/py3.13/docs.lock
@@ -34,12 +34,12 @@ babel==2.17.0
     #   sphinx
 beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -62,11 +62,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -83,7 +83,7 @@ docutils==0.22.4
     # via
     #   pydata-sphinx-theme
     #   sphinx
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -99,7 +99,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -129,14 +129,14 @@ jaraco-context==6.1.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -184,11 +184,11 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -196,7 +196,7 @@ multidict==6.7.0
     #   yarl
 myst-docutils==5.0.0
     # via -r requirements/static/ci/docs.txt
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -219,7 +219,7 @@ psutil==7.2.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -244,7 +244,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -254,7 +254,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   virtualenv
@@ -271,7 +271,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -354,7 +354,7 @@ urllib3==2.7.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -46,16 +46,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -63,7 +63,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1 ; sys_platform != 'win32'
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -90,7 +90,7 @@ cherrypy==18.10.0
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   pythonnet
@@ -105,11 +105,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -136,13 +136,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -163,7 +163,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -204,7 +204,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -212,7 +212,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -251,7 +251,7 @@ kazoo==2.10.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0 ; sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
@@ -285,11 +285,11 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/freebsd.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -301,12 +301,12 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
     #   pytest-salt-factories
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -318,7 +318,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0 ; sys_platform != 'win32'
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -356,7 +356,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -380,7 +380,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -392,7 +392,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -402,7 +402,7 @@ pyparsing==3.3.2 ; sys_platform != 'win32'
     # via junos-eznc
 pyserial==3.5 ; sys_platform != 'win32'
     # via junos-eznc
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -450,7 +450,7 @@ python-dateutil==2.9.0.post0
     #   kubernetes
     #   tempora
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   virtualenv
@@ -461,7 +461,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -496,7 +496,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -522,7 +522,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0 ; sys_platform != 'win32'
     # via junos-eznc
@@ -603,7 +603,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1 ; sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -626,7 +626,7 @@ wmi==1.5.1 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -380,7 +380,7 @@ pygments==2.20.0
     #   rich
 pyinotify==0.9.6 ; platform_system != 'openbsd' and sys_platform != 'darwin' and sys_platform != 'win32'
     # via -r requirements/static/ci/common.txt
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/lint.lock
+++ b/requirements/static/ci/py3.13/lint.lock
@@ -29,11 +29,11 @@ annotated-doc==0.0.4
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   typer
-ansible==14.0.0
+ansible==14.2.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/linux.txt
-ansible-core==2.21.0
+ansible-core==2.21.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   ansible
@@ -52,7 +52,7 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.13/linux.lock
     #   certvalidator
     #   oscrypto
-astroid==3.1.0
+astroid==3.3.11
     # via pylint
 attrs==25.4.0
     # via
@@ -70,18 +70,18 @@ boto==2.49.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -94,7 +94,7 @@ certvalidator==0.11.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -135,12 +135,12 @@ contextvars==2.4
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -171,7 +171,7 @@ dnspython==2.8.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/lint.txt
@@ -183,7 +183,7 @@ etcd3-py==0.1.6
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -207,7 +207,7 @@ gitdb==4.0.12
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -273,7 +273,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -282,7 +282,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -336,7 +336,7 @@ keyring==25.7.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
@@ -379,7 +379,7 @@ mdurl==0.1.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -398,12 +398,12 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -422,7 +422,7 @@ oscrypto==1.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -466,7 +466,7 @@ psutil==7.2.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -484,7 +484,7 @@ pycryptodomex==3.23.0
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -505,7 +505,7 @@ pyjwt==2.12.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   twilio
-pylint==3.1.1
+pylint==3.3.9
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
@@ -518,7 +518,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -548,7 +548,7 @@ python-dateutil==2.9.0.post0
     #   kubernetes
     #   tempora
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -563,7 +563,7 @@ python-gnupg==0.5.6
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/linux.txt
@@ -601,7 +601,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -642,7 +642,7 @@ rpds-py==0.30.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   boto3
@@ -762,7 +762,7 @@ vcert==0.9.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -786,7 +786,7 @@ werkzeug==3.1.8
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   moto
-xmldiff==2.7.0
+xmldiff==3.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt

--- a/requirements/static/ci/py3.13/linux.lock
+++ b/requirements/static/ci/py3.13/linux.lock
@@ -23,9 +23,9 @@ annotated-doc==0.0.4
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   typer
-ansible==14.0.0
+ansible==14.2.0
     # via -r requirements/static/ci/linux.txt
-ansible-core==2.21.0
+ansible-core==2.21.2
     # via ansible
 anyio==4.12.1
     # via httpx
@@ -55,16 +55,16 @@ bcrypt==5.0.0
     #   paramiko
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -74,7 +74,7 @@ certifi==2026.5.20
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -104,11 +104,11 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -134,13 +134,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -161,7 +161,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -209,7 +209,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -217,7 +217,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -253,7 +253,7 @@ kazoo==2.10.0
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 libnacl==2.1.0
     # via -r requirements/static/ci/common.txt
@@ -283,7 +283,7 @@ mdurl==0.1.2
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   markdown-it-py
-mercurial==7.2.2
+mercurial==7.2.3
     # via -r requirements/static/ci/linux.txt
 mock==5.2.0
     # via -r requirements/pytest.txt
@@ -299,12 +299,12 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
     #   pytest-salt-factories
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -316,7 +316,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 oscrypto==1.3.0
     # via certvalidator
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -355,7 +355,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -371,7 +371,7 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/linux.txt
 pygments==2.20.0
     # via
@@ -390,7 +390,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -399,7 +399,7 @@ pyparsing==3.3.2
     # via junos-eznc
 pyserial==3.5
     # via junos-eznc
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -448,7 +448,7 @@ python-dateutil==2.9.0.post0
     #   kubernetes
     #   tempora
     #   vcert
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   virtualenv
@@ -458,7 +458,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-python-telegram-bot==22.7
+python-telegram-bot==22.8
     # via -r requirements/static/ci/linux.txt
 pyvmomi==9.0.0.0
     # via -r requirements/static/ci/common.txt
@@ -487,7 +487,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -517,7 +517,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scp==0.15.0
     # via junos-eznc
@@ -596,7 +596,7 @@ urllib3==2.7.0
     #   responses
 vcert==0.9.1
     # via -r requirements/static/ci/common.txt
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -615,7 +615,7 @@ werkzeug==3.1.8
     #   -r requirements/static/ci/common.txt
     #   moto
     #   pytest-httpserver
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.2
     # via moto

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -38,22 +38,22 @@ bcrypt==5.0.0
     # via -r requirements/static/ci/common.txt
 boto==2.49.0
     # via -r requirements/static/ci/common.txt
-boto3==1.43.25
+boto3==1.43.51
     # via
     #   -r requirements/static/ci/common.txt
     #   moto
-botocore==1.43.25
+botocore==1.43.51
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -82,7 +82,7 @@ click==8.3.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   pythonnet
@@ -97,7 +97,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -123,13 +123,13 @@ dnspython==2.8.0
     # via
     #   -r requirements/static/ci/common.txt
     #   python-etcd
-docker==7.1.0
+docker==7.2.0
     # via -r requirements/pytest.txt
 durationpy==0.10
     # via kubernetes
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -150,7 +150,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -186,7 +186,7 @@ jaraco-context==6.1.2
     #   -r requirements/base.txt
     #   jaraco-text
     #   keyring
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -194,7 +194,7 @@ jaraco-functools==4.4.0
     #   jaraco-text
     #   keyring
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -218,7 +218,7 @@ junit-xml==1.9
     # via -r requirements/static/ci/common.txt
 keyring==25.7.0
     # via -r requirements/static/ci/common.txt
-kubernetes==36.0.2
+kubernetes==36.0.3
     # via -r requirements/static/ci/common.txt
 looseversion==1.3.0
     # via
@@ -248,7 +248,7 @@ mdurl==0.1.2
     #   markdown-it-py
 mock==5.2.0
     # via -r requirements/pytest.txt
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -260,7 +260,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -273,7 +273,7 @@ multidict==6.7.1
     #   yarl
 oauthlib==3.3.1
     # via requests-oauthlib
-packaging==24.0
+packaging==26.2
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -307,7 +307,7 @@ psutil==7.2.2
     #   pytest-salt-factories
     #   pytest-shell-utilities
     #   pytest-system-statistics
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -323,14 +323,14 @@ pycryptodomex==3.23.0
     #   -r requirements/static/ci/common.txt
 pyfakefs==6.0.0
     # via -r requirements/pytest.txt
-pygit2==1.19.2
+pygit2==1.19.3
     # via -r requirements/static/ci/windows.txt
 pygments==2.19.2
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -340,14 +340,14 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
     #   etcd3-py
 pyspnego==0.12.0
     # via requests-ntlm
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   -r requirements/pytest.txt
     #   pytest-custom-exit-code
@@ -392,7 +392,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   kubernetes
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   virtualenv
@@ -402,7 +402,7 @@ python-gnupg==0.5.6
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -437,7 +437,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -466,7 +466,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.txt
@@ -505,7 +505,7 @@ textfsm==2.1.0
     # via -r requirements/static/ci/common.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.txt
-tornado==6.5.6
+tornado==6.5.7
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -535,7 +535,7 @@ urllib3==2.7.0
     #   python-etcd
     #   requests
     #   responses
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -558,7 +558,7 @@ wmi==1.5.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-xmldiff==2.7.0
+xmldiff==3.0
     # via -r requirements/static/ci/common.txt
 xmltodict==1.0.4
     # via

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -97,7 +97,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -330,7 +330,7 @@ pygments==2.19.2
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   pytest
     #   rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/windows.txt
+++ b/requirements/static/ci/windows.txt
@@ -1,7 +1,7 @@
 dmidecode
 patch
 pygit2>=1.13.1,<1.18.0; python_version < '3.11'
-pygit2>=1.19.2; python_version >= '3.11'
+pygit2>=1.19.3; python_version >= '3.11'
 sed
 pywinrm>=0.5.0
 yamllint

--- a/requirements/static/pkg/freebsd.txt
+++ b/requirements/static/pkg/freebsd.txt
@@ -2,10 +2,10 @@
 # Any non hard dependencies of Salt for FreeBSD can go here
 # If they are freebsd specific, place "; sys_platform == 'freebsd'" in front of the requirement.
 cherrypy>=18.10.0
-cryptography>=46.0.7,<48.0.0
+cryptography>=49.0.0,<50.0.0
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.0.0,<26.2.0
+pyopenssl>=26.3.0,<26.4.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 setproctitle>=1.3.7

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -7,7 +7,7 @@ cherrypy>=18.10.0
 cheroot>=11.1.2
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.0.0,<26.2.0
+pyopenssl>=26.3.0,<26.4.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 setproctitle>=1.3.7
@@ -15,6 +15,6 @@ timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
 importlib-metadata>=8.7.0,<9.0.0; python_version < '3.10'
 importlib-metadata>=9.0.0; python_version >= '3.10'
-cryptography>=46.0.7,<48.0.0
+cryptography>=49.0.0,<50.0.0
 more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
 more-itertools>=11.1.0; python_version >= '3.10'

--- a/requirements/static/pkg/py3.10/darwin.lock
+++ b/requirements/static/pkg/py3.10/darwin.lock
@@ -16,11 +16,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -34,9 +34,9 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -44,7 +44,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -56,7 +56,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -75,13 +75,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -108,14 +108,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -129,7 +129,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -141,13 +141,13 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
@@ -157,7 +157,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -197,7 +197,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -16,11 +16,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -37,15 +37,15 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
 colorama==0.4.6 ; sys_platform == 'win32'
     # via typer
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -56,7 +56,7 @@ distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -68,7 +68,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -89,13 +89,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -128,14 +128,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -149,7 +149,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -162,11 +162,11 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -175,13 +175,13 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pytz==2024.1
     # via tempora
@@ -193,7 +193,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -237,7 +237,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -162,7 +162,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.lock
+++ b/requirements/static/pkg/py3.10/linux.lock
@@ -16,11 +16,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -37,9 +37,9 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/linux.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -48,7 +48,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -60,7 +60,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -81,13 +81,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -115,14 +115,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -136,7 +136,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -149,7 +149,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -158,7 +158,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
@@ -170,7 +170,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -212,7 +212,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -41,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -148,7 +148,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -16,11 +16,11 @@ attrs==25.4.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -35,13 +35,13 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 click==8.3.1
     # via typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -49,7 +49,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -61,7 +61,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -80,13 +80,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -108,21 +108,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.9.2
     # via
@@ -136,7 +136,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -148,21 +148,21 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via -r requirements/base.txt
 pywin32==312
     # via
@@ -172,7 +172,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -194,7 +194,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/windows.txt
-tornado==6.5.6
+tornado==6.5.7
     # via -r requirements/base.txt
 typer==0.24.1
     # via typer-slim
@@ -214,7 +214,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/darwin.lock
+++ b/requirements/static/pkg/py3.11/darwin.lock
@@ -14,11 +14,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -32,9 +32,9 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -42,7 +42,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -54,7 +54,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -73,13 +73,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -97,21 +97,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -125,7 +125,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -137,13 +137,13 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
@@ -153,7 +153,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -190,7 +190,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -156,7 +156,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -14,11 +14,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -35,15 +35,15 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
 colorama==0.4.6 ; sys_platform == 'win32'
     # via typer
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -54,7 +54,7 @@ distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -66,7 +66,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -87,13 +87,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -115,21 +115,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -143,7 +143,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -156,11 +156,11 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -169,13 +169,13 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pytz==2024.1
     # via tempora
@@ -187,7 +187,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -228,7 +228,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/linux.lock
+++ b/requirements/static/pkg/py3.11/linux.lock
@@ -14,11 +14,11 @@ attrs==23.2.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -35,9 +35,9 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/linux.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -46,7 +46,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -58,7 +58,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -79,13 +79,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -111,14 +111,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -132,7 +132,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -145,7 +145,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -154,7 +154,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
@@ -166,7 +166,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -205,7 +205,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -14,11 +14,11 @@ attrs==25.4.0
     # via aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -33,13 +33,13 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 click==8.3.1
     # via typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -47,7 +47,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -59,7 +59,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -78,13 +78,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -104,21 +104,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.9.2
     # via
@@ -132,7 +132,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -144,21 +144,21 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via -r requirements/base.txt
 pywin32==312
     # via
@@ -168,7 +168,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -190,7 +190,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/windows.txt
-tornado==6.5.6
+tornado==6.5.7
     # via -r requirements/base.txt
 typer==0.24.1
     # via typer-slim
@@ -207,7 +207,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -144,7 +144,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -39,7 +39,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/darwin.lock
+++ b/requirements/static/pkg/py3.12/darwin.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==23.2.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -30,9 +30,9 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -40,7 +40,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -52,7 +52,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -71,13 +71,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -95,21 +95,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -123,7 +123,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -135,13 +135,13 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
@@ -151,7 +151,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -188,7 +188,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -154,7 +154,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==23.2.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -33,15 +33,15 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
 colorama==0.4.6 ; sys_platform == 'win32'
     # via typer
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -52,7 +52,7 @@ distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -64,7 +64,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -85,13 +85,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -113,21 +113,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -141,7 +141,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -154,11 +154,11 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -167,13 +167,13 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pytz==2024.1
     # via tempora
@@ -185,7 +185,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -226,7 +226,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/linux.lock
+++ b/requirements/static/pkg/py3.12/linux.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==23.2.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -33,9 +33,9 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/linux.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -44,7 +44,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -56,7 +56,7 @@ frozenlist==1.7.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -77,13 +77,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.5.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -109,14 +109,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -130,7 +130,7 @@ propcache==0.3.2
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -143,7 +143,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -152,7 +152,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
     #   croniter
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
@@ -164,7 +164,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -203,7 +203,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.20.1
     # via aiohttp

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -37,7 +37,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -142,7 +142,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -31,13 +31,13 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 click==8.3.1
     # via typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -45,7 +45,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -57,7 +57,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -76,13 +76,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -102,21 +102,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.9.2
     # via
@@ -130,7 +130,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -142,21 +142,21 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via -r requirements/base.txt
 pywin32==312
     # via
@@ -166,7 +166,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -188,7 +188,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/windows.txt
-tornado==6.5.6
+tornado==6.5.7
     # via -r requirements/base.txt
 typer==0.24.1
     # via typer-slim
@@ -205,7 +205,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/darwin.lock
+++ b/requirements/static/pkg/py3.13/darwin.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -30,9 +30,9 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -40,7 +40,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -52,7 +52,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -71,13 +71,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -95,21 +95,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -123,7 +123,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -135,14 +135,14 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
@@ -150,7 +150,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -182,7 +182,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.22.0
     # via aiohttp

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -33,15 +33,15 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
 colorama==0.4.6 ; sys_platform == 'win32'
     # via typer
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -52,7 +52,7 @@ distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -64,7 +64,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -85,13 +85,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -113,21 +113,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -141,7 +141,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -154,11 +154,11 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -168,13 +168,13 @@ python-dateutil==2.9.0.post0
     #   -r requirements/static/pkg/freebsd.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pywin32==312 ; sys_platform == 'win32'
     # via
@@ -184,7 +184,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -220,7 +220,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -154,7 +154,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/linux.lock
+++ b/requirements/static/pkg/py3.13/linux.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -33,9 +33,9 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/linux.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -44,7 +44,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -56,7 +56,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -77,13 +77,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -109,14 +109,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -130,7 +130,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -143,7 +143,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -153,7 +153,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/static/pkg/linux.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
@@ -163,7 +163,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -197,7 +197,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.22.0
     # via aiohttp

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -37,7 +37,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -142,7 +142,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -31,13 +31,13 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 click==8.3.1
     # via typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -45,7 +45,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -57,7 +57,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -76,13 +76,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -102,21 +102,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.9.2
     # via
@@ -130,7 +130,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -142,21 +142,21 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via -r requirements/base.txt
 pywin32==312
     # via
@@ -166,7 +166,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -188,7 +188,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/windows.txt
-tornado==6.5.6
+tornado==6.5.7
     # via -r requirements/base.txt
 typer==0.24.1
     # via typer-slim
@@ -200,7 +200,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/darwin.lock
+++ b/requirements/static/pkg/py3.14/darwin.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -30,9 +30,9 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -40,7 +40,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -52,7 +52,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -71,13 +71,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -95,21 +95,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -123,7 +123,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -135,14 +135,14 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
@@ -150,7 +150,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -182,7 +182,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.22.0
     # via aiohttp

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -33,15 +33,15 @@ cherrypy==18.10.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-clr-loader==0.2.10 ; sys_platform == 'win32'
+clr-loader==0.3.1 ; sys_platform == 'win32'
     # via pythonnet
 colorama==0.4.6 ; sys_platform == 'win32'
     # via typer
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2 ; sys_platform != 'win32'
+croniter==6.2.4 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -52,7 +52,7 @@ distro==1.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -64,7 +64,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -85,13 +85,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -113,21 +113,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -141,7 +141,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -154,11 +154,11 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.11 ; sys_platform == 'win32'
+pymssql==2.3.13 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -168,13 +168,13 @@ python-dateutil==2.9.0.post0
     #   -r requirements/static/pkg/freebsd.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pythonnet==3.0.5 ; sys_platform == 'win32'
+pythonnet==3.1.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pywin32==312 ; sys_platform == 'win32'
     # via
@@ -184,7 +184,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -220,7 +220,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -154,7 +154,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pymssql==2.3.13 ; sys_platform == 'win32'
+pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/linux.lock
+++ b/requirements/static/pkg/py3.14/linux.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   cryptography
@@ -33,9 +33,9 @@ cherrypy==18.10.0
     #   -r requirements/static/pkg/linux.txt
 contextvars==2.4
     # via -r requirements/base.txt
-croniter==6.2.2
+croniter==6.2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -44,7 +44,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -56,7 +56,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -77,13 +77,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -109,14 +109,14 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.5.1
     # via
@@ -130,7 +130,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -143,7 +143,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -153,7 +153,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/static/pkg/linux.txt
     #   croniter
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via
@@ -163,7 +163,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -197,7 +197,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 yarl==1.22.0
     # via aiohttp

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -37,7 +37,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==49.0.0
+cryptography==48.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -142,7 +142,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.13
+pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -12,11 +12,11 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 attrs==25.4.0
     # via aiohttp
-certifi==2026.5.20
+certifi==2026.6.17
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   -r requirements/base.txt
     #   clr-loader
@@ -31,13 +31,13 @@ cherrypy==18.10.0
     # via -r requirements/base.txt
 click==8.3.1
     # via typer
-clr-loader==0.2.10
+clr-loader==0.3.1
     # via pythonnet
 colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==49.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -45,7 +45,7 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.31.0
     # via
     #   -r requirements/base.txt
     #   python-discovery
@@ -57,7 +57,7 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.50
+gitpython==3.1.52
     # via -r requirements/base.txt
 idna==3.18
     # via
@@ -76,13 +76,13 @@ jaraco-context==6.1.2
     # via
     #   -r requirements/base.txt
     #   jaraco-text
-jaraco-functools==4.4.0
+jaraco-functools==4.6.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   jaraco-text
     #   tempora
-jaraco-text==4.2.0
+jaraco-text==4.3.0
     # via
     #   -r requirements/base.txt
     #   jaraco-collections
@@ -102,21 +102,21 @@ markupsafe==2.1.5
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.1.0
     # via
     #   -r requirements/base.txt
     #   cheroot
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==26.2
     # via -r requirements/base.txt
 platformdirs==4.9.2
     # via
@@ -130,7 +130,7 @@ propcache==0.4.1
     #   yarl
 psutil==7.2.2
     # via -r requirements/base.txt
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via -r requirements/base.txt
 pycparser==3.0
     # via
@@ -142,21 +142,21 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.19.2
     # via rich
-pymssql==2.3.11
+pymssql==2.3.13
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.3.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   tempora
-python-discovery==1.4.0
+python-discovery==1.4.4
     # via virtualenv
 python-gnupg==0.5.6
     # via -r requirements/base.txt
-pythonnet==3.0.5
+pythonnet==3.1.0
     # via -r requirements/base.txt
 pywin32==312
     # via
@@ -166,7 +166,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -188,7 +188,7 @@ tempora==5.8.1
     # via portend
 timelib==0.3.0
     # via -r requirements/static/pkg/windows.txt
-tornado==6.5.6
+tornado==6.5.7
     # via -r requirements/base.txt
 typer==0.24.1
     # via typer-slim
@@ -200,7 +200,7 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.6.1
     # via -r requirements/base.txt
 wmi==1.5.1
     # via -r requirements/base.txt


### PR DESCRIPTION
## Summary
- #69828 bumped the win32 `pymssql` pin from 2.3.11 to 2.3.13, but pymssql 2.3.12+ no longer ships `win32` (32-bit Windows) wheels — only `win_amd64`.
- This breaks the `Build Salt Onedir / Windows (3.10.20, x86)` CI job with `ERROR: No matching distribution found for pymssql==2.3.13`.
- This PR reverts the pin back to `2.3.11`, the last release with win32 wheels.

## Test plan
- [ ] CI Windows x86 onedir build job passes