### PR TITLE
Allow libyaml-linked PyYAML wheel in Linux onedir builds

### DIFF
--- a/changelog/69907.fixed.md
+++ b/changelog/69907.fixed.md
@@ -1,0 +1,5 @@
+Include PyYAML manylinux wheel in Linux onedir builds so ``yaml.CSafeLoader``
+(and the libyaml-backed emitter) are available. Previously the ``--no-binary=:all:``
+pip invocation forced a PyYAML source build under the relenv toolchain, which
+lacks libyaml headers; PyYAML silently fell back to the pure-Python parser,
+significantly slowing config, pillar, and state parsing on large deployments.

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -699,8 +699,16 @@ def onedir_dependencies(
         env["RELENV_BUILDENV"] = "1"
         python_bin = env_scripts_dir / "python3"
         install_args.append("--no-binary=:all:")
+        # PyYAML's source build silently falls back to the pure-Python parser
+        # when libyaml headers are absent, and the relenv toolchain does not
+        # ship libyaml. That produces an onedir where yaml.CSafeLoader is
+        # missing, which makes salt fall back to the pure-Python SafeLoader
+        # and can slow config/pillar/state parsing by an order of magnitude
+        # on large deployments. The upstream PyYAML manylinux2014 wheel
+        # bundles libyaml (MIT-licensed) and is compatible with the relenv
+        # target platform, so allow it through --no-binary=:all: here.
         install_args.append(
-            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja,protobuf"
+            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja,protobuf,pyyaml"
         )
         # CMake 4.x removed support for cmake_minimum_required(VERSION < 3.5).
         # pyzmq's bundled libzmq still declares an older floor; set the policy


### PR DESCRIPTION
## What does this PR do?

Adds `pyyaml` to the `--only-binary` allow-list for Linux onedir builds so pip installs PyYAML's manylinux2014 wheel (which bundles libyaml) instead of source-building it under the relenv toolchain.

## Why

The Linux onedir build passes `--no-binary=:all:` to pip so every runtime dependency is compiled against the relenv toolchain. PyYAML's `setup.py` autodetects libyaml at compile time; because the relenv toolchain does not build or ship libyaml, the source build silently falls back to a pure-Python parser and the resulting onedir has no `yaml.CSafeLoader` and no `_yaml*.so` extension.

Salt's `yamlloader` uses `getattr(yaml, "CSafeLoader", yaml.SafeLoader)` so it does not crash, but every YAML load (configs, pillars, states, returners, mine, event bus) runs through the pure-Python parser, which is 10-20x slower. Users with segmented configs (many small pillar/state files) have reported `salt-run salt.cmd test.ping` taking ~20s where a libyaml-linked build completes in well under a second.

## Reproduction

On any current 3006.27 or 3008.1 onedir install:

```
/opt/saltstack/salt/bin/python3 -c "import yaml; print(hasattr(yaml, 'CSafeLoader'))"
False
```

The reporter's workaround is:

```
/opt/saltstack/salt/bin/python3 -m pip install --force-reinstall --no-deps --only-binary :all: PyYAML==6.0.3
```

which pulls the manylinux wheel and restores `CSafeLoader`. This PR does the equivalent at build time so users get a libyaml-linked PyYAML out of the box.

## Scope

Linux only. The Windows path does not use `--no-binary=:all:`, so pip already prefers the win_amd64 wheel (which bundles libyaml). macOS is unaffected for the same reason.

## Licensing

LibYAML is MIT-licensed, matching PyYAML itself; bundling it via the manylinux wheel introduces no new license obligations. This mirrors the existing precedent for `maturin`, `cassandra-driver`, `hatchling`, `cmake`, `ninja`, and `protobuf` in the same allow-list.

## Test plan

- [x] Reproduced on current 3008.1 onedir: `hasattr(yaml, 'CSafeLoader') == False`
- [x] Verified PyYAML 6.0.3 publishes cp3.10 through cp3.14 manylinux2014_x86_64 wheels
- [ ] Build Source Packages CI must pass on this branch to confirm pip accepts the new allow-list entry and produces an onedir with `_yaml*.so`

Fixes #69907