### PR TITLE
Restore mtime-based eviction on get_rsa_key

### DIFF
--- a/changelog/69941.fixed.md
+++ b/changelog/69941.fixed.md
@@ -1,0 +1,2 @@
+Restore mtime-based cache eviction on ``salt.crypt.get_rsa_key`` so a rotated
+private key on disk is reloaded without requiring a process restart.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -479,12 +479,30 @@ class PublicKeyString(PublicKey):
 
 
 @salt.utils.decorators.memoize
-def get_rsa_key(path, passphrase):
+def _get_key_with_evict(path, timestamp, passphrase):
     """
-    Read a private key off the disk. we memoize the constructed private key
-    based on the input args.
+    Load a private key from disk. ``timestamp`` is intended to be the
+    timestamp of the file's last modification. This function is memoized so
+    that when it is called with the same ``(path, timestamp, passphrase)``
+    tuple a second time the result is returned from the memoization. When the
+    file on disk is modified its mtime changes, the memoize key differs, and
+    the private key is re-loaded from disk.
     """
     return PrivateKey.from_file(path, passphrase).key
+
+
+def get_rsa_key(path, passphrase):
+    """
+    Read a private key off the disk. Poor man's simple cache in effect here,
+    we memoize the result of calling :func:`_get_key_with_evict`. This means
+    the first time :func:`_get_key_with_evict` is called with a path and a
+    timestamp the result is cached. If the file (the private key) does not
+    change then its timestamp will not change and the next time the result is
+    returned from the cache. If the key DOES change on disk, the next call
+    has different parameters and the function runs fully to retrieve the key
+    from disk.
+    """
+    return _get_key_with_evict(path, str(os.path.getmtime(path)), passphrase)
 
 
 def get_rsa_pub_key(path):

--- a/tests/pytests/unit/crypt/test_crypt_cryptography.py
+++ b/tests/pytests/unit/crypt/test_crypt_cryptography.py
@@ -1,11 +1,13 @@
 import hashlib
 import hmac
 import os
+import time
 from pathlib import Path
 
 import pytest
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
 
 import salt.config
 import salt.crypt as crypt
@@ -339,6 +341,67 @@ def test_loading_encrypted_openssl_format(openssl_encrypted_key, passphrase, tmp
         # rust layer.
         except BaseException as exc:  # pylint: disable=broad-except
             pytest.fail(f"Unexpected exception: {exc}")
+
+
+def _write_priv_pem(path):
+    key = _rsa.generate_private_key(65537, 2048)
+    path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+
+def _pub_bytes(priv):
+    return priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def test_get_rsa_key_evicts_on_mtime_change(tmp_path):
+    """
+    get_rsa_key must return the current key material after the file is
+    rewritten on disk. Regression: after the server-side PKI refactor
+    (PR #67799) the mtime was dropped from the memoize key so a rotated
+    private key was not reloaded until the process restarted.
+    """
+    keypath = tmp_path / "minion.pem"
+    _write_priv_pem(keypath)
+
+    k1 = salt.crypt.get_rsa_key(str(keypath), None)
+    pub1 = _pub_bytes(k1)
+
+    # Rotate the key on disk with new material and bump mtime past the
+    # 1-second filesystem resolution.
+    time.sleep(1.1)
+    _write_priv_pem(keypath)
+    now = time.time() + 2
+    os.utime(keypath, (now, now))
+
+    k2 = salt.crypt.get_rsa_key(str(keypath), None)
+    pub2 = _pub_bytes(k2)
+
+    on_disk = serialization.load_pem_private_key(keypath.read_bytes(), None)
+    pub_disk = _pub_bytes(on_disk)
+
+    assert pub_disk != pub1, "test setup: rewrite failed to produce a new key"
+    assert pub2 == pub_disk, "get_rsa_key returned a stale cached key"
+
+
+def test_get_rsa_key_uses_cache_without_mtime_change(tmp_path):
+    """
+    Without an mtime change the memoize should still short-circuit and
+    return the same in-memory key object.
+    """
+    keypath = tmp_path / "minion.pem"
+    _write_priv_pem(keypath)
+
+    k1 = salt.crypt.get_rsa_key(str(keypath), None)
+    k2 = salt.crypt.get_rsa_key(str(keypath), None)
+    assert k1 is k2
 
 
 @pytest.mark.skipif(not FIPS_TESTRUN, reason="Only valid when in FIPS mode")


### PR DESCRIPTION
## Summary

- Restore mtime-based cache eviction on `salt.crypt.get_rsa_key` so a rotated private key on disk is picked up without a process restart.
- Reintroduce the `_get_key_with_evict(path, timestamp, passphrase)` helper (memoized) and thread `str(os.path.getmtime(path))` through as the eviction key from `get_rsa_key`.
- Restore the eviction-semantics docstring from 3006.x, adapted to the 3008.x class layout that loads via `PrivateKey.from_file`.
- Add two regression tests: one that rotates the key on disk and asserts the new material is returned, and one that confirms the memoize still short-circuits when nothing changed.

## Investigation notes

The eviction was dropped as an incidental change in the server-side PKI refactor merged as #67799 ("new feature: refactor server-side PKI") by @mattp-, specifically follow-up commit `ce9308f126f` ("migrate remaining master side pki to cache"). That refactor moved the disk-load logic into `PrivateKey.from_file` and simplified the outer function to:

```python
@salt.utils.decorators.memoize
def get_rsa_key(path, passphrase):
    return PrivateKey.from_file(path, passphrase).key
```

The `@salt.utils.decorators.memoize` decorator is a plain str-keyed dict cache (see `salt/utils/decorators/__init__.py::memoize`) with no built-in mtime handling. Before the refactor, an inner `_get_key_with_evict(path, timestamp, passphrase)` was the memoized function and `get_rsa_key` supplied `str(os.path.getmtime(path))` as the eviction argument, so a rotated key file (new mtime) produced a different memoize key and the cached entry was bypassed. Collapsing to a single decorated function dropped that eviction semantic.

The mtime pattern still exists in `_auth_singleton_key` at `salt/crypt.py:893` for the `AsyncAuth` instance singleton cache, but that is a separate cache and does not compensate for the `get_rsa_key` regression.

This PR restores the original two-layer pattern with the newer `PrivateKey.from_file` loader inside the helper. It is intentionally the minimal restoration: no changes to `get_rsa_pub_key`, `PublicKey.decrypt`, or `PrivateKey.encrypt` caching.

## Test plan

- [x] `pytest tests/pytests/unit/crypt/` clean locally (31 passed, 5 FIPS-only skipped)
- [x] New `test_get_rsa_key_evicts_on_mtime_change` fails on unpatched 3008.x, passes with fix
- [x] `pre-commit run --files salt/crypt.py tests/pytests/unit/crypt/test_crypt_cryptography.py changelog/69941.fixed.md` clean
- [ ] Full CI green

Fixes #69941
