### PR TITLE
Support relenv option in salt-ssh roster entries (#69885)

### DIFF
--- a/changelog/69885.added.md
+++ b/changelog/69885.added.md
@@ -1,0 +1,5 @@
+Support a per-host ``relenv: True`` entry in the salt-ssh roster so that
+individual targets can use the relenv (Salt+Python bundled) deployment
+without forcing every host reached by a wildcard match to download the
+onedir tarball. Equivalent to the ``--relenv`` CLI flag but scoped to a
+single roster entry.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1145,6 +1145,7 @@ class Single:
         mods=None,
         fsclient=None,
         thin=None,
+        relenv=False,
         mine=False,
         minion_opts=None,
         identities_only=False,
@@ -1170,6 +1171,12 @@ class Single:
             self.wipe = False
         else:
             self.wipe = bool(self.opts.get("ssh_wipe"))
+        # Allow the roster to enable relenv per-host, mirroring the --relenv
+        # CLI flag.  This is additive only: an explicit CLI/global True must
+        # not be silently downgraded by a roster that omits the key.
+        # See #69885.
+        if relenv:
+            self.opts["relenv"] = True
         if kwargs.get("thin_dir"):
             self.thin_dir = kwargs["thin_dir"]
         elif self.winrm:

--- a/salt/config/schemas/ssh.py
+++ b/salt/config/schemas/ssh.py
@@ -85,6 +85,15 @@ class RosterEntryConfig(Schema):
             "components. Defaults to /tmp/salt-<hash>."
         ),
     )
+    relenv = BooleanItem(
+        title="Relenv",
+        description=(
+            "Deploy and use a relenv (Salt+Python bundled) environment on "
+            "the SSH target, equivalent to the --relenv CLI flag but scoped "
+            "to this roster entry."
+        ),
+        default=False,
+    )
     minion_opts = DictItem(
         title="Minion Options",
         description="Dictionary of minion options",

--- a/tests/pytests/integration/ssh/test_relenv_roster.py
+++ b/tests/pytests/integration/ssh/test_relenv_roster.py
@@ -1,0 +1,195 @@
+"""
+Integration tests for per-host ``relenv:`` roster support in salt-ssh.
+
+Regression coverage for https://github.com/saltstack/salt/issues/69885
+
+Prior to the fix, setting ``relenv: True`` on an individual roster entry was
+silently ignored -- only the global ``--relenv`` CLI flag (or Saltfile
+setting) actually toggled the relenv deployment path.  That forced operators
+of mixed fleets to either enable relenv globally (shipping the ~200MB onedir
+tarball to every host reached by a wildcard target) or forgo relenv entirely
+for hosts that legitimately needed it.
+
+These tests exercise the observable end-to-end behavior of ``Single``:
+
+    * The rendered ``thin_dir`` for a roster entry with ``relenv: True`` ends
+      in ``_salt_relenv`` (the suffix ``Single.__init__`` applies when
+      ``opts['relenv']`` is truthy).
+    * The rendered ``thin_dir`` for a roster entry without ``relenv`` (and
+      without global ``--relenv``) has no such suffix.
+    * When a roster contains both kinds of entries and salt-ssh targets them
+      via wildcard, each host gets its own deployment path -- the relenv host
+      gets the relenv thin_dir, the plain host keeps the classic thin_dir.
+      This is the mixed-fleet behavior the bug prevented.
+
+Cases that require a fully deployed relenv onedir (cases 1 and 3) reuse the
+session-scoped ``relenv_tarball_cached`` fixture from
+``tests/pytests/integration/ssh/conftest.py`` and skip when the tarball is
+not available locally, mirroring the pattern in ``test_deploy_relenv.py``.
+Case 2 does not need the tarball and always runs on supported platforms.
+"""
+
+import shutil
+
+import pytest
+
+import salt.utils.files
+import salt.utils.yaml
+
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_thin_dirs(salt_ssh_cli):
+    """
+    Best-effort cleanup of the on-disk thin directories the test creates.
+
+    We do not fail the test on cleanup errors -- the goal is only to keep
+    ``/var/tmp/.<user>_<uuid>_salt*`` from accumulating across runs.
+    """
+    try:
+        yield
+    finally:
+        # Query whichever thin_dir the default roster produced; individual
+        # tests may have created additional per-host thin_dirs but this
+        # covers the shared baseline.
+        try:
+            ret = salt_ssh_cli.run("config.get", "thin_dir")
+            if ret.returncode == 0 and ret.data:
+                shutil.rmtree(ret.data, ignore_errors=True)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+
+def _write_roster(tmp_path, name, entries):
+    """
+    Serialize a roster ``dict`` to a temp file under ``tmp_path`` and return
+    its path.  Kept local to this module to avoid coupling to unrelated
+    fixtures.
+    """
+    roster_file = tmp_path / name
+    with salt.utils.files.fopen(str(roster_file), "w") as wfh:
+        salt.utils.yaml.safe_dump(entries, wfh)
+    return roster_file
+
+
+def _base_entry(salt_ssh_roster_file):
+    """
+    Read the shared roster and return the ``localhost`` entry -- we reuse its
+    port/user/known_hosts wiring so the new roster files talk to the same
+    session sshd.
+    """
+    with salt.utils.files.fopen(salt_ssh_roster_file) as rfh:
+        data = salt.utils.yaml.safe_load(rfh)
+    return data["localhost"]
+
+
+def test_roster_relenv_true_uses_relenv_thin_dir(
+    salt_ssh_cli, salt_ssh_roster_file, tmp_path, relenv_tarball_cached
+):
+    """
+    Case 1: a roster entry with ``relenv: True`` deploys via the relenv path.
+
+    Observable: the target's ``thin_dir`` ends with ``_salt_relenv``.  Before
+    the fix, the roster key was dropped and ``thin_dir`` ended in plain
+    ``_salt``.
+    """
+    if relenv_tarball_cached is None:
+        pytest.skip("Relenv tarball not available")
+    entry = _base_entry(salt_ssh_roster_file)
+    entry_relenv = dict(entry)
+    entry_relenv["relenv"] = True
+    roster = {"localhost": entry_relenv}
+    roster_file = _write_roster(tmp_path, "roster-relenv-true", roster)
+
+    ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "config.get", "thin_dir")
+    assert ret.returncode == 0
+    assert ret.data
+    assert ret.data.endswith(
+        "_salt_relenv"
+    ), f"expected relenv thin_dir suffix, got {ret.data!r}"
+
+
+def test_roster_relenv_absent_uses_classic_thin_dir(
+    salt_ssh_cli, salt_ssh_roster_file, tmp_path
+):
+    """
+    Case 2: no ``relenv`` in the roster and no ``--relenv`` flag -- classic
+    thin deployment.
+
+    Observable: ``thin_dir`` ends with plain ``_salt`` (no ``_relenv``
+    suffix).  Guards against a regression where roster-relenv might leak into
+    hosts that never asked for it.
+    """
+    entry = _base_entry(salt_ssh_roster_file)
+    # Ensure no accidental relenv key survives.
+    entry_plain = {k: v for k, v in entry.items() if k != "relenv"}
+    roster = {"localhost": entry_plain}
+    roster_file = _write_roster(tmp_path, "roster-relenv-absent", roster)
+
+    ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "config.get", "thin_dir")
+    assert ret.returncode == 0
+    assert ret.data
+    assert ret.data.endswith(
+        "_salt"
+    ), f"expected classic thin_dir suffix, got {ret.data!r}"
+    assert not ret.data.endswith("_salt_relenv")
+
+
+def test_roster_relenv_mixed_fleet(
+    salt_ssh_cli, salt_ssh_roster_file, tmp_path, relenv_tarball_cached
+):
+    """
+    Case 3: mixed roster + wildcard target -- only the entry with
+    ``relenv: True`` gets the relenv deployment; the plain entry keeps the
+    classic thin deployment.
+
+    This is the scenario the bug fix exists for: prior to the fix, a
+    ``salt-ssh '*' test.ping`` against a roster where only some hosts had
+    ``relenv: True`` would treat every host as classic thin (silently
+    ignoring the roster key), forcing operators to opt in globally.
+    """
+    if relenv_tarball_cached is None:
+        pytest.skip("Relenv tarball not available")
+
+    entry = _base_entry(salt_ssh_roster_file)
+    entry_plain = {k: v for k, v in entry.items() if k != "relenv"}
+    entry_relenv = dict(entry_plain)
+    entry_relenv["relenv"] = True
+
+    roster = {
+        "host-thin": entry_plain,
+        "host-relenv": entry_relenv,
+    }
+    roster_file = _write_roster(tmp_path, "roster-relenv-mixed", roster)
+
+    ret = salt_ssh_cli.run(
+        f"--roster-file={roster_file}",
+        "config.get",
+        "thin_dir",
+        minion_tgt="*",
+    )
+    assert ret.returncode == 0
+    assert isinstance(
+        ret.data, dict
+    ), f"expected per-host dict, got {type(ret.data).__name__}: {ret.data!r}"
+    assert set(ret.data.keys()) == {"host-thin", "host-relenv"}, ret.data
+
+    thin_host_dir = ret.data["host-thin"]
+    relenv_host_dir = ret.data["host-relenv"]
+
+    assert thin_host_dir.endswith("_salt")
+    assert not thin_host_dir.endswith(
+        "_salt_relenv"
+    ), f"plain roster entry unexpectedly got relenv thin_dir: {thin_host_dir!r}"
+    assert relenv_host_dir.endswith(
+        "_salt_relenv"
+    ), f"relenv roster entry did not get relenv thin_dir: {relenv_host_dir!r}"
+
+    # Belt-and-suspenders cleanup for the extra per-host thin dirs the
+    # mixed-target run created.
+    for path in (thin_host_dir, relenv_host_dir):
+        shutil.rmtree(path, ignore_errors=True)

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -857,6 +857,62 @@ def test_cmd_run_not_set_path(opts, target):
     assert re.search('SET_PATH=""', ret)
 
 
+def test_single_relenv_from_roster_enables_relenv(opts, target):
+    """
+    Regression test for #69885: ``relenv: True`` in a roster entry must enable
+    the relenv deployment code path for that host, mirroring the ``--relenv``
+    CLI flag.  Previously the roster key was silently dropped, forcing users to
+    enable relenv globally (via CLI or Saltfile), which shipped the ~200MB
+    onedir to every target.
+    """
+    opts["ssh_wipe"] = True
+    # CLI/global default is thin (relenv not set).
+    opts.pop("relenv", None)
+    target["relenv"] = True
+
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "localhost",
+        mods={},
+        fsclient=None,
+        thin=salt.utils.thin.thin_path(opts["cachedir"]),
+        mine=False,
+        **target,
+    )
+
+    # The roster-level relenv=True must be honored via opts so the downstream
+    # thin_dir suffixing, shim selection, and tarball resolution all take the
+    # relenv branch.
+    assert single.opts.get("relenv") is True
+    assert single.thin_dir.endswith("_salt_relenv")
+
+
+def test_single_relenv_absent_from_roster_defaults_thin(opts, target):
+    """
+    Companion to #69885 regression test: omitting ``relenv`` from a roster
+    entry must NOT force relenv on that host, so wildcard salt-ssh calls keep
+    using the lightweight thin deployment for hosts that don't need relenv.
+    """
+    opts["ssh_wipe"] = True
+    opts.pop("relenv", None)
+    target.pop("relenv", None)
+
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "localhost",
+        mods={},
+        fsclient=None,
+        thin=salt.utils.thin.thin_path(opts["cachedir"]),
+        mine=False,
+        **target,
+    )
+
+    assert not single.opts.get("relenv")
+    assert not single.thin_dir.endswith("_salt_relenv")
+
+
 @pytest.mark.skip_on_windows(reason="SSH_PY_SHIM not set on windows")
 @pytest.mark.slow_test
 def test_cmd_block_python_version_error(opts, target):

--- a/tests/pytests/unit/config/schemas/test_ssh.py
+++ b/tests/pytests/unit/config/schemas/test_ssh.py
@@ -98,6 +98,16 @@ def test_config():
                 ),
                 "title": "Thin Directory",
             },
+            "relenv": {
+                "default": False,
+                "type": "boolean",
+                "description": (
+                    "Deploy and use a relenv (Salt+Python bundled) environment"
+                    " on the SSH target, equivalent to the --relenv CLI flag"
+                    " but scoped to this roster entry."
+                ),
+                "title": "Relenv",
+            },
             # The actuall representation of the minion options would make this HUGE!
             "minion_opts": ssh_schemas.DictItem(
                 title="Minion Options",
@@ -117,6 +127,7 @@ def test_config():
             "sudo",
             "timeout",
             "thin_dir",
+            "relenv",
             "minion_opts",
         ],
         "additionalProperties": False,
@@ -197,6 +208,21 @@ def test_config_validate():
                 "user": "root",
                 "passwd": "foo",
                 "minion_opts": {"interface": "0.0.0.0"},
+            },
+            ssh_schemas.RosterEntryConfig.serialize(),
+            format_checker=jsonschema.FormatChecker(),
+        )
+    except jsonschema.exceptions.ValidationError as exc:
+        pytest.fail(f"ValidationError raised: {exc}")
+
+    try:
+        # Regression for #69885 - roster may set relenv per host
+        jsonschema.validate(
+            {
+                "host": "127.1.0.1",
+                "user": "root",
+                "passwd": "foo",
+                "relenv": True,
             },
             ssh_schemas.RosterEntryConfig.serialize(),
             format_checker=jsonschema.FormatChecker(),


### PR DESCRIPTION
## Summary
Fixes #69885.

Adds a `relenv: True` roster key so individual salt-ssh targets can opt into the relenv (Salt+Python bundled) deployment. Previously the only way to enable relenv was globally (via `--relenv` CLI or Saltfile), which forced every host reached by a wildcard match to download the ~200MB onedir tarball. Users with mixed fleets (legacy-Python hosts needing relenv, modern hosts fine with thin) had no per-host toggle.

The roster value is additive to (and cannot silently downgrade) the existing global flag.

## Changes
- ``salt/client/ssh/__init__.py``: add explicit ``relenv=False`` kwarg to ``Single.__init__``; when truthy set ``self.opts["relenv"] = True`` before the ``thin_dir`` suffixing and shim-selection logic that already reads ``opts["relenv"]``. Per-host opts is safe to mutate because ``handle_routine`` deep-copies opts before the ``Single`` call.
- ``salt/config/schemas/ssh.py``: add ``relenv`` (``BooleanItem``, default ``False``) to ``RosterEntryConfig`` so the roster JSON schema accepts the key with ``additionalProperties: false``.
- ``changelog/69885.added.md``.

## Test plan
- [x] New unit tests in ``tests/pytests/unit/client/ssh/test_single.py`` (``test_single_relenv_from_roster_enables_relenv`` + ``test_single_relenv_absent_from_roster_defaults_thin``) exercise both directions of the toggle and assert on ``single.opts["relenv"]`` and ``single.thin_dir`` suffix. Both fail against pre-fix code, pass after.
- [x] Schema tests updated (``test_config``, ``test_config_validate``) to include the new key.
- [x] New end-to-end integration tests in ``tests/pytests/integration/ssh/test_relenv_roster.py`` drive a real salt-ssh master + sshd against three roster shapes: (1) single host with ``relenv: True`` -> deployed ``thin_dir`` ends in ``_salt_relenv``; (2) single host with no ``relenv`` key and no ``--relenv`` flag -> classic ``_salt`` suffix; (3) mixed-fleet roster with ``*`` target -> only the ``relenv: True`` host gets the relenv path, the plain host keeps the classic thin. Cases 1 and 3 fail against pre-fix code (roster key silently dropped, both hosts end up with ``_salt``), case 2 passes both ways. Cases 1 and 3 reuse the session-scoped ``relenv_tarball_cached`` fixture from the ssh conftest and skip if the onedir tarball isn't cached, mirroring ``test_deploy_relenv.py``.
- [x] Full ``tests/pytests/unit/client/ssh/test_single.py`` + ``tests/pytests/unit/config/schemas/test_ssh.py`` run clean.
- [x] Full ``tests/pytests/integration/ssh/test_relenv_roster.py`` runs clean locally (3 passed, ~32s) with the relenv tarball cached.
- [x] pre-commit clean.

## Sample roster
```yaml
web1:
  host: 192.168.42.1
  user: fred
  passwd: foobarbaz
  relenv: True   # new: opts this host into relenv, others stay on thin
```