### PR TITLE
ci: add name to release artifact list step for readability

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -31,7 +31,8 @@ jobs:
           name: ${{ inputs.name }}
           path: artifacts
       - run: find artifacts -maxdepth 1 -type f -printf '%f\n'
-      - id: list-files
+      - name: Build artifact file matrix
+        id: list-files
         run: |
           if [ "${{ inputs.pattern }}" != "" ]; then
             echo files="$(find artifacts -maxdepth 1 -type f -name '${{ inputs.pattern }}' -printf '%f\n' | jq -Rnc '[inputs | { file: "\(.)" }]')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

In `.github/workflows/release-artifact.yml`, the `list-files` step is an unnamed `run` block longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when building the upload matrix.

## Changes

Semantics are unchanged: same `id: list-files`, same `files` output, and the same job output wiring used by `upload-files`.

- Add `name: Build artifact file matrix` to the existing `list-files` step

## Test plan
- [ ] Confirm `list-files.outputs.files` still comes from `steps.list-files.outputs.files`
- [ ] Confirm the find/jq matrix script is unchanged
