### PR TITLE
Add winrepo_installer_cache_expire to clean up cached installer files

### DIFF
--- a/changelog/69817.added.md
+++ b/changelog/69817.added.md
@@ -1,0 +1,1 @@
+Added `winrepo_installer_cache_expire` minion config option to automatically remove cached winrepo installer/uninstaller files older than a configurable age each time `pkg.refresh_db` runs, preventing the minion cache from growing unbounded. Disabled by default.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3783,6 +3783,31 @@ the metadata will be refreshed.
 
     winrepo_cache_expire_max: 86400
 
+.. conf_minion:: winrepo_installer_cache_expire
+
+``winrepo_installer_cache_expire``
+-----------------------------------
+
+.. versionadded:: 3006.28
+
+Default: ``0``
+
+Every time :py:func:`pkg.refresh_db <salt.modules.win_pkg.refresh_db>` runs,
+installer/uninstaller files cached on the minion by
+:py:func:`pkg.install <salt.modules.win_pkg.install>` and
+:py:func:`pkg.remove <salt.modules.win_pkg.remove>` that are older than this
+many seconds will be removed, to keep them from accumulating indefinitely on
+the minion's disk. If set to ``0`` (the default), no cached installer files
+are ever removed.
+
+This is separate from ``winrepo_cache_expire_min``/``winrepo_cache_expire_max``
+above, which only control refresh timing of the windows repo metadata
+database, not the downloaded installer/uninstaller files themselves.
+
+.. code-block:: yaml
+
+    winrepo_installer_cache_expire: 2592000  # 30 days
+
 .. conf_minion:: winrepo_source_dir
 
 ``winrepo_source_dir``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -749,6 +749,7 @@ VALID_OPTS = immutabletypes.freeze(
         # be, we'll just skip type-checking.
         "winrepo_cache_expire_max": int,
         "winrepo_cache_expire_min": int,
+        "winrepo_installer_cache_expire": int,
         "winrepo_remotes": list,
         "winrepo_remotes_ng": list,
         "winrepo_ssl_verify": bool,
@@ -1251,6 +1252,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "winrepo_cachefile": "winrepo.p",
         "winrepo_cache_expire_max": 604800,
         "winrepo_cache_expire_min": 1800,
+        "winrepo_installer_cache_expire": 0,
         "winrepo_remotes": ["https://github.com/saltstack/salt-winrepo.git"],
         "winrepo_remotes_ng": ["https://github.com/saltstack/salt-winrepo-ng.git"],
         "winrepo_branch": "master",

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -988,6 +988,17 @@ def refresh_db(**kwargs):
         should be called to ensure the minion has the latest information about
         packages available to it.
 
+    .. note::
+        Each time this function runs, cached installer/uninstaller files
+        (downloaded by `pkg.install`/`pkg.remove`) that are older than
+        `winrepo_installer_cache_expire` seconds are also removed, to keep
+        them from accumulating indefinitely on the minion. This is disabled
+        by default; set `winrepo_installer_cache_expire` to a nonzero number
+        of seconds to opt in. This is separate from
+        `winrepo_cache_expire_min`/`winrepo_cache_expire_max`, which only
+        control refresh timing of the package metadata database, not the
+        downloaded installer files themselves.
+
     .. warning::
         Directories and files fetched from <winrepo_source_dir>
         (`/srv/salt/win/repo-ng`) will be processed in alphabetical order. If
@@ -1068,6 +1079,10 @@ def refresh_db(**kwargs):
         raise CommandExecutionError(
             "Failed to clear one or more winrepo cache files", info={"failed": failed}
         )
+
+    # Remove expired cached installer/uninstaller files, if the user has
+    # opted in via winrepo_installer_cache_expire
+    _clean_installer_cache(saltenv)
 
     # Clear the cache so that newly copied package definitions will be picked up
     fileserver = salt.fileserver.Fileserver(__opts__)
@@ -1161,6 +1176,103 @@ def _get_repo_details(saltenv):
         ("winrepo_source_dir", "local_dest", "winrepo_file", "winrepo_age"),
     )
     return repo_details(winrepo_source_dir, local_dest, winrepo_file, winrepo_age)
+
+
+def _installer_cache_file(saltenv):
+    """
+    Return the path to the file used to track installer/uninstaller files
+    that have been cached by ``pkg.install``/``pkg.remove`` for the given
+    saltenv, so they can later be expired by ``_clean_installer_cache``.
+    """
+    return os.path.join(_get_repo_details(saltenv).local_dest, "installer_cache.p")
+
+
+def _track_cached_installer(saltenv, path):
+    """
+    Record that ``path`` was cached by pkg.install/pkg.remove so that it can
+    be expired later on, if the user has opted in via
+    ``winrepo_installer_cache_expire``.
+    """
+    if not __opts__.get("winrepo_installer_cache_expire"):
+        return
+
+    cache_file = _installer_cache_file(saltenv)
+    cached = set()
+    try:
+        with salt.utils.files.fopen(cache_file, "rb") as fp_:
+            cached = set(salt.payload.loads(fp_.read()) or [])
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            log.error("Failed to read %s: %s", cache_file, exc)
+
+    if path in cached:
+        return
+
+    cached.add(path)
+    try:
+        with salt.utils.files.fopen(cache_file, "wb") as fp_:
+            fp_.write(salt.payload.dumps(list(cached)))
+    except OSError as exc:
+        log.error("Failed to write %s: %s", cache_file, exc)
+
+
+def _clean_installer_cache(saltenv):
+    """
+    Remove installer/uninstaller files cached by pkg.install/pkg.remove that
+    are older than ``winrepo_installer_cache_expire`` seconds. Disabled
+    (no-op) unless that option is set to a truthy value, so this is opt-in
+    and does not change default behavior.
+
+    Only files that this module itself cached (tracked via
+    ``_track_cached_installer``) are ever removed here; the rest of the
+    minion's ``extrn_files`` cache, which may be used by other
+    modules/states, is left untouched.
+    """
+    expire = __opts__.get("winrepo_installer_cache_expire")
+    if not expire:
+        return
+
+    cache_file = _installer_cache_file(saltenv)
+    try:
+        with salt.utils.files.fopen(cache_file, "rb") as fp_:
+            cached = set(salt.payload.loads(fp_.read()) or [])
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            log.error("Failed to read %s: %s", cache_file, exc)
+        return
+
+    if not cached:
+        return
+
+    threshold = time.time() - expire
+    remaining = set()
+    for path in cached:
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                log.error("Failed to get age of %s: %s", path, exc)
+                remaining.add(path)
+            # File no longer exists, drop it from the tracked set
+            continue
+
+        if mtime < threshold:
+            try:
+                os.remove(path)
+                log.debug("Removed expired winrepo installer cache file: %s", path)
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    log.error("Failed to remove %s: %s", path, exc)
+                    remaining.add(path)
+        else:
+            remaining.add(path)
+
+    if remaining != cached:
+        try:
+            with salt.utils.files.fopen(cache_file, "wb") as fp_:
+                fp_.write(salt.payload.dumps(list(remaining)))
+        except OSError as exc:
+            log.error("Failed to write %s: %s", cache_file, exc)
 
 
 def genrepo(**kwargs):
@@ -1795,6 +1907,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     log.error("Unable to cache %s", cache_file)
                     ret[pkg_name] = {"failed to cache cache_file": cache_file}
                     continue
+                _track_cached_installer(saltenv, cached_file)
 
             # If version is "latest" we always cache because "cp.is_cached" only
             # checks that the file exists, not that is has changed
@@ -1828,6 +1941,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     )
                     ret[pkg_name] = {"unable to cache": installer}
                     continue
+                _track_cached_installer(saltenv, cached_pkg)
         else:
             # Run the installer directly (not hosted on salt:, https:, etc.)
             cached_pkg = installer
@@ -2262,6 +2376,7 @@ def remove(name=None, pkgs=None, **kwargs):
                         log.error("Unable to cache %s", uninstaller)
                         ret[pkgname] = {"unable to cache": uninstaller}
                         continue
+                    _track_cached_installer(saltenv, cached_pkg)
 
             else:
                 # Run the uninstaller directly (not hosted on salt:, https:, etc.)

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -11,7 +11,9 @@ import salt.modules.config as config
 import salt.modules.cp as cp
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.win_pkg as win_pkg
+import salt.payload
 import salt.utils.data
+import salt.utils.files
 import salt.utils.platform
 import salt.utils.win_reg as win_reg
 from salt.exceptions import MinionError
@@ -1040,3 +1042,152 @@ def test_get_package_info_uses_opts_saltenv():
     ):
         win_pkg.get_package_info("chrome")
     mock_get_package_info.assert_called_once_with(name="chrome", saltenv="prod")
+
+
+def test_track_cached_installer_noop_when_disabled(tmp_path):
+    """
+    _track_cached_installer must not write a manifest when
+    winrepo_installer_cache_expire is disabled (the default).
+    """
+    cache_file = tmp_path / "installer_cache.p"
+    with patch.dict(
+        win_pkg.__opts__, {"winrepo_installer_cache_expire": 0}
+    ), patch.object(
+        win_pkg, "_installer_cache_file", MagicMock(return_value=str(cache_file))
+    ):
+        win_pkg._track_cached_installer("base", "C:\\fake\\path.exe")
+    assert not cache_file.exists()
+
+
+def test_track_cached_installer_writes_manifest(tmp_path):
+    """
+    _track_cached_installer must persist newly cached paths when the
+    feature is enabled.
+    """
+    cache_file = tmp_path / "installer_cache.p"
+    with patch.dict(
+        win_pkg.__opts__, {"winrepo_installer_cache_expire": 2592000}
+    ), patch.object(
+        win_pkg, "_installer_cache_file", MagicMock(return_value=str(cache_file))
+    ):
+        win_pkg._track_cached_installer("base", "C:\\fake\\path.exe")
+    assert cache_file.exists()
+    with salt.utils.files.fopen(str(cache_file), "rb") as fp_:
+        cached = salt.payload.loads(fp_.read())
+    assert list(cached) == ["C:\\fake\\path.exe"]
+
+
+def test_clean_installer_cache_noop_when_disabled(tmp_path):
+    """
+    _clean_installer_cache must not remove anything when
+    winrepo_installer_cache_expire is disabled (the default).
+    """
+    cache_file = tmp_path / "installer_cache.p"
+    with salt.utils.files.fopen(str(cache_file), "wb") as fp_:
+        fp_.write(salt.payload.dumps(["C:\\fake\\old.exe"]))
+
+    mock_remove = MagicMock()
+    with patch.dict(
+        win_pkg.__opts__, {"winrepo_installer_cache_expire": 0}
+    ), patch.object(
+        win_pkg, "_installer_cache_file", MagicMock(return_value=str(cache_file))
+    ), patch.object(
+        win_pkg.os, "remove", mock_remove
+    ):
+        win_pkg._clean_installer_cache("base")
+    mock_remove.assert_not_called()
+
+
+def test_clean_installer_cache_removes_expired_entries(tmp_path):
+    """
+    _clean_installer_cache must remove only tracked files older than
+    winrepo_installer_cache_expire seconds, leaving fresh entries in the
+    manifest and untouched on disk.
+    """
+    cache_file = tmp_path / "installer_cache.p"
+    old_path = "C:\\fake\\old.exe"
+    fresh_path = "C:\\fake\\fresh.exe"
+    with salt.utils.files.fopen(str(cache_file), "wb") as fp_:
+        fp_.write(salt.payload.dumps([old_path, fresh_path]))
+
+    now = 2_000_000
+    expire = 1_000
+    mtimes = {old_path: now - expire - 1, fresh_path: now - expire + 1}
+    mock_remove = MagicMock()
+    with patch.dict(
+        win_pkg.__opts__, {"winrepo_installer_cache_expire": expire}
+    ), patch.object(
+        win_pkg, "_installer_cache_file", MagicMock(return_value=str(cache_file))
+    ), patch.object(
+        win_pkg.time, "time", MagicMock(return_value=now)
+    ), patch.object(
+        win_pkg.os.path, "getmtime", MagicMock(side_effect=lambda p: mtimes[p])
+    ), patch.object(
+        win_pkg.os, "remove", mock_remove
+    ):
+        win_pkg._clean_installer_cache("base")
+
+    mock_remove.assert_called_once_with(old_path)
+    with salt.utils.files.fopen(str(cache_file), "rb") as fp_:
+        remaining = salt.payload.loads(fp_.read())
+    assert list(remaining) == [fresh_path]
+
+
+def test_clean_installer_cache_drops_missing_files(tmp_path):
+    """
+    _clean_installer_cache must silently drop manifest entries for files
+    that no longer exist, without raising or attempting to remove them.
+    """
+    cache_file = tmp_path / "installer_cache.p"
+    missing_path = "C:\\fake\\gone.exe"
+    with salt.utils.files.fopen(str(cache_file), "wb") as fp_:
+        fp_.write(salt.payload.dumps([missing_path]))
+
+    mock_remove = MagicMock()
+
+    def _raise_enoent(_path):
+        raise OSError(2, "No such file or directory")
+
+    with patch.dict(
+        win_pkg.__opts__, {"winrepo_installer_cache_expire": 1000}
+    ), patch.object(
+        win_pkg, "_installer_cache_file", MagicMock(return_value=str(cache_file))
+    ), patch.object(
+        win_pkg.os.path, "getmtime", MagicMock(side_effect=_raise_enoent)
+    ), patch.object(
+        win_pkg.os, "remove", mock_remove
+    ):
+        win_pkg._clean_installer_cache("base")
+
+    mock_remove.assert_not_called()
+    with salt.utils.files.fopen(str(cache_file), "rb") as fp_:
+        remaining = salt.payload.loads(fp_.read())
+    assert list(remaining) == []
+
+
+def test_refresh_db_calls_clean_installer_cache(tmp_path):
+    """
+    refresh_db() must sweep expired installer cache entries every time it
+    runs (the sweep itself is a no-op unless the user opted in).
+    """
+    repo_details = win_pkg.collections.namedtuple(
+        "RepoDetails",
+        ("winrepo_source_dir", "local_dest", "winrepo_file", "winrepo_age"),
+    )("salt://win/repo-ng/", str(tmp_path), str(tmp_path / "winrepo.p"), 0)
+
+    mock_clean = MagicMock()
+    mock_fileserver = MagicMock()
+    with patch.object(
+        win_pkg, "_get_repo_details", MagicMock(return_value=repo_details)
+    ), patch.object(win_pkg, "_clean_installer_cache", mock_clean), patch.object(
+        win_pkg, "genrepo", MagicMock(return_value={})
+    ), patch.object(
+        win_pkg.salt.fileserver, "Fileserver", MagicMock(return_value=mock_fileserver)
+    ), patch.dict(
+        win_pkg.__salt__, {"cp.cache_dir": MagicMock(return_value=[])}
+    ), patch.dict(
+        win_pkg.__opts__, {"cachedir": str(tmp_path)}
+    ):
+        win_pkg.refresh_db(saltenv="base")
+
+    mock_clean.assert_called_once_with("base")


### PR DESCRIPTION
### What does this PR do?
Salt never removed installer/uninstaller files downloaded by pkg.install and pkg.remove, causing the minion cache to grow unbounded (#69817). Add an opt-in winrepo_installer_cache_expire minion option that removes tracked installer cache files older than the configured age each time pkg.refresh_db runs. Disabled by default.

### What issues does this PR fix or reference?
Fixes #69817 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
