### PR TITLE
Fix docstring :param: names that do not match the signatures

### DIFF
--- a/changelog/69966.fixed.md
+++ b/changelog/69966.fixed.md
@@ -1,0 +1,1 @@
+Corrected 25 docstring `:param:` fields that named an argument the callable does not take.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -98,8 +98,6 @@ def get_local_client(
                            set_event_handler() API. Otherwise, operation
                            will be synchronous.
 
-    :param bool keep_loop: Do not destroy the event loop when closing the event
-                           subsriber.
 
     :param bool auto_reconnect: When True the event subscriber will reconnect
                                 automatically if a disconnect error is raised.

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -693,7 +693,6 @@ def auth(opts, whitelist=None, loaded_base_name=None):
 
     :param dict opts: The Salt options dictionary
 
-    :param LazyLoader functions: A LazyLoader instance returned from ``minion_mods``.
     :param list whitelist: A list of modules which should be whitelisted.
     :param str loaded_base_name: The imported modules namespace when imported
                                  by the salt loader.
@@ -808,7 +807,6 @@ def states(
 
     :param dict opts: The Salt options dictionary
     :param LazyLoader functions: A LazyLoader instance returned from ``minion_mods``.
-    :param LazyLoader runners: A LazyLoader instance returned from ``runner``.
     :param LazyLoader utils: A LazyLoader instance returned from ``utils``.
     :param LazyLoader serializers: An optional LazyLoader instance returned from ``serializers``.
     :param LazyLoader proxy: An optional LazyLoader instance returned from ``proxy``.

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -129,7 +129,7 @@ class LoadedFunc:
       - Makes sure functions are called with the correct loader's context.
       - Provides access to a wrapped func's __global__ attribute
 
-    :param func str: The function name to wrap
+    :param str name: The function name to wrap
     :param LazyLoader loader: The loader instance to use in the context when the wrapped callable is called.
     """
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -605,7 +605,7 @@ class Master(SMaster):
         """
         Create a salt master server instance
 
-        :param dict: The salt options
+        :param dict opts: The salt options
         """
         if zmq and ZMQ_VERSION_INFO < (3, 2):
             log.warning(
@@ -1146,7 +1146,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         """
         Process a command sent via an AES key
 
-        :param str load: Encrypted payload
+        :param str data: Encrypted payload
         :return: The result of passing the load to a function in AESFuncs corresponding to
                  the command specified in the load's 'cmd' key.
         """

--- a/salt/modules/baredoc.py
+++ b/salt/modules/baredoc.py
@@ -304,7 +304,7 @@ def state_docs(*names):
     Return the docstrings for all state modules. Optionally, specify a state module or a
     function to narrow the selection.
 
-    :param name: specify a specific module to list.
+    :param names: specify a specific module to list.
 
     CLI Example:
 
@@ -332,7 +332,7 @@ def module_docs(*names):
     Return the docstrings for all modules. Optionally, specify a module or a
     function to narrow the selection.
 
-    :param name: specify a specific module to list.
+    :param names: specify a specific module to list.
 
     CLI Example:
 

--- a/salt/modules/bcache.py
+++ b/salt/modules/bcache.py
@@ -505,7 +505,6 @@ def device(dev, stats=False, config=False, internals=False, superblock=False):
         salt '*' bcache.device /dev/sdc stats=True
 
     :param stats: include statistics
-    :param settings: include all settings
     :param internals: include all internals
     :param superblock: include superblock info
     """

--- a/salt/modules/cassandra_cql.py
+++ b/salt/modules/cassandra_cql.py
@@ -444,8 +444,6 @@ def cql_query(
     :type  cql_pass:       str
     :param port:           The Cassandra cluster port, defaults to None.
     :type  port:           int
-    :param params:         The parameters for the query, optional.
-    :type  params:         str
     :param protocol_version: Cassandra protocol version to use.
     :type  protocol_version: int
     :param load_balancing_policy: cassandra.policy class name to use

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -88,7 +88,7 @@ def _filter_dict(input_dict, search_key, search_value):
 
     :param input_dict:    is a dictionary whose values are lists of dictionaries
     :param search_key:    is the key in the leaf dictionaries
-    :param search_values: is the value in the leaf dictionaries
+    :param search_value: is the value in the leaf dictionaries
     :return:              filtered dictionary
     """
 

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -462,7 +462,7 @@ def diff(package_path, path):
     NOTE: this function includes all files (configuration and not), but does
     not work on binary content.
 
-    :param package: Full pack of the RPM file
+    :param package_path: Full pack of the RPM file
     :param path: Full path to the installed file
     :return: Difference or empty string. For binary files only a notification.
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -489,7 +489,7 @@ def get_jids_filter(count, filter_find_job=True):
     """
     Return a list of all jobs information filtered by the given criteria.
     :param int count: show not more than the count of most recent jobs
-    :param bool filter_find_jobs: filter out 'saltutil.find_job' jobs
+    :param bool filter_find_job: filter out 'saltutil.find_job' jobs
     """
     keys = []
     ret = []

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -501,7 +501,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
 def _purge_jobs(timestamp):
     """
     Purge records from the returner tables.
-    :param job_age_in_seconds:  Purge jobs older than this
+    :param timestamp:  Purge jobs older than this
     :return:
     """
     with _get_serv() as cursor:

--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -453,7 +453,7 @@ def _lookup_dnspython(name, rdtype, timeout=None, servers=None, secure=None):
     :param name: Name of record to search
     :param rdtype: DNS record type
     :param timeout: query timeout
-    :param server: [] of server(s) to try in order
+    :param servers: [] of server(s) to try in order
     :return: [] of records or False if error
     """
     resolver = dns.resolver.Resolver()
@@ -793,7 +793,7 @@ def aaaa_rec(rdata):
 def caa_rec(rdatas):
     """
     Validate and parse DNS record data for a CAA record
-    :param rdata: DNS record data
+    :param rdatas: DNS record data
     :return: dict w/fields
     """
     rschema = OrderedDict(
@@ -833,7 +833,7 @@ def mx_data(target, preference=10):
 def mx_rec(rdatas):
     """
     Validate and parse DNS record data for MX record(s)
-    :param rdata: DNS record data
+    :param rdatas: DNS record data
     :return: dict w/fields
     """
     rschema = OrderedDict(
@@ -965,7 +965,7 @@ def srv_name(svc, proto="tcp", domain=None):
 def srv_rec(rdatas):
     """
     Validate and parse DNS record data for SRV record(s)
-    :param rdata: DNS record data
+    :param rdatas: DNS record data
     :return: dict w/fields
     """
     rschema = OrderedDict(

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -510,8 +510,6 @@ class SaltEvent:
 
         :param tag: The tag to search for
         :type tag: str
-        :param tags_regex: List of re expressions to search for also
-        :type tags_regex: list[re.compile()]
         :return:
         """
         if match_func is None:

--- a/salt/utils/extend.py
+++ b/salt/utils/extend.py
@@ -197,11 +197,7 @@ def apply_template(template_dir, output_dir, context):
     Apply the template from the template directory to the output
     using the supplied context dict.
 
-    :param src: The source path
-    :type  src: ``str``
 
-    :param dst: The destination path
-    :type  dst: ``str``
 
     :param context: The dictionary to inject into the Jinja template as context
     :type  context: ``dict``

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -296,7 +296,7 @@ def ip_to_host(ip):
 def is_reachable_host(entity_name):
     """
     Returns a bool telling if the entity name is a reachable host (IPv4/IPv6/FQDN/etc).
-    :param hostname:
+    :param entity_name:
     :return:
     """
     try:

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -235,7 +235,6 @@ def _add_dependency(container, obj):
     Add a dependency to the top list.
 
     :param obj:
-    :param is_file:
     :return:
     """
     if os.path.basename(obj.__file__).split(".")[0] == "__init__":
@@ -249,8 +248,6 @@ def gte():
     This function is called externally from the alternative
     Python interpreter from within _get_tops function.
 
-    :param extra_mods:
-    :param so_mods:
     :return:
     """
     extra = salt.utils.json.loads(sys.argv[1])


### PR DESCRIPTION
### What does this PR do?

Twenty-six `:param:` fields name something the callable does not take. Docstrings only — no code, no behaviour, no tests.

Thirteen are renames:

| Where | Documented | Actual |
|---|---|---|
| `_filter_dict` (napalm_network) | `search_values` | `search_value` |
| `diff` (rpm_lowpkg) | `package` | `package_path` |
| `get_jids_filter` (local_cache) | `filter_find_jobs` | `filter_find_job` |
| `_purge_jobs` (pgjsonb) | `job_age_in_seconds` | `timestamp` |
| `TCPPuller.__init__` | `socket_path` | `path` |
| `_lookup_dnspython` | `server` | `servers` |
| `caa_rec`, `mx_rec`, `srv_rec` | `rdata` | `rdatas` |
| `state_docs`, `module_docs` (baredoc) | `name` | `names` |
| `AESFuncs._handle_aes` | `load` | `data` |
| `is_reachable_host` | `hostname` | `entity_name` |

Two had the field itself malformed rather than misnamed:

- `Master.__init__` has `:param dict: The salt options` — a type with no name, so Sphinx renders a parameter called `dict`. It is `opts`.
- `LoadedFunc` has `:param func str:` — the type and name are the wrong way round, and neither matches: the argument is `name`. `LoadedCoro` inherits `__init__` and carries the same line, so both are corrected.

The rest document an argument that is simply gone: `keep_loop` in `get_local_client`, `functions` in `auth`, `runners` in `states`, `settings` in `bcache.device`, `params` in `cql_query`, `tags_regex` in `_check_pending`, `src` and `dst` in `apply_template`, `is_file` in `_add_dependency`, and `extra_mods` and `so_mods` in `thin.gte`, which takes nothing at all. Where a `:type:` line accompanied the entry, it went with it.

One I left alone: the `Wildcard` class docstring in `zypperpkg` documents `:param ptn:` and `:return:`, which belong to `__call__`, not to `__init__`. Moving them is a restructure rather than a name fix, so that is your call.

Every entry was opened and read against its signature. `black --check` flags the same four files before and after this change, so nothing here is new.
