### PR TITLE
Stop building 32-bit (x86) Windows packages

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -159,7 +159,6 @@ def _build_matrix(os_kind, linux_arm_runner):
     if os_kind == "windows":
         _matrix = [
             {"arch": "amd64"},
-            {"arch": "x86"},
         ]
     elif os_kind == "macos":
         _matrix.append({"arch": "arm64"})

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -522,7 +522,7 @@ def macos(
         },
         "arch": {
             "help": "The architecture to build the package for",
-            "choices": ("x86", "amd64"),
+            "choices": ("amd64",),
             "required": True,
         },
         "sign": {


### PR DESCRIPTION
### What does this PR do?
Several build dependencies are dropping 32-bit Windows support, so remove the x86 leg from the Windows build matrix and reject it as a valid --arch choice for `tools pkg build windows`. Windows test jobs already only ran against amd64, so no test changes are needed.

### What issues does this PR fix or reference?
Fixes #69838 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
