### PR TITLE
Add Debian 13 (Trixie) to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -61,6 +61,7 @@ body:
         - centos-stream-9
         - debian-11
         - debian-12
+        - debian-13
         - fedora-42
         - macos-13
         - macos-14

--- a/changelog/69889.changed.md
+++ b/changelog/69889.changed.md
@@ -1,0 +1,1 @@
+Add Debian 13 (Trixie) to the bug report template


### PR DESCRIPTION
### What does this PR do?
Adds Debian 13 to the list of operating systems to choose when filling out a bug report

### What issues does this PR fix or reference?
Fixes #69889

### Previous Behavior
Debian 13 was not in the list of operating systems to choose



### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
