### PR TITLE
Add python.run and python.script execution and state modules

### DIFF
--- a/changelog/69836.added.md
+++ b/changelog/69836.added.md
@@ -1,0 +1,1 @@
+Add `python.run` and `python.script` execution and state modules to run Python code and scripts using the same Python interpreter that is running Salt.

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -173,6 +173,7 @@ execution modules
     pw_group
     pw_user
     pyenv
+    python
     quota
     rabbitmq
     rbac_solaris

--- a/doc/ref/modules/all/salt.modules.python.rst
+++ b/doc/ref/modules/all/salt.modules.python.rst
@@ -1,0 +1,7 @@
+.. _python-module:
+
+salt.modules.python
+====================
+
+.. automodule:: salt.modules.python
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -87,6 +87,7 @@ state modules
     process
     proxy
     pyenv
+    python
     quota
     rabbitmq_cluster
     rabbitmq_plugin

--- a/doc/ref/states/all/salt.states.python.rst
+++ b/doc/ref/states/all/salt.states.python.rst
@@ -1,0 +1,7 @@
+.. _python-state:
+
+salt.states.python
+====================
+
+.. automodule:: salt.states.python
+    :members:

--- a/salt/modules/python.py
+++ b/salt/modules/python.py
@@ -1,0 +1,411 @@
+"""
+Run commands and scripts using the same Python interpreter that is running
+Salt itself.
+
+Salt's packages bundle their own "onedir" Python build, separate from
+whatever Python (if any) is installed on the system. :py:func:`python.run
+<salt.modules.python.run>` and :py:func:`python.script
+<salt.modules.python.script>` always target that interpreter -
+:py:data:`sys.executable` - rather than whatever ``python``/``python3``
+happens to resolve to on ``PATH``.
+"""
+
+import logging
+import os
+import shutil
+import sys
+
+import salt.utils.args
+import salt.utils.files
+import salt.utils.platform
+import salt.utils.url
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "python"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def _get_python_executable():
+    """
+    Return the path to the Python interpreter currently running Salt.
+    """
+    return os.path.normpath(sys.executable)
+
+
+def run(
+    command=None,
+    args=None,
+    cwd=None,
+    stdin=None,
+    runas=None,
+    group=None,
+    env=None,
+    clean_env=False,
+    rstrip=True,
+    umask=None,
+    output_encoding=None,
+    output_loglevel="debug",
+    log_callback=None,
+    hide_output=False,
+    timeout=None,
+    reset_system_locale=True,
+    ignore_retcode=False,
+    use_vt=False,
+    bg=False,
+    password=None,
+    success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
+    **kwargs,
+):
+    """
+    Run a snippet of Python code, or pass raw arguments to the interpreter,
+    using the same Python that is running Salt.
+
+    command
+        A string of Python code to execute, passed to the interpreter as
+        ``-c command``.
+
+    args
+        Additional arguments to pass to the interpreter. Can be a list, or a
+        string which will be split using shell-like syntax. If ``command``
+        is not specified, ``args`` is used as the full argument list handed
+        to the interpreter, which makes it possible to invoke things like
+        ``-m some_module``.
+
+    cwd
+        The directory from which to execute the command. Defaults to the
+        home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    stdin
+        A string of standard input can be specified for the command to be
+        run using the ``stdin`` parameter.
+
+    runas
+        Specify an alternate user to run the command. The default behavior
+        is to run as the user under which Salt is running.
+
+    group
+        Group to run the command as. Not currently supported on Windows.
+
+    password
+        Windows only. Required when specifying ``runas``. This parameter
+        will be ignored on non-Windows platforms.
+
+    env
+        Environment variables to be set prior to execution.
+
+    clean_env
+        Attempt to clean out all other Salt-related environment variables.
+
+    rstrip
+        Strip all whitespace off the end of output before it is returned.
+
+    umask
+        The umask (in octal) to use when running the command.
+
+    output_encoding
+        Control the encoding used to decode the command's output.
+
+    output_loglevel : debug
+        Control the loglevel at which the output from the command is
+        logged to the minion log.
+
+    log_callback
+        A callback function that can be used to further process the
+        output/return message of the command.
+
+    hide_output : False
+        If ``True``, suppress stdout and stderr in the return data.
+
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with
+        sigkill.
+
+    reset_system_locale
+        Resets the system locale prior to executing the command.
+
+    ignore_retcode
+        If the exit code of the command is nonzero, this is treated as an
+        error condition, and the output from the command will be logged to
+        the minion log. Pass this argument as ``True`` to skip logging the
+        output if the command has a nonzero exit code.
+
+    use_vt
+        Use VT utils (saltstack) to stream the command output more
+        interactively to the console and the logs. This is experimental.
+
+    bg
+        If ``True``, run command in background and do not await or deliver
+        its results.
+
+    success_retcodes
+        A list of non-zero return codes that should be considered a
+        success. If the return code matches any in the list, it will be
+        overridden with zero.
+
+    success_stdout
+        A list of strings that when found in standard out should be
+        considered a success.
+
+    success_stderr
+        A list of strings that when found in standard error should be
+        considered a success.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' python.run command="print('hello world')"
+        salt '*' python.run args="-m json.tool foo.json"
+    """
+    python_exe = _get_python_executable()
+
+    if isinstance(args, str):
+        args = salt.utils.args.shlex_split(args)
+
+    cmd_list = [python_exe]
+    if command is not None:
+        cmd_list.extend(["-c", command])
+    if args:
+        cmd_list.extend(args)
+
+    if len(cmd_list) == 1:
+        raise SaltInvocationError("Must specify either 'command' or 'args'")
+
+    return __salt__["cmd.run_all"](
+        cmd_list,
+        cwd=cwd,
+        stdin=stdin,
+        runas=runas,
+        group=group,
+        python_shell=False,
+        env=env,
+        clean_env=clean_env,
+        rstrip=rstrip,
+        umask=umask,
+        output_encoding=output_encoding,
+        output_loglevel=output_loglevel,
+        log_callback=log_callback,
+        hide_output=hide_output,
+        timeout=timeout,
+        reset_system_locale=reset_system_locale,
+        ignore_retcode=ignore_retcode,
+        use_vt=use_vt,
+        bg=bg,
+        password=password,
+        success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
+        **kwargs,
+    )
+
+
+def script(
+    source,
+    args=None,
+    cwd=None,
+    stdin=None,
+    runas=None,
+    group=None,
+    env=None,
+    template=None,
+    umask=None,
+    output_encoding=None,
+    output_loglevel="debug",
+    log_callback=None,
+    hide_output=False,
+    timeout=None,
+    reset_system_locale=True,
+    saltenv=None,
+    use_vt=False,
+    bg=False,
+    password=None,
+    success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
+    **kwargs,
+):
+    """
+    Download a Python script from the master (or another supported
+    location) and execute it with the same Python interpreter that is
+    running Salt, regardless of the script's shebang line, executable bit,
+    or what ``python``/``python3`` resolves to on ``PATH``.
+
+    source
+        The location of the script to download. If the file is located on
+        the master in the directory named spam, and is called eggs, the
+        source string is ``salt://spam/eggs``.
+
+    args
+        String or list of command line args to pass to the script.
+
+    cwd
+        The directory from which to execute the command. Defaults to the
+        home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    stdin
+        A string of standard input can be specified for the command to be
+        run using the ``stdin`` parameter.
+
+    runas
+        Specify an alternate user to run the script as. The default
+        behavior is to run as the user under which Salt is running.
+
+    group
+        Group to run the script as. Not currently supported on Windows.
+
+    password
+        Windows only. Required when specifying ``runas``. This parameter
+        will be ignored on non-Windows platforms.
+
+    env
+        Environment variables to be set prior to execution.
+
+    template
+        If this setting is applied then the named templating engine will
+        be used to render the downloaded file. Currently jinja, mako, and
+        wempy are supported.
+
+    umask
+        The umask (in octal) to use when running the command.
+
+    output_encoding
+        Control the encoding used to decode the command's output.
+
+    output_loglevel : debug
+        Control the loglevel at which the output from the command is
+        logged to the minion log.
+
+    log_callback
+        A callback function that can be used to further process the
+        output/return message of the command.
+
+    hide_output : False
+        If ``True``, suppress stdout and stderr in the return data.
+
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with
+        sigkill.
+
+    reset_system_locale
+        Resets the system locale prior to executing the command.
+
+    saltenv : base
+        The Salt environment to use to resolve ``source``.
+
+    use_vt
+        Use VT utils (saltstack) to stream the command output more
+        interactively to the console and the logs. This is experimental.
+
+    bg
+        If ``True``, run command in background and do not await or deliver
+        its results.
+
+    success_retcodes
+        A list of non-zero return codes that should be considered a
+        success. If the return code matches any in the list, it will be
+        overridden with zero.
+
+    success_stdout
+        A list of strings that when found in standard out should be
+        considered a success.
+
+    success_stderr
+        A list of strings that when found in standard error should be
+        considered a success.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' python.script salt://scripts/runme.py
+        salt '*' python.script salt://scripts/runme.py 'arg1 arg2 "arg 3"'
+    """
+    if saltenv is None:
+        try:
+            saltenv = __opts__.get("saltenv", "base")
+        except NameError:
+            saltenv = "base"
+
+    def _cleanup_tempfile(path):
+        try:
+            __salt__["file.remove"](path)
+        except Exception as exc:  # pylint: disable=broad-except
+            log.error("python.script: Unable to clean tempfile '%s': %s", path, exc)
+
+    path = salt.utils.files.mkstemp(
+        dir=cwd, suffix=os.path.splitext(salt.utils.url.split_env(source)[0])[1]
+    )
+
+    if template:
+        fn_ = __salt__["cp.get_template"](source, path, template, saltenv, **kwargs)
+        if not fn_:
+            _cleanup_tempfile(path)
+            return {
+                "pid": 0,
+                "retcode": 1,
+                "stdout": "",
+                "stderr": "",
+                "cache_error": True,
+            }
+    else:
+        fn_ = __salt__["cp.cache_file"](source, saltenv)
+        if not fn_:
+            _cleanup_tempfile(path)
+            return {
+                "pid": 0,
+                "retcode": 1,
+                "stdout": "",
+                "stderr": "",
+                "cache_error": True,
+            }
+        shutil.copyfile(fn_, path)
+
+    if not salt.utils.platform.is_windows() and runas:
+        os.chown(path, __salt__["file.user_to_uid"](runas), -1)
+
+    if isinstance(args, str):
+        args = salt.utils.args.shlex_split(args)
+
+    python_exe = _get_python_executable()
+    cmd_list = [python_exe, path]
+    if args:
+        cmd_list.extend(args)
+
+    ret = __salt__["cmd.run_all"](
+        cmd_list,
+        cwd=cwd,
+        stdin=stdin,
+        runas=runas,
+        group=group,
+        python_shell=False,
+        env=env,
+        umask=umask,
+        output_encoding=output_encoding,
+        output_loglevel=output_loglevel,
+        log_callback=log_callback,
+        timeout=timeout,
+        reset_system_locale=reset_system_locale,
+        use_vt=use_vt,
+        bg=bg,
+        password=password,
+        success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
+        **kwargs,
+    )
+    _cleanup_tempfile(path)
+
+    if hide_output:
+        ret["stdout"] = ret["stderr"] = ""
+    return ret

--- a/salt/states/python.py
+++ b/salt/states/python.py
@@ -1,0 +1,331 @@
+"""
+Execution of Python code and scripts using Salt's own interpreter
+==================================================================
+
+The python state module runs Python code or scripts using the same
+interpreter that is running Salt, rather than whatever ``python``/
+``python3`` happens to resolve to on the target's ``PATH``.
+
+A simple example to execute a snippet of Python code:
+
+.. code-block:: yaml
+
+    write-marker-file:
+      python.run:
+        - name: open('/tmp/salt-marker', 'w').close()
+
+Download and run a script with the running Salt interpreter:
+
+.. code-block:: yaml
+
+    run-my-script:
+      python.script:
+        - source: salt://scripts/runme.py
+        - args: arg1 arg2
+"""
+
+import copy
+import logging
+import os
+
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "python"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def run(
+    name,
+    args=None,
+    cwd=None,
+    runas=None,
+    password=None,
+    env=None,
+    output_loglevel="debug",
+    hide_output=False,
+    timeout=None,
+    ignore_timeout=False,
+    use_vt=False,
+    success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
+    **kwargs,
+):
+    """
+    Run a snippet of Python code, using the same interpreter that is
+    running Salt, if certain circumstances are met.
+
+    name
+        The Python code to execute.
+
+    args
+        Additional arguments to pass to the interpreter (string or list).
+        Only used if ``name`` should not be treated as the ``-c`` command,
+        e.g. for ``-m module`` invocations.
+
+    cwd
+        The directory from which to execute the code. Defaults to the home
+        directory of the user specified by ``runas`` (or the user under
+        which Salt is running if ``runas`` is not specified).
+
+    runas
+        The user name (or uid) to run the code as.
+
+    password
+        Windows only. Required when specifying ``runas``. This parameter
+        will be ignored on non-Windows platforms.
+
+    env
+        A list of environment variables to be set prior to execution.
+
+    output_loglevel : debug
+        Control the loglevel at which the output from the command is
+        logged to the minion log.
+
+    hide_output : False
+        Suppress stdout and stderr in the state's results.
+
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with
+        sigkill.
+
+    ignore_timeout
+        Ignore the timeout of commands, which is useful for running nohup
+        processes.
+
+    use_vt
+        Use VT utils (saltstack) to stream the command output more
+        interactively to the console and the logs. This is experimental.
+
+    success_retcodes
+        A list of non-zero return codes that should be considered a
+        success.
+
+    success_stdout
+        A list of strings that when found in standard out should be
+        considered a success.
+
+    success_stderr
+        A list of strings that when found in standard error should be
+        considered a success.
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    if env is not None and not isinstance(env, (list, dict)):
+        ret["comment"] = "Invalidly-formatted 'env' parameter. See documentation."
+        return ret
+
+    cmd_kwargs = copy.deepcopy(kwargs)
+    cmd_kwargs.update(
+        {
+            "args": args,
+            "cwd": cwd,
+            "runas": runas,
+            "password": password,
+            "env": env,
+            "use_vt": use_vt,
+            "output_loglevel": output_loglevel,
+            "hide_output": hide_output,
+            "success_retcodes": success_retcodes,
+            "success_stdout": success_stdout,
+            "success_stderr": success_stderr,
+        }
+    )
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f'Python code "{name}" would have been executed'
+        return ret
+
+    if cwd and not os.path.isdir(cwd):
+        ret["comment"] = f'Desired working directory "{cwd}" is not available'
+        return ret
+
+    try:
+        cmd_all = __salt__["python.run"](command=name, timeout=timeout, **cmd_kwargs)
+    except CommandExecutionError as err:
+        ret["comment"] = str(err)
+        return ret
+
+    ret["changes"] = cmd_all
+    ret["result"] = not bool(cmd_all["retcode"])
+    ret["comment"] = f'Python code "{name}" run'
+
+    if ignore_timeout:
+        trigger = "Timed out after"
+        if ret["changes"].get("retcode") == 1 and trigger in ret["changes"].get(
+            "stdout", ""
+        ):
+            ret["changes"]["retcode"] = 0
+            ret["result"] = True
+
+    if __opts__["test"] and cmd_all["retcode"] == 0 and ret["changes"]:
+        ret["result"] = None
+    return ret
+
+
+def script(
+    name,
+    source=None,
+    template=None,
+    cwd=None,
+    runas=None,
+    password=None,
+    env=None,
+    timeout=None,
+    use_vt=False,
+    output_loglevel="debug",
+    hide_output=False,
+    defaults=None,
+    context=None,
+    success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
+    **kwargs,
+):
+    """
+    Download a Python script and execute it with the same interpreter that
+    is running Salt.
+
+    source
+        The location of the script to download. If the file is located on
+        the master in the directory named spam, and is called eggs, the
+        source string is ``salt://spam/eggs``.
+
+    name
+        Either "script arg1 arg2 arg3..." (if ``source`` is also given) or
+        a source "salt://...".
+
+    template
+        If this setting is applied then the named templating engine will
+        be used to render the downloaded file. Currently jinja, mako, and
+        wempy are supported.
+
+    cwd
+        The directory from which to execute the script. Defaults to the
+        home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    runas
+        Specify an alternate user to run the script as. The default
+        behavior is to run as the user under which Salt is running.
+
+    password
+        Windows only. Required when specifying ``runas``. This parameter
+        will be ignored on non-Windows platforms.
+
+    env
+        A list of environment variables to be set prior to execution.
+
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with
+        sigkill.
+
+    use_vt
+        Use VT utils (saltstack) to stream the command output more
+        interactively to the console and the logs. This is experimental.
+
+    output_loglevel : debug
+        Control the loglevel at which the output from the command is
+        logged to the minion log.
+
+    hide_output : False
+        Suppress stdout and stderr in the state's results.
+
+    context
+        Overrides default context variables passed to the template.
+
+    defaults
+        Default context passed to the template.
+
+    success_retcodes
+        A list of non-zero return codes that should be considered a
+        success.
+
+    success_stdout
+        A list of strings that when found in standard out should be
+        considered a success.
+
+    success_stderr
+        A list of strings that when found in standard error should be
+        considered a success.
+    """
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    if env is not None and not isinstance(env, (list, dict)):
+        ret["comment"] = "Invalidly-formatted 'env' parameter. See documentation."
+        return ret
+
+    if context and not isinstance(context, dict):
+        ret["comment"] = (
+            "Invalidly-formatted 'context' parameter. Must be formed as a dict."
+        )
+        return ret
+    if defaults and not isinstance(defaults, dict):
+        ret["comment"] = (
+            "Invalidly-formatted 'defaults' parameter. Must be formed as a dict."
+        )
+        return ret
+
+    tmpctx = defaults if defaults else {}
+    if context:
+        tmpctx.update(context)
+
+    cmd_kwargs = copy.deepcopy(kwargs)
+    cmd_kwargs.update(
+        {
+            "runas": runas,
+            "password": password,
+            "env": env,
+            "cwd": cwd,
+            "template": template,
+            "timeout": timeout,
+            "output_loglevel": output_loglevel,
+            "hide_output": hide_output,
+            "use_vt": use_vt,
+            "context": tmpctx,
+            "saltenv": __env__,
+            "success_retcodes": success_retcodes,
+            "success_stdout": success_stdout,
+            "success_stderr": success_stderr,
+        }
+    )
+
+    if source is None:
+        source = name
+
+    if not cmd_kwargs.get("args", None) and len(name.split()) > 1:
+        cmd_kwargs.update({"args": name.split(" ", 1)[1]})
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = f"Python script '{name}' would have been executed"
+        return ret
+
+    if cwd and not os.path.isdir(cwd):
+        ret["comment"] = f'Desired working directory "{cwd}" is not available'
+        return ret
+
+    try:
+        cmd_all = __salt__["python.script"](source, **cmd_kwargs)
+    except CommandExecutionError as err:
+        ret["comment"] = str(err)
+        return ret
+
+    ret["changes"] = cmd_all
+    ret["result"] = not bool(cmd_all["retcode"])
+    if ret.get("changes", {}).get("cache_error"):
+        ret["comment"] = f"Unable to cache script {source} from saltenv '{__env__}'"
+    else:
+        ret["comment"] = f"Python script '{name}' run"
+
+    if __opts__["test"] and cmd_all["retcode"] == 0 and ret["changes"]:
+        ret["result"] = None
+    return ret

--- a/tests/pytests/unit/modules/test_python.py
+++ b/tests/pytests/unit/modules/test_python.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for the salt.modules.python module
+"""
+
+import os
+import sys
+
+import pytest
+
+import salt.modules.python as python
+from salt.exceptions import SaltInvocationError
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules(minion_opts):
+    return {python: {"__opts__": minion_opts}}
+
+
+def test_get_python_executable():
+    assert python._get_python_executable() == os.path.normpath(sys.executable)
+
+
+def test_run_with_command():
+    run_all_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"cmd.run_all": run_all_mock}):
+        python.run(command="print(1)")
+
+    call_args = run_all_mock.call_args
+    cmd_list = call_args[0][0]
+    assert cmd_list == [python._get_python_executable(), "-c", "print(1)"]
+    assert call_args[1]["python_shell"] is False
+
+
+def test_run_with_args_only():
+    run_all_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"cmd.run_all": run_all_mock}):
+        python.run(args=["-m", "json.tool", "foo.json"])
+
+    cmd_list = run_all_mock.call_args[0][0]
+    assert cmd_list == [
+        python._get_python_executable(),
+        "-m",
+        "json.tool",
+        "foo.json",
+    ]
+
+
+def test_run_with_string_args():
+    run_all_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"cmd.run_all": run_all_mock}):
+        python.run(command="print(1)", args="foo bar")
+
+    cmd_list = run_all_mock.call_args[0][0]
+    assert cmd_list == [python._get_python_executable(), "-c", "print(1)", "foo", "bar"]
+
+
+def test_run_no_command_no_args_raises():
+    with pytest.raises(SaltInvocationError):
+        python.run()
+
+
+def test_script_cache_success():
+    run_all_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    cache_file_mock = MagicMock(return_value="/cache/path/myscript.py")
+    remove_mock = MagicMock()
+    salt_dunder = {
+        "cmd.run_all": run_all_mock,
+        "cp.cache_file": cache_file_mock,
+        "file.remove": remove_mock,
+        "file.user_to_uid": MagicMock(return_value=0),
+    }
+    with patch.dict(python.__salt__, salt_dunder), patch(
+        "shutil.copyfile", MagicMock()
+    ):
+        ret = python.script("salt://myscript.py", args=["foo", "bar"])
+
+    assert ret["retcode"] == 0
+    cache_file_mock.assert_called_once()
+    run_all_mock.assert_called_once()
+    cmd_list = run_all_mock.call_args[0][0]
+    assert cmd_list[0] == python._get_python_executable()
+    assert cmd_list[-2:] == ["foo", "bar"]
+    remove_mock.assert_called_once()
+
+
+def test_script_cache_error():
+    cache_file_mock = MagicMock(return_value=False)
+    remove_mock = MagicMock()
+    run_all_mock = MagicMock()
+    salt_dunder = {
+        "cmd.run_all": run_all_mock,
+        "cp.cache_file": cache_file_mock,
+        "file.remove": remove_mock,
+    }
+    with patch.dict(python.__salt__, salt_dunder):
+        ret = python.script("salt://myscript.py")
+
+    assert ret == {
+        "pid": 0,
+        "retcode": 1,
+        "stdout": "",
+        "stderr": "",
+        "cache_error": True,
+    }
+    run_all_mock.assert_not_called()
+
+
+def test_script_with_template():
+    run_all_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    get_template_mock = MagicMock(return_value="/cache/path/myscript.py")
+    remove_mock = MagicMock()
+    salt_dunder = {
+        "cmd.run_all": run_all_mock,
+        "cp.get_template": get_template_mock,
+        "file.remove": remove_mock,
+    }
+    with patch.dict(python.__salt__, salt_dunder):
+        ret = python.script("salt://myscript.py", template="jinja")
+
+    assert ret["retcode"] == 0
+    get_template_mock.assert_called_once()
+    run_all_mock.assert_called_once()

--- a/tests/pytests/unit/states/test_python.py
+++ b/tests/pytests/unit/states/test_python.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the salt.states.python module
+"""
+
+import pytest
+
+import salt.states.python as python
+from salt.exceptions import CommandExecutionError
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {python: {"__env__": "base", "__opts__": {"test": False}}}
+
+
+def test_run_test_mode():
+    name = "print(1)"
+    with patch.dict(python.__opts__, {"test": True}):
+        run_mock = MagicMock()
+        with patch.dict(python.__salt__, {"python.run": run_mock}):
+            ret = python.run(name)
+
+    assert ret["result"] is None
+    run_mock.assert_not_called()
+
+
+def test_run_invalid_env():
+    name = "print(1)"
+    ret = python.run(name, env="not-a-list-or-dict")
+    assert ret["result"] is False
+    assert "env" in ret["comment"]
+
+
+def test_run_success():
+    name = "print(1)"
+    run_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"python.run": run_mock}):
+        ret = python.run(name)
+
+    assert ret["result"] is True
+    run_mock.assert_called_once()
+    assert run_mock.call_args[1]["command"] == name
+
+
+def test_run_failure():
+    name = "raise ValueError()"
+    run_mock = MagicMock(return_value={"retcode": 1, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"python.run": run_mock}):
+        ret = python.run(name)
+
+    assert ret["result"] is False
+
+
+def test_run_exception():
+    name = "print(1)"
+    run_mock = MagicMock(side_effect=CommandExecutionError("boom"))
+    with patch.dict(python.__salt__, {"python.run": run_mock}):
+        ret = python.run(name)
+
+    assert ret["result"] is False
+    assert ret["comment"] == "boom"
+
+
+def test_run_cwd_not_dir():
+    name = "print(1)"
+    ret = python.run(name, cwd="/this/path/does/not/exist")
+    assert ret["result"] is False
+    assert "not available" in ret["comment"]
+
+
+def test_script_test_mode():
+    name = "salt://myscript.py"
+    with patch.dict(python.__opts__, {"test": True}):
+        script_mock = MagicMock()
+        with patch.dict(python.__salt__, {"python.script": script_mock}):
+            ret = python.script(name)
+
+    assert ret["result"] is None
+    script_mock.assert_not_called()
+
+
+def test_script_invalid_env():
+    name = "salt://myscript.py"
+    ret = python.script(name, env="not-a-list-or-dict")
+    assert ret["result"] is False
+    assert "env" in ret["comment"]
+
+
+def test_script_invalid_context():
+    name = "salt://myscript.py"
+    ret = python.script(name, context="not-a-dict")
+    assert ret["result"] is False
+    assert "context" in ret["comment"]
+
+
+def test_script_invalid_defaults():
+    name = "salt://myscript.py"
+    ret = python.script(name, defaults="not-a-dict")
+    assert ret["result"] is False
+    assert "defaults" in ret["comment"]
+
+
+def test_script_success():
+    name = "salt://myscript.py"
+    script_mock = MagicMock(return_value={"retcode": 0, "stdout": "", "stderr": ""})
+    with patch.dict(python.__salt__, {"python.script": script_mock}):
+        ret = python.script(name)
+
+    assert ret["result"] is True
+    script_mock.assert_called_once()
+
+
+def test_script_cache_error_comment():
+    name = "salt://myscript.py"
+    script_mock = MagicMock(
+        return_value={
+            "retcode": 1,
+            "stdout": "",
+            "stderr": "",
+            "cache_error": True,
+        }
+    )
+    with patch.dict(python.__salt__, {"python.script": script_mock}):
+        ret = python.script(name)
+
+    assert ret["result"] is False
+    assert "Unable to cache script" in ret["comment"]
+
+
+def test_script_cwd_not_dir():
+    name = "salt://myscript.py"
+    ret = python.script(name, cwd="/this/path/does/not/exist")
+    assert ret["result"] is False
+    assert "not available" in ret["comment"]


### PR DESCRIPTION
### What does this PR do?
Add a new `python` execution module (`python.run`, `python.script`) and paired `python` state module that run Python code and scripts using the same interpreter that is running the Salt minion/master, rather than whatever `python`/`python3` resolves to on PATH. This makes it possible to reliably target Salt's own bundled/onedir interpreter regardless of what's installed on the system.

### What issues does this PR fix or reference?
Fixes #69836

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
