### PR TITLE
Fix Element truth-value deprecation warnings in salt.utils.xmlutil

### DIFF
--- a/changelog/69903.fixed.md
+++ b/changelog/69903.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt.utils.xmlutil`` triggering a ``DeprecationWarning`` on every call by testing the truth value of ``xml.etree.ElementTree.Element`` objects directly instead of using ``len()``/``is not None`` checks. This affected ``salt.utils.aws.query()`` (used by the ``ec2`` cloud driver) and any other code parsing XML via ``salt.utils.xmlutil.to_dict()`` or ``change_xml()``.

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -29,7 +29,7 @@ def _to_dict(xmltree):
     """
     # If this object has no children, the for..loop below will return nothing
     # for it, so just return a single dict representing it.
-    if not xmltree:
+    if len(xmltree) == 0:
         name = _conv_name(xmltree.tag)
         return {name: xmltree.text}
 
@@ -38,7 +38,7 @@ def _to_dict(xmltree):
         name = _conv_name(item.tag)
 
         if name not in xmldict:
-            if item:
+            if len(item) > 0:
                 xmldict[name] = _to_dict(item)
             else:
                 xmldict[name] = item.text
@@ -61,7 +61,7 @@ def _to_full_dict(xmltree):
     for attrName, attrValue in xmltree.attrib.items():
         xmldict[attrName] = attrValue
 
-    if not xmltree:
+    if len(xmltree) == 0:
         if not xmldict:
             # If we don't have attributes, we should return the value as a string
             # ex: <entry>test</entry>
@@ -165,7 +165,7 @@ def clean_node(parent_map, node, ignored=None):
         len(node.attrib.keys() - (ignored or [])) == 0
         and not list(node)
         and not has_text
-        and parent
+        and parent is not None
     ):
         parent.remove(node)
         removed = True

--- a/tests/pytests/unit/utils/test_xmlutil.py
+++ b/tests/pytests/unit/utils/test_xmlutil.py
@@ -212,6 +212,28 @@ def test_change_xml_template_list(xml_doc):
     ]
 
 
+@pytest.mark.parametrize("attr", [False, True])
+def test_to_dict_does_not_trigger_element_truth_value_deprecation_warning(
+    xml_doc, attr, recwarn
+):
+    """
+    salt.utils.xmlutil.to_dict (and the clean_node helper used by change_xml)
+    used to test the truth value of ElementTree Element objects directly
+    (e.g. ``if not xmltree:``), which is deprecated: an Element's truth value
+    is based on whether it has children, which is confusing and slated to
+    change in a future Python release. See #69903.
+    """
+    xml.to_dict(xml_doc, attr)
+    xml.change_xml(xml_doc, {"name": None}, [{"path": "name", "xpath": "name"}])
+    deprecation_warnings = [
+        warning
+        for warning in recwarn.list
+        if issubclass(warning.category, DeprecationWarning)
+        and "truth value" in str(warning.message)
+    ]
+    assert not deprecation_warnings
+
+
 def test_strip_spaces():
     xml_str = """<domain>
             <name>test01</name>


### PR DESCRIPTION
## What does this PR do?

Fixes #69903.

`salt.utils.xmlutil._to_dict`, `_to_full_dict`, and `clean_node` tested the truth value of `xml.etree.ElementTree.Element` objects directly (e.g. `if not xmltree:`, `if item:`, `if ... and parent:`). An `Element`'s truth value is defined by whether it has children, which Python deprecates in favor of explicit `len(elem)`/`elem is not None` checks, emitting:

```
DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
```

`salt.utils.aws.query()` calls `xmlutil.to_dict()` on essentially every AWS API response, so this fires on every single AWS API call made through the `ec2` cloud driver (recently extracted to [saltext-cloud](https://github.com/salt-extensions/saltext-cloud)), and anywhere else parsing XML via this module (e.g. the virt module's `change_xml`).

This is the same class of issue as #56475 (`getchildren()` deprecation in the same file), which addressed iteration but missed truth-value testing.

## What issues does this PR fix or reference?

Fixes #69903
Related to #56475

## Previous Behavior

`salt.utils.xmlutil.to_dict()`/`change_xml()` emit `DeprecationWarning: Testing an element's truth value...` on every call.

## New Behavior

No warning is emitted; behavior of `to_dict()`/`change_xml()` is unchanged (verified against all existing `to_dict` test cases in both old- and new-style test suites, plus a new regression test asserting no such warning is raised).
