### PR TITLE
Release workflow fails when multiple draft releases exist for the target version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,12 @@ jobs:
           salt-version: "${{ inputs.salt-version }}"
           validate-version: true
 
+      - name: Check For Duplicate Draft Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tools ci check-draft-releases ${{ steps.setup-salt-version.outputs.salt-version }}
+
       - name: Get Salt Releases
         id: get-salt-releases
         env:

--- a/changelog/69861.fixed.md
+++ b/changelog/69861.fixed.md
@@ -1,0 +1,1 @@
+The release workflow now fails immediately with a clear error message if more than one draft release exists for the target version, preventing silent publication of the wrong artifact set.

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -168,6 +168,86 @@ def _build_matrix(os_kind, linux_arm_runner):
 
 
 @ci.command(
+    name="check-draft-releases",
+    arguments={
+        "salt_version": {
+            "help": "The salt version to check for duplicate draft releases.",
+            "metavar": "SALT_VERSION",
+        },
+        "repository": {
+            "help": "The repository to query for releases, e.g. saltstack/salt",
+        },
+    },
+)
+def check_draft_releases(
+    ctx: Context, salt_version: str, repository: str = "saltstack/salt"
+):
+    """
+    Fail if more than one draft release exists for the given salt version.
+
+    A duplicate draft release is almost always a human error during release
+    prep. Proceeding silently risks publishing the wrong artifact set.
+    """
+    tag = f"v{salt_version}" if not salt_version.startswith("v") else salt_version
+    ctx.info(
+        f"Checking for duplicate draft releases tagged {tag!r} in {repository!r} ..."
+    )
+
+    with ctx.web as web:
+        headers = {
+            "Accept": "application/vnd.github+json",
+        }
+        github_token = tools.utils.gh.get_github_token(ctx)
+        if github_token is not None:
+            headers["Authorization"] = f"Bearer {github_token}"
+        web.headers.update(headers)
+
+        page = 1
+        draft_releases = []
+        while True:
+            ret = web.get(
+                f"https://api.github.com/repos/{repository}/releases",
+                params={"per_page": 100, "page": page},
+            )
+            if ret.status_code != 200:
+                ctx.error(f"Failed to get releases for {repository!r}: {ret.reason}")
+                ctx.exit(1)
+            releases = ret.json()
+            if not releases:
+                break
+            for release in releases:
+                if release.get("draft", False) and release.get("tag_name") == tag:
+                    draft_releases.append(release)
+            if len(releases) < 100:
+                break
+            page += 1
+
+    if len(draft_releases) > 1:
+        ctx.error(
+            f"Found {len(draft_releases)} draft releases for {tag!r}. "
+            "There must be exactly one. Please delete the duplicate(s) before "
+            "re-running the release workflow. Duplicates found:"
+        )
+        for rel in draft_releases:
+            ctx.error(
+                f"  id={rel['id']}  name={rel['name']!r}  " f"url={rel['html_url']}"
+            )
+        ctx.exit(1)
+
+    if len(draft_releases) == 0:
+        ctx.warn(
+            f"No draft release found for {tag!r}. "
+            "The release workflow expects a draft release to exist at this point."
+        )
+    else:
+        ctx.info(
+            f"Found exactly one draft release for {tag!r}: "
+            f"id={draft_releases[0]['id']}  name={draft_releases[0]['name']!r}"
+        )
+    ctx.exit(0)
+
+
+@ci.command(
     name="get-releases",
     arguments={
         "repository": {


### PR DESCRIPTION
## Summary

- Adds `tools ci check-draft-releases <version>` command that queries the GitHub Releases API and exits non-zero if more than one draft release is found for the given tag, listing the duplicates with their IDs and URLs
- Adds a "Check For Duplicate Draft Releases" step to the `prepare-workflow` job in `release.yml`, executed immediately after version validation
- A zero-draft-release count is a warning (non-fatal); more than one is a hard failure

Fixes #69861