### PR TITLE
[Documentation] Fix request channel timeout default

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1319,13 +1319,13 @@ restart.
 
 .. versionadded:: 3006.2
 
-Default: ``30``
+Default: ``60``
 
-The default timeout timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
+The default timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
 
 .. code-block:: yaml
 
-    request_channel_timeout: 30
+    request_channel_timeout: 60
 
 ``request_channel_tries``
 -------------------------

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1318,13 +1318,13 @@ restart.
 
 .. versionadded:: 3006.2
 
-Default: ``30``
+Default: ``60``
 
-The default timeout timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
+The default timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
 
 .. code-block:: yaml
 
-    request_channel_timeout: 30
+    request_channel_timeout: 60
 
 ``request_channel_tries``
 -------------------------


### PR DESCRIPTION
### What does this PR do?

Corrects the documented `request_channel_timeout` default and YAML example from 30 seconds to 60 seconds, matching both `salt.channel.client.REQUEST_CHANNEL_TIMEOUT` and the minion configuration default. It also removes a duplicated `timeout` in the description.

### What issues does this PR fix or reference?

Fixes #66270

### Previous Behavior

The minion configuration reference incorrectly documented a 30-second default.

### New Behavior

The reference documents the actual 60-second default used by Salt.

### Merge requirements satisfied?

- [x] Docs
- [ ] Changelog - Not needed for a documentation-only correction
- [ ] Tests written/updated - Not needed because runtime behavior is unchanged

Validation: `git diff --check` passes. `rstcheck` was unavailable in the local environment.

### Commits signed with GPG?

No