### PR TITLE
Fixes for function handling

### DIFF
--- a/changelog/69901.fixed.md
+++ b/changelog/69901.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.utils.functools` `namespaced_function`/`alias_function` dropping keyword-only argument defaults in copied function

--- a/changelog/69906.fixed.md
+++ b/changelog/69906.fixed.md
@@ -1,0 +1,1 @@
+Fixed handling of keyword-only parameters and positional-only parameters when calling module functions, most notably from the CLI, in state application and via the mine or `module.run`.

--- a/changelog/69919.fixed.md
+++ b/changelog/69919.fixed.md
@@ -1,0 +1,1 @@
+Fixed `module.run` handling of positional arguments to parameters that have default values

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -601,17 +601,17 @@ class Resolver:
             )
             return ret
 
-        args = salt.utils.args.arg_lookup(self.auth[fstr])
-        for arg in args["args"]:
+        aspec = salt.utils.args.get_function_argspec(self.auth[fstr])
+        for arg in aspec.allreq:
             if arg in self.opts:
                 ret[arg] = self.opts[arg]
             elif arg.startswith("pass"):
                 ret[arg] = getpass.getpass(f"{arg}: ")
             else:
                 ret[arg] = input(f"{arg}: ")
-        for kwarg, default in list(args["kwargs"].items()):
+        for kwarg, default in aspec.alldefaults.items():
             if kwarg in self.opts:
-                ret["kwarg"] = self.opts[kwarg]
+                ret[kwarg] = self.opts[kwarg]
             else:
                 ret[kwarg] = input(f"{kwarg} [{default}]: ")
 

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -504,8 +504,8 @@ class Fileserver:
             fstr = f"{fsb}.envs"
             kwargs = (
                 {"ignore_cache": True}
-                if "ignore_cache" in _argspec(self.servers[fstr]).args
-                and self.opts["__role"] == "minion"
+                if self.opts["__role"] == "minion"
+                and "ignore_cache" in _argspec(self.servers[fstr]).namedargs
                 else {}
             )
             if sources:

--- a/salt/master.py
+++ b/salt/master.py
@@ -2494,7 +2494,7 @@ class ClearFuncs(TransportMethods):
 
                 # Check if 'minions' is included in returner's save_load arg_spec.
                 # This may be missing in custom returners, which we should warn about.
-                if "minions" not in arg_spec.args:
+                if "minions" not in arg_spec.namedargs:
                     log.critical(
                         "The specified returner used for the external job cache "
                         "'%s' does not have a 'minions' kwarg in the returner's "
@@ -2522,7 +2522,7 @@ class ClearFuncs(TransportMethods):
         # always write out to the master job caches
         try:
             fstr = "{}.save_load".format(self.opts["master_job_cache"])
-            self.mminion.returners[fstr](clear_load["jid"], clear_load, minions)
+            self.mminion.returners[fstr](clear_load["jid"], clear_load, minions=minions)
         except KeyError:
             log.critical(
                 "The specified returner used for the master job cache "

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -385,6 +385,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
     _args = []
     _kwargs = {}
     invalid_kwargs = []
+    named_args = argspec.namedargs
 
     for arg in args:
         if isinstance(arg, dict) and arg.get("__kwarg__", False) is True:
@@ -393,11 +394,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                 # Skip __kwarg__ when checking kwargs
                 if key == "__kwarg__":
                     continue
-                if (
-                    argspec.keywords
-                    or key in argspec.kwonlyargs
-                    or (key in argspec.args and key not in argspec.posonlyargs)
-                ):
+                if argspec.keywords or key in named_args:
                     # Function supports **kwargs or has a parameter with
                     # this name that can be passed a keyword argument.
                     _kwargs[key] = val
@@ -411,12 +408,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
         else:
             string_kwarg = salt.utils.args.parse_input([arg], condition=False)[1]
             if string_kwarg:
-                key = next(iter(string_kwarg))
-                if (
-                    argspec.keywords
-                    or key in argspec.kwonlyargs
-                    or (key in argspec.args and key not in argspec.posonlyargs)
-                ):
+                if argspec.keywords or next(iter(string_kwarg)) in named_args:
                     # Function supports **kwargs or has a parameter with
                     # this name that can be passed a keyword argument.
                     _kwargs.update(string_kwarg)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -393,30 +393,37 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                 # Skip __kwarg__ when checking kwargs
                 if key == "__kwarg__":
                     continue
-                if argspec.keywords or key in argspec.args:
-                    # Function supports **kwargs or is a positional argument to
-                    # the function.
+                if (
+                    argspec.keywords
+                    or key in argspec.kwonlyargs
+                    or (key in argspec.args and key not in argspec.posonlyargs)
+                ):
+                    # Function supports **kwargs or has a parameter with
+                    # this name that can be passed a keyword argument.
                     _kwargs[key] = val
                 else:
-                    # **kwargs not in argspec and parsed argument name not in
-                    # list of positional arguments. This keyword argument is
-                    # invalid.
+                    # **kwargs not in argspec and parsed argument name not
+                    # a parameter that can be passed a keyword argument.
+                    # This keyword argument is invalid.
                     invalid_kwargs.append(f"{key}={val}")
             continue
 
         else:
-            string_kwarg = salt.utils.args.parse_input([arg], condition=False)[
-                1
-            ]  # pylint: disable=W0632
+            string_kwarg = salt.utils.args.parse_input([arg], condition=False)[1]
             if string_kwarg:
-                if argspec.keywords or next(iter(string_kwarg.keys())) in argspec.args:
-                    # Function supports **kwargs or is a positional argument to
-                    # the function.
+                key = next(iter(string_kwarg))
+                if (
+                    argspec.keywords
+                    or key in argspec.kwonlyargs
+                    or (key in argspec.args and key not in argspec.posonlyargs)
+                ):
+                    # Function supports **kwargs or has a parameter with
+                    # this name that can be passed a keyword argument.
                     _kwargs.update(string_kwarg)
                 else:
-                    # **kwargs not in argspec and parsed argument name not in
-                    # list of positional arguments. This keyword argument is
-                    # invalid.
+                    # **kwargs not in argspec and parsed argument name not
+                    # a parameter that can be passed a keyword argument.
+                    # This keyword argument is invalid.
                     for key, val in string_kwarg.items():
                         invalid_kwargs.append(f"{key}={val}")
             else:

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -2009,7 +2009,7 @@ def runner(
 
     if name in rclient.functions:
         aspec = salt.utils.args.get_function_argspec(rclient.functions[name])
-        if "saltenv" in aspec.args:
+        if "saltenv" in aspec.namedargs:
             kwarg["saltenv"] = saltenv
 
     if name in ["state.orchestrate", "state.orch", "state.sls"]:
@@ -2095,7 +2095,7 @@ def wheel(name, *args, **kwargs):
     try:
         if name in wheel_client.functions:
             aspec = salt.utils.args.get_function_argspec(wheel_client.functions[name])
-            if "saltenv" in aspec.args:
+            if "saltenv" in aspec.namedargs:
                 valid_kwargs["saltenv"] = saltenv
 
         if jid:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -1147,10 +1147,12 @@ class Pillar:
         Builds actual pillar data structure and updates the ``pillar`` variable
         """
         ext = None
-        args = salt.utils.args.get_function_argspec(self.ext_pillars[key]).args
+        valid_kwargs = salt.utils.args.get_function_argspec(
+            self.ext_pillars[key]
+        ).namedargs
 
         if isinstance(val, dict):
-            if ("extra_minion_data" in args) and self.extra_minion_data:
+            if ("extra_minion_data" in valid_kwargs) and self.extra_minion_data:
                 ext = self.ext_pillars[key](
                     self.minion_id,
                     pillar,
@@ -1160,7 +1162,7 @@ class Pillar:
             else:
                 ext = self.ext_pillars[key](self.minion_id, pillar, **val)
         elif isinstance(val, list):
-            if ("extra_minion_data" in args) and self.extra_minion_data:
+            if ("extra_minion_data" in valid_kwargs) and self.extra_minion_data:
                 ext = self.ext_pillars[key](
                     self.minion_id,
                     pillar,
@@ -1170,7 +1172,7 @@ class Pillar:
             else:
                 ext = self.ext_pillars[key](self.minion_id, pillar, *val)
         else:
-            if ("extra_minion_data" in args) and self.extra_minion_data:
+            if ("extra_minion_data" in valid_kwargs) and self.extra_minion_data:
                 ext = self.ext_pillars[key](
                     self.minion_id,
                     pillar,

--- a/salt/state.py
+++ b/salt/state.py
@@ -1498,19 +1498,9 @@ class State:
         else:
             # First verify that the parameters are met
             aspec = salt.utils.args.get_function_argspec(self.states[full])
-            arglen = 0
-            deflen = 0
-            if isinstance(aspec.args, list):
-                arglen = len(aspec.args)
-            if isinstance(aspec.defaults, tuple):
-                deflen = len(aspec.defaults)
-            for ind in range(arglen - deflen):
-                if aspec.args[ind] not in data:
-                    errors.append(
-                        "Missing parameter {} for state {}".format(
-                            aspec.args[ind], full
-                        )
-                    )
+            for arg in aspec.allreq:
+                if arg not in data:
+                    errors.append(f"Missing parameter {arg} for state {full}")
         # If this chunk has a recursive require, then it will cause a
         # recursive loop when executing, check for it
         reqdec = ""

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -103,9 +103,9 @@ def _get_systemd_only(func, kwargs):
 
     ret = {}
     warnings = []
-    valid_args = _argspec(func).args
+    valid_kwargs = _argspec(func).namedargs
     for systemd_arg in SYSTEMD_ONLY:
-        if systemd_arg in kwargs and systemd_arg in valid_args:
+        if systemd_arg in kwargs and systemd_arg in valid_kwargs:
             if _get_systemd_only.HAS_SYSTEMD:
                 ret[systemd_arg] = kwargs[systemd_arg]
             else:

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -335,6 +335,24 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         kwdefaults = self.kwonlydefaults
         return tuple(kw for kw in self.kwonlyargs if kw not in kwdefaults)
 
+    @property
+    def allreq(self) -> tuple[str, ...]:
+        """
+        Tuple of parameters of any kind that require an argument.
+        """
+        return self.argreq + self.kwonlyreq
+
+    @property
+    def namedargs(self) -> tuple[str, ...]:
+        """
+        Tuple of parameters that can be passed by name.
+        The positional equivalent to this is just ``args``.
+        """
+        return (
+            tuple(arg for arg in self.args if arg not in self.posonlyargs)
+            + self.kwonlyargs
+        )
+
 
 def get_function_argspec(func, is_class_method=None) -> _ArgSpec:
     """

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -2,13 +2,15 @@
 Functions used for CLI argument handling
 """
 
-import copy
+from __future__ import annotations
+
 import fnmatch
 import inspect
 import logging
 import re
 import shlex
 import sys
+import typing
 from collections import namedtuple
 
 import salt.utils.data
@@ -223,10 +225,118 @@ def yamlify_arg(arg):
         return original_arg
 
 
-_ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
+class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
+    """
+    A Python 2 getargspec-style function specification.
+
+    Positional-only parameters are included in ``args`` and their defaults
+    in ``defaults``, matching the behavior of ``inspect.getfullargspec``.
+
+    Details about keyword-only and positional-only parameters are available
+    via the ``kwonlyargs``, ``kwonlydefaults`` and ``posonlyargs`` attributes,
+    which are not part of the tuple, keeping it unpackable as a 4-tuple for
+    backwards-compatibility.
+
+    Additional calculated properties expose different views on this data.
+    """
+
+    kwonlyargs: tuple[str, ...]
+    _kwonlydefaults: tuple[tuple[str, typing.Any], ...]
+    posonlyargs: tuple[str, ...]
+
+    def __new__(
+        cls,
+        args: list[str],
+        varargs: str | None,
+        keywords: str | None,
+        defaults: tuple[typing.Any, ...] | None,
+        kwonlyargs: tuple[str, ...] | None = None,
+        kwonlydefaults: tuple[tuple[str, typing.Any], ...] | None = None,
+        posonlyargs: tuple[str, ...] | None = None,
+    ):
+        self = super().__new__(cls, args, varargs, keywords, defaults)
+        self.kwonlyargs = kwonlyargs if kwonlyargs is not None else ()
+        self._kwonlydefaults = kwonlydefaults if kwonlydefaults is not None else ()
+        self.posonlyargs = posonlyargs if posonlyargs is not None else ()
+        return self
+
+    def __getnewargs__(self):
+        # Preserve the extra attributes through copy/pickle
+        return (*self, self.kwonlyargs, self._kwonlydefaults, self.posonlyargs)
+
+    @property
+    def argdefaults(self) -> dict[str, typing.Any]:
+        """
+        Mapping of name => default for any param that can be passed a positional argument.
+        The iteration order follows the positional argument order.
+        """
+        if not self.defaults:
+            return {}
+        defaults = list(zip(self.args[::-1], self.defaults[::-1]))
+        defaults.reverse()  # Since dicts are ordered (Py3.7+), ensure the order follows the params
+        return dict(defaults)
+
+    @property
+    def kwdefaults(self) -> dict[str, typing.Any]:
+        """
+        Mapping of name => default for any param that can be passed a keyword argument.
+        """
+        pos_kw_cnt = len(self.args) - len(self.posonlyargs)
+        if pos_kw_cnt < 1:
+            return self.kwonlydefaults
+        ret = dict(
+            zip(
+                self.args[-min(len(self.defaults or ()), pos_kw_cnt) :],
+                (self.defaults or [])[-pos_kw_cnt:],
+            )
+        )
+        ret.update(self._kwonlydefaults)
+        return ret
+
+    @property
+    def posonlydefaults(self) -> dict[str, typing.Any]:
+        """
+        Mapping of name => default for any param that must be passed a positional argument.
+        """
+        return {
+            name: default
+            for name, default in self.argdefaults.items()
+            if name in self.posonlyargs
+        }
+
+    @property
+    def kwonlydefaults(self) -> dict:
+        """
+        Mapping of name => default for any param that must be passed a keyword argument.
+        """
+        return dict(self._kwonlydefaults)
+
+    @property
+    def alldefaults(self) -> dict[str, typing.Any]:
+        """
+        Mapping of name => default for any param that has a default.
+        """
+        return self.argdefaults | self.kwonlydefaults
+
+    @property
+    def argreq(self) -> tuple[str, ...]:
+        """
+        Tuple of positional parameters that have no default.
+        """
+        if not self.defaults:
+            return tuple(self.args)
+        return tuple(self.args[: -len(self.defaults)])
+
+    @property
+    def kwonlyreq(self) -> tuple[str, ...]:
+        """
+        Tuple of keyword-only parameters that have no default.
+        """
+        kwdefaults = self.kwonlydefaults
+        return tuple(kw for kw in self.kwonlyargs if kw not in kwdefaults)
 
 
-def get_function_argspec(func, is_class_method=None):
+def get_function_argspec(func, is_class_method=None) -> _ArgSpec:
     """
     A small wrapper around inspect.signature that also supports callable objects and wrapped functions
 
@@ -254,19 +364,36 @@ def get_function_argspec(func, is_class_method=None):
     # Build a namedtuple which looks like the result of a Python 2 argspec
     args = []
     defaults = []
+    kwonlyargs = []
+    kwonlydefaults = []
+    posonlyargs = []
     varargs = keywords = None
     for param in sig.parameters.values():
-        if param.kind == param.POSITIONAL_OR_KEYWORD:
+        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
             args.append(param.name)
+            if param.kind == param.POSITIONAL_ONLY:
+                posonlyargs.append(param.name)
             if param.default is not inspect._empty:
                 defaults.append(param.default)
+        elif param.kind == param.KEYWORD_ONLY:
+            kwonlyargs.append(param.name)
+            if param.default is not inspect._empty:
+                kwonlydefaults.append((param.name, param.default))
         elif param.kind == param.VAR_POSITIONAL:
             varargs = param.name
         elif param.kind == param.VAR_KEYWORD:
             keywords = param.name
     if is_class_method:
         del args[0]
-    return _ArgSpec(args, varargs, keywords, tuple(defaults) or None)
+    return _ArgSpec(
+        args,
+        varargs,
+        keywords,
+        tuple(defaults) or None,
+        tuple(kwonlyargs),
+        tuple(kwonlydefaults),
+        tuple(posonlyargs),
+    )
 
 
 def shlex_split(s, **kwargs):
@@ -282,17 +409,17 @@ def shlex_split(s, **kwargs):
         return s
 
 
-def arg_lookup(fun, aspec=None):
+def arg_lookup(fun, aspec: _ArgSpec | None = None):
     """
     Return a dict containing the arguments and default arguments to the
     function.
     """
-    ret = {"kwargs": {}}
     if aspec is None:
         aspec = get_function_argspec(fun)
-    if aspec.defaults:
-        ret["kwargs"] = dict(zip(aspec.args[::-1], aspec.defaults[::-1]))
-    ret["args"] = [arg for arg in aspec.args if arg not in ret["kwargs"]]
+    ret = {
+        "args": list(aspec.argreq),
+        "kwargs": aspec.alldefaults,
+    }
     return ret
 
 
@@ -302,41 +429,31 @@ def argspec_report(functions, module=""):
     argspec function signatures
     """
     ret = {}
+
+    def _render(fun):
+        try:
+            aspec = get_function_argspec(functions[fun])
+        except TypeError:
+            # this happens if not callable
+            return
+        ret[fun] = {
+            "args": aspec.args if aspec.args else None,
+            "varargs": True if aspec.varargs else None,
+            "kwargs": True if aspec.keywords else None,
+            "defaults": aspec.defaults if aspec.defaults else None,
+            "posonlyargs": aspec.posonlyargs or None,
+            "kwonlyargs": aspec.kwonlyargs or None,
+            "kwonlydefaults": aspec.kwonlydefaults or None,
+        }
+
     if "*" in module or "." in module:
         for fun in fnmatch.filter(functions, module):
-            try:
-                aspec = get_function_argspec(functions[fun])
-            except TypeError:
-                # this happens if not callable
-                continue
-
-            args, varargs, kwargs, defaults = aspec
-
-            ret[fun] = {}
-            ret[fun]["args"] = args if args else None
-            ret[fun]["defaults"] = defaults if defaults else None
-            ret[fun]["varargs"] = True if varargs else None
-            ret[fun]["kwargs"] = True if kwargs else None
-
+            _render(fun)
     else:
         # "sys" should just match sys without also matching sysctl
         module_dot = module + "."
-
-        for fun in functions:
-            if fun.startswith(module_dot):
-                try:
-                    aspec = get_function_argspec(functions[fun])
-                except TypeError:
-                    # this happens if not callable
-                    continue
-
-                args, varargs, kwargs, defaults = aspec
-
-                ret[fun] = {}
-                ret[fun]["args"] = args if args else None
-                ret[fun]["defaults"] = defaults if defaults else None
-                ret[fun]["varargs"] = True if varargs else None
-                ret[fun]["kwargs"] = True if kwargs else None
+        for fun in (func for func in functions if func.startswith(module_dot)):
+            _render(fun)
 
     return ret
 
@@ -406,16 +523,11 @@ def format_call(
     ret["kwargs"] = {}
 
     aspec = get_function_argspec(fun, is_class_method=is_class_method)
-
-    arg_data = arg_lookup(fun, aspec)
-    args = arg_data["args"]
-    kwargs = arg_data["kwargs"]
-
     # Since we WILL be changing the data dictionary, let's change a copy of it
     data = data.copy()
 
-    missing_args = []
-
+    kwargs = aspec.kwdefaults
+    missing_kwargs = []
     for key in kwargs:
         try:
             kwargs[key] = data.pop(key)
@@ -423,21 +535,51 @@ def format_call(
             # Let's leave the default value in place
             pass
 
-    while args:
-        arg = args.pop(0)
+    for key in aspec.kwonlyreq:
+        try:
+            kwargs[key] = data.pop(key)
+        except KeyError:
+            # This is a required, keyword-only parameter
+            missing_kwargs.append(key)
+    if missing_kwargs:
+        missing_count = len(missing_kwargs)
+        missing_list = ", ".join(f"'{kw}'" for kw in missing_kwargs)
+        raise SaltInvocationError(
+            "{} missing {} required keyword-only argument{}: {}".format(
+                fun.__name__,
+                missing_count,
+                missing_count > 1 and "s" or "",
+                missing_list,
+            )
+        )
+
+    missing_args = []
+    for arg in aspec.argreq:
         try:
             ret["args"].append(data.pop(arg))
         except KeyError:
             missing_args.append(arg)
-
     if missing_args:
-        used_args_count = len(ret["args"]) + len(args)
-        args_count = used_args_count + len(missing_args)
+        args_count = len(aspec.argreq)
         raise SaltInvocationError(
-            "{} takes at least {} argument{} ({} given)".format(
-                fun.__name__, args_count, args_count > 1 and "s" or "", used_args_count
+            "{} takes at least {} argument{} ({} given). Missing: {}".format(
+                fun.__name__,
+                args_count,
+                args_count > 1 and "s" or "",
+                len(ret["args"]),
+                ", ".join(f"'{missing}'" for missing in missing_args),
             )
         )
+
+    # Positional-or-keyword parameters with defaults are handled in `kwargs`,
+    # which are all of them if any positional-only parameter has a default.
+    # We can thus simply append to `args`.
+    for name, default in aspec.posonlydefaults.items():
+        try:
+            val = data.pop(name)
+        except KeyError:
+            val = default
+        ret["args"].append(val)
 
     ret["kwargs"].update(kwargs)
 
@@ -455,38 +597,33 @@ def format_call(
 
     # Did not return yet? Lets gather any remaining and unexpected keyword
     # arguments
-    extra = {}
-    for key, value in data.items():
-        if key in expected_extra_kws:
-            continue
-        extra[key] = copy.deepcopy(value)
+    extra = tuple(key for key in data if key not in expected_extra_kws)
+    if not extra:
+        return ret
 
-    if extra:
-        # Found unexpected keyword arguments, raise an error to the user
-        if len(extra) == 1:
-            msg = "'{0[0]}' is an invalid keyword argument for '{1}'".format(
-                list(extra.keys()),
-                ret.get(
-                    # In case this is being called for a state module
-                    "full",
-                    # Not a state module, build the name
-                    f"{fun.__module__}.{fun.__name__}",
-                ),
-            )
-        else:
-            msg = "{} and '{}' are invalid keyword arguments for '{}'".format(
-                ", ".join([f"'{e}'" for e in extra][:-1]),
-                list(extra.keys())[-1],
-                ret.get(
-                    # In case this is being called for a state module
-                    "full",
-                    # Not a state module, build the name
-                    f"{fun.__module__}.{fun.__name__}",
-                ),
-            )
-
-        raise SaltInvocationError(msg)
-    return ret
+    # Found unexpected keyword arguments, raise an error to the user
+    if len(extra) == 1:
+        msg = "'{}' is an invalid keyword argument for '{}'".format(
+            extra[0],
+            ret.get(
+                # In case this is being called for a state module
+                "full",
+                # Not a state module, build the name
+                f"{fun.__module__}.{fun.__name__}",
+            ),
+        )
+    else:
+        msg = "{} and '{}' are invalid keyword arguments for '{}'".format(
+            ", ".join([f"'{e}'" for e in extra][:-1]),
+            extra[-1],
+            ret.get(
+                # In case this is being called for a state module
+                "full",
+                # Not a state module, build the name
+                f"{fun.__module__}.{fun.__name__}",
+            ),
+        )
+    raise SaltInvocationError(msg)
 
 
 def parse_function(s):

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -2,8 +2,6 @@
 Functions used for CLI argument handling
 """
 
-from __future__ import annotations
-
 import fnmatch
 import inspect
 import logging
@@ -240,19 +238,19 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
     Additional calculated properties expose different views on this data.
     """
 
-    kwonlyargs: tuple[str, ...]
-    _kwonlydefaults: tuple[tuple[str, typing.Any], ...]
-    posonlyargs: tuple[str, ...]
+    kwonlyargs: "tuple[str, ...]"
+    _kwonlydefaults: "tuple[tuple[str, typing.Any], ...]"
+    posonlyargs: "tuple[str, ...]"
 
     def __new__(
         cls,
-        args: list[str],
-        varargs: str | None,
-        keywords: str | None,
-        defaults: tuple[typing.Any, ...] | None,
-        kwonlyargs: tuple[str, ...] | None = None,
-        kwonlydefaults: tuple[tuple[str, typing.Any], ...] | None = None,
-        posonlyargs: tuple[str, ...] | None = None,
+        args: "list[str]",
+        varargs: "str | None",
+        keywords: "str | None",
+        defaults: "tuple[typing.Any, ...] | None",
+        kwonlyargs: "tuple[str, ...] | None" = None,
+        kwonlydefaults: "tuple[tuple[str, typing.Any], ...] | None" = None,
+        posonlyargs: "tuple[str, ...] | None" = None,
     ):
         self = super().__new__(cls, args, varargs, keywords, defaults)
         self.kwonlyargs = kwonlyargs if kwonlyargs is not None else ()
@@ -265,7 +263,7 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return (*self, self.kwonlyargs, self._kwonlydefaults, self.posonlyargs)
 
     @property
-    def argdefaults(self) -> dict[str, typing.Any]:
+    def argdefaults(self) -> "dict[str, typing.Any]":
         """
         Mapping of name => default for any param that can be passed a positional argument.
         The iteration order follows the positional argument order.
@@ -277,7 +275,7 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return dict(defaults)
 
     @property
-    def kwdefaults(self) -> dict[str, typing.Any]:
+    def kwdefaults(self) -> "dict[str, typing.Any]":
         """
         Mapping of name => default for any param that can be passed a keyword argument.
         """
@@ -294,7 +292,7 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return ret
 
     @property
-    def posonlydefaults(self) -> dict[str, typing.Any]:
+    def posonlydefaults(self) -> "dict[str, typing.Any]":
         """
         Mapping of name => default for any param that must be passed a positional argument.
         """
@@ -312,14 +310,14 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return dict(self._kwonlydefaults)
 
     @property
-    def alldefaults(self) -> dict[str, typing.Any]:
+    def alldefaults(self) -> "dict[str, typing.Any]":
         """
         Mapping of name => default for any param that has a default.
         """
-        return self.argdefaults | self.kwonlydefaults
+        return {**self.argdefaults, **self.kwonlydefaults}
 
     @property
-    def argreq(self) -> tuple[str, ...]:
+    def argreq(self) -> "tuple[str, ...]":
         """
         Tuple of positional parameters that have no default.
         """
@@ -328,7 +326,7 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return tuple(self.args[: -len(self.defaults)])
 
     @property
-    def kwonlyreq(self) -> tuple[str, ...]:
+    def kwonlyreq(self) -> "tuple[str, ...]":
         """
         Tuple of keyword-only parameters that have no default.
         """
@@ -336,14 +334,14 @@ class _ArgSpec(namedtuple("ArgSpec", "args varargs keywords defaults")):
         return tuple(kw for kw in self.kwonlyargs if kw not in kwdefaults)
 
     @property
-    def allreq(self) -> tuple[str, ...]:
+    def allreq(self) -> "tuple[str, ...]":
         """
         Tuple of parameters of any kind that require an argument.
         """
         return self.argreq + self.kwonlyreq
 
     @property
-    def namedargs(self) -> tuple[str, ...]:
+    def namedargs(self) -> "tuple[str, ...]":
         """
         Tuple of parameters that can be passed by name.
         The positional equivalent to this is just ``args``.
@@ -427,7 +425,7 @@ def shlex_split(s, **kwargs):
         return s
 
 
-def arg_lookup(fun, aspec: _ArgSpec | None = None):
+def arg_lookup(fun, aspec: "_ArgSpec | None" = None):
     """
     Return a dict containing the arguments and default arguments to the
     function.

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -61,6 +61,9 @@ def namespaced_function(function, global_dict, defaults=None, preserve_context=N
         closure=function.__closure__,
     )
     new_namespaced_function.__dict__.update(function.__dict__)
+    if function.__kwdefaults__ is not None:
+        # Only Py 3.13+ accept this in FunctionType.__new__
+        new_namespaced_function.__kwdefaults__ = function.__kwdefaults__.copy()
     return new_namespaced_function
 
 
@@ -76,6 +79,9 @@ def alias_function(fun, name, doc=None):
         fun.__closure__,
     )
     alias_fun.__dict__.update(fun.__dict__)
+    if fun.__kwdefaults__ is not None:
+        # Only Py 3.13+ accept this in FunctionType.__new__
+        alias_fun.__kwdefaults__ = fun.__kwdefaults__.copy()
 
     if doc and isinstance(doc, str):
         alias_fun.__doc__ = doc

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -115,65 +115,125 @@ def parse_function(function_arguments):
     return {"args": function_args, "kwargs": function_kwargs}
 
 
-def call_function(salt_function, *args, **kwargs):
+def call_function(fun, *passed_args, **passed_kwargs):
     """
-    Calls a function from the specified module.
+    Call a function.
 
-    :param function salt_function: Function reference to call
-    :return: The result of the function call
+    Variadic positional args to this function are parsed into positional and named
+    arguments to the function. Anything but a dict becomes a positional argument.
+    A dict specifies one or more named arguments. If multiple dicts specify the
+    same named argument, the one that was passed first wins. Named arguments are
+    not necessarily passed as keyword arguments - positional-only parameters and
+    positional-or-keyword ones without defaults are always passed their values
+    positionally, even if they were received in a dict.
+
+    Variadic keyword args to this function are treated like a positional dict
+    that was passed as the first one, overriding any named arg set by other dicts
+    in the variadic positional args.
+
+    This function handles all types of parameters - positional-only, keyword-only,
+    positional-or-keyword, all with default values and without as well as variadic
+    positional and keyword arguments.
+
+    :param function fun: Function reference to call
+    :return: Result of the function call
     """
-    argspec = salt.utils.args.get_function_argspec(salt_function)
-    # function_kwargs is initialized to a dictionary of keyword arguments the function to be run accepts
-    function_kwargs = dict(
-        zip(
-            argspec.args[-len(argspec.defaults or []) :],
-            argspec.defaults or [],
-        )
-    )
-    # expected_args is initialized to a list of positional arguments that the function to be run accepts
-    expected_args = argspec.args[
-        : len(argspec.args or []) - len(argspec.defaults or [])
-    ]
-    function_args, kw_to_arg_type = [], {}
-    for funcset in reversed(args or []):
-        if not isinstance(funcset, dict):
-            # We are just receiving a list of args to the function to be run, so just append
-            # those to the arg list that we will pass to the func.
-            function_args.append(funcset)
+    spec = salt.utils.args.get_function_argspec(fun)
+    argreq, posonly = spec.argreq, spec.posonlyargs
+    fargs, fkwargs, named_params = [], {}, {}
+    kw_to_arg, kw_to_posarg = {}, {}
+
+    # First, collect all arguments.
+    # The previous implementation reversed the iteration, so be compatible and do the same.
+    # That ensures the *first* dict that specifies a named argument wins, not the last.
+    for arg in reversed(passed_args):
+        if isinstance(arg, dict):
+            named_params.update(arg)
         else:
-            for kwarg_key in funcset.keys():
-                # We are going to pass in a keyword argument. The trick here is to make certain
-                # that if we find that in the *args* list that we pass it there and not as a kwarg
-                if kwarg_key in expected_args:
-                    kw_to_arg_type[kwarg_key] = funcset[kwarg_key]
-                else:
-                    # Otherwise, we're good and just go ahead and pass the keyword/value pair into
-                    # the kwargs list to be run.
-                    function_kwargs.update(funcset)
-    function_args.reverse()
-    # Add kwargs passed as kwargs :)
-    function_kwargs.update(kwargs)
-    for arg in expected_args:
-        if arg in kw_to_arg_type:
-            function_args.append(kw_to_arg_type[arg])
-    _exp_prm = len(argspec.args or []) - len(argspec.defaults or [])
-    _passed_prm = len(function_args)
-    missing = []
-    if _exp_prm > _passed_prm:
-        for arg in argspec.args[_passed_prm:]:
-            if arg not in function_kwargs:
-                missing.append(arg)
-            else:
-                # Found the expected argument as a keyword
-                # increase the _passed_prm count
-                _passed_prm += 1
-    if missing:
-        raise SaltInvocationError("Missing arguments: {}".format(", ".join(missing)))
-    elif _exp_prm > _passed_prm:
+            fargs.append(arg)
+    fargs.reverse()
+
+    # Make kwargs override anything set before. Usually, named params are meant to be passed either
+    # as dicts in `passed_args` (module.run) or as passed_kwargs (mine.update), not both.
+    named_params.update(passed_kwargs)
+    # Now map params to their destination.
+    # Parameters without defaults receive their arguments positionally.
+    # We also want to support mapping named arguments to posonly args.
+    for name, val in named_params.items():
+        if name in posonly:
+            kw_to_posarg[name] = val
+        elif name in argreq:
+            kw_to_arg[name] = val
+        else:
+            fkwargs[name] = val
+    if len(fargs) > len(spec.args) and not spec.varargs:
         raise SaltInvocationError(
-            "Function expects {} positional parameters, got only {}".format(
-                _exp_prm, _passed_prm
+            f"{fun.__name__} only takes {len(spec.args)} positional parameters, got {(len(fargs))}"
+        )
+
+    missing_pos = []
+    # Discover missing positional args without defaults in kwargs, otherwise fail.
+    for arg in argreq[len(fargs) :]:
+        if arg in kw_to_arg:
+            fargs.append(kw_to_arg.pop(arg))
+        elif arg in kw_to_posarg:
+            fargs.append(kw_to_posarg.pop(arg))
+        else:
+            missing_pos.append(arg)
+    if missing_pos:
+        raise SaltInvocationError(f"Missing arguments: {', '.join(missing_pos)}")
+
+    # Discover arguments to positional-only params with defaults
+    posonly_defaults = spec.posonlydefaults
+    for arg in posonly[len(fargs) :]:
+        if arg in kw_to_posarg:
+            fargs.append(kw_to_posarg.pop(arg))
+        else:
+            fargs.append(posonly_defaults[arg])
+
+    # positional param names that already have an argument
+    taken_pos = set(spec.args[: len(fargs)])
+    # Set defaults of unspecified params that can receive a named argument in the parsed kwargs.
+    # This seems redundant, but it's what the previous implementation did.
+    for name, default in spec.kwdefaults.items():
+        if name not in fkwargs and name not in taken_pos:
+            fkwargs[name] = default
+
+    # Ensure we have all required keyword-only args
+    kwonlyreq = spec.kwonlyreq
+    missing_kw = tuple(kw for kw in kwonlyreq if kw not in fkwargs)
+    if missing_kw:
+        missing_count = len(missing_kw)
+        raise SaltInvocationError(
+            "{} missing {} required keyword-only argument{}: {}".format(
+                fun.__name__,
+                missing_count,
+                missing_count > 1 and "s" or "",
+                ", ".join(f"'{missing}'" for missing in missing_kw),
             )
         )
 
-    return salt_function(*function_args, **function_kwargs)
+    # Set of parameter names of positional-or-keyword ones that would receive both positional and kw args.
+    duplicate_args = taken_pos.intersection(fkwargs)
+
+    if spec.keywords and kw_to_posarg:
+        # Python allows calling `def f(a, /, **kwargs)` with `f("foo", a="a")`
+        # and puts `a` into kwargs. Let's mirror that.
+        fkwargs.update(kw_to_posarg)
+        kw_to_posarg.clear()
+
+    if not (kw_to_arg or kw_to_posarg or duplicate_args):
+        # If we did not receive args to the same parameter both positionally and by name, we're fine.
+        return fun(*fargs, **fkwargs)
+
+    # We want to fail here because we got multiple values for a single argument.
+    # Python would fail with a TypeError anyways, but we can tell the user when it affects multiple args.
+    duplicate_args = duplicate_args.union(kw_to_posarg).union(kw_to_arg)
+    if len(duplicate_args) == 1:
+        raise SaltInvocationError(
+            f"{fun.__name__}() got multiple values for argument '{duplicate_args.pop()}'"
+        )
+    raise SaltInvocationError(
+        f"{fun.__name__}() got multiple values for arguments "
+        + ", ".join(f"'{arg}'" for arg in spec.args if arg in duplicate_args)
+    )

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -190,11 +190,15 @@ salt/proxy/*:
 
 salt/state.py:
   - pytests.functional.modules.state.test_jinja_filters
+  - pytests.integration.states.test_arg_kinds
   - integration.states.test_compiler
   - integration.states.test_handle_error
   - integration.states.test_handle_iorder
   - integration.states.test_match
   - integration.states.test_renderers
+
+salt/states/module.py:
+  - pytests.integration.states.test_arg_kinds
 
 salt/utils/decorators/*:
   - integration.modules.test_decorators
@@ -202,6 +206,10 @@ salt/utils/decorators/*:
 salt/(utils|renderers)/jinja\.py:
   - pytests.functional.modules.state.test_jinja_filters
   - integration.states.test_renderers
+
+salt/utils/(args|functools)\.py:
+  - pytests.integration.modules.test_arg_kinds
+  - pytests.integration.states.test_arg_kinds
 
 salt/utils/minions.py:
   - pytests.integration.cli.test_matcher

--- a/tests/pytests/functional/utils/functools/test_alias_function.py
+++ b/tests/pytests/functional/utils/functools/test_alias_function.py
@@ -8,4 +8,4 @@ def test_kwarg_defaults_preserved():
     func2 = alias_function(func, "func2")
 
     assert func(None) == "foo"
-    assert func2(None) == "foo"
+    assert func2(None) == "foo"  # pylint: disable=not-callable

--- a/tests/pytests/functional/utils/functools/test_alias_function.py
+++ b/tests/pytests/functional/utils/functools/test_alias_function.py
@@ -1,0 +1,11 @@
+from salt.utils.functools import alias_function
+
+
+def test_kwarg_defaults_preserved():
+    def func(_arg, *, default="foo"):
+        return default
+
+    func2 = alias_function(func, "func2")
+
+    assert func(None) == "foo"
+    assert func2(None) == "foo"

--- a/tests/pytests/functional/utils/functools/test_namespaced_function.py
+++ b/tests/pytests/functional/utils/functools/test_namespaced_function.py
@@ -139,4 +139,4 @@ def test_kwarg_defaults_preserved():
     func2 = namespaced_function(func, globals())
 
     assert func(None) == "foo"
-    assert func2(None) == "foo"
+    assert func2(None) == "foo"  # pylint: disable=not-callable

--- a/tests/pytests/functional/utils/functools/test_namespaced_function.py
+++ b/tests/pytests/functional/utils/functools/test_namespaced_function.py
@@ -130,3 +130,13 @@ def test_deprecated_preserve_context_kwarg(preserve_context):
         "for removal in 3008.0 (Argon) and no longer does anything for the function "
         "being namespaced."
     )
+
+
+def test_kwarg_defaults_preserved():
+    def func(_arg, *, default="foo"):
+        return default
+
+    func2 = namespaced_function(func, globals())
+
+    assert func(None) == "foo"
+    assert func2(None) == "foo"

--- a/tests/pytests/integration/modules/test_arg_kinds.py
+++ b/tests/pytests/integration/modules/test_arg_kinds.py
@@ -1,0 +1,125 @@
+"""
+Ensure execution module functions with positional-only and keyword-only
+parameters are handled correctly.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def arg_kinds_module(salt_master, salt_minion):
+    contents = """
+    def regular(first, second=2, third=3):
+        return {"first": first, "second": second, "third": third}
+
+
+    def kwonly(first, *, second, third="three"):
+        return {"first": first, "second": second, "third": third}
+
+
+    def kwonly_defaults(a, b=1, *, c):
+        return {"a": a, "b": b, "c": c}
+
+
+    def posonly(first, /, second="two"):
+        return {"first": first, "second": second}
+
+
+    def posonly_default(first, second="two", /, third="three"):
+        return {"first": first, "second": second, "third": third}
+
+
+    def posonly_kwargs(a=1, /, **kwargs):
+        return {"a": a, "kwargs": {k: v for k, v in kwargs.items() if not k.startswith("__")}}
+
+
+    def all_together(pos1, /, kwpos2, kwpos3="3", *args, kwreq, kwopt="opt", kwopt2="h", **kwargs):
+        assert "__pub_fun" in kwargs, "no __pub_fun"
+        assert "__pub_jid" in kwargs, "no __pub_jid"
+        assert "__pub_pid" in kwargs, "no __pub_pid"
+        assert "__pub_tgt" in kwargs, "no __pub_tgt"
+        return {"pos1": pos1, "kwpos2": kwpos2, "kwpos3": kwpos3, "args": args, "kwreq": kwreq, "kwopt": kwopt, "kwopt2": kwopt2, "kwargs": {k: v for k, v in kwargs.items() if not k.startswith("__")}}
+    """
+    salt_call_cli = salt_minion.salt_call_cli()
+    with salt_master.state_tree.base.temp_file("_modules/arg_kinds.py", contents):
+        ret = salt_call_cli.run("saltutil.sync_modules")
+        assert ret.returncode == 0
+        yield
+    ret = salt_call_cli.run("saltutil.sync_modules")
+    assert ret.returncode == 0
+
+
+def test_kwonly(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.kwonly", "one", "second=owt")
+    assert ret.returncode == 0, ret
+    assert ret.data == {"first": "one", "second": "owt", "third": "three"}
+
+
+def test_kwonly_positional_rejected(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.kwonly", "one", "two", "four")
+    assert ret.returncode > 0
+    assert "takes 1 positional argument" in str(ret.data or ret.stderr)
+
+
+def test_kwonly_defaults_are_applied_correctly(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.kwonly_defaults", "A", b="B")
+    assert ret.returncode > 0
+    assert "missing 1 required keyword-only" in str(ret.data or ret.stderr)
+
+
+def test_posonly(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.posonly", "one")
+    assert ret.returncode == 0
+    assert ret.data == {"first": "one", "second": "two"}
+
+
+def test_posonly_passed_by_name_rejected(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.posonly", "first=one")
+    assert ret.returncode != 0
+    assert "keyword arguments are not valid" in str(ret.data or ret.stderr)
+
+
+def test_posonly_default(salt_call_cli):
+    ret = salt_call_cli.run("arg_kinds.posonly_default", "one", third="eerht")
+    assert ret.returncode == 0
+    assert ret.data == {"first": "one", "second": "two", "third": "eerht"}
+
+
+def test_posonly_with_kwargs(salt_call_cli):
+    """
+    Python allows ``def f(a, /, **kwargs)`` being called with ``f("first_a", a="other_a")``.
+    Ensure we handle that case.
+    """
+    ret = salt_call_cli.run("arg_kinds.posonly_kwargs", "A", a="foo")
+    assert ret.returncode == 0
+    assert ret.data == {"a": "A", "kwargs": {"a": "foo"}}
+
+
+def test_all_together(salt_call_cli):
+    ret = salt_call_cli.run(
+        "arg_kinds.all_together",
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        kwopt="g",
+        kwreq="f",
+        pos1="i",
+        quux="j",
+    )
+    assert ret.returncode == 0
+    assert ret.data == {
+        "pos1": "a",
+        "kwpos2": "b",
+        "kwpos3": "c",
+        "args": ["d", "e"],
+        "kwreq": "f",
+        "kwopt": "g",
+        "kwopt2": "h",
+        "kwargs": {"pos1": "i", "quux": "j"},
+    }

--- a/tests/pytests/integration/states/test_arg_kinds.py
+++ b/tests/pytests/integration/states/test_arg_kinds.py
@@ -92,9 +92,12 @@ def test_kwonly_defaults_required_kwonly_missing(salt_call_cli, salt_master):
     with salt_master.state_tree.base.temp_file("kwonly_defaults_miss.sls", contents):
         ret = salt_call_cli.run("state.apply", "kwonly_defaults_miss")
     assert ret.returncode != 0, ret
-    assert any(
-        "missing 1 required keyword-only" in stream
-        for stream in (ret.stdout, ret.stderr)
+    # Ensure state verification catches it, not salt.utils.args.format_call
+    single_ret = ret.data[next(iter(ret.data))]
+    assert single_ret["result"] is False
+    assert (
+        "Missing parameter c for state arg_kinds.kwonly_defaults"
+        in single_ret["comment"]
     )
 
 

--- a/tests/pytests/integration/states/test_arg_kinds.py
+++ b/tests/pytests/integration/states/test_arg_kinds.py
@@ -1,0 +1,219 @@
+"""
+Ensure state module functions with positional-only and keyword-only
+parameters are handled correctly.
+
+Also ensure module.run works with these param kinds.
+"""
+
+import pytest
+
+from tests.pytests.integration.modules.test_arg_kinds import (  # pylint: disable=unused-import
+    arg_kinds_module,
+)
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def arg_kinds_state(salt_master, salt_minion):
+    contents = """
+    def kwonly(name, first, *, second, third="three"):
+        return {"name": name, "result": True, "comment": "", "changes": {"first": first, "second": second, "third": third}}
+
+
+    def kwonly_defaults(name, a, b=1, *, c):
+        return {"name": name, "result": True, "comment": "", "changes": {"a": a, "b": b, "c": c}}
+
+
+    def posonly(name, first, /, second, third="three"):
+        return {"name": name, "result": True, "comment": "", "changes": {"first": first, "second": second, "third": third}}
+
+
+    def posonly_default(name, first, second="two", /, third="three"):
+        return {"name": name, "result": True, "comment": "", "changes": {"first": first, "second": second, "third": third}}
+
+
+    def posonly_kwargs(name, a=1, /, **kwargs):
+        return {"name": name, "result": True, "comment": "", "changes": {"a": a, "kwargs": {k: v for k, v in kwargs.items() if not k.startswith("__")}}}
+    """
+    salt_call_cli = salt_minion.salt_call_cli()
+    with salt_master.state_tree.base.temp_file("_states/arg_kinds.py", contents):
+        ret = salt_call_cli.run("saltutil.sync_states")
+        assert ret.returncode == 0
+        assert "states.arg_kinds" in ret.data
+        yield
+    ret = salt_call_cli.run("saltutil.sync_states")
+    assert ret.returncode == 0
+
+
+def test_kwonly(salt_call_cli, salt_master):
+    contents = """
+    foo:
+      arg_kinds.kwonly:
+        - first: one
+        - second: two
+    """
+    with salt_master.state_tree.base.temp_file("kwonly.sls", contents):
+        ret = salt_call_cli.run("state.apply", "kwonly")
+    assert ret.returncode == 0, ret
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "first": "one",
+        "second": "two",
+        "third": "three",
+    }
+
+
+def test_kwonly_defaults(salt_call_cli, salt_master):
+    contents = """
+    foo:
+      arg_kinds.kwonly_defaults:
+        - a: a
+        - c: c
+    """
+    with salt_master.state_tree.base.temp_file("kwonly_defaults.sls", contents):
+        ret = salt_call_cli.run("state.apply", "kwonly_defaults")
+    assert ret.returncode == 0, ret
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "a": "a",
+        "b": 1,
+        "c": "c",
+    }
+
+
+def test_kwonly_defaults_required_kwonly_missing(salt_call_cli, salt_master):
+    contents = """
+    foo:
+      arg_kinds.kwonly_defaults:
+        - a: one
+        - b: two
+    """
+    with salt_master.state_tree.base.temp_file("kwonly_defaults_miss.sls", contents):
+        ret = salt_call_cli.run("state.apply", "kwonly_defaults_miss")
+    assert ret.returncode != 0, ret
+    assert any(
+        "missing 1 required keyword-only" in stream
+        for stream in (ret.stdout, ret.stderr)
+    )
+
+
+def test_posonly(salt_call_cli, salt_master):
+    contents = """
+    foo:
+      arg_kinds.posonly:
+        - first: one
+        - second: owt
+    """
+    with salt_master.state_tree.base.temp_file("posonly.sls", contents):
+        ret = salt_call_cli.run("state.apply", "posonly")
+    assert ret.returncode == 0, ret
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "first": "one",
+        "second": "owt",
+        "third": "three",
+    }
+
+
+def test_posonly_with_kwargs(salt_call_cli, salt_master):
+    """
+    Python allows ``def f(a, /, **kwargs)`` being called with ``f("first_a", a="other_a")``.
+    Ensure we handle that case somehow in states, where posargs don't exist:
+    Since the high data is compiled into low chunk dicts, we can only drop
+    the kwarg and ensure the posarg is passed.
+    """
+    contents = """
+    foo:
+      arg_kinds.posonly_kwargs:
+        - a: a
+        - a: foo
+    """
+    with salt_master.state_tree.base.temp_file("posonly_kwargs.sls", contents):
+        ret = salt_call_cli.run("state.apply", "posonly_kwargs")
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"] == {
+        "a": "foo",
+        "kwargs": {},
+    }
+
+
+def test_module_run_positional_params(salt_call_cli, salt_master):
+    """
+    Ensure module.run works when passing positional params to args with defaults.
+    """
+    contents = """
+    foo:
+      module.run:
+        - arg_kinds.regular:
+            - 10
+            - 20
+            - 30
+    """
+    with salt_master.state_tree.base.temp_file("pos_param_mr.sls", contents):
+        ret = salt_call_cli.run("state.apply", "pos_param_mr")
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"]["arg_kinds.regular"] == {
+        "first": 10,
+        "second": 20,
+        "third": 30,
+    }
+
+
+def test_module_run_with_posonly(salt_call_cli, salt_master):
+    """
+    Ensure posonly args specified as posargs work.
+    """
+    contents = """
+    foo:
+      module.run:
+        - arg_kinds.posonly:
+            - foo
+    """
+    with salt_master.state_tree.base.temp_file("posonly_mr.sls", contents):
+        ret = salt_call_cli.run("state.apply", "posonly_mr")
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"]["arg_kinds.posonly"] == {
+        "first": "foo",
+        "second": "two",
+    }
+
+
+def test_module_run_with_posonly_and_kwargs_containing_same_name(
+    salt_call_cli, salt_master
+):
+    """
+    Python allows ``def f(a, /, **kwargs)`` being called with ``f("first_a", a="other_a")``.
+    Ensure we handle that case.
+    """
+    contents = """
+    foo:
+      module.run:
+        - arg_kinds.posonly_kwargs:
+          - foo
+          - a: bar
+    """
+    with salt_master.state_tree.base.temp_file("posonly_kwargs_mr.sls", contents):
+        ret = salt_call_cli.run("state.apply", "posonly_kwargs_mr")
+    assert ret.returncode == 0
+    assert ret.data[next(iter(ret.data))]["changes"]["arg_kinds.posonly_kwargs"] == {
+        "a": "foo",
+        "kwargs": {"a": "bar"},
+    }
+
+
+def test_module_run_with_required_kwonly_missing(salt_call_cli, salt_master):
+    """
+    Ensure defaults are mapped correctly when a required kwarg-only param
+    follows a regular one with a default.
+    """
+    contents = """
+    foo:
+      module.run:
+        - arg_kinds.kwonly_defaults:
+          - a: A
+          - b: B
+    """
+    with salt_master.state_tree.base.temp_file("kwonly_defaults_mr.sls", contents):
+        ret = salt_call_cli.run("state.apply", "kwonly_defaults_mr")
+    assert ret.returncode > 0
+    assert "missing 1 required" in ret.data[next(iter(ret.data))]["comment"]

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -28,6 +28,17 @@ from salt.exceptions import (
     SaltReqTimeoutError,
     SaltSystemExit,
 )
+from tests.pytests.unit.utils.test_args import (
+    _all,
+    _default,
+    _kwargs,
+    _kwonly_no_pos,
+    _kwonly_req,
+    _nodefault,
+    _noparams,
+    _posonly,
+    _posonly_default_no_regular,
+)
 from tests.support.mock import MagicMock, patch
 
 log = logging.getLogger(__name__)
@@ -1514,20 +1525,167 @@ async def test_syndic_async_req_channel(syndic_opts):
     assert isinstance(syndic.async_req_channel, salt.channel.client.AsyncReqChannel)
 
 
-@pytest.mark.slow_test
-def test_load_args_and_kwargs(minion_opts):
-    """
-    Ensure load_args_and_kwargs performs correctly
-    """
-    _args = [{"max": 40, "__kwarg__": True}]
-    ret = salt.minion.load_args_and_kwargs(test_mod.rand_sleep, _args)
-    assert ret == ([], {"max": 40})
-    assert all([True if "__kwarg__" in item else False for item in _args])
+@pytest.mark.parametrize(
+    "fun,args,expected",
+    (
+        # No arguments
+        pytest.param(_noparams, [], ([], {}), id="no_params"),
+        # Plain positional arguments
+        pytest.param(_nodefault, [1, 2, 3], ([1, 2, 3], {}), id="poskw_req_by_pos"),
+        # Non-string arguments and dicts without __kwarg__ stay positional
+        pytest.param(
+            _nodefault,
+            [{"first": 1}, [2], None],
+            ([{"first": 1}, [2], None], {}),
+            id="kw_requires_dict_with_kwarg_key",
+        ),
+        # __kwarg__ dicts are parsed into kwargs
+        pytest.param(
+            _default,
+            [1, 2, {"third": 3, "__kwarg__": True}],
+            ([1, 2], {"third": 3}),
+            id="dict_with_kwarg_key_to_single_kwarg",
+        ),
+        # A single __kwarg__ dict can specify multiple kwargs
+        pytest.param(
+            _default,
+            [1, {"second": 2, "third": 3, "__kwarg__": True}],
+            ([1], {"second": 2, "third": 3}),
+            id="dict_with_kwarg_key_to_multiple_kwargs",
+        ),
+        # String kwargs are parsed, their values are yamlified
+        pytest.param(
+            _default, [1, 2, "third=3"], ([1, 2], {"third": 3}), id="string_to_kwarg"
+        ),
+        # Strings that don't parse as kwargs stay positional
+        pytest.param(
+            _nodefault,
+            ["one", "a==b", "key = val"],
+            (["one", "a==b", "key = val"], {}),
+            id="string_no_kwarg",
+        ),
+        # Keyword-only parameters are valid kwargs, as dicts and strings
+        pytest.param(
+            _kwonly_req,
+            [1, {"third": 3, "__kwarg__": True}],
+            ([1], {"third": 3}),
+            id="kwonly_from_dict",
+        ),
+        pytest.param(
+            _kwonly_no_pos,
+            ["second=2", "third=3"],
+            ([], {"second": 2, "third": 3}),
+            id="kwonly_from_string",
+        ),
+        # Positional-only parameters are passed positionally
+        pytest.param(_posonly, [1, 2, 3, 4], ([1, 2, 3, 4], {}), id="posonly_by_pos"),
+        # Unknown names are valid kwargs when the function accepts **kwargs
+        pytest.param(
+            _kwargs,
+            [1, {"fourth": 4, "__kwarg__": True}, "fifth=5"],
+            ([1], {"fourth": 4, "fifth": 5}),
+            id="unknown_named_into_variadic_keywords",
+        ),
+        # Positional-only names are valid kwargs with **kwargs present,
+        # where they end up as keyword arguments (mirroring Python)
+        pytest.param(
+            _all,
+            [1, {"second": 2, "__kwarg__": True}],
+            ([1], {"second": 2}),
+            id="posonly_name_into_kwargs",
+        ),
+        # Real execution module function
+        pytest.param(
+            test_mod.rand_sleep,
+            [{"max": 40, "__kwarg__": True}],
+            ([], {"max": 40}),
+            id="real_module",
+        ),
+    ),
+)
+def test_load_args_and_kwargs(fun, args, expected):
+    ret = salt.minion.load_args_and_kwargs(fun, args)
+    assert ret == expected
 
-    # Test invalid arguments
-    _args = [{"max_sleep": 40, "__kwarg__": True}]
-    with pytest.raises(salt.exceptions.SaltInvocationError):
-        ret = salt.minion.load_args_and_kwargs(test_mod.rand_sleep, _args)
+
+@pytest.mark.parametrize(
+    "fun,args,match",
+    (
+        # Unknown kwarg name without **kwargs to receive it (dict form)
+        pytest.param(
+            _default,
+            [1, {"fourth": 4, "__kwarg__": True}],
+            r"not valid: fourth=4",
+            id="unknown_kwarg_from_dict",
+        ),
+        # Unknown kwarg name without **kwargs to receive it (string form)
+        pytest.param(
+            _default,
+            [1, "fourth=4"],
+            r"not valid: fourth=4",
+            id="unknown_kwarg_from_string",
+        ),
+        # Positional-only parameters cannot be passed by name
+        pytest.param(
+            _posonly,
+            [{"first": 1, "__kwarg__": True}, 2, 3],
+            r"not valid: first=1",
+            id="posonly_req_by_name",
+        ),
+        pytest.param(
+            _posonly_default_no_regular,
+            [1, "second=2"],
+            r"not valid: second=2",
+            id="posonly_default_by_name",
+        ),
+        # All invalid kwargs are collected into a single error
+        pytest.param(
+            _default,
+            [{"fourth": 4, "__kwarg__": True}, "fifth=5"],
+            r"not valid: fourth=4, fifth=5",
+            id="unknown_kwarg_multi",
+        ),
+    ),
+)
+def test_load_args_and_kwargs_invalid_kwargs(fun, args, match):
+    with pytest.raises(salt.exceptions.SaltInvocationError, match=match):
+        salt.minion.load_args_and_kwargs(fun, args)
+
+
+def test_load_args_and_kwargs_ignore_invalid():
+    """
+    With ignore_invalid=True, invalid kwargs are dropped silently.
+    """
+    args = [1, {"third": 3, "fourth": 4, "__kwarg__": True}, "fifth=5"]
+    ret = salt.minion.load_args_and_kwargs(_default, args, ignore_invalid=True)
+    assert ret == ([1], {"third": 3})
+
+
+def test_load_args_and_kwargs_pub_data():
+    """
+    Publish data is packed into __pub_* kwargs, but only if the
+    function accepts **kwargs.
+    """
+    data = {"jid": "20240101000000000000", "user": "root"}
+    ret = salt.minion.load_args_and_kwargs(_kwargs, [1], data=data)
+    assert ret == (
+        [1],
+        {"__pub_jid": "20240101000000000000", "__pub_user": "root"},
+    )
+
+    ret = salt.minion.load_args_and_kwargs(_default, [1, 2], data=data)
+    assert ret == ([1, 2], {})
+
+
+def test_load_args_and_kwargs_input_not_modified():
+    """
+    The input argument list is passed on the wire and reused (e.g. in the
+    job cache), ensure __kwarg__ markers are not stripped from it.
+    """
+    args = [1, {"third": 3, "__kwarg__": True}]
+    ret = salt.minion.load_args_and_kwargs(_default, args)
+    assert ret == ([1], {"third": 3})
+    assert args == [1, {"third": 3, "__kwarg__": True}]
 
 
 async def test_connect_master_salt_client_error(minion_opts, connect_master_mock):

--- a/tests/pytests/unit/test_pillar.py
+++ b/tests/pytests/unit/test_pillar.py
@@ -278,7 +278,7 @@ def test_ext_pillar_no_extra_minion_data_val_dict():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", {"arg": "foo"}, "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -288,7 +288,7 @@ def test_ext_pillar_no_extra_minion_data_val_dict():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", {"arg": "foo"}, "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -319,7 +319,7 @@ def test_ext_pillar_no_extra_minion_data_val_list():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", ["foo"], "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with("mocked-minion", "fake_pillar", "foo")
@@ -327,7 +327,7 @@ def test_ext_pillar_no_extra_minion_data_val_list():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", ["foo"], "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with("mocked-minion", "fake_pillar", "foo")
@@ -356,7 +356,7 @@ def test_ext_pillar_no_extra_minion_data_val_elem():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", "fake_val", "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -366,7 +366,7 @@ def test_ext_pillar_no_extra_minion_data_val_elem():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", "fake_val", "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -399,7 +399,7 @@ def test_ext_pillar_with_extra_minion_data_val_dict():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", {"arg": "foo"}, "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -409,7 +409,7 @@ def test_ext_pillar_with_extra_minion_data_val_dict():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", {"arg": "foo"}, "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -445,7 +445,7 @@ def test_ext_pillar_with_extra_minion_data_val_list():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", ["bar"], "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with("mocked-minion", "fake_pillar", "bar")
@@ -453,7 +453,7 @@ def test_ext_pillar_with_extra_minion_data_val_list():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", ["bar"], "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(
@@ -486,7 +486,7 @@ def test_ext_pillar_with_extra_minion_data_val_elem():
     # ext pillar function doesn't have the extra_minion_data arg
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=[])),
+        MagicMock(return_value=MagicMock(namedargs=[])),
     ):
         pillar._external_pillar_data("fake_pillar", "bar", "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with("mocked-minion", "fake_pillar", "bar")
@@ -494,7 +494,7 @@ def test_ext_pillar_with_extra_minion_data_val_elem():
     mock_ext_pillar_func.reset_mock()
     with patch(
         "salt.utils.args.get_function_argspec",
-        MagicMock(return_value=MagicMock(args=["extra_minion_data"])),
+        MagicMock(return_value=MagicMock(namedargs=["extra_minion_data"])),
     ):
         pillar._external_pillar_data("fake_pillar", "bar", "fake_ext_pillar")
     mock_ext_pillar_func.assert_called_once_with(

--- a/tests/pytests/unit/utils/test_args.py
+++ b/tests/pytests/unit/utils/test_args.py
@@ -302,8 +302,20 @@ def test_get_function_argspec(fun, expected):
         "kwdefaults": {},
         "posonlydefaults": {},
         "alldefaults": {},
+        "allreq": (),
+        "namedargs": (),
     }
     expected = defaults | expected
+    # Fill allreq/namedargs from expected data to avoid repetition
+    if expected["argreq"] or expected["kwonlyreq"]:
+        expected["allreq"] = expected["allreq"] or (
+            expected["argreq"] + expected["kwonlyreq"]
+        )
+    if expected["args"] or expected["kwonlyargs"]:
+        expected["namedargs"] = expected["namedargs"] or (
+            tuple(arg for arg in expected["args"] if arg not in expected["posonlyargs"])
+            + expected["kwonlyargs"]
+        )
     spec = salt.utils.args.get_function_argspec(fun)
     for attr, exp in expected.items():
         assert getattr(spec, attr) == exp

--- a/tests/pytests/unit/utils/test_args.py
+++ b/tests/pytests/unit/utils/test_args.py
@@ -1,11 +1,12 @@
+import copy
+import functools
 import logging
-from collections import namedtuple
+import pickle
 
 import pytest
 
 import salt.utils.args
 from salt.exceptions import SaltInvocationError
-from tests.support.mock import DEFAULT, patch
 
 log = logging.getLogger(__name__)
 
@@ -25,94 +26,345 @@ def test_clean_kwargs():
     assert salt.utils.args.clean_kwargs(foo_bar="gwar") == {"foo_bar": "gwar"}
 
 
-def test_get_function_argspec():
-    class DummyClass:
-        def __init__(self, first):
-            pass
-
-        def __call__(self, first):
-            pass
-
-    dummy_class = DummyClass("foo")
-
-    def dummy_func_nodefault(first, second, third):
+class _CallableClass:
+    def __init__(self, first):
         pass
 
-    def dummy_func_default(first, second, third="fourth"):
+    def __call__(self, first):
         pass
 
-    def dummy_func_varargs_keywords(*args, **kwargs):
-        pass
 
-    def dummy_func_annotations(first: int, second: str) -> bool:
-        pass
+def _noparams():
+    return locals()
 
-    _ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
 
-    # Callable class instance
-    expected_argspec = _ArgSpec(
-        args=["first"],
-        varargs=None,
-        keywords=None,
-        defaults=None,
-    )
-    ret = salt.utils.args.get_function_argspec(dummy_class)
-    assert ret == expected_argspec
+def _nodefault(first, second, third):
+    return locals()
 
-    # Function with no varargs, no keywords, and no defaults
-    expected_argspec = _ArgSpec(
-        args=["first", "second", "third"],
-        varargs=None,
-        keywords=None,
-        defaults=None,
-    )
-    ret = salt.utils.args.get_function_argspec(dummy_func_nodefault)
-    assert ret == expected_argspec
 
-    # Function with no varargs, no keywords, and one default
-    expected_argspec = _ArgSpec(
-        args=["first", "second", "third"],
-        varargs=None,
-        keywords=None,
-        defaults=("fourth",),
-    )
-    ret = salt.utils.args.get_function_argspec(dummy_func_default)
-    assert ret == expected_argspec
+def _default(first, second, third="3"):
+    return locals()
 
-    # Function with annotations
-    expected_argspec = _ArgSpec(
-        args=["first", "second"],
-        varargs=None,
-        keywords=None,
-        defaults=None,
-    )
-    ret = salt.utils.args.get_function_argspec(dummy_func_annotations)
-    assert ret == expected_argspec
 
-    # Function with both varargs and keywords
-    expected_argspec = _ArgSpec(
-        args=[],
-        varargs="args",
-        keywords="kwargs",
-        defaults=None,
-    )
-    ret = salt.utils.args.get_function_argspec(dummy_func_varargs_keywords)
-    assert ret == expected_argspec
+def _defaults(first, second=2, third=3):
+    return locals()
 
+
+def _alldefault(first=None, second=None, third=None):
+    return locals()
+
+
+def _varargs_keywords(*args, **kwargs):
+    return locals()
+
+
+def _annotations(first: int, second: str) -> bool:
+    return locals()
+
+
+def _kwargs(first, second=None, third=None, **kwargs):
+    return locals()
+
+
+def _posonly(first, second, /, third, fourth=4):
+    return locals()
+
+
+def _posonly_default(first, second="two", /, third="three"):
+    return locals()
+
+
+def _posonly_default_no_regular(first, second="two", /):
+    return locals()
+
+
+def _posonly_no_default(first, second, /):
+    return locals()
+
+
+def _kwonly(first, *args, second, third="three", **kwargs):
+    return locals()
+
+
+def _kwonly_req(first, second=None, *, third):
+    return locals()
+
+
+def _kwonly_reqs(first, second=None, *, third, fourth, fifth=None):
+    return locals()
+
+
+def _kwonly_no_pos(*, second, third="three"):
+    return locals()
+
+
+def _posonly_kwonly(first, /, *, second, third="three"):
+    return locals()
+
+
+def _all(
+    first,
+    second=None,
+    /,
+    third=3,
+    *varargs,
+    fourth,
+    fifth,
+    sixth="6",
+    seventh=2.72,
+    **kvarargs,
+):
+    return locals()
+
+
+@pytest.mark.parametrize(
+    "fun,expected",
+    (
+        # Callable class instance, inspected via __call__
+        pytest.param(
+            _CallableClass("foo"),
+            {"args": ["first"], "argreq": ("first",)},
+            id="callable_class",
+        ),
+        # Function without any parameters
+        pytest.param(_noparams, {}, id="no_params"),
+        # Positional-or-keyword parameters only, no defaults
+        pytest.param(
+            _nodefault,
+            {
+                "args": ["first", "second", "third"],
+                "argreq": ("first", "second", "third"),
+            },
+            id="poskw_nodefault",
+        ),
+        # Positional-or-keyword parameters, one default
+        pytest.param(
+            _default,
+            {
+                "args": ["first", "second", "third"],
+                "defaults": ("3",),
+                "argreq": ("first", "second"),
+                "kwdefaults": {"third": "3"},
+                "argdefaults": {"third": "3"},
+                "alldefaults": {"third": "3"},
+            },
+            id="poskw_default",
+        ),
+        # Annotations don't influence the spec
+        pytest.param(
+            _annotations,
+            {"args": ["first", "second"], "argreq": ("first", "second")},
+            id="annotations",
+        ),
+        # Variadic args/kwargs only
+        pytest.param(
+            _varargs_keywords,
+            {"varargs": "args", "keywords": "kwargs"},
+            id="args_kwargs_only",
+        ),
+        # Positional-only without defaults, mixed with positional-or-keyword
+        pytest.param(
+            _posonly,
+            {
+                "args": ["first", "second", "third", "fourth"],
+                "defaults": (4,),
+                "posonlyargs": ("first", "second"),
+                "argreq": ("first", "second", "third"),
+                "argdefaults": {"fourth": 4},
+                "kwdefaults": {"fourth": 4},
+                "alldefaults": {"fourth": 4},
+            },
+            id="posonly_req_poskw_default",
+        ),
+        # Positional-only without defaults and no other parameters
+        pytest.param(
+            _posonly_no_default,
+            {
+                "args": ["first", "second"],
+                "posonlyargs": ("first", "second"),
+                "argreq": ("first", "second"),
+            },
+            id="posonly_only_nodefault",
+        ),
+        # Positional-only with default, defaults spanning the `/` boundary
+        pytest.param(
+            _posonly_default,
+            {
+                "args": ["first", "second", "third"],
+                "defaults": ("two", "three"),
+                "posonlyargs": ("first", "second"),
+                "argreq": ("first",),
+                "argdefaults": {"second": "two", "third": "three"},
+                "kwdefaults": {"third": "three"},
+                "posonlydefaults": {"second": "two"},
+                "alldefaults": {"second": "two", "third": "three"},
+            },
+            id="posonly_default_poskw_default",
+        ),
+        # Positional-only with default and no other parameters -
+        # nothing can be passed a keyword argument
+        pytest.param(
+            _posonly_default_no_regular,
+            {
+                "args": ["first", "second"],
+                "defaults": ("two",),
+                "posonlyargs": ("first", "second"),
+                "argreq": ("first",),
+                "argdefaults": {"second": "two"},
+                "kwdefaults": {},
+                "posonlydefaults": {"second": "two"},
+                "alldefaults": {"second": "two"},
+            },
+            id="posonly_only_default",
+        ),
+        # Keyword-only, required and with default, plus variadic args/kwargs
+        pytest.param(
+            _kwonly,
+            {
+                "args": ["first"],
+                "varargs": "args",
+                "keywords": "kwargs",
+                "argreq": ("first",),
+                "kwonlyargs": ("second", "third"),
+                "kwonlyreq": ("second",),
+                "kwonlydefaults": {"third": "three"},
+                "kwdefaults": {"third": "three"},
+                "alldefaults": {"third": "three"},
+            },
+            id="poskw_req_kwonly_req_and_default_args_kwargs",
+        ),
+        # Keyword-only without any positional parameters
+        pytest.param(
+            _kwonly_no_pos,
+            {
+                "kwonlyargs": ("second", "third"),
+                "kwonlyreq": ("second",),
+                "kwonlydefaults": {"third": "three"},
+                "kwdefaults": {"third": "three"},
+                "alldefaults": {"third": "three"},
+            },
+            id="kwonly_only_req_and_default",
+        ),
+        # Positional-only and keyword-only without positional-or-keyword ones
+        pytest.param(
+            _posonly_kwonly,
+            {
+                "args": ["first"],
+                "posonlyargs": ("first",),
+                "argreq": ("first",),
+                "kwonlyargs": ("second", "third"),
+                "kwonlyreq": ("second",),
+                "kwonlydefaults": {"third": "three"},
+                "kwdefaults": {"third": "three"},
+                "alldefaults": {"third": "three"},
+            },
+            id="no_poskw",
+        ),
+        # All parameter kinds combined
+        pytest.param(
+            _all,
+            {
+                "args": ["first", "second", "third"],
+                "varargs": "varargs",
+                "keywords": "kvarargs",
+                "defaults": (None, 3),
+                "posonlyargs": ("first", "second"),
+                "kwonlyargs": ("fourth", "fifth", "sixth", "seventh"),
+                "kwonlydefaults": {"sixth": "6", "seventh": 2.72},
+                "kwonlyreq": ("fourth", "fifth"),
+                "argreq": ("first",),
+                "argdefaults": {"second": None, "third": 3},
+                "kwdefaults": {"third": 3, "sixth": "6", "seventh": 2.72},
+                "posonlydefaults": {"second": None},
+                "alldefaults": {
+                    "second": None,
+                    "third": 3,
+                    "sixth": "6",
+                    "seventh": 2.72,
+                },
+            },
+            id="all_param_kinds",
+        ),
+    ),
+)
+def test_get_function_argspec(fun, expected):
+    defaults = {
+        "args": [],
+        "varargs": None,
+        "keywords": None,
+        "defaults": None,
+        "posonlyargs": (),
+        "kwonlyargs": (),
+        "kwonlydefaults": {},
+        "kwonlyreq": (),
+        "argreq": (),
+        "argdefaults": {},
+        "kwdefaults": {},
+        "posonlydefaults": {},
+        "alldefaults": {},
+    }
+    expected = defaults | expected
+    spec = salt.utils.args.get_function_argspec(fun)
+    for attr, exp in expected.items():
+        assert getattr(spec, attr) == exp
+    if expected["argdefaults"]:
+        argdefault_order = list(spec.argdefaults)
+        expected_order = expected["args"][-len(argdefault_order) :]
+        assert argdefault_order == expected_order
+
+
+def test_get_function_argspec_is_class_method():
     # Test that is_class_method=True is respected. Note that we don't
     # actually have a decorated function from rest_tornado here to test
     # this case, but we're testing for the behavior we expect, which is
     # that the first argument is popped off of the args.
-    expected_argspec = _ArgSpec(
+    expected_argspec = salt.utils.args._ArgSpec(
         args=["second", "third"],
         varargs=None,
         keywords=None,
         defaults=None,
     )
-    ret = salt.utils.args.get_function_argspec(
-        dummy_func_nodefault, is_class_method=True
-    )
+    ret = salt.utils.args.get_function_argspec(_nodefault, is_class_method=True)
     assert ret == expected_argspec
+
+
+def test_get_function_argspec_wrapped():
+    """
+    Wrappers with a ``__wrapped__`` attribute are unwrapped,
+    the spec describes the innermost function.
+    """
+
+    @functools.wraps(_posonly_kwonly)
+    def _wrapper(*args, **kwargs):
+        return _posonly_kwonly(*args, **kwargs)
+
+    spec = salt.utils.args.get_function_argspec(_wrapper)
+    assert spec.args == ["first"]
+    assert spec.posonlyargs == ("first",)
+    assert spec.kwonlyargs == ("second", "third")
+    assert spec.kwonlydefaults == {"third": "three"}
+
+
+def test_get_function_argspec_not_callable():
+    with pytest.raises(TypeError, match="is not a callable"):
+        salt.utils.args.get_function_argspec("not_a_callable")
+
+
+def test_get_function_argspec_copy_preserves_extras():
+    """
+    The extra attributes are not part of the tuple, ensure they survive
+    copy/pickle roundtrips via __getnewargs__.
+    """
+    spec = salt.utils.args.get_function_argspec(_posonly_kwonly)
+    for copied in (
+        copy.copy(spec),
+        copy.deepcopy(spec),
+        pickle.loads(pickle.dumps(spec)),
+    ):
+        assert copied == spec
+        assert copied.posonlyargs == spec.posonlyargs
+        assert copied.kwonlyargs == spec.kwonlyargs
+        assert copied.kwonlydefaults == spec.kwonlydefaults
 
 
 def test_parse_kwarg():
@@ -124,101 +376,330 @@ def test_parse_kwarg():
 
 
 def test_arg_lookup():
-    def dummy_func(first, second, third, fourth="fifth"):
-        pass
-
     expected_dict = {
-        "args": ["first", "second", "third"],
-        "kwargs": {"fourth": "fifth"},
+        "args": ["first", "second"],
+        "kwargs": {"third": "3"},
     }
-    ret = salt.utils.args.arg_lookup(dummy_func)
+    ret = salt.utils.args.arg_lookup(_default)
+    assert ret == expected_dict
+
+    # Keyword-only defaults are part of kwargs, positional-only
+    # parameters of args
+    expected_dict = {
+        "args": ["first"],
+        "kwargs": {"third": "three"},
+    }
+    ret = salt.utils.args.arg_lookup(_posonly_kwonly)
     assert ret == expected_dict
 
 
-def test_format_call():
-    with patch("salt.utils.args.arg_lookup") as arg_lookup:
-
-        def dummy_func(first=None, second=None, third=None):
-            pass
-
-        arg_lookup.return_value = {
-            "args": ["first", "second", "third"],
-            "kwargs": {},
-        }
-        get_function_argspec = DEFAULT
-        get_function_argspec.return_value = namedtuple(
-            "ArgSpec", "args varargs keywords defaults"
-        )(
-            args=["first", "second", "third", "fourth"],
-            varargs=None,
-            keywords=None,
-            defaults=("fifth",),
-        )
-
-        # Make sure we raise an error if we don't pass in the requisite number of arguments
-        with pytest.raises(SaltInvocationError):
-            salt.utils.args.format_call(dummy_func, {"1": 2})
-
-        # Make sure we warn on invalid kwargs
-        with pytest.raises(SaltInvocationError):
-            salt.utils.args.format_call(
-                dummy_func, {"first": 2, "seconds": 2, "third": 3}
-            )
-
-        ret = salt.utils.args.format_call(
-            dummy_func,
+@pytest.mark.parametrize(
+    "fun,data,exp_extra,expected",
+    (
+        # Positional-or-keyword: required passed positionally, defaults
+        # overridden / partially overridden / fully materialized
+        pytest.param(
+            _defaults,
+            {"first": 10, "second": 20, "third": 30},
+            (),
+            {"args": [10], "kwargs": {"second": 20, "third": 30}},
+            id="poskw_default_override_full",
+        ),
+        pytest.param(
+            _defaults,
+            {"first": 10, "second": 20},
+            (),
+            {"args": [10], "kwargs": {"second": 20, "third": 3}},
+            id="poskw_default_override_partial",
+        ),
+        pytest.param(
+            _defaults,
+            {"first": 10},
+            (),
+            {"args": [10], "kwargs": {"second": 2, "third": 3}},
+            id="poskw_default_preserved",
+        ),
+        # expected_extra_kws that are absent from data are ignored
+        pytest.param(
+            _nodefault,
             {"first": 2, "second": 2, "third": 3},
-            expected_extra_kws=("first", "second", "third"),
-        )
-        assert ret == {"args": [], "kwargs": {}}
+            ("fourth", "fifth"),
+            {"args": [2, 2, 3], "kwargs": {}},
+            id="poskw_req_expected_extra_kws_irrelevant",
+        ),
+        pytest.param(
+            _alldefault,
+            {"first": 2, "second": 2, "third": 3},
+            ("fourth", "fifth"),
+            {"args": [], "kwargs": {"first": 2, "second": 2, "third": 3}},
+            id="poskw_default_expected_extra_kws_irrelevant",
+        ),
+        # Extra data keys are packed into **kwargs
+        pytest.param(
+            _kwargs,
+            {"first": 2, "second": 2, "third": 3, "fourth": 4},
+            (),
+            {"args": [2], "kwargs": {"second": 2, "third": 3, "fourth": 4}},
+            id="kwargs_extra_kws_passed",
+        ),
+        # Extra data keys matching expected_extra_kws are excluded from **kwargs
+        pytest.param(
+            _kwargs,
+            {"first": 2, "second": 2, "third": 3, "fourth": 4},
+            ("fourth", "fifth"),
+            {"args": [2], "kwargs": {"second": 2, "third": 3}},
+            id="kwargs_expected_extra_kws_filtered",
+        ),
+        # Required keyword-only argument, remaining defaults materialized
+        pytest.param(
+            _kwonly_req,
+            {"first": 1, "third": 3},
+            (),
+            {"args": [1], "kwargs": {"second": None, "third": 3}},
+            id="poskw_req_and_default_preserved_kwonly_req",
+        ),
+        # expected_extra_kws don't shadow actual parameter names
+        pytest.param(
+            _kwonly_req,
+            {"first": 1, "third": 3},
+            ("second", "third"),
+            {"args": [1], "kwargs": {"second": None, "third": 3}},
+            id="expected_extra_kw_dont_shadow_params_poskw_kwonly",
+        ),
+        # Multiple required keyword-only arguments
+        pytest.param(
+            _kwonly_reqs,
+            {"first": 1, "third": 3, "fourth": 4},
+            (),
+            {
+                "args": [1],
+                "kwargs": {"second": None, "third": 3, "fourth": 4, "fifth": None},
+            },
+            id="kwonly_req_multi",
+        ),
+        # Required positional-only arguments are bound by name,
+        # but passed positionally
+        pytest.param(
+            _posonly,
+            {"first": 1, "second": 2, "third": 3},
+            (),
+            {"args": [1, 2, 3], "kwargs": {"fourth": 4}},
+            id="posonly_req_poskw_req_and_default_preserved",
+        ),
+        pytest.param(
+            _posonly,
+            {"first": 1, "second": 2, "third": 3},
+            ("first", "second"),
+            {"args": [1, 2, 3], "kwargs": {"fourth": 4}},
+            id="expected_extra_kw_dont_shadow_params_posonly",
+        ),
+        # Positional-only default is materialized positionally
+        pytest.param(
+            _posonly_default,
+            {"first": 1},
+            (),
+            {"args": [1, "two"], "kwargs": {"third": "three"}},
+            id="posonly_req_and_default_preserved_poskw_default_preserved",
+        ),
+        # Positional-only default overridden by name, passed positionally
+        pytest.param(
+            _posonly_default,
+            {"first": 1, "second": 22, "third": 33},
+            (),
+            {"args": [1, 22], "kwargs": {"third": 33}},
+            id="posonly_req_and_default_override_poskw_default_override",
+        ),
+        # Positional-only only: defaults never end up in kwargs
+        pytest.param(
+            _posonly_default_no_regular,
+            {"first": 1},
+            (),
+            {"args": [1, "two"], "kwargs": {}},
+            id="posonly_req_and_default_preserved",
+        ),
+        pytest.param(
+            _posonly_default_no_regular,
+            {"first": 1, "second": 22},
+            (),
+            {"args": [1, 22], "kwargs": {}},
+            id="posonly_req_and_default_override",
+        ),
+        # Keyword-only without positional parameters: defaults overridable
+        pytest.param(
+            _kwonly_no_pos,
+            {"second": 2, "third": 33},
+            (),
+            {"args": [], "kwargs": {"second": 2, "third": 33}},
+            id="kwonly_only_req_and_default_override",
+        ),
+        # ... and materialized when not supplied
+        pytest.param(
+            _kwonly_no_pos,
+            {"second": 2},
+            (),
+            {"args": [], "kwargs": {"second": 2, "third": "three"}},
+            id="kwonly_only_req_and_default_preserved",
+        ),
+        # Positional-only plus keyword-only, no positional-or-keyword ones
+        pytest.param(
+            _posonly_kwonly,
+            {"first": 1, "second": 2, "third": 33},
+            (),
+            {"args": [1], "kwargs": {"second": 2, "third": 33}},
+            id="posonly_req_kwonly_req_and_default_override",
+        ),
+        # All parameter kinds: extra data keys packed into **kwargs
+        pytest.param(
+            _all,
+            {
+                "first": 1,
+                "second": 2,
+                "fourth": 4,
+                "fifth": 5,
+                "seventh": 7,
+                "eighth": 8,
+                "ninth": 9,
+            },
+            (),
+            {
+                "args": [1, 2],
+                "kwargs": {
+                    "third": 3,
+                    "fourth": 4,
+                    "fifth": 5,
+                    "sixth": "6",
+                    "seventh": 7,
+                    "eighth": 8,
+                    "ninth": 9,
+                },
+            },
+            id="all_param_kinds_extra_kws_passed",
+        ),
+        # All parameter kinds with expected_extra_kws filtering
+        pytest.param(
+            _all,
+            {
+                "first": 1,
+                "second": 2,
+                "fourth": 4,
+                "fifth": 5,
+                "seventh": 7,
+                "eighth": 8,
+                "ninth": 9,
+            },
+            ("eighth",),
+            {
+                "args": [1, 2],
+                "kwargs": {
+                    "third": 3,
+                    "fourth": 4,
+                    "fifth": 5,
+                    "sixth": "6",
+                    "seventh": 7,
+                    "ninth": 9,
+                },
+            },
+            id="all_param_kinds_expected_extra_kws_filtered",
+        ),
+    ),
+)
+def test_format_call(fun, data, exp_extra, expected):
+    ret = salt.utils.args.format_call(fun, data, expected_extra_kws=exp_extra)
+    assert ret == expected
 
 
-def test_format_call_simple_args():
-    def foo(one, two=2, three=3):
-        pass
-
-    assert salt.utils.args.format_call(foo, dict(one=10, two=20, three=30)) == {
-        "args": [10],
-        "kwargs": dict(two=20, three=30),
-    }
-    assert salt.utils.args.format_call(foo, dict(one=10, two=20)) == {
-        "args": [10],
-        "kwargs": dict(two=20, three=3),
-    }
-    assert salt.utils.args.format_call(foo, dict(one=2)) == {
-        "args": [2],
-        "kwargs": dict(two=2, three=3),
-    }
-
-
-def test_format_call_mimic_typeerror_exceptions():
-    def foo(one, two=2, three=3):
-        pass
-
-    def foo2(one, two, three=3):
-        pass
-
-    with pytest.raises(SaltInvocationError) as exc:
-        salt.utils.args.format_call(foo, dict(two=3))
-    assert "foo takes at least 1 argument (0 given)" in str(exc)
-
-    with pytest.raises(SaltInvocationError) as exc:
-        salt.utils.args.format_call(foo2, dict(one=1))
-    assert "foo2 takes at least 2 arguments (1 given)" in str(exc)
+@pytest.mark.parametrize(
+    "func,args,ctx",
+    (
+        # Missing required positional-or-keyword argument (singular message)
+        pytest.param(
+            _defaults,
+            {"second": 3},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_defaults takes at least 1 argument \(0 given\). Missing: 'first'",
+            ),
+            id="posorkw_req_missing",
+        ),
+        # Missing required positional-or-keyword argument (plural message)
+        pytest.param(
+            _nodefault,
+            {"first": 1},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_nodefault takes at least 3 arguments \(1 given\). Missing: 'second', 'third'",
+            ),
+            id="posorkw_req_missing_multi",
+        ),
+        # Missing required positional-only argument counts as well
+        pytest.param(
+            _posonly,
+            {"second": 2, "third": 3},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_posonly takes at least 3 arguments \(2 given\). Missing: 'first'",
+            ),
+            id="posonly_posorkw_req_missing",
+        ),
+        # Unknown key in data without **kwargs to receive it (single)
+        pytest.param(
+            _alldefault,
+            {"first": 2, "seconds": 2, "third": 3},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"'seconds' is an invalid keyword argument for.*_alldefault",
+            ),
+            id="unknown_kwarg",
+        ),
+        # Unknown keys in data without **kwargs to receive them (multiple)
+        pytest.param(
+            _alldefault,
+            {"firsts": 2, "seconds": 2, "thirds": 3},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"'firsts', 'seconds' and 'thirds' are invalid keyword arguments for.*_alldefault",
+            ),
+            id="unknown_kwarg_multi",
+        ),
+        # Missing required keyword-only argument (singular message)
+        pytest.param(
+            _kwonly_req,
+            {"first": 1},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_kwonly_req missing 1 required keyword-only argument: 'third'",
+            ),
+            id="kwonly_req_missing",
+        ),
+        # Missing required keyword-only arguments (plural message)
+        pytest.param(
+            _kwonly_reqs,
+            {"first": 1},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_kwonly_reqs missing 2 required keyword-only arguments: 'third', 'fourth'",
+            ),
+            id="kwonly_req_missing_multi",
+        ),
+    ),
+)
+def test_format_call_exceptions(func, args, ctx):
+    with ctx:
+        salt.utils.args.format_call(func, args)
 
 
 def test_argspec_report():
-    def _test_spec(arg1, arg2, kwarg1=None):
-        pass
-
-    test_functions = {"test_module.test_spec": _test_spec}
+    test_functions = {"test_module.test_spec": _default}
     ret = salt.utils.args.argspec_report(test_functions, "test_module.test_spec")
     assert ret == {
         "test_module.test_spec": {
             "kwargs": None,
-            "args": ["arg1", "arg2", "kwarg1"],
-            "defaults": (None,),
+            "args": ["first", "second", "third"],
+            "defaults": ("3",),
             "varargs": None,
+            "posonlyargs": None,
+            "kwonlyargs": None,
+            "kwonlydefaults": None,
         }
     }
 

--- a/tests/pytests/unit/utils/test_functools.py
+++ b/tests/pytests/unit/utils/test_functools.py
@@ -1,0 +1,381 @@
+import logging
+
+import pytest
+
+import salt.utils.functools
+from salt.exceptions import SaltInvocationError
+from tests.pytests.unit.utils.test_args import (
+    _default,
+    _defaults,
+    _kwargs,
+    _kwonly,
+    _kwonly_reqs,
+    _nodefault,
+    _noparams,
+    _posonly,
+    _posonly_default,
+    _posonly_default_no_regular,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _varargs(first, second=None, *args):
+    return locals()
+
+
+def _posonly_args(first, /, second, third="three", *args):
+    return locals()
+
+
+def _posonly_kwargs(first, second="two", /, third="three", **kwargs):
+    return locals()
+
+
+@pytest.mark.parametrize("in_kwargs", (False, True))
+@pytest.mark.parametrize(
+    "fun,args,kwargs,expected",
+    (
+        pytest.param(_noparams, [], {}, {}, id="no_params"),
+        # Positional-or-keyword: positionally, by name, mixed
+        pytest.param(
+            _nodefault,
+            [1, 2, 3],
+            {},
+            {"first": 1, "second": 2, "third": 3},
+            id="posorkw_req_by_pos",
+        ),
+        pytest.param(
+            _nodefault,
+            [],
+            {"first": 1, "second": 2, "third": 3},
+            {"first": 1, "second": 2, "third": 3},
+            id="posorkw_req_by_name",
+        ),
+        pytest.param(
+            _nodefault,
+            [1, 2],
+            {"third": 3},
+            {"first": 1, "second": 2, "third": 3},
+            id="posorkw_req_by_mixed",
+        ),
+        # Defaults are applied, overridable positionally and by name
+        pytest.param(
+            _default,
+            [1, 2],
+            {},
+            {"first": 1, "second": 2, "third": "3"},
+            id="posorkw_default_preserved",
+        ),
+        pytest.param(
+            _default,
+            [1, 2, 4],
+            {},
+            {"first": 1, "second": 2, "third": 4},
+            id="posorkw_default_override_by_name",
+        ),
+        pytest.param(
+            _default,
+            [1, 2],
+            {"third": 4},
+            {"first": 1, "second": 2, "third": 4},
+            id="posorkw_default_override_by_pos",
+        ),
+        pytest.param(
+            _default,
+            [1],
+            {"second": 2, "third": 4},
+            {"first": 1, "second": 2, "third": 4},
+            id="posorkw_req_by_mixed_default_override_by_name",
+        ),
+        # The first dict specifying a named argument wins
+        pytest.param(
+            _default,
+            [1, 2, {"third": 31}, {"third": 32}],
+            {},
+            {"first": 1, "second": 2, "third": 31},
+            id="named_param_first_arg_dict_wins",
+        ),
+        # A single dict can specify multiple named arguments
+        pytest.param(
+            _default,
+            [{"first": 1, "second": 2, "third": 4}],
+            {},
+            {"first": 1, "second": 2, "third": 4},
+            id="single_dict_multiple_kw",
+        ),
+        # Excess positional arguments flow into *args
+        pytest.param(
+            _varargs,
+            [1, 2, 3, 4, 5],
+            {},
+            {"first": 1, "second": 2, "args": (3, 4, 5)},
+            id="variadic_positional",
+        ),
+        # Unknown named arguments flow into **kwargs
+        pytest.param(
+            _kwargs,
+            [1],
+            {"second": 2, "third": 3, "fourth": 4, "fifth": 5},
+            {"first": 1, "second": 2, "third": 3, "kwargs": {"fourth": 4, "fifth": 5}},
+            id="variadic_kw",
+        ),
+        # Positional-only, required passed positionally and optional by name
+        pytest.param(
+            _posonly,
+            [1],
+            {"second": 2, "third": 3},
+            {"first": 1, "second": 2, "third": 3, "fourth": 4},
+            id="posonly_req_by_pos_default_override_by_name",
+        ),
+        # Positional-only defaults are applied ...
+        pytest.param(
+            _posonly_default,
+            [1],
+            {},
+            {"first": 1, "second": "two", "third": "three"},
+            id="posonly_req_by_pos_default_preserved",
+        ),
+        # ... overridable positionally ...
+        pytest.param(
+            _posonly_default,
+            [1, 2, 3],
+            {},
+            {"first": 1, "second": 2, "third": 3},
+            id="posonly_req_by_pos_default_override_by_pos",
+        ),
+        # ... and by name, in which case they are still passed positionally
+        pytest.param(
+            _posonly_default,
+            [1],
+            {"second": 2, "third": 3},
+            {"first": 1, "second": 2, "third": 3},
+            id="posonly_req_by_pos_default_override_by_name",
+        ),
+        pytest.param(
+            _posonly_default_no_regular,
+            [1],
+            {"second": 22},
+            {"first": 1, "second": 22},
+            id="posonly_req_by_pos_default_override_by_name_no_poskw",
+        ),
+        pytest.param(
+            _posonly_default_no_regular,
+            [],
+            {"first": 1},
+            {"first": 1, "second": "two"},
+            id="posonly_req_by_name_default_preserved_no_poskw",
+        ),
+        pytest.param(
+            _posonly_default_no_regular,
+            [1, 2],
+            {},
+            {"first": 1, "second": 2},
+            id="posonly_req_by_pos_default_override_by_pos_no_poskw",
+        ),
+        # Positional-only combined with *args overflow
+        pytest.param(
+            _posonly_args,
+            [1, 2, 3, 4, 5, 6],
+            {},
+            {"first": 1, "second": 2, "third": 3, "args": (4, 5, 6)},
+            id="posonly_poskw_variadic_positional",
+        ),
+        # Everything by name, extras into **kwargs
+        pytest.param(
+            _posonly_kwargs,
+            [],
+            {"first": 1, "second": 2, "third": 3, "fourth": 4, "fifth": 5},
+            {"first": 1, "second": 2, "third": 3, "kwargs": {"fourth": 4, "fifth": 5}},
+            id="posonly_req_default_poskw_variadic_keyword",
+        ),
+        # A named argument for an already filled positional-only slot goes
+        # into **kwargs, mirroring Python calling conventions
+        pytest.param(
+            _posonly_kwargs,
+            [1],
+            {"first": 2},
+            {"first": 1, "second": "two", "third": "three", "kwargs": {"first": 2}},
+            id="posonly_req_by_pos_same_name_into_variadic_keyword",
+        ),
+        # Keyword-only arguments with *args/**kwargs present
+        pytest.param(
+            _kwonly,
+            [1, 2, 3],
+            {"second": 2, "third": 3, "fourth": 4},
+            {
+                "first": 1,
+                "second": 2,
+                "third": 3,
+                "args": (2, 3),
+                "kwargs": {"fourth": 4},
+            },
+            id="poskw_req_by_pos_variadic_positional_kwonly_req_variadic_keyword",
+        ),
+        pytest.param(
+            _kwonly,
+            [],
+            {"first": 1, "second": 2},
+            {"first": 1, "second": 2, "third": "three", "args": (), "kwargs": {}},
+            id="poskw_req_by_name_kwonly_req_no_variadic_args",
+        ),
+        # Keyword-only arguments on a function without **kwargs
+        pytest.param(
+            _kwonly_reqs,
+            [1],
+            {"third": 3, "fourth": 4},
+            {"first": 1, "second": None, "third": 3, "fourth": 4, "fifth": None},
+            id="poskw_req_by_name_default_preserved_kwonly_req_default_override",
+        ),
+    ),
+)
+def test_call_function(fun, args, kwargs, expected, in_kwargs):
+    if in_kwargs:
+        pass_args = args
+        pass_kwargs = kwargs
+    else:
+        pass_args = list(args) + list(dict((item,)) for item in kwargs.items())
+        pass_kwargs = {}
+    res = salt.utils.functools.call_function(fun, *pass_args, **pass_kwargs)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "fun,args,kwargs,expected",
+    (
+        # Kwargs to `call_function` override named arguments passed as dicts
+        pytest.param(
+            _defaults,
+            [{"first": 1}],
+            {"first": 11},
+            {"first": 11, "second": 2, "third": 3},
+            id="override_poskw",
+        ),
+        pytest.param(
+            _default,
+            [1, 2, {"third": 3}],
+            {"third": 4},
+            {"first": 1, "second": 2, "third": 4},
+            id="override_poskw_default",
+        ),
+        pytest.param(
+            _posonly_default,
+            [{"first": 1}],
+            {"first": 11},
+            {"first": 11, "second": "two", "third": "three"},
+            id="override_posonly",
+        ),
+        pytest.param(
+            _posonly_default,
+            [1, {"second": 2}],
+            {"second": 22},
+            {"first": 1, "second": 22, "third": "three"},
+            id="override_posonly_default",
+        ),
+        pytest.param(
+            _kwonly,
+            [1, {"second": 2}],
+            {"second": 22},
+            {"first": 1, "second": 22, "third": "three", "args": (), "kwargs": {}},
+            id="override_kwonly",
+        ),
+        pytest.param(
+            _kwonly,
+            [1, {"second": 2}, {"third": 3}],
+            {"third": 33},
+            {"first": 1, "second": 2, "third": 33, "args": (), "kwargs": {}},
+            id="override_kwonly_default",
+        ),
+    ),
+)
+def test_call_function_kwarg_overrides(fun, args, kwargs, expected):
+    res = salt.utils.functools.call_function(fun, *args, **kwargs)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "fun,args,kwargs,ctx",
+    (
+        # Too many positional arguments without *args to receive them
+        pytest.param(
+            _posonly,
+            (1, 2, 3, 4, 5, 6),
+            {},
+            pytest.raises(
+                SaltInvocationError, match=".*only takes 4 positional parameters, got 6"
+            ),
+            id="posonly_poskw_too_many_positional",
+        ),
+        # Missing required positional arguments
+        pytest.param(
+            _posonly,
+            (1,),
+            {},
+            pytest.raises(
+                SaltInvocationError, match="Missing arguments: second, third"
+            ),
+            id="posonly_req_poskw_req_missing",
+        ),
+        # Missing required keyword-only argument (singular message)
+        pytest.param(
+            _kwonly,
+            (1,),
+            {},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_kwonly missing 1 required keyword-only argument: 'second'",
+            ),
+            id="kwonly_missing",
+        ),
+        # Missing required keyword-only arguments (plural message)
+        pytest.param(
+            _kwonly_reqs,
+            (1,),
+            {},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_kwonly_reqs missing 2 required keyword-only arguments: 'third', 'fourth'",
+            ),
+            id="kwonly_missing_multi",
+        ),
+        # Positional-or-keyword argument passed both positionally and by name
+        pytest.param(
+            _posonly_kwargs,
+            (1, 2, 3),
+            {"first": "ends_up_in_kwargs", "third": "boom"},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_posonly_kwargs\(\) got multiple values for argument 'third'",
+            ),
+            id="poskw_duplicate_arguments",
+        ),
+        # Positional-only arg passed both positionally and by name, without **kwargs
+        pytest.param(
+            _posonly_default,
+            [1],
+            {"first": 2},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_posonly_default\(\) got multiple values for argument 'first'",
+            ),
+            id="posonly_duplicate_arguments",
+        ),
+        # Multiple duplicated arguments are reported together, without **kwargs
+        # to route the positional-only one into
+        pytest.param(
+            _posonly,
+            (1, 2, 3, 4),
+            {"first": 11, "third": 33, "fourth": 44},
+            pytest.raises(
+                SaltInvocationError,
+                match=r"_posonly\(\) got multiple values for arguments 'first', 'third', 'fourth'",
+            ),
+            id="posonly_and_poskw_duplicate_arguments_multi",
+        ),
+    ),
+)
+def test_call_function_exceptions(fun, args, kwargs, ctx):
+    with ctx:
+        salt.utils.functools.call_function(
+            fun, *args, *(dict((item,)) for item in kwargs.items())
+        )


### PR DESCRIPTION
### What does this PR do?
* Accounts for `__kwdefaults__` in `namespaced_function`/`alias_function`
* Accounts for positional-only and keyword-only parameters in `salt.utils.args.get_function_argspec`/`salt.utils.args.format_call`/`salt.utils.functools.call_function`/`salt.minion.load_args_and_kwargs`
* Fixes logic errors in `salt.utils.functools.call_function`

### What issues does this PR fix or reference?
Fixes: #69901
Fixes: #69906 
Fixes: #69919 

### Previous Behavior
* copying drops defaults for keyword-only arguments
* passing keyword-only args on the CLI, to states and in other contexts fails (3006)/required keyword-only params in functions that have pos-or-keyword params with defaults receive the defaults of the latter when called in contexts other than the CLI (3007+)
* `module.run`/the mine merges defaults of pos-or-kw into kwargs when the same param already has a positional arg, causing multiple values to be passed to a single param

### New Behavior
* copying retains the function signature as expected
* passing keyword-only args on the CLI, to states and in other contexts works as expected (3006)/when this is merged forward, required keyword-only params do not cause confusion regarding which param is required and which one should receive a default
* `module.run`/the mine do not merge defaults of params already receiving a positional argument into kwargs and the function call succeeds as expected

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes