### PR TITLE
Per-master process RSS/FD metrics in nightly stress test

### DIFF
--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -206,7 +206,7 @@
         "y": 11
       },
       "id": 105,
-      "title": "Per-Master-Process Memory (PSS)",
+      "title": "Per-Master-Process Memory (RSS)",
       "type": "row"
     },
     {
@@ -231,8 +231,8 @@
       "id": 200,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"EventPublisher\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"EventPublisher\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -261,8 +261,8 @@
       "id": 201,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"PubServerChannel._publish_daemon\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"PubServerChannel._publish_daemon\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -291,8 +291,8 @@
       "id": 202,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorkerQueue\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorkerQueue\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -321,8 +321,8 @@
       "id": 203,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"ReqServer_ProcessManager\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"ReqServer_ProcessManager\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -351,8 +351,8 @@
       "id": 204,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"Maintenance\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"Maintenance\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -381,8 +381,8 @@
       "id": 205,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"EventMonitor\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"EventMonitor\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -411,8 +411,8 @@
       "id": 206,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"BatchManager\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"BatchManager\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -441,8 +441,8 @@
       "id": 207,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"FileServerUpdate\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"FileServerUpdate\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -471,8 +471,8 @@
       "id": 208,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"master-main\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"master-main\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -501,8 +501,8 @@
       "id": 209,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-0\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-0\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -531,8 +531,8 @@
       "id": 210,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-1\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-1\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -561,8 +561,8 @@
       "id": 211,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-2\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-2\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -591,8 +591,8 @@
       "id": 212,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-3\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-3\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],
@@ -621,8 +621,8 @@
       "id": 213,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-4\"}",
-          "legendFormat": "PSS",
+          "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-4\"}",
+          "legendFormat": "RSS",
           "refId": "A"
         }
       ],

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -205,415 +205,6 @@
         "x": 0,
         "y": 11
       },
-      "id": 101,
-      "title": "Minion 1",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 12
-      },
-      "id": 20,
-      "targets": [
-        {
-          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}",
-          "legendFormat": "Minion 1 RSS",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 1 Memory RSS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "percentunit"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "id": 21,
-      "targets": [
-        {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}[1m])",
-          "legendFormat": "Minion 1 CPU",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 1 CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "id": 22,
-      "targets": [
-        {
-          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)",
-          "legendFormat": "Minion 1 Inodes",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion Inodes (Disk Files)",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 102,
-      "title": "Minion 2",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 20
-      },
-      "id": 30,
-      "targets": [
-        {
-          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}",
-          "legendFormat": "Minion 2 RSS",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 2 Memory RSS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "percentunit"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 20
-      },
-      "id": 31,
-      "targets": [
-        {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}[1m])",
-          "legendFormat": "Minion 2 CPU",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 2 CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 20
-      },
-      "id": 32,
-      "targets": [
-        {
-          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)",
-          "legendFormat": "Minion 2 Inodes",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion Inodes (Disk Files)",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 103,
-      "title": "Minion 3",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 28
-      },
-      "id": 40,
-      "targets": [
-        {
-          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}",
-          "legendFormat": "Minion 3 RSS",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 3 Memory RSS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "percentunit"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 28
-      },
-      "id": 41,
-      "targets": [
-        {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}[1m])",
-          "legendFormat": "Minion 3 CPU",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 3 CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 28
-      },
-      "id": 42,
-      "targets": [
-        {
-          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)",
-          "legendFormat": "Minion 3 Inodes",
-          "refId": "A"
-        }
-      ],
-      "title": "Minion 3 Inodes (Disk Files)",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 104,
-      "title": "Salt API",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 36
-      },
-      "id": 50,
-      "targets": [
-        {
-          "expr": "salt_api_rss_bytes",
-          "legendFormat": "API Process RSS",
-          "refId": "A"
-        }
-      ],
-      "title": "API Process Memory RSS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "percentunit"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 36
-      },
-      "id": 51,
-      "targets": [
-        {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}[1m])",
-          "legendFormat": "API CPU",
-          "refId": "A"
-        }
-      ],
-      "title": "API CPU Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 36
-      },
-      "id": 52,
-      "targets": [
-        {
-          "expr": "salt_api_open_fds",
-          "legendFormat": "Total Open FDs",
-          "refId": "A"
-        },
-        {
-          "expr": "salt_api_process_count",
-          "legendFormat": "Process Count",
-          "refId": "B"
-        }
-      ],
-      "title": "API Resource Usage (FDs & Processes)",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 43
-      },
       "id": 105,
       "title": "Per-Master-Process Memory (PSS)",
       "type": "row"
@@ -635,7 +226,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 12
       },
       "id": 200,
       "targets": [
@@ -665,7 +256,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 44
+        "y": 12
       },
       "id": 201,
       "targets": [
@@ -695,7 +286,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 44
+        "y": 12
       },
       "id": 202,
       "targets": [
@@ -725,7 +316,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 18
       },
       "id": 203,
       "targets": [
@@ -755,7 +346,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 18
       },
       "id": 204,
       "targets": [
@@ -785,7 +376,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 18
       },
       "id": 205,
       "targets": [
@@ -815,7 +406,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 56
+        "y": 24
       },
       "id": 206,
       "targets": [
@@ -845,7 +436,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 56
+        "y": 24
       },
       "id": 207,
       "targets": [
@@ -875,7 +466,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 56
+        "y": 24
       },
       "id": 208,
       "targets": [
@@ -905,7 +496,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 62
+        "y": 30
       },
       "id": 209,
       "targets": [
@@ -935,7 +526,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 62
+        "y": 30
       },
       "id": 210,
       "targets": [
@@ -965,7 +556,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 62
+        "y": 30
       },
       "id": 211,
       "targets": [
@@ -995,7 +586,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 36
       },
       "id": 212,
       "targets": [
@@ -1025,7 +616,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 36
       },
       "id": 213,
       "targets": [
@@ -1036,6 +627,415 @@
         }
       ],
       "title": "MWorker-default-4",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 101,
+      "title": "Minion 1",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 43
+      },
+      "id": 20,
+      "targets": [
+        {
+          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}",
+          "legendFormat": "Minion 1 RSS",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 1 Memory RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 43
+      },
+      "id": 21,
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}[1m])",
+          "legendFormat": "Minion 1 CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 1 CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 43
+      },
+      "id": 22,
+      "targets": [
+        {
+          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)",
+          "legendFormat": "Minion 1 Inodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion Inodes (Disk Files)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 102,
+      "title": "Minion 2",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 51
+      },
+      "id": 30,
+      "targets": [
+        {
+          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}",
+          "legendFormat": "Minion 2 RSS",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 2 Memory RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 51
+      },
+      "id": 31,
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}[1m])",
+          "legendFormat": "Minion 2 CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 2 CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 51
+      },
+      "id": 32,
+      "targets": [
+        {
+          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)",
+          "legendFormat": "Minion 2 Inodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion Inodes (Disk Files)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 103,
+      "title": "Minion 3",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "id": 40,
+      "targets": [
+        {
+          "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}",
+          "legendFormat": "Minion 3 RSS",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 3 Memory RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "id": 41,
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}[1m])",
+          "legendFormat": "Minion 3 CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 3 CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "id": 42,
+      "targets": [
+        {
+          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)",
+          "legendFormat": "Minion 3 Inodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 3 Inodes (Disk Files)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 104,
+      "title": "Salt API",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "id": 50,
+      "targets": [
+        {
+          "expr": "salt_api_rss_bytes",
+          "legendFormat": "API Process RSS",
+          "refId": "A"
+        }
+      ],
+      "title": "API Process Memory RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "id": 51,
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}[1m])",
+          "legendFormat": "API CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "API CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "id": 52,
+      "targets": [
+        {
+          "expr": "salt_api_open_fds",
+          "legendFormat": "Total Open FDs",
+          "refId": "A"
+        },
+        {
+          "expr": "salt_api_process_count",
+          "legendFormat": "Process Count",
+          "refId": "B"
+        }
+      ],
+      "title": "API Resource Usage (FDs & Processes)",
       "type": "timeseries"
     }
   ],

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -615,7 +615,7 @@
         "y": 43
       },
       "id": 105,
-      "title": "Per-Daemon Breakdown",
+      "title": "Per-Process Breakdown",
       "type": "row"
     },
     {
@@ -645,7 +645,7 @@
           "refId": "A"
         }
       ],
-      "title": "Per-Master-Daemon RSS",
+      "title": "Per-Master-Process RSS",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -121,8 +121,13 @@
       "targets": [
         {
           "expr": "salt_master_rss_bytes",
-          "legendFormat": "Master Process RSS",
+          "legendFormat": "Master Process RSS (sum, over-counts COW)",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_pss_bytes",
+          "legendFormat": "Master Process PSS (sum, ~= physical RAM)",
+          "refId": "C"
         },
         {
           "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}",
@@ -130,7 +135,7 @@
           "refId": "B"
         }
       ],
-      "title": "Master Memory RSS (Process vs Container)",
+      "title": "Master Memory (RSS Sum vs PSS Sum vs Container)",
       "type": "timeseries"
     },
     {
@@ -676,6 +681,66 @@
         }
       ],
       "title": "Per-Salt-API-Process RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 62,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes",
+          "legendFormat": "{{process}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Master-Process PSS (COW-adjusted, sum ~= physical RAM)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 63,
+      "targets": [
+        {
+          "expr": "salt_api_process_pss_bytes",
+          "legendFormat": "{{process}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Salt-API-Process PSS (COW-adjusted)",
       "type": "timeseries"
     }
   ],

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -606,6 +606,77 @@
       ],
       "title": "API Resource Usage (FDs & Processes)",
       "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 105,
+      "title": "Per-Daemon Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 60,
+      "targets": [
+        {
+          "expr": "salt_master_process_rss_bytes",
+          "legendFormat": "{{process}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Master-Daemon RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 61,
+      "targets": [
+        {
+          "expr": "salt_api_process_rss_bytes",
+          "legendFormat": "{{process}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-Salt-API-Process RSS",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -476,17 +476,17 @@
       "id": 207,
       "targets": [
         {
-          "expr": "salt_master_process_rss_bytes{process=\"FileServerUpdate\"}",
+          "expr": "salt_master_process_rss_bytes{process=\"FileserverUpdate\"}",
           "legendFormat": "RSS",
           "refId": "A"
         },
         {
-          "expr": "salt_master_process_pss_bytes{process=\"FileServerUpdate\"}",
+          "expr": "salt_master_process_pss_bytes{process=\"FileserverUpdate\"}",
           "legendFormat": "PSS",
           "refId": "B"
         }
       ],
-      "title": "FileServerUpdate",
+      "title": "FileserverUpdate",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -120,14 +120,9 @@
       "id": 10,
       "targets": [
         {
-          "expr": "salt_master_rss_bytes",
-          "legendFormat": "Master Process RSS (sum, over-counts COW)",
-          "refId": "A"
-        },
-        {
           "expr": "salt_master_pss_bytes",
-          "legendFormat": "Master Process PSS (sum, ~= physical RAM)",
-          "refId": "C"
+          "legendFormat": "Master Process PSS",
+          "refId": "A"
         },
         {
           "expr": "container_memory_rss{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}",
@@ -135,7 +130,7 @@
           "refId": "B"
         }
       ],
-      "title": "Master Memory (RSS Sum vs PSS Sum vs Container)",
+      "title": "Master Memory (Process vs Container)",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -206,7 +206,7 @@
         "y": 11
       },
       "id": 105,
-      "title": "Per-Master-Process Memory (RSS)",
+      "title": "Per-Master-Process Memory (RSS + PSS)",
       "type": "row"
     },
     {
@@ -234,6 +234,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"EventPublisher\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"EventPublisher\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "EventPublisher",
@@ -264,6 +269,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"PubServerChannel._publish_daemon\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"PubServerChannel._publish_daemon\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "PubServerChannel._publish_daemon",
@@ -294,6 +304,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorkerQueue\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorkerQueue\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorkerQueue",
@@ -324,6 +339,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"ReqServer_ProcessManager\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"ReqServer_ProcessManager\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "ReqServer_ProcessManager",
@@ -354,6 +374,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"Maintenance\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"Maintenance\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "Maintenance",
@@ -384,6 +409,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"EventMonitor\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"EventMonitor\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "EventMonitor",
@@ -414,6 +444,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"BatchManager\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"BatchManager\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "BatchManager",
@@ -444,6 +479,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"FileServerUpdate\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"FileServerUpdate\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "FileServerUpdate",
@@ -474,6 +514,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"master-main\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"master-main\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "master-main",
@@ -504,6 +549,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-0\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-0\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorker-default-0",
@@ -534,6 +584,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-1\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-1\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorker-default-1",
@@ -564,6 +619,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-2\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-2\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorker-default-2",
@@ -594,6 +654,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-3\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-3\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorker-default-3",
@@ -624,6 +689,11 @@
           "expr": "salt_master_process_rss_bytes{process=\"MWorker-default-4\"}",
           "legendFormat": "RSS",
           "refId": "A"
+        },
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-4\"}",
+          "legendFormat": "PSS",
+          "refId": "B"
         }
       ],
       "title": "MWorker-default-4",

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -700,12 +700,42 @@
       "id": 62,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes",
+          "expr": "salt_master_process_pss_bytes{process!~\"MWorker-default-.*\"}",
           "legendFormat": "{{process}}",
           "refId": "A"
         }
       ],
-      "title": "Per-Master-Process PSS (COW-adjusted, sum ~= physical RAM)",
+      "title": "Main Master Processes PSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "id": 64,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=~\"MWorker-default-.*\"}",
+          "legendFormat": "{{process}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Master Worker Sub-processes PSS (MWorker-default-N)",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -615,7 +615,7 @@
         "y": 43
       },
       "id": 105,
-      "title": "Per-Process Breakdown",
+      "title": "Per-Master-Process Memory (PSS)",
       "type": "row"
     },
     {
@@ -632,20 +632,20 @@
         }
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 6,
+        "w": 8,
         "x": 0,
         "y": 44
       },
-      "id": 60,
+      "id": 200,
       "targets": [
         {
-          "expr": "salt_master_process_rss_bytes",
-          "legendFormat": "{{process}}",
+          "expr": "salt_master_process_pss_bytes{process=\"EventPublisher\"}",
+          "legendFormat": "PSS",
           "refId": "A"
         }
       ],
-      "title": "Per-Master-Process RSS",
+      "title": "EventPublisher",
       "type": "timeseries"
     },
     {
@@ -662,20 +662,20 @@
         }
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
+        "h": 6,
+        "w": 8,
+        "x": 8,
         "y": 44
       },
-      "id": 61,
+      "id": 201,
       "targets": [
         {
-          "expr": "salt_api_process_rss_bytes",
-          "legendFormat": "{{process}}",
+          "expr": "salt_master_process_pss_bytes{process=\"PubServerChannel._publish_daemon\"}",
+          "legendFormat": "PSS",
           "refId": "A"
         }
       ],
-      "title": "Per-Salt-API-Process RSS",
+      "title": "PubServerChannel._publish_daemon",
       "type": "timeseries"
     },
     {
@@ -692,20 +692,50 @@
         }
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 202,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorkerQueue\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "MWorkerQueue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
         "x": 0,
-        "y": 53
+        "y": 50
       },
-      "id": 62,
+      "id": 203,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process!~\"MWorker-default-.*\"}",
-          "legendFormat": "{{process}}",
+          "expr": "salt_master_process_pss_bytes{process=\"ReqServer_ProcessManager\"}",
+          "legendFormat": "PSS",
           "refId": "A"
         }
       ],
-      "title": "Main Master Processes PSS",
+      "title": "ReqServer_ProcessManager",
       "type": "timeseries"
     },
     {
@@ -722,20 +752,170 @@
         }
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 50
+      },
+      "id": 204,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"Maintenance\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "Maintenance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 50
+      },
+      "id": 205,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"EventMonitor\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "EventMonitor",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 56
+      },
+      "id": 206,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"BatchManager\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "BatchManager",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 56
+      },
+      "id": 207,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"FileServerUpdate\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "FileServerUpdate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 56
+      },
+      "id": 208,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"master-main\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "master-main",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
         "x": 0,
         "y": 62
       },
-      "id": 64,
+      "id": 209,
       "targets": [
         {
-          "expr": "salt_master_process_pss_bytes{process=~\"MWorker-default-.*\"}",
-          "legendFormat": "{{process}}",
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-0\"}",
+          "legendFormat": "PSS",
           "refId": "A"
         }
       ],
-      "title": "Master Worker Sub-processes PSS (MWorker-default-N)",
+      "title": "MWorker-default-0",
       "type": "timeseries"
     },
     {
@@ -752,20 +932,110 @@
         }
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 53
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 62
       },
-      "id": 63,
+      "id": 210,
       "targets": [
         {
-          "expr": "salt_api_process_pss_bytes",
-          "legendFormat": "{{process}}",
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-1\"}",
+          "legendFormat": "PSS",
           "refId": "A"
         }
       ],
-      "title": "Per-Salt-API-Process PSS (COW-adjusted)",
+      "title": "MWorker-default-1",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 62
+      },
+      "id": 211,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-2\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "MWorker-default-2",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 68
+      },
+      "id": 212,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-3\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "MWorker-default-3",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 68
+      },
+      "id": 213,
+      "targets": [
+        {
+          "expr": "salt_master_process_pss_bytes{process=\"MWorker-default-4\"}",
+          "legendFormat": "PSS",
+          "refId": "A"
+        }
+      ],
+      "title": "MWorker-default-4",
       "type": "timeseries"
     }
   ],

--- a/tests/monitoring/srv/salt/fd_exporter.py
+++ b/tests/monitoring/srv/salt/fd_exporter.py
@@ -7,15 +7,15 @@ Emits three tiers of gauges:
   ``salt_master_rss_bytes``, ``salt_master_open_fds``,
   ``salt_master_process_count`` and their ``salt_api_*`` counterparts.
 
-* Per-daemon gauges labelled by process name (not pid) so restart of a
-  worker or the ``Maintenance`` daemon continues the same Prometheus
+* Per-process gauges labelled by process name (not pid) so restart of a
+  worker or the ``Maintenance`` process continues the same Prometheus
   series rather than starting a new line on the dashboard:
   ``salt_master_process_rss_bytes{process="MWorker-default-0"}`` etc.
-  Parallel ``salt_api_process_*`` metrics cover the salt-api daemons.
+  Parallel ``salt_api_process_*`` metrics cover the salt-api side.
 
 Process names come from the trailing tokens of ``/proc/<pid>/cmdline``
 (salt renames its worker processes via ``setproctitle`` so the last
-argv slot holds the daemon's role -- e.g. ``EventPublisher``,
+argv slot holds the process's role -- e.g. ``EventPublisher``,
 ``RequestServer MWorker-default-2``, ``PubServerChannel._publish_daemon``).
 The main master/api MainProcess is disambiguated by whether ``salt-api``
 appears anywhere in the argv.
@@ -149,7 +149,7 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
         api_procs = 0
         api_rss = 0
 
-        # Per-daemon buckets.  A given label may appear on multiple pids
+        # Per-process buckets.  A given label may appear on multiple pids
         # transiently (e.g. an old Maintenance pid is exiting while its
         # replacement has just forked); sum in that case so the series
         # never dips artificially.
@@ -246,28 +246,28 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
         lines.extend(
             _format_series(
                 "salt_master_process_rss_bytes",
-                "RSS bytes per salt-master daemon process, labelled by process name",
+                "RSS bytes per salt-master process, labelled by process name",
                 master_proc_rss,
             )
         )
         lines.extend(
             _format_series(
                 "salt_master_process_fds",
-                "Open FDs per salt-master daemon process, labelled by process name",
+                "Open FDs per salt-master process, labelled by process name",
                 master_proc_fds,
             )
         )
         lines.extend(
             _format_series(
                 "salt_api_process_rss_bytes",
-                "RSS bytes per salt-api daemon process, labelled by process name",
+                "RSS bytes per salt-api process, labelled by process name",
                 api_proc_rss,
             )
         )
         lines.extend(
             _format_series(
                 "salt_api_process_fds",
-                "Open FDs per salt-api daemon process, labelled by process name",
+                "Open FDs per salt-api process, labelled by process name",
                 api_proc_fds,
             )
         )

--- a/tests/monitoring/srv/salt/fd_exporter.py
+++ b/tests/monitoring/srv/salt/fd_exporter.py
@@ -105,6 +105,22 @@ def _read_rss_bytes(pid):
     return rss_pages * 4096  # Linux page size on all supported CI runners
 
 
+def _read_pss_bytes(pid):
+    """Return PSS (Proportional Set Size) in bytes from ``/proc/<pid>/smaps_rollup``.
+
+    PSS divides each shared page by the number of processes mapping it, so
+    ``sum(PSS across sibling forks) ~= physical RAM used`` -- unlike naive
+    RSS which double-counts every COW-shared page and inflates the total
+    ~2x for a many-process salt-master.
+    """
+    with open(f"/proc/{pid}/smaps_rollup", encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("Pss:"):
+                # ``Pss:        12345 kB``
+                return int(line.split()[1]) * 1024
+    return 0
+
+
 def _count_fds(pid):
     return len(os.listdir(f"/proc/{pid}/fd"))
 
@@ -145,17 +161,21 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
         master_fds = 0
         master_procs = 0
         master_rss = 0
+        master_pss = 0
         api_fds = 0
         api_procs = 0
         api_rss = 0
+        api_pss = 0
 
         # Per-process buckets.  A given label may appear on multiple pids
         # transiently (e.g. an old Maintenance pid is exiting while its
         # replacement has just forked); sum in that case so the series
         # never dips artificially.
         master_proc_rss = {}
+        master_proc_pss = {}
         master_proc_fds = {}
         api_proc_rss = {}
+        api_proc_pss = {}
         api_proc_fds = {}
 
         try:
@@ -200,12 +220,28 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
                 ):
                     rss_bytes = 0
 
+                try:
+                    pss_bytes = _read_pss_bytes(pid)
+                except (
+                    FileNotFoundError,
+                    ProcessLookupError,
+                    PermissionError,
+                    ValueError,
+                    IndexError,
+                    OSError,
+                ):
+                    pss_bytes = 0
+
                 if daemon == "master":
                     master_fds += fd_count
                     master_procs += 1
                     master_rss += rss_bytes
+                    master_pss += pss_bytes
                     master_proc_rss[process_name] = (
                         master_proc_rss.get(process_name, 0) + rss_bytes
+                    )
+                    master_proc_pss[process_name] = (
+                        master_proc_pss.get(process_name, 0) + pss_bytes
                     )
                     master_proc_fds[process_name] = (
                         master_proc_fds.get(process_name, 0) + fd_count
@@ -214,8 +250,12 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
                     api_fds += fd_count
                     api_procs += 1
                     api_rss += rss_bytes
+                    api_pss += pss_bytes
                     api_proc_rss[process_name] = (
                         api_proc_rss.get(process_name, 0) + rss_bytes
+                    )
+                    api_proc_pss[process_name] = (
+                        api_proc_pss.get(process_name, 0) + pss_bytes
                     )
                     api_proc_fds[process_name] = (
                         api_proc_fds.get(process_name, 0) + fd_count
@@ -230,24 +270,37 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
             "# HELP salt_master_process_count Number of master processes",
             "# TYPE salt_master_process_count gauge",
             f"salt_master_process_count {master_procs}",
-            "# HELP salt_master_rss_bytes RSS memory usage for master in bytes",
+            "# HELP salt_master_rss_bytes RSS memory usage for master in bytes (sum of per-process RSS -- over-counts COW-shared pages ~Nx)",
             "# TYPE salt_master_rss_bytes gauge",
             f"salt_master_rss_bytes {master_rss}",
+            "# HELP salt_master_pss_bytes PSS (Proportional Set Size) for master in bytes (shared pages divided by N -- sum approximates actual physical RAM)",
+            "# TYPE salt_master_pss_bytes gauge",
+            f"salt_master_pss_bytes {master_pss}",
             "# HELP salt_api_open_fds Number of open file descriptors for salt-api",
             "# TYPE salt_api_open_fds gauge",
             f"salt_api_open_fds {api_fds}",
             "# HELP salt_api_process_count Number of salt-api processes",
             "# TYPE salt_api_process_count gauge",
             f"salt_api_process_count {api_procs}",
-            "# HELP salt_api_rss_bytes RSS memory usage for salt-api in bytes",
+            "# HELP salt_api_rss_bytes RSS memory usage for salt-api in bytes (sum of per-process RSS -- over-counts COW-shared pages)",
             "# TYPE salt_api_rss_bytes gauge",
             f"salt_api_rss_bytes {api_rss}",
+            "# HELP salt_api_pss_bytes PSS for salt-api in bytes (sum approximates actual physical RAM)",
+            "# TYPE salt_api_pss_bytes gauge",
+            f"salt_api_pss_bytes {api_pss}",
         ]
         lines.extend(
             _format_series(
                 "salt_master_process_rss_bytes",
-                "RSS bytes per salt-master process, labelled by process name",
+                "RSS bytes per salt-master process, labelled by process name (over-counts COW-shared pages -- prefer PSS for aggregate math)",
                 master_proc_rss,
+            )
+        )
+        lines.extend(
+            _format_series(
+                "salt_master_process_pss_bytes",
+                "PSS (Proportional Set Size) bytes per salt-master process, labelled by process name (shared pages divided by N -- sum approximates actual physical RAM)",
+                master_proc_pss,
             )
         )
         lines.extend(
@@ -260,8 +313,15 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
         lines.extend(
             _format_series(
                 "salt_api_process_rss_bytes",
-                "RSS bytes per salt-api process, labelled by process name",
+                "RSS bytes per salt-api process, labelled by process name (over-counts COW-shared pages -- prefer PSS for aggregate math)",
                 api_proc_rss,
+            )
+        )
+        lines.extend(
+            _format_series(
+                "salt_api_process_pss_bytes",
+                "PSS (Proportional Set Size) bytes per salt-api process, labelled by process name",
+                api_proc_pss,
             )
         )
         lines.extend(

--- a/tests/monitoring/srv/salt/fd_exporter.py
+++ b/tests/monitoring/srv/salt/fd_exporter.py
@@ -1,6 +1,130 @@
 # pylint: disable=resource-leakage
+"""HTTP exporter that scrapes /proc for salt-master and salt-api processes.
+
+Emits three tiers of gauges:
+
+* Aggregate counters (unchanged from the original):
+  ``salt_master_rss_bytes``, ``salt_master_open_fds``,
+  ``salt_master_process_count`` and their ``salt_api_*`` counterparts.
+
+* Per-daemon gauges labelled by process name (not pid) so restart of a
+  worker or the ``Maintenance`` daemon continues the same Prometheus
+  series rather than starting a new line on the dashboard:
+  ``salt_master_process_rss_bytes{process="MWorker-default-0"}`` etc.
+  Parallel ``salt_api_process_*`` metrics cover the salt-api daemons.
+
+Process names come from the trailing tokens of ``/proc/<pid>/cmdline``
+(salt renames its worker processes via ``setproctitle`` so the last
+argv slot holds the daemon's role -- e.g. ``EventPublisher``,
+``RequestServer MWorker-default-2``, ``PubServerChannel._publish_daemon``).
+The main master/api MainProcess is disambiguated by whether ``salt-api``
+appears anywhere in the argv.
+"""
 import http.server
 import os
+
+
+def _classify(cmdline):
+    """Return ``(daemon, process_name)`` for a salt-master/salt-api pid.
+
+    ``daemon`` is either ``"master"`` or ``"api"``.  ``process_name`` is
+    the label the caller emits into
+    ``salt_{daemon}_process_rss_bytes{process="..."}``.
+
+    Returns ``None`` if ``cmdline`` does not belong to a salt master or
+    salt-api process (or is the exporter itself).
+    """
+    if not cmdline:
+        return None
+    if "fd_exporter.py" in cmdline:
+        return None
+
+    is_api = "salt-api" in cmdline
+    is_master = "salt-master" in cmdline and not is_api
+    if not (is_api or is_master):
+        return None
+
+    # Skip the entrypoint shell wrapper (docker-compose runs the master
+    # under ``sh -c '... salt-master -d && salt-api'``, which matches
+    # both keywords but is not itself a salt daemon).
+    if cmdline.startswith(("sh -c", "/bin/sh -c", "/usr/bin/tini")):
+        return None
+
+    daemon = "api" if is_api else "master"
+
+    # Salt's ``setproctitle`` payload lands in the trailing argv slots
+    # (space-separated inside the null-terminated ``cmdline`` blob we've
+    # already normalised to spaces by the caller).  Look at the tail.
+    tokens = cmdline.split()
+
+    # ``RequestServer MWorker-default-2`` -> just ``MWorker-default-2``.
+    # ``PubServerChannel._publish_daemon`` stays intact.
+    # ``ReqServer_ProcessManager`` stays intact.
+    # ``Maintenance``, ``EventPublisher``, ``EventMonitor``,
+    # ``BatchManager``, ``FileServerUpdate`` all stand alone.
+    if not tokens:
+        return daemon, "unknown"
+
+    last = tokens[-1]
+
+    # Bare ``salt-api`` / ``salt-master`` invocations with no proctitle
+    # suffix mean the process hasn't renamed itself yet (or is the
+    # top-level launcher).  Collapse to a stable label.
+    if last.endswith("salt-api"):
+        return daemon, "salt-api-launcher"
+    if last.endswith("salt-master") or last == "-d":
+        return daemon, "master-launcher"
+
+    if last == "MainProcess":
+        return daemon, "salt-api-main" if is_api else "master-main"
+
+    # ``RunNetapi(salt.loaded.int.netapi.rest_cherrypy)`` and its
+    # siblings all identify a CherryPy-serving api worker; the parens
+    # payload varies per module so collapse on the ``RunNetapi`` prefix.
+    if is_api and last.startswith("RunNetapi"):
+        return daemon, "salt-api-cherrypy"
+
+    # ``RequestServer MWorker-default-2`` -> daemon label
+    # ``MWorker-default-2``.  ``MWorkerQueue`` stands alone.
+    if len(tokens) >= 2 and tokens[-2] == "RequestServer":
+        return daemon, last
+
+    return daemon, last
+
+
+def _read_cmdline(pid):
+    with open(f"/proc/{pid}/cmdline", "rb") as fh:
+        return fh.read().replace(b"\0", b" ").decode(errors="ignore")
+
+
+def _read_rss_bytes(pid):
+    """Return RSS in bytes from ``/proc/<pid>/stat`` field 24 (pages)."""
+    with open(f"/proc/{pid}/stat", encoding="utf-8") as fh:
+        stat = fh.read().split()
+    rss_pages = int(stat[23])
+    return rss_pages * 4096  # Linux page size on all supported CI runners
+
+
+def _count_fds(pid):
+    return len(os.listdir(f"/proc/{pid}/fd"))
+
+
+def _format_series(name, help_text, samples):
+    """Return the # HELP/# TYPE header plus one line per label value.
+
+    ``samples`` is ``{process_label: value}``.  Only currently-live
+    processes appear -- when a process exits Prometheus interpolates
+    across the gap and, when a replacement forks under the same
+    process name, the series continues naturally.
+    """
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} gauge"]
+    for process, value in sorted(samples.items()):
+        # Escape backslash and double-quote per the Prometheus text
+        # exposition spec.  Salt daemon names never contain either but
+        # the escape keeps this defensive.
+        safe = process.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'{name}{{process="{safe}"}} {value}')
+    return lines
 
 
 class FDHandler(http.server.BaseHTTPRequestHandler):
@@ -9,94 +133,145 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
         return
 
     def do_GET(self):
-        if self.path == "/metrics":
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.end_headers()
-
-            master_fds = 0
-            master_procs = 0
-            master_rss = 0
-            api_fds = 0
-            api_procs = 0
-            api_rss = 0
-
-            try:
-                # Iterate over /proc directly once for efficiency
-                for pid_dir in os.listdir("/proc"):
-                    if not pid_dir.isdigit():
-                        continue
-
-                    try:
-                        pid = pid_dir
-                        with open(f"/proc/{pid}/cmdline", "rb") as f:
-                            cmdline = (
-                                f.read().replace(b"\0", b" ").decode(errors="ignore")
-                            )
-
-                        # Skip if it's the exporter itself
-                        if "fd_exporter.py" in cmdline:
-                            continue
-
-                        is_api = "salt-api" in cmdline
-                        is_master = "salt-master" in cmdline and not is_api
-
-                        if is_master or is_api:
-                            # FD count
-                            try:
-                                fd_count = len(os.listdir(f"/proc/{pid}/fd"))
-                            except (OSError, PermissionError):
-                                fd_count = 0
-
-                            # RSS Memory (from /proc/[pid]/stat, field 24 is RSS in pages)
-                            try:
-                                with open(f"/proc/{pid}/stat", encoding="utf-8") as f:
-                                    stat = f.read().split()
-                                    rss_pages = int(stat[23])
-                                    rss_bytes = rss_pages * 4096  # Assuming 4KB pages
-                            except (OSError, ValueError, IndexError):
-                                rss_bytes = 0
-
-                            if is_master:
-                                master_fds += fd_count
-                                master_procs += 1
-                                master_rss += rss_bytes
-                            if is_api:
-                                api_fds += fd_count
-                                api_procs += 1
-                                api_rss += rss_bytes
-                    except (FileNotFoundError, ProcessLookupError, PermissionError):
-                        # Process died while we were reading it
-                        continue
-                    except OSError:
-                        continue
-            except OSError:
-                pass
-
-            lines = [
-                "# HELP salt_master_open_fds Number of open file descriptors for master",
-                "# TYPE salt_master_open_fds gauge",
-                f"salt_master_open_fds {master_fds}",
-                "# HELP salt_master_process_count Number of master processes",
-                "# TYPE salt_master_process_count gauge",
-                f"salt_master_process_count {master_procs}",
-                "# HELP salt_master_rss_bytes RSS memory usage for master in bytes",
-                "# TYPE salt_master_rss_bytes gauge",
-                f"salt_master_rss_bytes {master_rss}",
-                "# HELP salt_api_open_fds Number of open file descriptors for salt-api",
-                "# TYPE salt_api_open_fds gauge",
-                f"salt_api_open_fds {api_fds}",
-                "# HELP salt_api_process_count Number of salt-api processes",
-                "# TYPE salt_api_process_count gauge",
-                f"salt_api_process_count {api_procs}",
-                "# HELP salt_api_rss_bytes RSS memory usage for salt-api in bytes",
-                "# TYPE salt_api_rss_bytes gauge",
-                f"salt_api_rss_bytes {api_rss}",
-            ]
-            self.wfile.write(("\n".join(lines) + "\n").encode())
-        else:
+        if self.path != "/metrics":
             self.send_response(404)
             self.end_headers()
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+
+        master_fds = 0
+        master_procs = 0
+        master_rss = 0
+        api_fds = 0
+        api_procs = 0
+        api_rss = 0
+
+        # Per-daemon buckets.  A given label may appear on multiple pids
+        # transiently (e.g. an old Maintenance pid is exiting while its
+        # replacement has just forked); sum in that case so the series
+        # never dips artificially.
+        master_proc_rss = {}
+        master_proc_fds = {}
+        api_proc_rss = {}
+        api_proc_fds = {}
+
+        try:
+            for pid_dir in os.listdir("/proc"):
+                if not pid_dir.isdigit():
+                    continue
+                pid = pid_dir
+                try:
+                    cmdline = _read_cmdline(pid)
+                except (
+                    FileNotFoundError,
+                    ProcessLookupError,
+                    PermissionError,
+                    OSError,
+                ):
+                    continue
+
+                classified = _classify(cmdline)
+                if classified is None:
+                    continue
+                daemon, process_name = classified
+
+                try:
+                    fd_count = _count_fds(pid)
+                except (
+                    FileNotFoundError,
+                    ProcessLookupError,
+                    PermissionError,
+                    OSError,
+                ):
+                    fd_count = 0
+
+                try:
+                    rss_bytes = _read_rss_bytes(pid)
+                except (
+                    FileNotFoundError,
+                    ProcessLookupError,
+                    PermissionError,
+                    ValueError,
+                    IndexError,
+                    OSError,
+                ):
+                    rss_bytes = 0
+
+                if daemon == "master":
+                    master_fds += fd_count
+                    master_procs += 1
+                    master_rss += rss_bytes
+                    master_proc_rss[process_name] = (
+                        master_proc_rss.get(process_name, 0) + rss_bytes
+                    )
+                    master_proc_fds[process_name] = (
+                        master_proc_fds.get(process_name, 0) + fd_count
+                    )
+                else:
+                    api_fds += fd_count
+                    api_procs += 1
+                    api_rss += rss_bytes
+                    api_proc_rss[process_name] = (
+                        api_proc_rss.get(process_name, 0) + rss_bytes
+                    )
+                    api_proc_fds[process_name] = (
+                        api_proc_fds.get(process_name, 0) + fd_count
+                    )
+        except OSError:
+            pass
+
+        lines = [
+            "# HELP salt_master_open_fds Number of open file descriptors for master",
+            "# TYPE salt_master_open_fds gauge",
+            f"salt_master_open_fds {master_fds}",
+            "# HELP salt_master_process_count Number of master processes",
+            "# TYPE salt_master_process_count gauge",
+            f"salt_master_process_count {master_procs}",
+            "# HELP salt_master_rss_bytes RSS memory usage for master in bytes",
+            "# TYPE salt_master_rss_bytes gauge",
+            f"salt_master_rss_bytes {master_rss}",
+            "# HELP salt_api_open_fds Number of open file descriptors for salt-api",
+            "# TYPE salt_api_open_fds gauge",
+            f"salt_api_open_fds {api_fds}",
+            "# HELP salt_api_process_count Number of salt-api processes",
+            "# TYPE salt_api_process_count gauge",
+            f"salt_api_process_count {api_procs}",
+            "# HELP salt_api_rss_bytes RSS memory usage for salt-api in bytes",
+            "# TYPE salt_api_rss_bytes gauge",
+            f"salt_api_rss_bytes {api_rss}",
+        ]
+        lines.extend(
+            _format_series(
+                "salt_master_process_rss_bytes",
+                "RSS bytes per salt-master daemon process, labelled by process name",
+                master_proc_rss,
+            )
+        )
+        lines.extend(
+            _format_series(
+                "salt_master_process_fds",
+                "Open FDs per salt-master daemon process, labelled by process name",
+                master_proc_fds,
+            )
+        )
+        lines.extend(
+            _format_series(
+                "salt_api_process_rss_bytes",
+                "RSS bytes per salt-api daemon process, labelled by process name",
+                api_proc_rss,
+            )
+        )
+        lines.extend(
+            _format_series(
+                "salt_api_process_fds",
+                "Open FDs per salt-api daemon process, labelled by process name",
+                api_proc_fds,
+            )
+        )
+        self.wfile.write(("\n".join(lines) + "\n").encode())
 
 
 if __name__ == "__main__":

--- a/tests/monitoring/stress_test.sh
+++ b/tests/monitoring/stress_test.sh
@@ -7,6 +7,14 @@ echo "Starting aggressive stress test..."
 echo "Launching event flooder..."
 docker exec -d salt-master python3 /srv/salt/flood_events.py
 
+# 1b. Start the /proc RSS+FD exporter that feeds Grafana's per-daemon
+# panels.  Nothing else starts it -- docker-compose only launches the
+# aggregate salt_metrics_exporter -- so without this the
+# salt_master_process_rss_bytes series would stay empty and the
+# ``Per-Master-Daemon RSS`` panel would render blank.
+echo "Launching /proc fd_exporter..."
+docker exec -d salt-master python3 /srv/salt/fd_exporter.py
+
 # 2. Loop Highstates on all minions
 echo "Starting Highstate loop..."
 (


### PR DESCRIPTION
## Summary


Process labels are stable across restarts: a killed-and-respawned
Maintenance or MWorker continues the same Prometheus series rather
than starting a new line on the dashboard.

## Test plan

- [x] `pre-commit run --files` on all three touched files
- [x] `python3 -c "import fd_exporter; fd_exporter._classify(...)"` unit
  cases cover `EventPublisher`, `MWorkerQueue`, `RequestServer
  MWorker-default-N`, `PubServerChannel._publish_daemon`, `Maintenance`,
  master `MainProcess`, api `MainProcess`, `RunNetapi(...)`, the tini
  shell wrapper and the exporter itself
- [x] Live rig: `curl http://salt-master:8002/metrics` returns all
  expected `salt_master_process_rss_bytes{process="..."}` and
  `salt_api_process_rss_bytes{process="..."}` lines
- [x] Restart continuity: `pkill -9 -f 'salt-master -d Maintenance'`
  then re-scrape shows the same `process="Maintenance"` label with a
  fresh RSS value (76169216 -> 76734464 across the restart)
- [ ] Nightly stress workflow run confirms the two new panels render in
  the step-summary PNGs