### PR TITLE
fix(minion): run own job when target id equals a managed resource id

### DIFF
--- a/changelog/69867.fixed.md
+++ b/changelog/69867.fixed.md
@@ -1,0 +1,1 @@
+Fixed the minion skipping its own job when the target id equals a managed resource id. A bare-glob target matching the minion's own id is no longer treated as a pure resource target, so the minion runs the job locally in addition to dispatching it to the matching resource.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -5118,6 +5118,7 @@ class Minion(MinionBase):
         if (
             tgt_type == "glob"
             and isinstance(tgt, str)
+            and tgt != self.opts.get("id")
             and not any(c in tgt for c in ("*", "?", "["))
         ):
             resources = self.opts.get("resources", {})

--- a/tests/pytests/unit/test_minion_resources.py
+++ b/tests/pytests/unit/test_minion_resources.py
@@ -72,6 +72,26 @@ def test_resolve_resource_targets_glob_exact_managed_resource_id(minion_with_res
     assert targets == [{"id": "dummy-02", "type": "dummy"}]
 
 
+def test_pure_resource_target_excludes_own_minion_id(minion_opts):
+    """A bare id that is BOTH the minion's own id and a managed resource id is
+    not a pure-resource target, so the minion still runs its own job."""
+    minion_opts["resources"] = RESOURCES
+    minion_opts["multiprocessing"] = False
+    minion_opts["id"] = "dummy-01"
+    with mock_patch("salt.minion.Minion.gen_modules"):
+        with mock_patch("salt.minion.Minion.connect_master"):
+            m = salt.minion.Minion(minion_opts, load_grains=False)
+    own_id = {"tgt": "dummy-01", "tgt_type": "glob", "fun": "test.ping", "arg": []}
+    other_resource = {
+        "tgt": "dummy-02",
+        "tgt_type": "glob",
+        "fun": "test.ping",
+        "arg": [],
+    }
+    assert m._is_pure_resource_target(own_id) is False
+    assert m._is_pure_resource_target(other_resource) is True
+
+
 def test_resolve_resource_targets_list_bare_ids(minion_with_resources):
     load = {
         "tgt": "dummy-02,node1",


### PR DESCRIPTION
### What does this PR do?

Fixes #69867.

When a minion's own id is *also* one of its managed resource ids, a bare (wildcard-free) glob target equal to that id is misclassified as a **pure resource target**. `_target_load` then sets `minion_is_target` to `False`, so the minion dispatches the job to the matching resource but **skips running it on itself**.

The offending branch in `Minion._is_pure_resource_target` matches any bare glob against every managed resource id without excluding the minion's own id:

```python
if (
    tgt_type == "glob"
    and isinstance(tgt, str)
    and not any(c in tgt for c in ("*", "?", "[")):
):
    resources = self.opts.get("resources", {})
    for rids in resources.values():
        if tgt in rids:
            return True
```

### How does this PR fix it?

Exclude the minion's own id from that bare-id match:

```python
    and tgt != self.opts.get("id")
```

A target equal to the minion's own id is therefore no longer "pure resource", so `minion_is_target` stays `True` and the minion runs the job locally **in addition to** dispatching it to the resource. A bare id that is only a resource id (not the minion's own) is unaffected.

### Tests

Added `test_pure_resource_target_excludes_own_minion_id` in `tests/pytests/unit/test_minion_resources.py`. It builds a minion whose id (`dummy-01`) is also a managed resource id and asserts:

- `_is_pure_resource_target` is `False` for the own-id target (fails before this change, passes after),
- and still `True` for a different resource id (`dummy-02`), guarding against over-correction.

`python -m pytest tests/pytests/unit/test_minion_resources.py` — 62 passed locally.
