### PR TITLE
Skip PyPI upload for patch releases (e.g. 3008.1-1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPi
-    if: ${{ always() && ! failure() && ! cancelled() && github.event.repository.fork != true }}
+    if: ${{ always() && ! failure() && ! cancelled() && github.event.repository.fork != true && !contains(inputs.salt-version, '-') }}
     needs:
       - prepare-workflow
       - release

--- a/changelog/69862.fixed.md
+++ b/changelog/69862.fixed.md
@@ -1,0 +1,1 @@
+Skip the PyPI upload step for patch releases (versions containing a ``-N`` suffix, e.g. ``3008.1-1``) since those are RPM-specific packaging revisions and the base Python package is already on PyPI.


### PR DESCRIPTION
Fixes #69862

- Patch releases like `3008.1-1` are RPM packaging revisions; the Python package is unchanged and already on PyPI
- Uploading them creates a spurious `3008.1.post1` post-release entry on PyPI
- Add `!contains(inputs.salt-version, '-')` guard to the `publish-pypi` job `if` condition