### PR TITLE
Fix typo in file.directory clean example docs

### DIFF
--- a/changelog/68316.fixed.md
+++ b/changelog/68316.fixed.md
@@ -1,0 +1,1 @@
+Fixed typo in ``file.directory`` docs: "will crete the file" -> "will create the file".

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3797,7 +3797,7 @@ def directory(
     Because ``cmd.run`` has no way of communicating that it's creating a file,
     ``will_always_clean`` will remove the newly created file. Of course, every
     time the states run the same thing will happen - the
-    ``silly_way_of_creating_a_file`` will crete the file and
+    ``silly_way_of_creating_a_file`` will create the file and
     ``will_always_clean`` will always remove it. Over and over again, no matter
     how many times you run it.
 


### PR DESCRIPTION
### What does this PR do?

Fixes a small spelling typo in the `file.directory` state docstring example for `clean`.

### What issues does this PR fix or reference?
Fixes #68316

### Previous Behavior
The docs said "will crete the file".

### New Behavior
The docs say "will create the file".

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No