### PR TITLE
Fix postgres execution not respecting configuration values

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -140,7 +140,7 @@ def _find_pg_binary(util):
 
     Helper function to locate various psql related binaries
     """
-    pg_bin_dir = __salt__["config.option"]("postgres.bins_dir")
+    pg_bin_dir = __salt__["config.get"]("postgres:bins_dir")
     if pg_bin_dir:
         util_bin = salt.utils.path.which(os.path.join(pg_bin_dir, util))
         if util_bin:
@@ -156,13 +156,13 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
     kwargs = {
         "reset_system_locale": False,
         "clean_env": True,
-        "timeout": __salt__["config.option"](
-            "postgres.timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+        "timeout": __salt__["config.get"](
+            "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
         ),
     }
     if runas is None:
         if not host:
-            host = __salt__["config.option"]("postgres.host")
+            host = __salt__["config.get"]("postgres:host")
         if not host or host.startswith("/"):
             if "FreeBSD" in __grains__["os_family"]:
                 runas = "postgres"
@@ -178,7 +178,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
         kwargs["runas"] = runas
 
     if password is None:
-        password = __salt__["config.option"]("postgres.pass")
+        password = __salt__["config.get"]("postgres:pass")
     if password is not None:
         pgpassfile = salt.utils.files.mkstemp(text=True)
         with salt.utils.files.fopen(pgpassfile, "w") as fp_:
@@ -262,8 +262,8 @@ def _run_initdb(
     kwargs = dict(
         runas=runas,
         clean_env=True,
-        timeout=__salt__["config.option"](
-            "postgres.timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+        timeout=__salt__["config.get"](
+            "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
         ),
     )
     cmdstr = shlex.join(cmd)
@@ -344,13 +344,13 @@ def _connection_defaults(user=None, host=None, port=None, maintenance_db=None):
     values assigned to missing values.
     """
     if not user:
-        user = __salt__["config.option"]("postgres.user")
+        user = __salt__["config.get"]("postgres:user")
     if not host:
-        host = __salt__["config.option"]("postgres.host")
+        host = __salt__["config.get"]("postgres:host")
     if not port:
-        port = __salt__["config.option"]("postgres.port")
+        port = __salt__["config.get"]("postgres:port")
     if not maintenance_db:
-        maintenance_db = __salt__["config.option"]("postgres.maintenance_db")
+        maintenance_db = __salt__["config.get"]("postgres:maintenance_db")
 
     return (user, host, port, maintenance_db)
 


### PR DESCRIPTION
### What does this PR do?
Modifies the postgres execution module to respect the configuration set by changing all calls from `config.option` to `config.get` and setting the string delimiters to colons.

As noted in the related issue I opened:
```
# salt-call config.option

Passed invalid arguments: option() missing 1 required positional argument: 'value'.

Usage:

Returns the setting for the specified config value. The priority for
matches is the same as in :py:func:`config.get <salt.modules.config.get>`,
only this function does not recurse into nested data structures. Another
difference between this function and :py:func:`config.get
<salt.modules.config.get>` is that it comes with a set of "sane defaults".
To view these, you can run the following command:
```

It seems like `config.option` is just the wrong function to use and `config.get` is the correct one.

Before this fix:
```
# salt-call postgres.psql_query "SELECT current_user, session_user;"
local:
    |_
      ----------
      current_user:
          postgres
      session_user:
          postgres
```

After:

```
# salt-call postgres.psql_query "SELECT current_user, session_user;"
local:
    |_
      ----------
      current_user:
          salt_admin
      session_user:
          salt_admin
```

I do not know if this should go in the 3006.x. I sort of suspect that it should but I have not tested this at all on 3006.x so I have made this PR. If you would like to change it to 3006.x let me know and I can do that work.

### What issues does this PR fix or reference?
Fixes #69971 

### Previous Behavior
postgres module was not respecting the configuration set in either the pillars or minion configuration file.

### New Behavior
postgres module now respects configuration values.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->