### PR TITLE
fix: correct typo 'crete' to 'create' in file.directory docstring

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4264,7 +4264,7 @@ def directory(
     Because ``cmd.run`` has no way of communicating that it's creating a file,
     ``will_always_clean`` will remove the newly created file. Of course, every
     time the states run the same thing will happen - the
-    ``silly_way_of_creating_a_file`` will crete the file and
+    ``silly_way_of_creating_a_file`` will create the file and
     ``will_always_clean`` will always remove it. Over and over again, no matter
     how many times you run it.
 


### PR DESCRIPTION
Fixes a typo in the `salt.states.file.directory` docstring where 'will crete the file' should read 'will create the file'. Closes #68316.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._