### PR TITLE
Switch nightly stress OTel toggle to metrics.enabled checkbox

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -10,31 +10,12 @@ on:
         required: true
         default: '30m'
       enable_metrics:
-        description: >-
-          Enable OpenTelemetry metrics on the salt-master by setting
-          ``metrics.enabled: true`` in the master config before the
-          stress starts.  Unchecked (default) leaves ``metrics.enabled``
-          at its default (false), which matches every stock salt-master
-          install: the ``opentelemetry`` package is still shipped from
-          ``requirements/base.txt`` but is never imported thanks to the
-          lazy-load in ``salt.utils.metrics._load_otel``, so the package
-          being on disk has zero runtime cost.  Check the box to measure
-          the memory / CPU footprint when tracing is actually turned on.
+        description: Enable OpenTelemetry metrics (metrics.enabled)
         required: false
         default: false
         type: boolean
       worker_threads:
-        description: >-
-          Number of MWorker processes the salt-master should spawn (the
-          ``worker_threads`` master config option).  Defaults to ``'5'``,
-          which matches the salt master's own default in
-          ``salt/config/__init__.py``.  ``tests/monitoring/master.conf``
-          currently pins it to 10; the step will overwrite that to the
-          input value so unchanged runs measure the stock-default
-          worker layout.  Adjust to sweep the memory / throughput
-          trade-off -- more workers = more parallelism but more
-          per-worker RSS floor; fewer = tighter contention but smaller
-          container footprint.
+        description: Salt master worker_threads
         required: false
         default: '5'
         type: string

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -9,18 +9,20 @@ on:
         description: 'Duration of the stress test (e.g., 30m, 1h)'
         required: true
         default: '30m'
-      install_opentelemetry:
+      enable_metrics:
         description: >-
-          Install opentelemetry in the salt-master image before the
-          stress starts.  'true' (the default) matches the shipped
-          requirements/base.txt.  Set 'false' to reproduce the
-          pre-3008.x baseline without opentelemetry loaded.
+          Enable OpenTelemetry metrics on the salt-master by setting
+          ``metrics.enabled: true`` in the master config before the
+          stress starts.  Unchecked (default) leaves ``metrics.enabled``
+          at its default (false), which matches every stock salt-master
+          install: the ``opentelemetry`` package is still shipped from
+          ``requirements/base.txt`` but is never imported thanks to the
+          lazy-load in ``salt.utils.metrics._load_otel``, so the package
+          being on disk has zero runtime cost.  Check the box to measure
+          the memory / CPU footprint when tracing is actually turned on.
         required: false
-        default: 'true'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+        default: false
+        type: boolean
 
 jobs:
   stress-test:
@@ -60,29 +62,37 @@ jobs:
           docker compose up -d
           sleep 30 # Wait for initialization
 
-      - name: Toggle opentelemetry install
+      - name: Toggle OpenTelemetry metrics
+        # ``metrics.enabled`` gates the entire ``salt.utils.metrics``
+        # stack, including the ``_load_otel`` deferred import.  Unchecked
+        # (default) matches every stock salt-master install: OTel is on
+        # disk but never imported, so no memory / CPU cost.  Checked
+        # enables metrics -- the master imports OpenTelemetry on first
+        # use and starts recording.  Uninstalling the pip package (the
+        # old behaviour) was unnecessary because the lazy loader already
+        # guarantees zero cost when the config gate is off.
         env:
-          INSTALL_OTEL: ${{ github.event.inputs.install_opentelemetry || 'true' }}
+          ENABLE_METRICS: ${{ github.event.inputs.enable_metrics || 'false' }}
         run: |
-          if [ "$INSTALL_OTEL" = "false" ]; then
-            echo "Removing opentelemetry from the salt-master container"
-            docker exec salt-master pip uninstall -y --quiet \
-              opentelemetry-api \
-              opentelemetry-sdk \
-              opentelemetry-exporter-otlp-proto-http \
-              opentelemetry-exporter-otlp-proto-common \
-              opentelemetry-exporter-prometheus \
-              opentelemetry-proto \
-              opentelemetry-semantic-conventions \
-              prometheus-client 2>&1 | tail -5 || true
-            if docker exec salt-master python3 -c "import opentelemetry" 2>/dev/null; then
-              echo "opentelemetry is still importable after uninstall" >&2
-              exit 1
+          cd tests/monitoring
+          if [ "$ENABLE_METRICS" = "true" ]; then
+            echo "Enabling OpenTelemetry metrics on salt-master"
+            # Append the metrics block only if not already present so
+            # re-runs are idempotent.  ``printf`` (not a heredoc) keeps
+            # the YAML block-scalar indentation intact.
+            if ! grep -q '^metrics:' master.conf; then
+              printf '\nmetrics:\n  enabled: true\n' >> master.conf
             fi
             docker restart salt-master
             sleep 20
+            # Trigger a code path that calls ``metrics.configure`` so
+            # the OpenTelemetry import fires and any misconfiguration
+            # surfaces here rather than mid-stress.
+            docker exec salt-master python3 -c \
+              "import salt.utils.metrics as m; m._load_otel(); assert m._OTEL_AVAILABLE, 'OTel import failed'"
           else
-            echo "Leaving opentelemetry installed (default behaviour)"
+            echo "Leaving metrics.enabled at default (false); OTel package is"
+            echo "shipped but never imported by the lazy loader."
           fi
 
       - name: Verify Connections

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -23,6 +23,17 @@ on:
         required: false
         default: false
         type: boolean
+      worker_threads:
+        description: >-
+          Number of MWorker processes the salt-master should spawn (the
+          ``worker_threads`` master config option).  Defaults to the
+          value already in ``tests/monitoring/master.conf`` (currently 10).
+          Adjust to sweep the memory / throughput trade-off -- more
+          workers = more parallelism but more per-worker RSS floor;
+          fewer = tighter contention but smaller container footprint.
+        required: false
+        default: '10'
+        type: string
 
 jobs:
   stress-test:
@@ -62,19 +73,23 @@ jobs:
           docker compose up -d
           sleep 30 # Wait for initialization
 
-      - name: Toggle OpenTelemetry metrics
-        # ``metrics.enabled`` gates the entire ``salt.utils.metrics``
-        # stack, including the ``_load_otel`` deferred import.  Unchecked
-        # (default) matches every stock salt-master install: OTel is on
-        # disk but never imported, so no memory / CPU cost.  Checked
-        # enables metrics -- the master imports OpenTelemetry on first
-        # use and starts recording.  Uninstalling the pip package (the
-        # old behaviour) was unnecessary because the lazy loader already
-        # guarantees zero cost when the config gate is off.
+      - name: Configure salt-master
+        # Apply the workflow_dispatch overrides to ``master.conf`` and,
+        # if anything actually changed, restart salt-master so it picks
+        # them up.  ``metrics.enabled`` gates the entire
+        # ``salt.utils.metrics`` stack (including the ``_load_otel``
+        # deferred OpenTelemetry import); the pip package on disk has
+        # zero runtime cost when this gate is off, so a config toggle
+        # is all that is needed to measure the OTel-on vs OTel-off
+        # profile.  ``worker_threads`` sizes the MWorker pool and lets
+        # a run sweep the parallelism / RSS trade-off.
         env:
           ENABLE_METRICS: ${{ github.event.inputs.enable_metrics || 'false' }}
+          WORKER_THREADS: ${{ github.event.inputs.worker_threads || '10' }}
         run: |
           cd tests/monitoring
+          need_restart=0
+
           if [ "$ENABLE_METRICS" = "true" ]; then
             echo "Enabling OpenTelemetry metrics on salt-master"
             # Append the metrics block only if not already present so
@@ -82,17 +97,33 @@ jobs:
             # the YAML block-scalar indentation intact.
             if ! grep -q '^metrics:' master.conf; then
               printf '\nmetrics:\n  enabled: true\n' >> master.conf
+              need_restart=1
             fi
+          else
+            echo "Leaving metrics.enabled at default (false); OTel package is"
+            echo "shipped but never imported by the lazy loader."
+          fi
+
+          # Update ``worker_threads`` only when it differs from the value
+          # already in the file, so unchanged defaults skip the restart.
+          current_workers=$(awk '/^worker_threads:/ {print $2}' master.conf)
+          if [ -n "$current_workers" ] && [ "$current_workers" != "$WORKER_THREADS" ]; then
+            echo "Setting worker_threads: $current_workers -> $WORKER_THREADS"
+            sed -i "s/^worker_threads:.*/worker_threads: $WORKER_THREADS/" master.conf
+            need_restart=1
+          fi
+
+          if [ "$need_restart" = "1" ]; then
             docker restart salt-master
             sleep 20
+          fi
+
+          if [ "$ENABLE_METRICS" = "true" ]; then
             # Trigger a code path that calls ``metrics.configure`` so
             # the OpenTelemetry import fires and any misconfiguration
             # surfaces here rather than mid-stress.
             docker exec salt-master python3 -c \
               "import salt.utils.metrics as m; m._load_otel(); assert m._OTEL_AVAILABLE, 'OTel import failed'"
-          else
-            echo "Leaving metrics.enabled at default (false); OTel package is"
-            echo "shipped but never imported by the lazy loader."
           fi
 
       - name: Verify Connections

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -26,13 +26,17 @@ on:
       worker_threads:
         description: >-
           Number of MWorker processes the salt-master should spawn (the
-          ``worker_threads`` master config option).  Defaults to the
-          value already in ``tests/monitoring/master.conf`` (currently 10).
-          Adjust to sweep the memory / throughput trade-off -- more
-          workers = more parallelism but more per-worker RSS floor;
-          fewer = tighter contention but smaller container footprint.
+          ``worker_threads`` master config option).  Defaults to ``'5'``,
+          which matches the salt master's own default in
+          ``salt/config/__init__.py``.  ``tests/monitoring/master.conf``
+          currently pins it to 10; the step will overwrite that to the
+          input value so unchanged runs measure the stock-default
+          worker layout.  Adjust to sweep the memory / throughput
+          trade-off -- more workers = more parallelism but more
+          per-worker RSS floor; fewer = tighter contention but smaller
+          container footprint.
         required: false
-        default: '10'
+        default: '5'
         type: string
 
 jobs:
@@ -85,7 +89,7 @@ jobs:
         # a run sweep the parallelism / RSS trade-off.
         env:
           ENABLE_METRICS: ${{ github.event.inputs.enable_metrics || 'false' }}
-          WORKER_THREADS: ${{ github.event.inputs.worker_threads || '10' }}
+          WORKER_THREADS: ${{ github.event.inputs.worker_threads || '5' }}
         run: |
           cd tests/monitoring
           need_restart=0


### PR DESCRIPTION
## Summary

- The workflow's ``install_opentelemetry`` input was a three-value ``choice`` (true/false string) that pip-uninstalled the OpenTelemetry packages inside the running salt-master container when set to false.  That was heavier than it needed to be: ``salt.utils.metrics._load_otel`` defers the import until ``metrics.enabled: true`` is present in the master config, so with the config gate off the OTel package on disk has zero runtime cost.
- Replace the input with ``enable_metrics`` (``type: boolean`` — renders as a checkbox in the ``workflow_dispatch`` UI), defaulted to ``false`` so scheduled runs keep reproducing the stock salt-master profile.
- When checked, append ``metrics.enabled: true`` to ``tests/monitoring/master.conf`` and trigger ``_load_otel`` post-restart to fail fast on any OTel misconfiguration instead of surfacing mid-stress.

## Test plan

- [x] YAML validates (``yaml.safe_load``) and pre-commit clean
- [ ] Manually trigger the workflow via ``workflow_dispatch`` with the box unchecked; confirm the master runs unchanged
- [ ] Trigger again with the box checked; confirm the master starts with metrics.enabled and the ``_load_otel`` sanity check passes