### PR TITLE
Fix concurrent state.* runs when queue=True and JID sorts high (#69826)

### DIFF
--- a/changelog/69825.fixed.md
+++ b/changelog/69825.fixed.md
@@ -1,0 +1,6 @@
+Fixed ``state.apply queue=True`` allowing more than one concurrent ``state.*``
+execution when the new job's JID sorted lexically higher than an already-running
+job's JID. ``check_prior_running_states`` now blocks on any real running
+state.* process regardless of JID ordering, while still allowing the state
+queue processor to dequeue the oldest queued placeholder without deadlocking
+on younger queued siblings.

--- a/salt/utils/state.py
+++ b/salt/utils/state.py
@@ -206,12 +206,23 @@ def check_prior_running_states(opts, jid, active_jobs):
             if str(data_jid) == str(jid):
                 continue
 
-            # Only block if the other job is OLDER than the current one.
-            # This ensures FIFO ordering and prevents deadlocks where two
-            # jobs block each other.
-            # Salt JIDs are usually timestamp-based strings (e.g. 20230524100000)
-            # which sort correctly as strings OR ints.
-            if str(data_jid) < str(jid):
+            # A real running state.* job (non-zero PID) must always block,
+            # regardless of how its JID sorts relative to ours. Comparing by
+            # JID here would let a concurrently running job whose JID sorts
+            # *higher* than ours slip past the check, breaking the "one
+            # state run at a time per minion" guarantee (issue #69825).
+            #
+            # Queued placeholder entries (pid == 0, produced by scanning the
+            # queue directories above) represent jobs that have not yet
+            # started. For those, block only when the placeholder's JID
+            # sorts before ours so the queue processor can dequeue the
+            # oldest queued JID without deadlocking on younger siblings.
+            # Salt JIDs are usually timestamp-based strings (e.g.
+            # 20230524100000) which sort correctly as strings OR ints.
+            pid = data.get("pid")
+            if pid:
+                ret.append(data)
+            elif str(data_jid) < str(jid):
                 ret.append(data)
         except (ValueError, TypeError):
             continue

--- a/tests/pytests/unit/modules/state/test_state.py
+++ b/tests/pytests/unit/modules/state/test_state.py
@@ -1378,3 +1378,63 @@ class TestCheckPriorRunningStates:
             # Since mock_listdir returns the same for both calls in this mock setup,
             # it finds the same file twice.
             assert len(result) == 2
+
+    def test_check_prior_running_states_blocks_on_higher_jid_running(self):
+        """
+        Regression test for issue #69825.
+
+        A concurrently running state.* job whose JID sorts *higher* than the
+        current JID must still block the current job. The previous
+        ``str(data_jid) < str(jid)`` filter only counted strictly older JIDs,
+        which allowed two state.* runs to dispatch concurrently on a single
+        minion when their JID mint order and their per-subprocess queue-check
+        order disagreed.
+        """
+        opts = {"cachedir": "/tmp/does-not-exist-69825"}
+        # Simulate a real running state.* job (non-zero PID) whose JID is
+        # higher (numerically/lexically greater) than the current JID.
+        active_jobs = [
+            {
+                "jid": "20260718005610738474",
+                "fun": "state.apply",
+                "pid": 12345,
+            }
+        ]
+        current_jid = "20260718005610231848"
+
+        result = salt.utils.state.check_prior_running_states(
+            opts, current_jid, active_jobs
+        )
+
+        assert len(result) == 1, (
+            "A running state.* job with a higher JID must block the current"
+            " job to preserve the 'one state run per minion' guarantee."
+        )
+        assert result[0]["jid"] == "20260718005610738474"
+
+    def test_check_prior_running_states_ignores_higher_jid_queued_placeholder(
+        self,
+    ):
+        """
+        Companion invariant for issue #69825.
+
+        Queued (not yet running) entries -- represented by a placeholder
+        with ``pid == 0`` -- should only block the current job when they
+        sort *before* it, so the state-queue processor can safely dequeue
+        the oldest queued JID without deadlocking on younger siblings.
+        """
+        opts = {"cachedir": "/tmp/does-not-exist-69825"}
+        # Two placeholder queued entries: one older, one newer than us.
+        active_jobs = [
+            {"jid": "20260718005609000000", "fun": "state.apply", "pid": 0},
+            {"jid": "20260718005611000000", "fun": "state.apply", "pid": 0},
+        ]
+        current_jid = "20260718005610000000"
+
+        result = salt.utils.state.check_prior_running_states(
+            opts, current_jid, active_jobs
+        )
+
+        # Only the strictly older queued placeholder should block.
+        assert len(result) == 1
+        assert result[0]["jid"] == "20260718005609000000"


### PR DESCRIPTION
### What does this PR do?
Cherry-Pick of https://github.com/saltstack/salt/pull/69826 (2ccaa61dccf009d6b610a9d0ee9d2fa45289114f)

`state.apply queue=True` (and every `state.*` function that honors the `queue` argument) is documented to guarantee at most one `state.*` execution per minion at a time. In practice, when several state runs were published to the same minion in rapid succession, more than one could dispatch concurrently to the `proc/` directory instead of serializing through `queues/<master>/state_queue/`.

The root cause was the JID string comparison in
`salt.utils.state.check_prior_running_states`: it only treated *strictly older* JIDs as blocking, so any concurrently running state whose JID sorted higher than the current one was silently ignored. The result was two active proc entries whenever `_check_queue` for a new job happened to run before the peer subprocess's proc file was on disk.

`check_prior_running_states` now blocks on any real running state.* process (non-zero PID) regardless of JID ordering, while queued placeholders (`pid == 0`, produced by scanning the state_queue / job_queue directories) continue to use the FIFO comparison so the state-queue processor can dequeue the oldest queued JID without deadlocking on its younger siblings.

### What issues does this PR fix or reference?
Fixes #69825

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
