### PR TITLE
Fix queuing of concurrent jobs jid conditional 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,12 @@ jobs:
           salt-version: "${{ inputs.salt-version }}"
           validate-version: true
 
+      - name: Check For Duplicate Draft Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tools ci check-draft-releases ${{ steps.setup-salt-version.outputs.salt-version }}
+
       - name: Get Salt Releases
         id: get-salt-releases
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
 
   publish-draft:
     name: Publish Relase v${{ needs.prepare-workflow.outputs.salt-version }}
-    if: ${{ !cancelled() && always() }}
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-22.04
     needs:
       - check-requirements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPi
-    if: ${{ always() && ! failure() && ! cancelled() && github.event.repository.fork != true }}
+    if: ${{ always() && ! failure() && ! cancelled() && github.event.repository.fork != true && !contains(inputs.salt-version, '-') }}
     needs:
       - prepare-workflow
       - release

--- a/changelog/69825.fixed.md
+++ b/changelog/69825.fixed.md
@@ -1,0 +1,6 @@
+Fixed ``state.apply queue=True`` allowing more than one concurrent ``state.*``
+execution when the new job's JID sorted lexically higher than an already-running
+job's JID. ``check_prior_running_states`` now blocks on any real running
+state.* process regardless of JID ordering, while still allowing the state
+queue processor to dequeue the oldest queued placeholder without deadlocking
+on younger queued siblings.

--- a/changelog/69861.fixed.md
+++ b/changelog/69861.fixed.md
@@ -1,0 +1,1 @@
+The release workflow now fails immediately with a clear error message if more than one draft release exists for the target version, preventing silent publication of the wrong artifact set.

--- a/changelog/69862.fixed.md
+++ b/changelog/69862.fixed.md
@@ -1,0 +1,1 @@
+Skip the PyPI upload step for patch releases (versions containing a ``-N`` suffix, e.g. ``3008.1-1``) since those are RPM-specific packaging revisions and the base Python package is already on PyPI.

--- a/changelog/69863.fixed.md
+++ b/changelog/69863.fixed.md
@@ -1,0 +1,1 @@
+The release workflow no longer publishes the draft GitHub release when the PyPI upload step fails.

--- a/salt/utils/state.py
+++ b/salt/utils/state.py
@@ -206,12 +206,23 @@ def check_prior_running_states(opts, jid, active_jobs):
             if str(data_jid) == str(jid):
                 continue
 
-            # Only block if the other job is OLDER than the current one.
-            # This ensures FIFO ordering and prevents deadlocks where two
-            # jobs block each other.
-            # Salt JIDs are usually timestamp-based strings (e.g. 20230524100000)
-            # which sort correctly as strings OR ints.
-            if str(data_jid) < str(jid):
+            # A real running state.* job (non-zero PID) must always block,
+            # regardless of how its JID sorts relative to ours. Comparing by
+            # JID here would let a concurrently running job whose JID sorts
+            # *higher* than ours slip past the check, breaking the "one
+            # state run at a time per minion" guarantee (issue #69825).
+            #
+            # Queued placeholder entries (pid == 0, produced by scanning the
+            # queue directories above) represent jobs that have not yet
+            # started. For those, block only when the placeholder's JID
+            # sorts before ours so the queue processor can dequeue the
+            # oldest queued JID without deadlocking on younger siblings.
+            # Salt JIDs are usually timestamp-based strings (e.g.
+            # 20230524100000) which sort correctly as strings OR ints.
+            pid = data.get("pid")
+            if pid:
+                ret.append(data)
+            elif str(data_jid) < str(jid):
                 ret.append(data)
         except (ValueError, TypeError):
             continue

--- a/tests/pytests/unit/modules/state/test_state.py
+++ b/tests/pytests/unit/modules/state/test_state.py
@@ -1378,3 +1378,63 @@ class TestCheckPriorRunningStates:
             # Since mock_listdir returns the same for both calls in this mock setup,
             # it finds the same file twice.
             assert len(result) == 2
+
+    def test_check_prior_running_states_blocks_on_higher_jid_running(self):
+        """
+        Regression test for issue #69825.
+
+        A concurrently running state.* job whose JID sorts *higher* than the
+        current JID must still block the current job. The previous
+        ``str(data_jid) < str(jid)`` filter only counted strictly older JIDs,
+        which allowed two state.* runs to dispatch concurrently on a single
+        minion when their JID mint order and their per-subprocess queue-check
+        order disagreed.
+        """
+        opts = {"cachedir": "/tmp/does-not-exist-69825"}
+        # Simulate a real running state.* job (non-zero PID) whose JID is
+        # higher (numerically/lexically greater) than the current JID.
+        active_jobs = [
+            {
+                "jid": "20260718005610738474",
+                "fun": "state.apply",
+                "pid": 12345,
+            }
+        ]
+        current_jid = "20260718005610231848"
+
+        result = salt.utils.state.check_prior_running_states(
+            opts, current_jid, active_jobs
+        )
+
+        assert len(result) == 1, (
+            "A running state.* job with a higher JID must block the current"
+            " job to preserve the 'one state run per minion' guarantee."
+        )
+        assert result[0]["jid"] == "20260718005610738474"
+
+    def test_check_prior_running_states_ignores_higher_jid_queued_placeholder(
+        self,
+    ):
+        """
+        Companion invariant for issue #69825.
+
+        Queued (not yet running) entries -- represented by a placeholder
+        with ``pid == 0`` -- should only block the current job when they
+        sort *before* it, so the state-queue processor can safely dequeue
+        the oldest queued JID without deadlocking on younger siblings.
+        """
+        opts = {"cachedir": "/tmp/does-not-exist-69825"}
+        # Two placeholder queued entries: one older, one newer than us.
+        active_jobs = [
+            {"jid": "20260718005609000000", "fun": "state.apply", "pid": 0},
+            {"jid": "20260718005611000000", "fun": "state.apply", "pid": 0},
+        ]
+        current_jid = "20260718005610000000"
+
+        result = salt.utils.state.check_prior_running_states(
+            opts, current_jid, active_jobs
+        )
+
+        # Only the strictly older queued placeholder should block.
+        assert len(result) == 1
+        assert result[0]["jid"] == "20260718005609000000"

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -170,6 +170,86 @@ def _build_matrix(os_kind, linux_arm_runner):
 
 
 @ci.command(
+    name="check-draft-releases",
+    arguments={
+        "salt_version": {
+            "help": "The salt version to check for duplicate draft releases.",
+            "metavar": "SALT_VERSION",
+        },
+        "repository": {
+            "help": "The repository to query for releases, e.g. saltstack/salt",
+        },
+    },
+)
+def check_draft_releases(
+    ctx: Context, salt_version: str, repository: str = "saltstack/salt"
+):
+    """
+    Fail if more than one draft release exists for the given salt version.
+
+    A duplicate draft release is almost always a human error during release
+    prep. Proceeding silently risks publishing the wrong artifact set.
+    """
+    tag = f"v{salt_version}" if not salt_version.startswith("v") else salt_version
+    ctx.info(
+        f"Checking for duplicate draft releases tagged {tag!r} in {repository!r} ..."
+    )
+
+    with ctx.web as web:
+        headers = {
+            "Accept": "application/vnd.github+json",
+        }
+        github_token = tools.utils.gh.get_github_token(ctx)
+        if github_token is not None:
+            headers["Authorization"] = f"Bearer {github_token}"
+        web.headers.update(headers)
+
+        page = 1
+        draft_releases = []
+        while True:
+            ret = web.get(
+                f"https://api.github.com/repos/{repository}/releases",
+                params={"per_page": 100, "page": page},
+            )
+            if ret.status_code != 200:
+                ctx.error(f"Failed to get releases for {repository!r}: {ret.reason}")
+                ctx.exit(1)
+            releases = ret.json()
+            if not releases:
+                break
+            for release in releases:
+                if release.get("draft", False) and release.get("tag_name") == tag:
+                    draft_releases.append(release)
+            if len(releases) < 100:
+                break
+            page += 1
+
+    if len(draft_releases) > 1:
+        ctx.error(
+            f"Found {len(draft_releases)} draft releases for {tag!r}. "
+            "There must be exactly one. Please delete the duplicate(s) before "
+            "re-running the release workflow. Duplicates found:"
+        )
+        for rel in draft_releases:
+            ctx.error(
+                f"  id={rel['id']}  name={rel['name']!r}  " f"url={rel['html_url']}"
+            )
+        ctx.exit(1)
+
+    if len(draft_releases) == 0:
+        ctx.warn(
+            f"No draft release found for {tag!r}. "
+            "The release workflow expects a draft release to exist at this point."
+        )
+    else:
+        ctx.info(
+            f"Found exactly one draft release for {tag!r}: "
+            f"id={draft_releases[0]['id']}  name={draft_releases[0]['name']!r}"
+        )
+    ctx.exit(0)
+
+
+@ci.command(
     name="get-releases",
     arguments={
         "repository": {


### PR DESCRIPTION
Bring in the fixes for #69825 into the 3008.1-patch release.

Always queue state jobs even when the job to be queued has a newer JID than the one in progress.

When many jobs are sent to the minion all at once the order at which they start on the minion is not guaranteed. This change ensures we never allow more than one state job to be run concurrently when the queue=True attribute is set. 