### PR TITLE
Correct pywinrm distribution name in HAS_WINRM detection (salt-cloud WinRM)

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -80,9 +80,11 @@ try:
     import importlib
     import importlib.metadata
 
-    # Verify WinRM 0.3.0 or greater
+    # Verify WinRM 0.3.0 or greater. The PyPI distribution is "pywinrm"
+    # (imported as `winrm`); looking up "winrm" raises PackageNotFoundError
+    # (an ImportError subclass), leaving HAS_WINRM always False. See #69976.
 
-    version = importlib.metadata.version("winrm")
+    version = importlib.metadata.version("pywinrm")
     if not salt.utils.versions.compare(version, ">=", WINRM_MIN_VER):
         HAS_WINRM = False
     else:

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -561,6 +561,29 @@ def test_winrm_pinnned_version():
             assert winrm_version >= "0.3.0"
 
 
+def test_has_winrm_detection_uses_pywinrm_distribution():
+    """
+    HAS_WINRM must be detected via the "pywinrm" distribution name (the PyPI
+    package), not "winrm". ``importlib.metadata.version("winrm")`` raises
+    ``PackageNotFoundError`` (an ``ImportError`` subclass), which the surrounding
+    ``except ImportError`` swallows, leaving ``HAS_WINRM`` always ``False`` and
+    breaking salt-cloud WinRM deployments. See #69976.
+    """
+    import importlib.metadata
+
+    import salt.utils.versions
+
+    try:
+        pywinrm_version = importlib.metadata.version("pywinrm")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("pywinrm is not installed in this env.")
+    if not salt.utils.versions.compare(pywinrm_version, ">=", cloud.WINRM_MIN_VER):
+        pytest.skip(
+            f"pywinrm {pywinrm_version} is older than required {cloud.WINRM_MIN_VER}."
+        )
+    assert cloud.HAS_WINRM is True
+
+
 def test_ssh_gateway_arguments_default_alive_args():
     server_alive_interval = 60
     server_alive_count_max = 3


### PR DESCRIPTION
## Problem

`salt-cloud` Windows deployments with `use_winrm: true` always fail with

```
[ERROR ] WinRM requested but module winrm could not be imported.
Ensure you are using version 0.3.0 or higher.
```

even when `pywinrm` (>= 0.3.0) is installed (#69976).

Root cause is in the `HAS_WINRM` detection block of `salt/utils/cloud.py`:

```python
version = importlib.metadata.version("winrm")   # wrong distribution name
```

The PyPI package is distributed as **`pywinrm`** (imported as `winrm`). `importlib.metadata.version("winrm")` raises `PackageNotFoundError`, which is a subclass of `ImportError`, so the surrounding `except ImportError:` swallows it and `HAS_WINRM` is left `False` unconditionally.

## Fix

Use the correct distribution name:

```diff
-    version = importlib.metadata.version("winrm")
+    version = importlib.metadata.version("pywinrm")
```

Notably the existing `test_winrm_pinnned_version` already queries `version("pywinrm")`, so the test suite was using the right name while the source wasn't.

## Verification

Reproduced the detection logic directly (Python 3.12, `pywinrm` 0.5.0 installed):

```
lookup 'winrm'  -> raises PackageNotFoundError (subclass of ImportError) -> HAS_WINRM = False  (bug)
lookup 'pywinrm' -> '0.5.0'                                                -> HAS_WINRM = True   (fixed)
```

Added a regression test (`test_has_winrm_detection_uses_pywinrm_distribution`) that asserts `salt.utils.cloud.HAS_WINRM` is `True` when `pywinrm` is installed (skips otherwise) — it fails with the old `"winrm"` lookup and passes after the fix.

Closes #69976