### PR TITLE
Patch vendored tornado for CVE-2026-49853 (auth/cookie header leak on cross-origin redirect)

### DIFF
--- a/changelog/69845.fixed.md
+++ b/changelog/69845.fixed.md
@@ -1,0 +1,4 @@
+Patch the vendored tornado ``SimpleAsyncHTTPClient`` for CVE-2026-49853: the
+``Authorization`` and ``Cookie`` headers, along with ``auth_username`` and
+``auth_password``, are no longer forwarded to a different origin when
+following an HTTP redirect.

--- a/salt/ext/tornado/simple_httpclient.py
+++ b/salt/ext/tornado/simple_httpclient.py
@@ -510,10 +510,24 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         if self._should_follow_redirect():
             assert isinstance(self.request, _RequestProxy)
             new_request = copy.copy(self.request.request)
+            new_request.headers = self.request.headers.copy()
             new_request.url = urlparse.urljoin(self.request.url,
                                                self.headers["Location"])
             new_request.max_redirects = self.request.max_redirects - 1
             del new_request.headers["Host"]
+            # CVE-2026-49853: don't forward credentials to a different
+            # origin when following a redirect.
+            parsed_orig_url = urlparse.urlsplit(original_request.url)
+            parsed_new_url = urlparse.urlsplit(new_request.url)
+            if (parsed_orig_url.scheme != parsed_new_url.scheme or
+                    parsed_orig_url.netloc != parsed_new_url.netloc):
+                new_request.auth_username = None
+                new_request.auth_password = None
+                for h in ["Authorization", "Cookie"]:
+                    try:
+                        del new_request.headers[h]
+                    except KeyError:
+                        pass
             # http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.4
             # Client SHOULD make a GET request after a 303.
             # According to the spec, 302 should be followed by the same
@@ -527,7 +541,7 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                 for h in ["Content-Length", "Content-Type",
                           "Content-Encoding", "Transfer-Encoding"]:
                     try:
-                        del self.request.headers[h]
+                        del new_request.headers[h]
                     except KeyError:
                         pass
             new_request.original_request = original_request

--- a/salt/ext/tornado/test/simple_httpclient_test.py
+++ b/salt/ext/tornado/test/simple_httpclient_test.py
@@ -12,7 +12,7 @@ import socket
 import ssl
 import sys
 
-from salt.ext.tornado.escape import to_unicode
+from salt.ext.tornado.escape import to_unicode, url_escape
 from salt.ext.tornado import gen
 from salt.ext.tornado.httpclient import AsyncHTTPClient
 from salt.ext.tornado.httputil import HTTPHeaders, ResponseStartLine
@@ -659,6 +659,46 @@ class HostnameMappingTestCase(AsyncHTTPTestCase):
         response = self.wait()
         response.rethrow()
         self.assertEqual(response.body, b'Hello world!')
+
+
+class HeaderEchoHandler(RequestHandler):
+    def get(self):
+        self.finish("%s|%s" % (self.request.headers.get("Authorization", ""),
+                               self.request.headers.get("Cookie", "")))
+
+
+class CrossOriginRedirectTestCase(AsyncHTTPTestCase):
+    # Regression test for CVE-2026-49853: Authorization/Cookie headers
+    # (and auth_username/auth_password) must not be forwarded to a
+    # different origin when following a redirect.
+    def setUp(self):
+        super(CrossOriginRedirectTestCase, self).setUp()
+        self.http_client = SimpleAsyncHTTPClient(
+            self.io_loop,
+            hostname_mapping={'other.example.com': '127.0.0.1'})
+
+    def get_app(self):
+        return Application([
+            url("/redirect", RedirectHandler),
+            url("/echo_headers", HeaderEchoHandler),
+        ])
+
+    def test_cross_origin_redirect_strips_auth_and_cookie(self):
+        target = 'http://other.example.com:%d/echo_headers' % self.get_http_port()
+        response = self.fetch(
+            '/redirect?url=%s' % url_escape(target),
+            auth_username='foo', auth_password='bar',
+            headers=HTTPHeaders({"Cookie": "session=secret"}))
+        response.rethrow()
+        self.assertEqual(response.body, b"|")
+
+    def test_same_origin_redirect_keeps_auth_and_cookie(self):
+        response = self.fetch(
+            '/redirect?url=%s' % url_escape('/echo_headers'),
+            auth_username='foo', auth_password='bar',
+            headers=HTTPHeaders({"Cookie": "session=secret"}))
+        response.rethrow()
+        self.assertEqual(response.body, b"Basic Zm9vOmJhcg==|session=secret")
 
 
 class ResolveTimeoutTestCase(AsyncHTTPTestCase):


### PR DESCRIPTION
### What does this PR do?
SimpleAsyncHTTPClient forwarded the Authorization/Cookie headers and auth_username/auth_password to a different origin when following a redirect, because the redirected request's headers were only ever a shallow-copy alias of the original request's headers. Explicitly copy the headers before mutating them, and strip credentials when the redirect target's scheme/host/port differs from the original request.

Fixing the aliasing bug also exposed a latent issue: the existing Content-Length/Content-Type/etc. stripping for 302/303-to-GET redirects deleted from the original request's headers instead of the new request's, which only worked by accident because of the aliasing. Both now correctly target the new request.

### What issues does this PR fix or reference?
Fixes #69845 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
