### PR TITLE
Add 3008.x to the list of major versions in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -44,6 +44,7 @@ body:
       options:
         - 3006.x
         - 3007.x
+        - 3008.x
   - type: dropdown
     id: operating-systems
     validations:

--- a/changelog/69020.changed.md
+++ b/changelog/69020.changed.md
@@ -1,0 +1,1 @@
+Add 3008.x to the list of major versions in the bug report template


### PR DESCRIPTION
### What does this PR do?
Adds 3008.x to the list of major versions in the bug report template

### What issues does this PR fix or reference?
Fixes #69020 

### Previous Behavior
Only 3006.x and 3007.x were able to be selected as major versions in the bug report template

### New Behavior
Adds 3008.x as an option

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
