### PR TITLE
Fix: draft release published even when PyPI upload fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
 
   publish-draft:
     name: Publish Relase v${{ needs.prepare-workflow.outputs.salt-version }}
-    if: ${{ !cancelled() && always() }}
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-22.04
     needs:
       - check-requirements

--- a/changelog/69863.fixed.md
+++ b/changelog/69863.fixed.md
@@ -1,0 +1,1 @@
+The release workflow no longer publishes the draft GitHub release when the PyPI upload step fails.


### PR DESCRIPTION
Fixes #69863

- `publish-draft` job used `always()` which caused it to run even when `publish-pypi` failed
- Replace `always()` with `!failure()` so the draft is only published when all upstream jobs succeed