### PR TITLE
Label y-axis units on stress-test CPU and inode panels

### DIFF
--- a/tests/monitoring/render_panels.py
+++ b/tests/monitoring/render_panels.py
@@ -122,6 +122,14 @@ def _bytes_unit(unit_hint: str) -> bool:
     return unit_hint.lower() in ("bytes", "decbytes", "kbytes", "mbytes", "gbytes")
 
 
+def _is_percentunit(unit_hint: str) -> bool:
+    return unit_hint.lower() == "percentunit"
+
+
+def _is_count_unit(unit_hint: str) -> bool:
+    return unit_hint.lower() == "short"
+
+
 def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     """Return a matplotlib Figure for ``panel``, or ``None`` if no series."""
     targets = panel.get("targets") or []
@@ -130,6 +138,8 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
 
     unit_hint = panel.get("fieldConfig", {}).get("defaults", {}).get("unit") or ""
     is_bytes = _bytes_unit(unit_hint)
+    is_percentunit = _is_percentunit(unit_hint)
+    is_count = _is_count_unit(unit_hint)
 
     fig, ax = plt.subplots(figsize=(11, 4))
     series_count = 0
@@ -165,6 +175,14 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     ax.set_title(panel.get("title") or "panel", fontsize=11)
     if is_bytes:
         ax.set_ylabel("MB")
+    elif is_percentunit:
+        # Grafana's percentunit is a 0-1 ratio (1.0 == 1 CPU core, not 1% of
+        # the host); rate(container_cpu_usage_seconds_total[...]) values here
+        # are already in that ratio, so label explicitly to avoid confusing
+        # "1.2" with "1.2% of the host" instead of 1.2 CPU cores.
+        ax.set_ylabel("CPU cores (1.0 = 1 core)")
+    elif is_count:
+        ax.set_ylabel("count")
     ax.xaxis.set_major_formatter(DateFormatter("%H:%M"))
     ax.tick_params(axis="x", rotation=30, labelsize=8)
     ax.tick_params(axis="y", labelsize=8)


### PR DESCRIPTION
## What does this PR do

Fixes #69944.

Adds explicit y-axis labels for the two panel unit types in `tests/monitoring/render_panels.py` that were previously unlabeled:

- **CPU Usage panels** (Master, Minion 1-3, API) use Grafana's `percentunit` (a 0-1 ratio where `1.0` == 1 full CPU core), matching `rate(container_cpu_usage_seconds_total[...])` from cAdvisor. Without a label, a value like `1.2` is easy to misread as "1.2% of the host" instead of 1.2 CPU cores.
- **Minion Inodes (Disk Files) panels** use Grafana's `short` unit (a plain count from `inodes_total - inodes_free`) and also had no y-axis label.

This follows the exact same pattern the file already uses for byte-family units (`ax.set_ylabel("MB")`), just extended to the other two unit types actually present in `salt_monitoring.json`.

## What issues does this PR fix or reference

Fixes #69944

## Merge requirements satisfied

* [x] New/modified test cases in this PR are consistent with existing test coverage. This is a CI-tooling script (renders diagnostic PNGs for the nightly stress test dashboard), not covered by Salt's own test suite; verified manually against the checked-in `salt_monitoring.json` unit definitions (`percentunit` for the CPU panels, `short` for the inode panels).

If your PR is still in progress please convert it to a draft PR.