### PR TITLE
Label y-axis units on stress-test CPU and inode panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,3 @@ nox.*.tar.xz
 /.gemini
 venv311/
 venv312/
-.cursor-ai/

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ nox.*.tar.xz
 /.gemini
 venv311/
 venv312/
+.cursor-ai/

--- a/tests/monitoring/render_panels.py
+++ b/tests/monitoring/render_panels.py
@@ -122,6 +122,14 @@ def _bytes_unit(unit_hint: str) -> bool:
     return unit_hint.lower() in ("bytes", "decbytes", "kbytes", "mbytes", "gbytes")
 
 
+def _is_percentunit(unit_hint: str) -> bool:
+    return unit_hint.lower() == "percentunit"
+
+
+def _is_count_unit(unit_hint: str) -> bool:
+    return unit_hint.lower() == "short"
+
+
 def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     """Return a matplotlib Figure for ``panel``, or ``None`` if no series."""
     targets = panel.get("targets") or []
@@ -130,6 +138,8 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
 
     unit_hint = panel.get("fieldConfig", {}).get("defaults", {}).get("unit") or ""
     is_bytes = _bytes_unit(unit_hint)
+    is_percentunit = _is_percentunit(unit_hint)
+    is_count = _is_count_unit(unit_hint)
 
     fig, ax = plt.subplots(figsize=(11, 4))
     series_count = 0
@@ -165,6 +175,14 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     ax.set_title(panel.get("title") or "panel", fontsize=11)
     if is_bytes:
         ax.set_ylabel("MB")
+    elif is_percentunit:
+        # Grafana's percentunit is a 0-1 ratio (1.0 == 1 CPU core, not 1% of
+        # the host); rate(container_cpu_usage_seconds_total[...]) values here
+        # are already in that ratio, so label explicitly to avoid confusing
+        # "1.2" with "1.2% of the host" instead of 1.2 CPU cores.
+        ax.set_ylabel("CPU cores (1.0 = 1 core)")
+    elif is_count:
+        ax.set_ylabel("count")
     ax.xaxis.set_major_formatter(DateFormatter("%H:%M"))
     ax.tick_params(axis="x", rotation=30, labelsize=8)
     ax.tick_params(axis="y", labelsize=8)


### PR DESCRIPTION
## Summary
Backport of the y-axis unit labeling fix (originally targeting `master`) to `3008.x`.

- CPU Usage panels (Master, Minion 1-3, API) use Grafana's `percentunit` (0-1 ratio where 1.0 == 1 full CPU core, matching `rate(container_cpu_usage_seconds_total[...])` semantics from cAdvisor). Without a label, a value like 1.2 is easy to misread as "1.2% of the host" rather than 1.2 CPU cores.
- Minion Inodes panels use Grafana's `short` unit (a plain count) and also had no y-axis label.
- `render_panels.py` already special-cases bytes-family units to convert to MB and label the axis; this follows the same pattern for `percentunit` and `short` so every rendered panel states what its numbers mean.

Fixes #69944

## Test plan
- [x] Verified locally that `render_panels.py` renders y-axis labels for the affected panels