### PR TITLE
Nightly stress: duration input as 0.5h..5.5h dropdown

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -6,9 +6,22 @@ on:
   workflow_dispatch:
     inputs:
       duration:
-        description: 'Duration of the stress test (e.g., 30m, 1h)'
+        description: Stress test duration (GitHub-hosted runner caps at 6h)
         required: true
-        default: '30m'
+        default: '0.5h'
+        type: choice
+        options:
+          - '0.5h'
+          - '1h'
+          - '1.5h'
+          - '2h'
+          - '2.5h'
+          - '3h'
+          - '3.5h'
+          - '4h'
+          - '4.5h'
+          - '5h'
+          - '5.5h'
       enable_metrics:
         description: Enable OpenTelemetry metrics (metrics.enabled)
         required: false
@@ -158,7 +171,7 @@ jobs:
           STRESS_PID=$!
 
           # Default to 30m if not workflow_dispatch
-          DURATION="${{ github.event.inputs.duration || '30m' }}"
+          DURATION="${{ github.event.inputs.duration || '0.5h' }}"
           echo "Running stress test for $DURATION..."
 
           # Use sleep with suffix support (m, h)


### PR DESCRIPTION
## Summary

- Replace the ``duration`` free-text input with a ``type: choice`` dropdown of 0.5h increments from **0.5h to 5.5h**.  Stops at 5.5h because GitHub-hosted runners hard-cap job runtime at 6h — a longer value would just get killed at the platform level (verified: no way to raise this on hosted runners as of Aug 2026).
- Default flips from ``30m`` to the functionally-identical ``0.5h`` so the default matches one of the dropdown values.
- ``sleep \$DURATION`` in the run step already handles the decimal-hour format (``1.5h`` etc.) with no other changes needed.

## Test plan

- [x] YAML validates and pre-commit clean
- [x] Confirmed every dropdown value converts to a sleep-compatible seconds value under the 6h cap (max 5.5h = 19800s)
- [ ] Trigger via ``workflow_dispatch``, pick a non-default value, confirm the stress runs for the selected duration