### PR TITLE
Fix OptsDict.__len__ to honor ancestor-chain deletions

### DIFF
--- a/salt/utils/optsdict.py
+++ b/salt/utils/optsdict.py
@@ -694,27 +694,19 @@ class OptsDict(dict):
 
     def __len__(self) -> int:
         """
-        Return total number of keys, honoring ``_DELETED`` markers anywhere
-        in the parent chain.
+        Return the number of live keys visible from this node.
 
-        ``len()`` was previously implemented as ``iter(self)`` +
-        ``dict.__len__(self)``, which walked the entire parent chain,
-        allocated a fresh ``items`` dict holding every key/value pair,
-        cleared the underlying dict, and re-inserted every entry -- all
-        just to return the count.  Under salt-api stress that produced
-        ~1 MB of transient allocation per call.  ``len()`` never needs
-        the underlying-dict sync that ``__iter__`` performs (Python's
-        ``len()`` slot dispatches through this override, not through
-        the underlying dict).
+        A key is live when the closest layer that defines it (``self._local``,
+        then each ancestor's ``_local``, then the root ``_base``) does not
+        mark it ``_DELETED``.  ``_get_all_keys`` yields the union of every
+        name reachable through the parent chain; ``key in self`` applies the
+        deletion-aware lookup, so a key deleted at any level -- including an
+        intermediate ancestor whose ``_DELETED`` sentinel never appears in
+        ``self._local`` -- is correctly excluded from the count.
 
-        The first cut of this optimization subtracted only ``_DELETED``
-        markers found in ``self._local``, which was incorrect: a key
-        deleted in an intermediate ancestor (say a parent between the
-        current node and the root ``_base``) was still counted because
-        the deletion marker never appears in ``self._local``.  Match
-        ``__contains__`` semantics instead -- it already walks the
-        parent chain in the correct order and returns ``False`` for
-        any key whose closest layer marks it deleted.
+        The count is computed without materialising a fresh ``items`` dict
+        or triggering the underlying-dict sync that ``__iter__`` performs;
+        Python's ``len()`` slot dispatches directly through this override.
         """
         with self._ensure_lock():
             return sum(1 for key in self._get_all_keys() if key in self)

--- a/salt/utils/optsdict.py
+++ b/salt/utils/optsdict.py
@@ -694,22 +694,30 @@ class OptsDict(dict):
 
     def __len__(self) -> int:
         """
-        Return total number of keys, excluding those deleted locally.
+        Return total number of keys, honoring ``_DELETED`` markers anywhere
+        in the parent chain.
 
-        The previous implementation called ``iter(self)``, which walked the
-        entire parent chain, allocated a fresh ``items`` dict holding every
-        key/value pair, cleared the underlying dict, and re-inserted every
-        entry -- all just to return ``dict.__len__(self)``.  Under
-        salt-api stress that produced ~1 MB of transient allocation per
-        call.  ``len()`` never needs the underlying-dict sync that
-        ``__iter__`` performs (Python's ``len()`` slot dispatches through
-        this override, not through the underlying dict), so count via the
-        cheap key set and subtract locally-deleted keys.
+        ``len()`` was previously implemented as ``iter(self)`` +
+        ``dict.__len__(self)``, which walked the entire parent chain,
+        allocated a fresh ``items`` dict holding every key/value pair,
+        cleared the underlying dict, and re-inserted every entry -- all
+        just to return the count.  Under salt-api stress that produced
+        ~1 MB of transient allocation per call.  ``len()`` never needs
+        the underlying-dict sync that ``__iter__`` performs (Python's
+        ``len()`` slot dispatches through this override, not through
+        the underlying dict).
+
+        The first cut of this optimization subtracted only ``_DELETED``
+        markers found in ``self._local``, which was incorrect: a key
+        deleted in an intermediate ancestor (say a parent between the
+        current node and the root ``_base``) was still counted because
+        the deletion marker never appears in ``self._local``.  Match
+        ``__contains__`` semantics instead -- it already walks the
+        parent chain in the correct order and returns ``False`` for
+        any key whose closest layer marks it deleted.
         """
         with self._ensure_lock():
-            return len(self._get_all_keys()) - sum(
-                1 for v in self._local.values() if v is _DELETED
-            )
+            return sum(1 for key in self._get_all_keys() if key in self)
 
     def __contains__(self, key: str) -> bool:
         """Check if key exists in local, parent chain, or base (excluding deleted keys)."""

--- a/tests/pytests/unit/utils/test_optsdict.py
+++ b/tests/pytests/unit/utils/test_optsdict.py
@@ -201,6 +201,23 @@ class TestOptsDictBasics:
         assert len(root) == 3
         assert set(iter(child)) == {"b", "c", "d"}
 
+    def test_len_excludes_key_deleted_in_ancestor(self):
+        """A key deleted in an ancestor (not in self) must not count.
+
+        Regression test for the bug in the first cut of the
+        ``__len__`` rewrite (#69939): counting only ``_DELETED``
+        markers in ``self._local`` missed markers on intermediate
+        parents.  Reported by @charzl on the PR review.
+        """
+        grandparent = OptsDict.from_dict({"a": 1, "b": 2, "c": 3}, name="grandparent")
+        parent = OptsDict.from_parent(grandparent, name="parent")
+        del parent["b"]
+
+        child = OptsDict.from_parent(parent, name="child")
+
+        assert "b" not in child
+        assert len(child) == 2
+
     def test_len_after_delete_of_local_only_key(self):
         """Deleting a key that lives only in ``_local`` truly removes it and
         does not leave a ``_DELETED`` sentinel to skew the count."""


### PR DESCRIPTION
## Summary

- Regression from #69939.  The first cut of the ``__len__`` optimization subtracted only ``_DELETED`` sentinels found in ``self._local`` — which misses the case where a key was deleted in an intermediate ancestor (grandparent has the key, parent deletes it, child inherits: ``__contains__`` says the key is absent, but ``__len__`` still counted it).
- Route ``__len__`` through ``__contains__``, which already walks the parent chain in the correct order (closest layer wins).  Lock is ``RLock`` so reentrance is safe.
- Regression test added, credit to @charzl on the #69939 review for spotting and providing the reproducer.

Fixes #69947

## Test plan

- [x] ``pytest tests/pytests/unit/utils/test_optsdict.py`` — 62 passed (61 pre-existing + 1 new regression)
- [x] Confirmed the reproducer FAILS on the pre-fix (merged) 3008.x head — returns ``len(child) == 3`` — and passes with this diff
- [ ] CI green