### PR TITLE
Make salt.loader.resource_modules deny-by-default (fixes #69881)

### DIFF
--- a/changelog/69881.fixed.md
+++ b/changelog/69881.fixed.md
@@ -1,0 +1,8 @@
+Per-resource-type execution loaders (``salt.loader.resource_modules``) no
+longer include stock ``salt/modules/*`` — the loader is now deny-by-default
+and exposes only modules discovered under ``resources/<rtype>/modules/``
+override directories. Managing-minion access remains available via the
+``__minion__`` escape hatch. Restores the documented Resources safety
+contract: ``salt <resource-id> cmd.run …`` (or ``grains.setval``,
+``file.remove``, etc.) now returns "Function '…' is not supported for
+resource type '…'" instead of silently executing on the managing minion.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -304,6 +304,89 @@ def _module_dirs(
     )
 
 
+def _resource_type_module_dirs(
+    opts,
+    ext_type,
+    tag=None,
+    int_type=None,
+    base_path=None,
+    load_extensions=True,
+):
+    """
+    Return ONLY the per-resource-type override directories for a given
+    ``ext_type`` (``modules``, ``states``, etc.) — no stock salt/ dir,
+    no plain extension_modules dir, no plain entry-point dir.
+
+    Layers checked, in priority order:
+
+    * ``<cli module_dir>/resources/<rtype>/<ext_type>/`` for each
+      ``opts["module_dirs"]`` entry
+    * ``<extension_modules>/resources/<rtype>/<ext_type>/``
+    * ``<entry-point-package>/resources/<rtype>/<ext_type>/`` for every
+      entry-point-contributed package under ``salt.loader``
+    * ``<SALT_BASE_PATH>/resources/<rtype>/<ext_type>/``
+
+    ``opts["resource_type"]`` MUST be set; if it is not, this returns an
+    empty list (callers should not build a resource-scoped loader
+    without a resource type).
+
+    This helper is what :func:`resource_modules` uses to build a
+    per-resource-type execution loader that is deny-by-default: only
+    modules explicitly shipped for the resource type are reachable via
+    ``__salt__`` in a resource context.  Managing-minion access remains
+    available via the ``__minion__`` escape hatch.
+    """
+    rtype = opts.get("resource_type")
+    if not rtype:
+        return []
+
+    subpath_parts = ("resources", rtype, int_type or ext_type)
+
+    def _per_type(base):
+        if not base:
+            return []
+        candidate = os.path.join(base, *subpath_parts)
+        return [candidate] if os.path.isdir(candidate) else []
+
+    cli_per_type = []
+    for _dir in opts.get("module_dirs", []):
+        cli_per_type.extend(_per_type(_dir))
+
+    ext_per_type = _per_type(opts.get("extension_modules"))
+
+    # Walk the same entry-point packages :func:`_module_dirs` would
+    # walk, but only accept their per-type overlay dir — never the
+    # entry-point's own ``<ext_type>`` root.
+    entry_point_per_type = []
+    if load_extensions:
+        for entry_point in entrypoints.iter_entry_points("salt.loader"):
+            with catch_entry_points_exception(entry_point) as ctx:
+                loaded_entry_point = entry_point.load()
+            if ctx.exception_caught:
+                continue
+            if isinstance(loaded_entry_point, types.ModuleType):
+                for loaded_entry_point_path in loaded_entry_point.__path__:
+                    entry_point_per_type.extend(_per_type(loaded_entry_point_path))
+            # Function-style entry points are considered path providers
+            # in :func:`_module_dirs`; we take their parent dir as the
+            # package root and probe for the per-type overlay under it.
+            elif isinstance(loaded_entry_point, types.FunctionType):
+                with catch_entry_points_exception(entry_point) as ctx:
+                    loaded_entry_point_value = loaded_entry_point()
+                if ctx.exception_caught:
+                    continue
+                if isinstance(loaded_entry_point_value, dict):
+                    for path in loaded_entry_point_value.get(ext_type, ()):
+                        entry_point_per_type.extend(_per_type(os.path.dirname(path)))
+                else:
+                    for path in loaded_entry_point_value:
+                        entry_point_per_type.extend(_per_type(os.path.dirname(path)))
+
+    sys_per_type = _per_type(base_path or str(SALT_BASE_PATH))
+
+    return cli_per_type + ext_per_type + entry_point_per_type + sys_per_type
+
+
 def minion_mods(
     opts,
     context=None,
@@ -633,6 +716,16 @@ def resource_modules(
     a key), and call ``__salt__["x.y"]`` to dispatch through the
     resource itself.
 
+    The loader is **deny-by-default**: only modules discovered under
+    ``resources/<resource_type>/modules/`` overlay directories are
+    reachable via ``__salt__``.  Stock ``salt/modules/*`` are NOT
+    exposed here; targeting a resource with a stock function name
+    (``salt <rid> cmd.run …``) surfaces the "Function 'cmd.run' is not
+    supported for resource type 'X'" guard in ``_thread_return``
+    instead of silently running against the managing minion.  Types
+    that intentionally want stock behavior ship a thin override that
+    calls back through ``__minion__``.
+
     :param dict opts: The Salt options dictionary.  A copy is made and
         ``resource_type`` is injected before passing to the loader.
     :param str resource_type: The resource type string (e.g. ``"dummy"``).
@@ -665,7 +758,7 @@ def resource_modules(
         pack["__minion__"] = minion_mods
 
     return LazyLoader(
-        _module_dirs(resource_opts, "modules", "module"),
+        _resource_type_module_dirs(resource_opts, "modules", "module"),
         resource_opts,
         tag="module",
         pack=pack,

--- a/tests/pytests/integration/resources/test_dummy_resource.py
+++ b/tests/pytests/integration/resources/test_dummy_resource.py
@@ -269,46 +269,38 @@ def test_grain_targeting_only_matching_resource(salt_minion, salt_cli):
         assert data is True or data == {}, f"Unexpected response shape: {data!r}"
 
 
-def test_grains_items_returns_resource_grains_not_minion_grains(salt_minion, salt_cli):
+def test_grains_items_rejected_when_dummy_ships_no_grains_override(
+    salt_minion, salt_cli
+):
     """
-    ``salt 'dummy-01' grains.items`` must return the dummy resource's grains
-    (produced by ``salt.resources.dummy.grains``), not the managing minion's
-    grains. This exercises the end-to-end grain-swap pipeline:
+    ``salt 'dummy-01' grains.items`` — the ``dummy`` resource type ships no
+    per-type ``grains`` override, so under the deny-by-default resource
+    loader (#69881) ``grains.items`` is not reachable via the resource
+    surface.  The dispatch returns the "not supported for resource type"
+    rejection at the minion, and the CLI response is keyed to the
+    resource id (not the managing minion).
 
-    * Master targeting matches the bare resource id ``dummy-01`` and
-      dispatches a job whose payload includes ``resource_target`` for the
-      ``dummy`` type.
-    * Minion ``_thread_return`` packs ``__grains__`` from
-      ``resource_funcs["dummy.grains"]()`` before the function runs.
-    * The function (``grains.items``) returns the resource grain dict.
-    * Master ``_return`` re-keys ``resource_id`` → response key ``dummy-01``.
+    NOTE: this replaces an earlier test that asserted
+    ``salt.resources.dummy.grains()`` was reachable through the resource
+    loader's ``__grains__`` swap.  The swap still runs when a resource
+    function IS present in the loader — but ``grains.items`` itself
+    isn't there.  A dummy resource type that wanted to expose grains
+    would ship ``salt/resources/dummy/modules/grains.py`` (thin-wrap
+    ``__resource_funcs__["dummy.grains"]()`` or ``__minion__["grains.items"]``).
     """
     ret = salt_cli.run("grains.items", minion_tgt="dummy-01")
-    assert ret.returncode == 0, ret
+    # Rejection returns non-zero.
+    assert ret.returncode != 0, ret
 
     data = _salt_cli_json_dict(ret)
     assert isinstance(data, dict), f"Expected dict, got: {data!r}"
-    # Salt-factories unwraps the single-key envelope when ``minion_tgt`` is
-    # the only response key, so ``data`` may be either the grains dict itself
-    # or ``{"dummy-01": grains_dict}``. Accept both shapes.
-    grains = data.get("dummy-01") if "dummy-01" in data else data
+    payload = data.get("dummy-01") if "dummy-01" in data else data
     assert isinstance(
-        grains, dict
-    ), f"Expected dict for dummy-01 grains, got: {grains!r}"
-
-    # The resource grains must be present.
-    assert grains.get("dummy_grain_1") == "one"
-    assert grains.get("dummy_grain_2") == "two"
-    assert grains.get("dummy_grain_3") == "three"
-    assert grains.get("resource_id") == "dummy-01"
-
-    # The managing minion's grains must NOT bleed through. ``os`` is a stock
-    # core grain on every supported Linux/macOS test target; if it appears
-    # the swap didn't take effect.
-    assert "os" not in grains, (
-        "Managing minion's 'os' grain leaked into resource grains response — "
-        "the dispatch path is returning minion grains instead of resource grains"
-    )
+        payload, str
+    ), f"Expected rejection string for dummy-01 grains.items, got: {payload!r}"
+    assert "not supported for resource type 'dummy'" in payload, payload
+    # The managing minion must NOT appear at the top level.
+    assert salt_minion.id not in data, data
 
 
 def test_grain_pcre_targeting_matches_resources(salt_minion, salt_cli):
@@ -414,34 +406,26 @@ def test_pillar_addition_at_runtime_registers_new_resource(
 
 def test_state_single_against_resource_no_phantom_no_response(salt_minion, salt_cli):
     """
-    Regression for ``RESOURCE_STATE_RETURN_ATTRIBUTION_BUG.md``.
+    Regression for ``RESOURCE_STATE_RETURN_ATTRIBUTION_BUG.md`` — updated
+    for the #69881 deny-by-default loader.
 
     A merge-fun state job against a pure-resource compound target —
     ``salt -C 'T@dummy:dummy-01' state.single test.nop ...`` — must not
     produce a ``Minion did not return. [No response]`` line for the
     targeted resource id. The original bug report observed both a
-    successful state result *and* a phantom resource-id timeout in the
-    CLI output, indicating the master's wait set wrongly contained the
+    resource-side return *and* a phantom resource-id timeout in the CLI
+    output, indicating the master's wait set wrongly contained the
     resource id alongside the managing minion.
 
-    ``state.single`` is in :py:attr:`~salt.minion.Minion._MERGE_RESOURCE_FUNS`,
-    so the design has the managing minion run the state inline and
-    return ONE combined response under its own id. The master's
-    targeting path (``CkMinions._check_resource_minions``) is supposed
-    to remap pure-resource ``T@`` terms to the managing minion's id
-    for merge funs — the bug is when that remap is bypassed and the
-    resource id ends up in the wait set too, where it never produces a
-    separate return and times out.
-
-    Mirrors the bug's reproduction shape against the bundled ``dummy``
-    type (the original report used ``vcenter`` from a Salt extension).
-    Pins the in-tree contract end-to-end so a regression in the wait-set
-    logic — e.g. an `_augment_with_resources` path firing for compound
-    targets, or a merge-fun check skipped because ``fun`` plumbing
-    drops out somewhere — fails this assertion loudly.
+    Post-#69881: the ``dummy`` resource type ships no per-type
+    ``state.py`` override, so the per-resource loader rejects
+    ``state.single`` with "not supported for resource type 'dummy'."
+    The "no phantom did not return" contract still applies — the
+    rejection IS a real return; there must not be a separate
+    "did not return" line for the resource id alongside it.
 
     Asserts:
-      * The state runs (``test.nop`` chunk appears in the response).
+      * The rejection is present under the resource id key.
       * No ``did not return`` / ``No response`` text in stdout or stderr.
       * No top-level response key whose value is a "did not return"
         error string.
@@ -469,45 +453,42 @@ def test_state_single_against_resource_no_phantom_no_response(salt_minion, salt_
     data = _salt_cli_json_dict(ret)
     assert isinstance(data, dict), f"Expected dict, got: {data!r}"
 
-    # No top-level response key with an error-string value (the bug
-    # produced ``{"<resource-id>": "Minion did not return..."}``
-    # alongside the real result).
+    # No top-level response key with a "did not return" error string
+    # (the original bug produced ``{"<resource-id>": "Minion did not
+    # return..."}`` alongside the real result).
     for key, value in data.items():
         assert not (isinstance(value, str) and "did not return" in value.lower()), (
             f"Response contains a 'did not return' string under key "
             f"{key!r}: {value!r}"
         )
 
-    # The state must have actually run somewhere in the response.
-    def _has_state_result(node):
-        if isinstance(node, dict):
-            if any(k.endswith("_|-nop") for k in node):
-                return True
-            return any(_has_state_result(v) for v in node.values())
-        return False
-
-    assert _has_state_result(
-        data
-    ), f"No test.nop state result anywhere in the response payload: {data!r}"
+    # The rejection must land under the resource id (this IS the
+    # resource's return; the "no phantom did not return" contract is
+    # satisfied because the resource returned a real value, just a
+    # negative one).
+    assert (
+        target_id in data
+    ), f"Expected resource id {target_id!r} in response; got {list(data)}"
+    body = data[target_id]
+    assert isinstance(body, str), f"Expected rejection string, got: {body!r}"
+    assert "not supported for resource type 'dummy'" in body, body
 
 
 def test_state_single_against_single_resource_keyed_by_resource_id(
     salt_minion, salt_cli
 ):
     """
-    Desired API shape (Option B from the design discussion): for a
-    merge-fun state job against a pure-resource compound target, the
+    For a state job against a pure-resource compound target, the
     response must be keyed by the **resource id**, not by the managing
     minion. Matches the shape of ``test.ping`` against the same target
     so consumers can write one ``data[resource_id]`` pattern regardless
     of function.
 
-    Today the framework folds per-resource state results into a single
-    return under the managing minion's id with state-chunk keys
-    prefixed by the resource id. This test fails until the minion's
-    merge-fold path is changed to emit one return per resource with
-    ``ret["resource_id"]`` set (then the master's existing
-    ``resource_id`` remap re-keys the response to the resource id).
+    Post-#69881: the ``dummy`` resource type ships no per-type
+    ``state.py`` override, so ``state.single`` is rejected at the
+    per-resource loader with "not supported for resource type 'dummy'".
+    The key-by-resource-id shape contract still holds — the rejection
+    string lands under the resource id, not under the managing minion.
     """
     target_id = DUMMY_RESOURCES[0]
     ret = salt_cli.run(
@@ -517,48 +498,40 @@ def test_state_single_against_single_resource_keyed_by_resource_id(
         "name=resource-id-keyed-state-return",
         minion_tgt=f"T@dummy:{target_id}",
     )
-    assert ret.returncode == 0, ret
+    # Rejection returns non-zero.
+    assert ret.returncode != 0, ret
 
     data = _salt_cli_json_dict(ret)
     assert isinstance(data, dict), f"Expected dict, got: {data!r}"
 
-    # Top-level key must be the resource id.
-    assert target_id in data, (
-        f"Expected top-level response key {target_id!r}; "
-        f"got {list(data)} (managing-minion-id keying is the OLD shape)."
-    )
-    # The managing minion must NOT appear at the top level.
+    # Top-level key must be the resource id (not the managing minion).
+    assert (
+        target_id in data
+    ), f"Expected top-level response key {target_id!r}; got {list(data)}"
     assert salt_minion.id not in data, (
         f"Managing minion {salt_minion.id!r} appears as response key; "
-        f"merge-fun state returns must be keyed by resource id only."
+        f"resource-scoped returns must be keyed by resource id only."
     )
 
     body = data[target_id]
-    assert isinstance(body, dict), f"Resource body must be dict, got: {body!r}"
-
-    # State-chunk keys inside the resource body must NOT be prefixed
-    # with the resource id any more — the wrapping key already conveys
-    # provenance, so the prefix is redundant noise.
-    chunk_keys = [k for k in body if k.endswith("_|-nop")]
-    assert chunk_keys, f"No test.nop chunk in resource body: {body!r}"
-    for k in chunk_keys:
-        parts = k.split("_|-")
-        # State low key shape: ``{module}_|-{id}_|-{name}_|-{function}``.
-        # parts[1] is the state id; with resource-id-keyed responses it
-        # should be the plain state id (no leading "<rid> " prefix).
-        assert not parts[1].startswith(f"{target_id} "), (
-            f"State id {parts[1]!r} still has the redundant resource-id "
-            f"prefix. With resource-id-keyed responses the wrapping key "
-            f"already conveys the resource."
-        )
+    assert isinstance(
+        body, str
+    ), f"Expected rejection string under {target_id!r}, got: {body!r}"
+    assert "not supported for resource type 'dummy'" in body, body
 
 
 def test_state_single_against_bare_type_returns_per_resource(salt_minion, salt_cli):
     """
-    Bare-type merge fun (``T@dummy`` matches all 3 dummy resources): the
-    response must contain one top-level entry per resource — matching
-    how ``salt -C 'T@dummy' test.ping`` already renders — instead of a
-    single merged block under the managing minion id.
+    Bare-type resource target (``T@dummy`` matches all 3 dummy
+    resources): the response must contain one top-level entry per
+    resource — matching how ``salt -C 'T@dummy' test.ping`` already
+    renders — instead of a single merged block under the managing
+    minion id.
+
+    Post-#69881: ``state.single`` is rejected per resource (dummy
+    ships no ``state.py`` override), so each per-resource entry
+    carries the "not supported for resource type" string.  The
+    per-resource shape contract still holds.
     """
     ret = salt_cli.run(
         "-C",
@@ -567,7 +540,8 @@ def test_state_single_against_bare_type_returns_per_resource(salt_minion, salt_c
         "name=bare-type-per-resource-return",
         minion_tgt="T@dummy",
     )
-    assert ret.returncode == 0, ret
+    # Rejection returns non-zero.
+    assert ret.returncode != 0, ret
 
     data = ret.data
     assert isinstance(data, dict), f"Expected dict, got: {data!r}"
@@ -582,9 +556,8 @@ def test_state_single_against_bare_type_returns_per_resource(salt_minion, salt_c
     ), f"Managing minion unexpectedly in bare-type response: {list(data)}"
 
     for rid, body in data.items():
-        assert isinstance(body, dict), f"{rid!r} body not dict: {body!r}"
-        chunk_keys = [k for k in body if k.endswith("_|-nop")]
-        assert chunk_keys, f"No test.nop chunk under {rid!r}: {body!r}"
+        assert isinstance(body, str), f"{rid!r} body not string: {body!r}"
+        assert "not supported for resource type 'dummy'" in body, (rid, body)
 
 
 def test_state_single_against_bare_resource_id_keyed_by_resource_id(
@@ -595,28 +568,20 @@ def test_state_single_against_bare_resource_id_keyed_by_resource_id(
     resource id, ``tgt_type=glob``, no wildcards) must return under
     the resource id — same shape as ``salt 'dummy-01' test.ping``.
 
-    The minion-side bug: for a bare-id glob target, ``minion_matches``
-    is False (the target string isn't the managing minion's id) so
-    ``minion_is_target`` would normally be False; meanwhile
-    ``_is_pure_resource_target`` only recognised compound ``T@`` /
-    ``M@`` expressions as pure-resource, so the merge-fold + per-resource
-    fan-out logic both got skipped. A bare-id glob with a merge-mode
-    state function ran nothing on the managing minion and produced no
-    return — only the master's "did not return" timeout.
+    The minion-side bug this test guards against: for a bare-id glob
+    target, ``_is_pure_resource_target`` used to only recognise
+    compound ``T@`` / ``M@`` expressions as pure-resource, so a bare-id
+    glob for a merge-mode function produced no return — only the
+    master's "did not return" timeout.  The fix in ``salt/minion.py``
+    recognises an exact (no-wildcard) glob whose ``tgt`` names a
+    managed resource as a pure-resource target so the resource
+    dispatch fires.
 
-    The fix is two-sided in ``salt/minion.py``:
-
-    * ``_is_pure_resource_target`` recognises an exact (no-wildcard)
-      glob whose ``tgt`` names a managed resource as a pure-resource
-      target.
-    * ``_target_load`` treats the managing minion as a target whenever
-      ``is_merge_fun and resource_targets``, regardless of whether the
-      glob also matched the minion's own id — the managing minion has
-      to run the inline merge for the resource.
-
-    Non-merge funs (``test.ping``) already worked through the
-    per-resource fan-out path; this test asserts merge funs now work
-    too with the same shape.
+    Post-#69881: ``state.single`` is rejected at the per-resource
+    loader (dummy ships no ``state.py`` override).  The bare-id
+    keying + no-phantom-timeout contracts still hold — the response
+    lands under the resource id with the "not supported for resource
+    type" rejection, and there is no phantom "did not return" line.
     """
     target_id = DUMMY_RESOURCES[0]
     ret = salt_cli.run(
@@ -625,7 +590,8 @@ def test_state_single_against_bare_resource_id_keyed_by_resource_id(
         "name=bare-id-keyed-state-return",
         minion_tgt=target_id,
     )
-    assert ret.returncode == 0, ret
+    # Rejection returns non-zero.
+    assert ret.returncode != 0, ret
 
     data = _salt_cli_json_dict(ret)
     # Salt-factories unwraps single-key envelopes when ``minion_tgt``
@@ -635,18 +601,22 @@ def test_state_single_against_bare_resource_id_keyed_by_resource_id(
         # Managing minion must not appear at the top level.
         assert salt_minion.id not in data, (
             f"Managing minion {salt_minion.id!r} appears as response key; "
-            f"bare-id merge-fun state returns must be keyed by resource id."
+            f"bare-id resource returns must be keyed by resource id."
         )
     else:
         # Unwrapped envelope: body IS the resource's payload.
         body = data
-    assert isinstance(body, dict), f"Resource body must be dict, got: {body!r}"
-
-    chunk_keys = [k for k in body if k.endswith("_|-nop")]
-    assert chunk_keys, f"No test.nop chunk in resource body: {body!r}"
+    assert isinstance(body, str), f"Expected rejection string, got: {body!r}"
+    assert "not supported for resource type 'dummy'" in body, body
     # No phantom "did not return" entries.
     if isinstance(data, dict):
         for key, value in data.items():
             assert not (
                 isinstance(value, str) and "did not return" in value.lower()
             ), f"Phantom 'did not return' under {key!r}: {value!r}"
+    # And no such phrase in stdout/stderr either.
+    combined_output = (ret.stdout or "") + "\n" + (ret.stderr or "")
+    assert "did not return" not in combined_output.lower(), (
+        f"Phantom 'Minion did not return' in output: "
+        f"stdout={ret.stdout!r} stderr={ret.stderr!r}"
+    )

--- a/tests/pytests/integration/resources/test_resource_loader_strict.py
+++ b/tests/pytests/integration/resources/test_resource_loader_strict.py
@@ -1,0 +1,113 @@
+"""
+End-to-end integration tests for the deny-by-default surface of
+:func:`salt.loader.resource_modules` (issue #69881).
+
+The per-resource execution loader must expose ONLY modules discovered
+under ``resources/<rtype>/modules/`` overlay directories, plus the
+``__minion__`` escape hatch.  Targeting a resource with a stock salt
+execution module (``cmd.run``, ``grains.setval``, ``file.remove``, …)
+must surface the "not supported for resource type" rejection at the
+minion — never silently execute on the managing minion.
+
+Runs against the real minion/master fixtures in :mod:`conftest`; the
+``dummy`` resource type ships per-type ``test.py`` override only, so
+these calls exercise the deny-by-default path for every other slot.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.slow_test]
+
+
+@pytest.mark.parametrize(
+    "fun,args",
+    [
+        # ``cmd.run`` is the most dangerous stock leak — the reporter's
+        # PoC ran ``cmd.run 'hostname; id; pwd'`` and got managing-minion
+        # host identity attributed to the resource id.
+        ("cmd.run", ["echo strict-resource-loader-canary"]),
+        # ``grains.setval`` writes to the managing minion's grains file
+        # (``/etc/salt/grains``) — silent misattribution + persistent
+        # state mutation.
+        ("grains.setval", ["strict_probe", "resource-leak"]),
+        # ``file.remove`` is a destructive filesystem op on the managing
+        # minion.  Just try to remove a benign path; the point is the
+        # dispatch never reaches the function.
+        ("file.remove", ["/tmp/strict-loader-nonexistent-canary"]),
+        # ``sys.list_functions`` used to leak the full stock surface —
+        # ~1300 functions — via the resource loader.  After the fix it's
+        # rejected too (types that want introspection ship an override).
+        ("sys.list_functions", []),
+    ],
+)
+def test_stock_module_rejected_on_resource_target(salt_minion, salt_cli, fun, args):
+    """
+    ``salt <resource-id> <stock.fun> …`` returns the "not supported for
+    resource type" rejection instead of silently executing on the
+    managing minion.
+
+    Regression guard for #69881.  Before the fix, the resource loader
+    included every stock salt/modules/ file, so the dispatch happily
+    ran the function in the managing minion process while attributing
+    the return to the resource id.
+    """
+    ret = salt_cli.run(fun, *args, minion_tgt="dummy-01")
+    # ret.data may be either the bare string (single-target) or a dict.
+    if isinstance(ret.data, dict):
+        payload = ret.data.get("dummy-01", ret.data)
+    else:
+        payload = ret.data
+    assert isinstance(payload, str), (fun, ret.data)
+    assert "not supported for resource type 'dummy'" in payload, (fun, payload)
+    # Sanity: the response is keyed to the resource id, not the minion id.
+    assert salt_minion.id not in (ret.data or {}), (fun, ret.data)
+
+
+def test_per_type_override_reachable_on_resource_target(salt_minion, salt_cli):
+    """
+    Positive case: ``test.ping`` IS shipped as a per-type override at
+    ``salt/resources/dummy/modules/test.py``, so it MUST be reachable
+    on a dummy resource target.  Without this test, a regression that
+    over-restricts the loader (e.g. drops every layer including the
+    in-tree overlay) would still pass the deny-by-default tests above.
+    """
+    ret = salt_cli.run("test.ping", minion_tgt="dummy-01")
+    assert ret.returncode == 0, ret
+    if isinstance(ret.data, dict):
+        payload = ret.data.get("dummy-01", ret.data)
+    else:
+        payload = ret.data
+    assert payload is True, ret.data
+
+
+def test_grains_setval_does_not_touch_managing_minion(
+    salt_minion, salt_cli, salt_call_cli
+):
+    """
+    ``salt <rid> grains.setval …`` used to write to the managing
+    minion's persistent grains file.  Assert the grain the operator
+    tried to set is NOT present in the managing minion's grains after
+    the dispatch is rejected — the resource-loader guard is the only
+    thing preventing the write, so any regression would show up here.
+    """
+    grain_key = "strict_loader_persistent_probe"
+    grain_val = "resource-leak-must-not-persist"
+
+    ret = salt_cli.run("grains.setval", grain_key, grain_val, minion_tgt="dummy-01")
+    # The rejection may come back with a non-zero rc; either way the
+    # write must not have happened.
+    payload = ret.data
+    if isinstance(payload, dict):
+        payload = payload.get("dummy-01", payload)
+    assert isinstance(payload, str), payload
+    assert "not supported for resource type 'dummy'" in payload, payload
+
+    # Verify the managing minion's grains do NOT carry the probe.
+    grains_ret = salt_call_cli.run("grains.get", grain_key)
+    assert grains_ret.returncode == 0, grains_ret
+    # ``grains.get`` returns an empty string for a missing key.
+    assert grains_ret.data in ("", None), (
+        f"managing minion's grains carry {grain_key}={grains_ret.data!r} "
+        "— the resource-loader guard leaked and grains.setval ran on the "
+        "managing minion."
+    )

--- a/tests/pytests/unit/cli/test_caller_resources.py
+++ b/tests/pytests/unit/cli/test_caller_resources.py
@@ -151,29 +151,34 @@ def test_r_pure_compound_excludes_managing_minion(call_opts):
     assert set(payload.keys()) == {"dummy-01", "dummy-02", "dummy-03"}
 
 
-def test_r_grains_items_returns_per_resource_grains(call_opts):
+def test_r_grains_items_not_supported_without_override(call_opts):
     """
-    ``salt-call -r --tgt dummy-01 grains.items`` must return the dummy
-    resource's own grain dict — not the managing minion's grains. The
-    per-resource ``__grains__`` swap mirrors what ``Minion._thread_return``
-    does for master-driven resource jobs.
+    ``salt-call -r --tgt dummy-01 grains.items`` — the ``dummy`` resource
+    type ships no ``grains.py`` override, so ``grains.items`` is not
+    reachable via the per-resource loader (deny-by-default surface,
+    #69881 fix).  The caller returns the "not supported for resource
+    type" rejection instead of falling through to the managing minion's
+    stock ``grains.items``.
+
+    A type that legitimately wants to expose grains still can — by
+    shipping ``resources/<rtype>/modules/grains.py`` that returns the
+    resource's grains (or thin-wraps ``__minion__["grains.items"]``).
     """
     call_opts["resources_dispatch"] = True
     call_opts["resources_tgt"] = "dummy-01"
     call_opts["fun"] = "grains.items"
     caller = _build_caller(call_opts)
     payload = caller._call_with_resources()["return"]
-    assert isinstance(payload, dict), payload
-    # Resource grains include a ``resource_id`` key set to the rid.
-    assert payload.get("resource_id") == "dummy-01", payload
-    assert payload.get("dummy_grain_1") == "one", payload
+    assert isinstance(payload, str), payload
+    assert "not supported for resource type 'dummy'" in payload, payload
 
 
-def test_r_grains_items_per_resource_for_each_target(call_opts):
+def test_r_grains_items_not_supported_per_target(call_opts):
     """
-    With multiple resource targets, each entry in the response dict gets
-    the corresponding resource's own grains, not a shared snapshot from
-    the last loader call.
+    With multiple resource targets and no per-type ``grains`` override,
+    each entry in the response dict carries the "not supported for
+    resource type" rejection.  This is the deny-by-default surface —
+    stock modules never leak through the per-resource loader.
     """
     call_opts["resources_dispatch"] = True
     call_opts["resources_tgt"] = "T@dummy"
@@ -184,33 +189,30 @@ def test_r_grains_items_per_resource_for_each_target(call_opts):
     assert isinstance(payload, dict), payload
     for rid in ("dummy-01", "dummy-02", "dummy-03"):
         assert rid in payload, payload
-        assert payload[rid].get("resource_id") == rid, (rid, payload[rid])
+        assert isinstance(payload[rid], str), (rid, payload[rid])
+        assert "not supported for resource type 'dummy'" in payload[rid], (
+            rid,
+            payload[rid],
+        )
 
 
-@pytest.mark.timeout(180, func_only=True)
-def test_r_state_apply_logical_resource_no_state_module(call_opts):
+def test_r_state_apply_not_supported_without_override(call_opts):
     """
-    state.apply against a logical resource type (no per-resource state
-    override module) routes through the standard ``state.py`` (the
-    narrow guard in ``salt/modules/state.py`` only opts out for
-    ``ssh``).  The state run finds no matching state module for the
-    .sls referenced state (dummy resources don't ship a
-    ``dummy_test`` state module), and produces ``result: False``
-    state entries — one per resource — keyed in the master merge
-    format with the resource id prefixed onto each state id.
+    ``salt-call -r state.apply`` against a logical resource type with no
+    per-resource ``state.py`` override — after #69881 the resource
+    loader is deny-by-default, so ``state.apply`` is not present.  The
+    caller emits the "not supported for resource type" rejection for
+    each matched resource.
 
-    This is the expected behaviour for logical resources: the dispatch
-    succeeds (no caller-level rejection), the state machinery runs,
-    and the operator sees per-resource provenance for whatever the
-    state run produced.
+    ``state.apply`` is a merge fun: the managing minion runs its own
+    state.apply first, then per-resource results are folded in with
+    prefixed keys.  For a rejected resource, the fold produces a
+    ``no_|-<rid>_|-<rid>_|-None`` key whose comment carries the
+    rejection string.
 
-    Runs ``state.apply`` three times (once per dummy resource), each of
-    which spins up a HighState and loads state modules.  Local
-    wall-clock is ~3-5 s; under coverage tracing on a loaded GHA
-    runner the cumulative cost has been observed at 30-60 s.  The
-    explicit ``@pytest.mark.timeout(180)`` override raises the global
-    90 s pytest-timeout default so a slow runner doesn't trip the
-    wall-clock before the test's logical assertions run.
+    A resource type that intends operators to run state runs against it
+    ships ``resources/<rtype>/modules/state.py`` that either implements
+    the state protocol or thin-wraps ``__minion__["state.apply"]``.
     """
     call_opts["resources_dispatch"] = True
     call_opts["fun"] = "state.apply"
@@ -218,20 +220,12 @@ def test_r_state_apply_logical_resource_no_state_module(call_opts):
     caller = _build_caller(call_opts)
     payload = caller._call_with_resources()["return"]
     assert isinstance(payload, dict), payload
-    # Master merge format prefixes each state id with the rid; e.g.
-    # ``dummy_test_|-dummy-01 ping the resource_|-...``
-    rid_keys = {
-        rid: [k for k in payload if isinstance(payload[k], dict) and f"{rid} " in k]
-        for rid in ("dummy-01", "dummy-02", "dummy-03")
-    }
-    for rid, keys in rid_keys.items():
-        assert keys, f"No prefixed state entries for {rid}: {list(payload)}"
-        for k in keys:
-            entry = payload[k]
-            assert entry["result"] is False, (k, entry)
-            assert (
-                "not available" in entry["comment"] or "not found" in entry["comment"]
-            ), (
-                k,
-                entry,
-            )
+    for rid in ("dummy-01", "dummy-02", "dummy-03"):
+        key = f"no_|-{rid}_|-{rid}_|-None"
+        assert key in payload, (rid, list(payload))
+        entry = payload[key]
+        assert entry["result"] is False, (rid, entry)
+        assert "not supported for resource type 'dummy'" in entry["comment"], (
+            rid,
+            entry,
+        )

--- a/tests/pytests/unit/loader/test_per_resource_overrides.py
+++ b/tests/pytests/unit/loader/test_per_resource_overrides.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the per-type directory override mechanism introduced
-for Gap 2 / Gap 4 / Gap 5.
+for Gap 2 / Gap 4 / Gap 5, and for the deny-by-default surface of
+:func:`salt.loader.resource_modules`.
 
 The salt loader's :func:`_module_dirs` checks for
 ``resources/<rtype>/<ext_type>/`` subdirectories under every layer that
@@ -9,14 +10,19 @@ entry-point packages, the in-tree salt package).  When found, the
 per-type subdir is prepended before that layer's standard directory,
 giving per-type overrides priority for that layer.
 
+The per-resource execution loader built by :func:`resource_modules`
+must expose **only** per-type override modules (from those overlay
+dirs) plus the ``__minion__`` escape hatch.  Stock ``salt/modules/*``
+must not be reachable via that loader — resource-context code that
+needs the managing minion calls ``__minion__["module.fun"]`` explicitly.
+
 These tests exercise the override mechanism end-to-end:
 
-* A resource type that opts in via ``<extension_modules>/resources/<rtype>/modules/state.py``
-  — its ``state.sls`` wins when the per-resource loader is built for
-  that rtype.
-* A resource type with no override — the standard ``salt/modules/state.py``
-  is the one that gets resolved (Gap 5 fix: standard ``state.py`` no
-  longer has a broad ``__virtual__`` guard against ``resource_type``).
+* A resource type that opts in via ``<extension_modules>/resources/<rtype>/modules/test.py``
+  — its ``test.whoami`` is present and callable when the per-resource
+  loader is built for that rtype.
+* A resource type with no override — the resource loader is empty
+  (no stock modules leak through).
 * The ``__minion__`` dunder is packed into the per-resource execution
   loader when ``minion_mods`` is supplied — providing the escape-hatch
   back to the managing minion's loader.
@@ -81,13 +87,20 @@ def test_per_type_dir_override_wins_over_standard(loader_opts):
     assert loader["test.whoami"]() == "override-wins"
 
 
-def test_no_override_falls_through_to_standard_state_module(loader_opts):
+def test_no_override_hides_stock_modules(loader_opts):
     """
-    Resource type with no per-type override for ``state.py``: the standard
-    ``salt.modules.state`` is loaded via the per-resource loader (post-Gap-5
-    fix — no broad ``__virtual__`` guard).  The operator can run
-    ``state.sls`` against the resource without the type having to ship its
-    own override.
+    Resource type with no per-type overrides: the per-resource loader
+    exposes NO stock ``salt/modules/*`` functions.  The documented
+    Resources safety contract requires that ``salt <resource-id> cmd.run
+    …`` / ``grains.setval …`` / ``state.sls …`` fail with "not supported
+    for resource type" instead of silently executing on the managing
+    minion.  The resource loader is the surface that decides this — if
+    stock modules are present here, they will run.
+
+    NOTE: this replaces an earlier test that asserted stock ``state.sls``
+    was present in the resource loader.  That assertion documented the
+    buggy behavior fixed by #69881; the contract restored here matches
+    the resource-loader design (deny-by-default, type-local only).
     """
     utils = salt.loader.utils(loader_opts)
     rfuncs = salt.loader.resource(loader_opts, utils=utils)
@@ -95,11 +108,62 @@ def test_no_override_falls_through_to_standard_state_module(loader_opts):
         loader_opts, "logical_test", resource_funcs=rfuncs, utils=utils
     )
 
-    # state.sls is present despite no per-type override existing for
-    # 'logical_test'.  This is the GAP5 win.
-    assert "state.sls" in loader, sorted(
-        k for k in loader.keys() if k.startswith("state.")
-    )[:10]
+    leaked = sorted(
+        k
+        for k in loader.keys()
+        if k.split(".", 1)[0]
+        in (
+            "cmd",
+            "state",
+            "grains",
+            "file",
+            "system",
+            "disk",
+            "pkg",
+            "service",
+            "sys",
+            "saltutil",
+        )
+    )
+    assert not leaked, (
+        "stock salt/modules leaked into the resource loader for a type "
+        f"with no per-type overrides: {leaked[:20]}"
+    )
+    # Empty surface is the correct default for an inventory-only resource
+    # type that ships no override modules.
+    assert list(loader.keys()) == [], sorted(loader.keys())[:20]
+
+
+def test_per_type_override_present_and_callable(loader_opts):
+    """
+    A per-type override at <extmods>/resources/<rtype>/modules/<slot>.py
+    is present in the per-resource loader AND stock modules for the same
+    resource-type surface are absent.  Confirms deny-by-default plus the
+    per-type overlay together — the override is what the operator gets
+    to invoke against the resource, nothing more.
+    """
+    body = "def ping():\n    return 'override-pong'\n"
+    _drop_override(loader_opts["extension_modules"], "posovr", "test", body)
+
+    utils = salt.loader.utils(loader_opts)
+    rfuncs = salt.loader.resource(loader_opts, utils=utils)
+    loader = salt.loader.resource_modules(
+        loader_opts, "posovr", resource_funcs=rfuncs, utils=utils
+    )
+
+    assert "test.ping" in loader, sorted(
+        k for k in loader.keys() if k.startswith("test.")
+    )
+    assert loader["test.ping"]() == "override-pong"
+
+    # Only the override slot's functions are visible; no stock cmd/state/…
+    leaked = sorted(
+        k
+        for k in loader.keys()
+        if k.split(".", 1)[0]
+        in ("cmd", "state", "grains", "file", "system", "sys", "saltutil")
+    )
+    assert not leaked, leaked[:20]
 
 
 def test_minion_mods_packed_as_dunder(loader_opts):


### PR DESCRIPTION
## What's broken

`salt.loader.resource_modules()` layered per-type overlays over the full stock module set, so `salt <resource-id> cmd.run …` silently ran on the managing minion instead of failing with "Function 'X' is not supported for resource type 'Y'". Fixes #69881.

## Fix

`salt/loader/__init__.py`: new `_resource_type_module_dirs()` helper accepts only each layer's `resources/<rtype>/<ext_type>/` overlay. `resource_modules()` uses it — deny-by-default, `__minion__` escape hatch unchanged.

## Tests

- Unit: `test_per_resource_overrides.py`, `test_caller_resources.py` — 14 passing.
- Integration: `test_resource_loader_strict.py` — 6 passing (stock-module rejection, override reachability, managing-minion grains untouched).

## Merge-forward

Base `3007.x`; pipeline carries to `3008.x` and `master`.

Fixes #69881