### PR TITLE
Patch vendored tornado for CVE-2026-49855 (gzip decompression bomb)

### DIFF
--- a/changelog/69848.fixed.md
+++ b/changelog/69848.fixed.md
@@ -1,0 +1,4 @@
+Patch the vendored tornado ``_GzipMessageDelegate`` for CVE-2026-49855: the
+cumulative size of decompressed gzip response bodies is now checked against
+``max_body_size``, preventing a malicious server from exhausting client
+memory with a small, highly-compressed response (a "gzip bomb").

--- a/salt/ext/tornado/http1connection.py
+++ b/salt/ext/tornado/http1connection.py
@@ -151,7 +151,8 @@ class HTTP1Connection(httputil.HTTPConnection):
         been read.
         """
         if self.params.decompress:
-            delegate = _GzipMessageDelegate(delegate, self.params.chunk_size)
+            delegate = _GzipMessageDelegate(delegate, self.params.chunk_size,
+                                            self._max_body_size)
         return self._read_message(delegate)
 
     @gen.coroutine
@@ -625,9 +626,11 @@ class HTTP1Connection(httputil.HTTPConnection):
 class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
     """Wraps an `HTTPMessageDelegate` to decode ``Content-Encoding: gzip``.
     """
-    def __init__(self, delegate, chunk_size):
+    def __init__(self, delegate, chunk_size, max_body_size):
         self._delegate = delegate
         self._chunk_size = chunk_size
+        self._max_body_size = max_body_size
+        self._decompressed_body_size = 0
         self._decompressor = None
 
     def headers_received(self, start_line, headers):
@@ -649,6 +652,10 @@ class _GzipMessageDelegate(httputil.HTTPMessageDelegate):
                 decompressed = self._decompressor.decompress(
                     compressed_data, self._chunk_size)
                 if decompressed:
+                    self._decompressed_body_size += len(decompressed)
+                    if self._decompressed_body_size > self._max_body_size:
+                        raise httputil.HTTPInputError(
+                            "decompressed body too large")
                     ret = self._delegate.data_received(decompressed)
                     if ret is not None:
                         yield ret

--- a/salt/ext/tornado/test/simple_httpclient_test.py
+++ b/salt/ext/tornado/test/simple_httpclient_test.py
@@ -737,6 +737,25 @@ class MaxBodySizeTest(AsyncHTTPTestCase):
         self.assertEqual(response.code, 599)
 
 
+class GzipBombTest(AsyncHTTPTestCase):
+    # Regression test for CVE-2026-49855: a small gzip-compressed response
+    # that decompresses far past max_body_size must be rejected instead of
+    # being buffered in full.
+    def get_app(self):
+        class BombHandler(RequestHandler):
+            def get(self):
+                self.write("a" * 1024 * 1024 * 10)
+
+        return Application([('/bomb', BombHandler)], gzip=True)
+
+    def get_http_client(self):
+        return SimpleAsyncHTTPClient(io_loop=self.io_loop, max_body_size=1024 * 64)
+
+    def test_gzip_bomb_rejected(self):
+        response = self.fetch('/bomb')
+        self.assertEqual(response.code, 599)
+
+
 class MaxBufferSizeTest(AsyncHTTPTestCase):
     def get_app(self):
 


### PR DESCRIPTION
### What does this PR do?
_GzipMessageDelegate.data_received tracked only the compressed size of gzip response bodies against max_body_size, not the decompressed size. A malicious server could return a small, highly-compressed response that expands to gigabytes on the client, exhausting memory.

Track the cumulative decompressed size and raise HTTPInputError once it exceeds max_body_size, matching the check already done for compressed sizes elsewhere in http1connection.py.

### What issues does this PR fix or reference?
Fixes #69848 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
