### PR TITLE
[3008.x] Fix nested SyncWrapper deadlock in tcp.PublishServer.publish (#69986)

### DIFF
--- a/changelog/69986.fixed.md
+++ b/changelog/69986.fixed.md
@@ -1,1 +1,4 @@
-Fix MWorker deadlock in TCP PublishServer under async fire_event load
+Fix MWorker deadlock in TCP PublishServer under async fire_event load.
+Also fix a related fd leak in ``_TCPPubServerPublisher.close`` that caused
+``fd X added twice`` / ``Already reading`` log floods on the minion IPC
+puller under sustained fire_event traffic.

--- a/changelog/69986.fixed.md
+++ b/changelog/69986.fixed.md
@@ -1,0 +1,1 @@
+Fix MWorker deadlock in TCP PublishServer under async fire_event load

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1670,6 +1670,21 @@ class TCPPuller:
         # Mirror ``salt.transport.ipc.IPCServer.handle_stream``: read the
         # 4-byte length, then exactly that many payload bytes, unpack
         # once.
+        try:
+            await self._handle_stream_loop(stream)
+        finally:
+            # Ensure the stream is fully closed on the way out --
+            # otherwise its fd stays registered in the io_loop's
+            # selector until GC eventually runs, and any subsequent
+            # accept()'d socket assigned the same fd number fails
+            # with ``fd X added twice`` (#69992).
+            try:
+                if not stream.closed():
+                    stream.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    async def _handle_stream_loop(self, stream):
         while not stream.closed():
             try:
                 length_bytes = await stream.read_bytes(4)
@@ -1718,6 +1733,14 @@ class TCPPuller:
                         "Client disconnected from IPC %s:%s", self.host, self.port
                     )
                 break
+            except tornado.iostream.StreamBufferFullError:
+                # Peer stopped reading and our per-stream write buffer
+                # filled up.  This is a genuine backpressure signal,
+                # not a corrupted stream.  Log once and continue --
+                # ``read_bytes`` (called for the reader) does not raise
+                # this itself, but the payload_handler can if it
+                # forwarded to a slow subscriber.
+                log.error("Stream buffer full while handling stream")
             except OSError as exc:
                 # On occasion an exception will occur with
                 # an error code of 0, it's a spurious exception.
@@ -1729,8 +1752,27 @@ class TCPPuller:
                     )
                 else:
                     log.error("Exception occurred while handling stream: %s", exc)
+                    # A non-zero OSError from ``read_bytes`` means the
+                    # underlying socket/stream is unusable; retrying
+                    # will hit the same error immediately, spinning at
+                    # wire speed.  Bail out and let the connection be
+                    # re-established by the peer (#69992).
+                    break
             except Exception as exc:  # pylint: disable=broad-except
-                log.error("Exception occurred while handling stream: %s", exc)
+                # ``StreamAlreadyReadingError`` (raised as a plain
+                # ``Exception`` subclass) is the canonical footgun
+                # here: it means another coroutine already has an
+                # in-flight ``read_bytes`` on this same stream, and
+                # every retry from within this loop raises the same
+                # error immediately -- flooding logs and pinning a CPU
+                # core.  Break out; the accept side will hand us a
+                # fresh stream on the next connection (#69992).
+                log.error(
+                    "Exception occurred while handling stream: %s",
+                    exc,
+                    exc_info=True,
+                )
+                break
 
     def handle_connection(self, connection, address):
         log.trace(
@@ -2261,13 +2303,19 @@ class _TCPPubServerPublisher:
 
         if self.stream is not None and not self.stream.closed():
             try:
-                # Explicitly close the underlying socket before closing the stream
-                # to ensure file descriptors are released immediately
-                if hasattr(self.stream, "socket") and self.stream.socket is not None:
-                    try:
-                        self.stream.socket.close()
-                    except Exception:  # pylint: disable=broad-except
-                        pass
+                # ``IOStream.close()`` handles both un-registering the fd
+                # from the io_loop and closing the underlying socket.
+                # Do NOT ``self.stream.socket.close()`` first: that
+                # invalidates ``self.stream.fileno()`` so tornado's
+                # ``io_loop.remove_handler(self.fileno())`` inside
+                # ``IOStream.close()`` silently no-ops, leaving the fd
+                # registered in the selector.  A subsequent socket that
+                # gets the same fd number then fails with ``fd X added
+                # twice`` and, worse, the next ``read_bytes`` on the
+                # affected stream loops forever raising ``Already
+                # reading`` -- flooding logs at wire speed and killing
+                # the pytest process with SIGKILL under log-file backpressure
+                # (#69992 CI Test Package failures).
                 self.stream.close()
             except OSError as exc:
                 if exc.errno != errno.EBADF:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -2010,11 +2010,9 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
             loop = None
         if loop is not None:
             # Get or create a lock for this loop to prevent concurrent
-            # publisher creation (#69986 race condition fix)
-            lock = self._async_pubs_locks.get(loop)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._async_pubs_locks[loop] = lock
+            # publisher creation (#69986 race condition fix).
+            # Use setdefault() which is atomic due to GIL in CPython.
+            lock = self._async_pubs_locks.setdefault(loop, asyncio.Lock())
 
             async with lock:
                 async_pub = self._async_pubs.get(loop)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -21,6 +21,7 @@ import time
 import urllib
 import uuid
 import warnings
+import weakref
 
 import tornado
 import tornado.concurrent
@@ -1823,6 +1824,13 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         self.pub_server = None
         self.io_loop = None
         self._closing = False
+        # Async-fast-path publishers, cached per running asyncio loop
+        # (#69986).  A raw ``_TCPPubServerPublisher`` bound to the
+        # caller's own loop avoids the loop-mismatch hang that arises
+        # from awaiting ``pub_sock.send`` (which is tied to
+        # ``pub_sock``'s dedicated SyncWrapper loop) from an unrelated
+        # loop.
+        self._async_pubs = weakref.WeakKeyDictionary()
 
     @classmethod
     def support_ssl(cls):
@@ -1972,14 +1980,6 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
                 self.pull_path,
             ),
             loop_kwarg="io_loop",
-            # Force the sync form for sync-context callers (this
-            # ``connect`` method is a plain sync def).  #69986: the
-            # class-level ``async_methods`` was emptied to keep raw
-            # coroutines available for async-context callers of
-            # ``publish``/``send``; explicit passthrough here so
-            # ``self.pub_sock.connect(timeout=...)`` below still
-            # blocks the way callers expect.
-            async_methods=["connect", "_connect"],
         )
         self.pub_sock.connect(timeout=timeout)
 
@@ -1987,17 +1987,75 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         self, payload, **kwargs
     ):  # pylint: disable=invalid-overridden-method
         """
-        Publish "load" to minions
+        Publish "load" to minions.
+
+        On a running asyncio loop, use a raw ``_TCPPubServerPublisher``
+        bound to that loop (cached per-loop).  Do NOT use
+        ``self.pub_sock`` -- it is a
+        ``SyncWrapper(_TCPPubServerPublisher)`` whose internal
+        ``IOStream`` is tied to the SyncWrapper's dedicated io_loop; an
+        ``await`` on ``pub_sock.send(...)`` from a different loop hangs
+        because the write-future callback fires on the wrong loop
+        (#69986).
+
+        With no running loop, keep the legacy ``self.pub_sock`` path so
+        external sync callers still get blocking send.
         """
+        if self._closing:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None:
+            async_pub = self._async_pubs.get(loop)
+            if async_pub is None or not async_pub.connected():
+                async_pub = _TCPPubServerPublisher(
+                    self.pull_host,
+                    self.pull_port,
+                    self.pull_path,
+                    io_loop=tornado.ioloop.IOLoop.current(),
+                )
+                await async_pub.connect()
+                self._async_pubs[loop] = async_pub
+            try:
+                await async_pub.send(payload)
+                return
+            except tornado.iostream.StreamClosedError:
+                try:
+                    async_pub.close()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+                async_pub = _TCPPubServerPublisher(
+                    self.pull_host,
+                    self.pull_port,
+                    self.pull_path,
+                    io_loop=tornado.ioloop.IOLoop.current(),
+                )
+                await async_pub.connect()
+                self._async_pubs[loop] = async_pub
+                await async_pub.send(payload)
+                return
         if not self.pub_sock:
             self.connect()
-        # ``self.pub_sock.send`` returns a raw coroutine (#69986:
-        # ``_TCPPubServerPublisher.async_methods`` no longer lists
-        # ``send``), so ``await`` it on the current loop.
-        await self.pub_sock.send(payload)
+        self.pub_sock.send(payload)
 
     def close(self):
         self._closing = True
+        # Release per-loop async publishers (#69986).
+        try:
+            snapshot = list(self._async_pubs.items())
+        except Exception:  # pylint: disable=broad-except
+            snapshot = []
+        for _loop, async_pub in snapshot:
+            try:
+                async_pub.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+        try:
+            self._async_pubs.clear()
+        except Exception:  # pylint: disable=broad-except
+            pass
         if self.pub_sock:
             # pub_sock is a SyncWrapper - need to call close() on the wrapper itself
             import salt.utils.asynchronous
@@ -2050,13 +2108,11 @@ class _TCPPubServerPublisher:
     class directly.
     """
 
-    # Empty on purpose (#69986).  See ``PublishServer.async_methods``
-    # for the rationale: the sync ``_wrap`` form for a coroutine
-    # method wedges the caller's asyncio loop via ``thread.join()``
-    # inside their ``async def``.  Callers that need a blocking
-    # behaviour should ``io_loop.run_sync(publisher.send(...))``
-    # explicitly instead.
-    async_methods = []
+    async_methods = [
+        "send",
+        "connect",
+        "_connect",
+    ]
     close_methods = [
         "close",
     ]

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1778,9 +1778,14 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
     # TODO: opts!
     # Based on default used in tornado.netutil.bind_sockets()
     backlog = 128
-    async_methods = [
-        "publish",
-    ]
+    # ``publish`` intentionally NOT listed here (#69986): the
+    # ``SyncWrapper._wrap`` sync form for a coroutine method spawns a
+    # thread and blocks on ``thread.join()`` inside the caller's
+    # ``async def``, wedging the outer loop.  With ``publish`` absent
+    # from ``async_methods``, ``SyncWrapper.__getattr__`` returns the
+    # raw coroutine method and the caller can await it (or
+    # ``create_task`` it) without wedging.
+    async_methods = []
     close_methods = [
         "close",
     ]
@@ -1967,6 +1972,14 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
                 self.pull_path,
             ),
             loop_kwarg="io_loop",
+            # Force the sync form for sync-context callers (this
+            # ``connect`` method is a plain sync def).  #69986: the
+            # class-level ``async_methods`` was emptied to keep raw
+            # coroutines available for async-context callers of
+            # ``publish``/``send``; explicit passthrough here so
+            # ``self.pub_sock.connect(timeout=...)`` below still
+            # blocks the way callers expect.
+            async_methods=["connect", "_connect"],
         )
         self.pub_sock.connect(timeout=timeout)
 
@@ -1978,7 +1991,10 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         """
         if not self.pub_sock:
             self.connect()
-        self.pub_sock.send(payload)
+        # ``self.pub_sock.send`` returns a raw coroutine (#69986:
+        # ``_TCPPubServerPublisher.async_methods`` no longer lists
+        # ``send``), so ``await`` it on the current loop.
+        await self.pub_sock.send(payload)
 
     def close(self):
         self._closing = True
@@ -2034,11 +2050,13 @@ class _TCPPubServerPublisher:
     class directly.
     """
 
-    async_methods = [
-        "send",
-        "connect",
-        "_connect",
-    ]
+    # Empty on purpose (#69986).  See ``PublishServer.async_methods``
+    # for the rationale: the sync ``_wrap`` form for a coroutine
+    # method wedges the caller's asyncio loop via ``thread.join()``
+    # inside their ``async def``.  Callers that need a blocking
+    # behaviour should ``io_loop.run_sync(publisher.send(...))``
+    # explicitly instead.
+    async_methods = []
     close_methods = [
         "close",
     ]

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1831,6 +1831,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         # ``pub_sock``'s dedicated SyncWrapper loop) from an unrelated
         # loop.
         self._async_pubs = weakref.WeakKeyDictionary()
+        self._async_pubs_locks = weakref.WeakKeyDictionary()
 
     @classmethod
     def support_ssl(cls):
@@ -2008,32 +2009,41 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         except RuntimeError:
             loop = None
         if loop is not None:
-            async_pub = self._async_pubs.get(loop)
-            if async_pub is None or not async_pub.connected():
-                async_pub = _TCPPubServerPublisher(
-                    self.pull_host,
-                    self.pull_port,
-                    self.pull_path,
-                    io_loop=tornado.ioloop.IOLoop.current(),
-                )
-                await async_pub.connect()
-                self._async_pubs[loop] = async_pub
+            # Get or create a lock for this loop to prevent concurrent
+            # publisher creation (#69986 race condition fix)
+            lock = self._async_pubs_locks.get(loop)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._async_pubs_locks[loop] = lock
+
+            async with lock:
+                async_pub = self._async_pubs.get(loop)
+                if async_pub is None or not async_pub.connected():
+                    async_pub = _TCPPubServerPublisher(
+                        self.pull_host,
+                        self.pull_port,
+                        self.pull_path,
+                        io_loop=tornado.ioloop.IOLoop.current(),
+                    )
+                    await async_pub.connect()
+                    self._async_pubs[loop] = async_pub
             try:
                 await async_pub.send(payload)
                 return
             except tornado.iostream.StreamClosedError:
-                try:
-                    async_pub.close()
-                except Exception:  # pylint: disable=broad-except
-                    pass
-                async_pub = _TCPPubServerPublisher(
-                    self.pull_host,
-                    self.pull_port,
-                    self.pull_path,
-                    io_loop=tornado.ioloop.IOLoop.current(),
-                )
-                await async_pub.connect()
-                self._async_pubs[loop] = async_pub
+                async with lock:
+                    try:
+                        async_pub.close()
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                    async_pub = _TCPPubServerPublisher(
+                        self.pull_host,
+                        self.pull_port,
+                        self.pull_path,
+                        io_loop=tornado.ioloop.IOLoop.current(),
+                    )
+                    await async_pub.connect()
+                    self._async_pubs[loop] = async_pub
                 await async_pub.send(payload)
                 return
         if not self.pub_sock:
@@ -2054,6 +2064,10 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
                 pass
         try:
             self._async_pubs.clear()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        try:
+            self._async_pubs_locks.clear()
         except Exception:  # pylint: disable=broad-except
             pass
         if self.pub_sock:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -925,11 +925,9 @@ class SaltEvent:
         ).add(1, attributes={"tag_prefix": _event_tag_prefix(tag)})
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
-        if self._run_io_loop_sync:
-            # pusher is a SyncWrapper; publish() runs synchronously.
-            self.pusher.publish(msg)
-        else:
-            await self.pusher.publish(msg)
+        # ``pusher.publish`` returns a raw coroutine on both paths
+        # (#69986); we're inside an ``async def`` so ``await`` it.
+        await self.pusher.publish(msg)
         if cb is not None:
             warn_until(
                 3009,
@@ -970,8 +968,13 @@ class SaltEvent:
         event = self.pack(tag, data, max_size=self.opts["max_event_size"])
         msg = salt.utils.stringutils.to_bytes(event, "utf-8")
         if self._run_io_loop_sync:
+            # ``pusher.publish`` is exposed as a raw coroutine method
+            # by SyncWrapper (see #69986 -- ``publish`` was removed
+            # from ``PublishServer.async_methods`` to avoid the
+            # ``thread.join()`` wedge inside async callers).  Calling
+            # it returns a coroutine we must drive somehow.
             try:
-                self.pusher.publish(msg)
+                result = self.pusher.publish(msg)
             except Exception as exc:  # pylint: disable=broad-except
                 log.debug(
                     "Publisher send failed with exception: %s",
@@ -979,6 +982,21 @@ class SaltEvent:
                     exc_info_on_loglevel=logging.DEBUG,
                 )
                 raise
+            if asyncio.iscoroutine(result):
+                try:
+                    running_loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    running_loop = None
+                if running_loop is not None:
+                    # Async context: fire-and-forget on the running
+                    # loop.  Don't ``await`` -- this method is sync.
+                    task = running_loop.create_task(result)
+                    self._publish_tasks.add(task)
+                    task.add_done_callback(self._publish_tasks.discard)
+                else:
+                    # Sync context: drive the coroutine to completion
+                    # on the SyncWrapper's owned io_loop.
+                    self.pusher.io_loop.run_sync(lambda: result)
         else:
             task = self.io_loop.create_task(self.pusher.publish(msg))
             self._publish_tasks.add(task)

--- a/tests/pytests/functional/transport/tcp/test_deadlock_delivery_check.py
+++ b/tests/pytests/functional/transport/tcp/test_deadlock_delivery_check.py
@@ -1,0 +1,155 @@
+"""
+Companion check for the #69986 fix.  Confirms that events are actually
+delivered to the puller (not silently dropped by an unawaited
+coroutine).  Fails on any "fix" that trades deadlock for silent event
+loss.
+"""
+
+import multiprocessing
+import socket
+import threading
+import time
+
+import pytest
+
+
+def _find_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _child_fire_events(opts, sock_dir, publish_done):
+    import asyncio
+
+    import salt.utils.event
+
+    event = salt.utils.event.get_master_event(opts, sock_dir=sock_dir, listen=False)
+
+    async def _publish():
+        for i in range(5):
+            event.fire_event({"i": i, "pad": "x" * 128}, tag=f"delivery/{i}")
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(0.5)  # let scheduled tasks drain
+        publish_done.value = 1
+
+    asyncio.run(_publish())
+
+
+@pytest.mark.timeout(30, method="thread")
+def test_fire_event_from_async_context_actually_delivers(tmp_path):
+    """
+    After fire_event() returns from async context, the events MUST
+    actually reach the puller.  If a "fix" returns unawaited coroutines
+    from ``pusher.publish``, events are silently dropped and this test
+    catches it.
+    """
+    pull_port = _find_free_port()
+    pub_port = _find_free_port()
+    sock_dir = str(tmp_path)
+    opts = {
+        "ipc_mode": "tcp",
+        "ipc_write_buffer": 0,
+        "publish_port": pub_port,
+        "tcp_master_pub_port": pub_port,
+        "tcp_master_pull_port": pull_port,
+        "master_ip": "127.0.0.1",
+        "transport": "tcp",
+        "id": "test-master",
+        "sock_dir": sock_dir,
+        "order_masters": False,
+        "publish_signing_algorithm": "PKCS1v15-SHA1",
+        "acceptance_wait_time": 1,
+        "acceptance_wait_time_max": 1,
+        "loop_interval": 1,
+        "max_event_size": 1048576,
+        "tcp_keepalive": True,
+        "tcp_keepalive_idle": 300,
+        "tcp_keepalive_cnt": -1,
+        "tcp_keepalive_intvl": -1,
+    }
+
+    # Real listener that DRAINS everything.  We only want to verify
+    # bytes arrive.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", pull_port))
+    listener.listen(16)
+
+    received_bytes = bytearray()
+    stop_accept = threading.Event()
+
+    def _accept_and_drain():
+        conns = []
+        try:
+            while not stop_accept.is_set():
+                try:
+                    listener.settimeout(0.2)
+                    conn, _ = listener.accept()
+                    conns.append(conn)
+                    conn.setblocking(False)
+                except TimeoutError:
+                    pass
+                except OSError:
+                    break
+                for c in list(conns):
+                    try:
+                        data = c.recv(65536)
+                        if data:
+                            received_bytes.extend(data)
+                    except (BlockingIOError, InterruptedError):
+                        pass
+                    except OSError:
+                        conns.remove(c)
+        finally:
+            for c in conns:
+                try:
+                    c.close()
+                except OSError:
+                    pass
+
+    acc = threading.Thread(target=_accept_and_drain, daemon=True)
+    acc.start()
+
+    try:
+        ctx = multiprocessing.get_context("fork")
+        publish_done = ctx.Value("i", 0)
+        proc = ctx.Process(
+            target=_child_fire_events,
+            args=(opts, sock_dir, publish_done),
+            daemon=True,
+        )
+        proc.start()
+        proc.join(timeout=15)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=3)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+
+        # Give the drainer thread a moment to catch any last bytes.
+        time.sleep(0.5)
+
+        assert publish_done.value == 1, "child did not complete publishes"
+        # Sanity: at least ONE of the 5 event tags shows up in the
+        # bytes.  If the fix returns unawaited coroutines from
+        # pusher.publish, received_bytes will be empty (or only
+        # contain the connect handshake).
+        found_tags = sum(
+            1 for i in range(5) if f"delivery/{i}".encode() in received_bytes
+        )
+        assert found_tags >= 1, (
+            f"No events delivered to puller: received_bytes={len(received_bytes)} "
+            f"bytes; found_tags={found_tags}/5.  A 'fix' that returns "
+            f"unawaited coroutines from pusher.publish silently drops events."
+        )
+    finally:
+        stop_accept.set()
+        try:
+            listener.close()
+        except OSError:
+            pass
+        acc.join(timeout=5)

--- a/tests/pytests/functional/transport/tcp/test_deadlock_direct_repro.py
+++ b/tests/pytests/functional/transport/tcp/test_deadlock_direct_repro.py
@@ -1,0 +1,165 @@
+"""
+Complementary repro for #69986: does calling PublishServer.publish
+DIRECTLY (not through SyncWrapper) from an async context also wedge?
+
+This isolates whether the deadlock is intrinsic to PublishServer.publish
+or arises from the SyncWrapper wrapping.
+"""
+
+import multiprocessing
+import socket
+import threading
+import time
+
+import pytest
+
+
+def _find_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _child_run(opts, pub_port, pull_port, heartbeat_ticks, publish_done):
+    import asyncio
+
+    import salt.transport.tcp
+
+    server = salt.transport.tcp.PublishServer(
+        opts,
+        pub_host="127.0.0.1",
+        pub_port=pub_port,
+        pull_host="127.0.0.1",
+        pull_port=pull_port,
+    )
+
+    async def _heartbeat(stop_event):
+        while not stop_event.is_set():
+            with heartbeat_ticks.get_lock():
+                heartbeat_ticks.value += 1
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=0.05)
+            except asyncio.TimeoutError:
+                pass
+
+    async def _publish():
+        payload = b"x" * (256 * 1024)
+        # DIRECT await -- bypass SyncWrapper entirely.  On unpatched
+        # code, PublishServer.publish still internally routes through
+        # SyncWrapper(_TCPPubServerPublisher), so the outer loop
+        # wedges anyway.  On the fix, publish takes the async fast
+        # path (raw _TCPPubServerPublisher on the running loop).
+        for _ in range(200):
+            await server.publish(payload)
+        publish_done.value = 1
+
+    async def _main():
+        stop = asyncio.Event()
+        hb = asyncio.create_task(_heartbeat(stop))
+        await asyncio.sleep(0.1)
+        pub_task = asyncio.create_task(_publish())
+        try:
+            # Keep the loop alive for the parent's sample window.
+            await asyncio.sleep(6.0)
+        finally:
+            stop.set()
+            pub_task.cancel()
+            hb.cancel()
+
+    asyncio.run(_main())
+
+
+@pytest.mark.timeout(60, method="thread")
+def test_direct_publish_from_async_context(tmp_path):
+    pull_port = _find_free_port()
+    pub_port = _find_free_port()
+    opts = {
+        "ipc_mode": "tcp",
+        "ipc_write_buffer": 0,
+        "publish_port": pub_port,
+        "tcp_master_pub_port": pub_port,
+        "tcp_master_pull_port": pull_port,
+        "master_ip": "127.0.0.1",
+        "transport": "tcp",
+        "id": "test-master",
+        "sock_dir": str(tmp_path),
+        "order_masters": False,
+        "publish_signing_algorithm": "PKCS1v15-SHA1",
+        "acceptance_wait_time": 1,
+        "acceptance_wait_time_max": 1,
+        "loop_interval": 1,
+        "max_event_size": 2 * 1024 * 1024,
+        "tcp_keepalive": True,
+        "tcp_keepalive_idle": 300,
+        "tcp_keepalive_cnt": -1,
+        "tcp_keepalive_intvl": -1,
+    }
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+    listener.bind(("127.0.0.1", pull_port))
+    listener.listen(16)
+
+    stop_accept = threading.Event()
+    accepted = []
+
+    def _accept_loop():
+        while not stop_accept.is_set():
+            try:
+                listener.settimeout(0.5)
+                conn, _ = listener.accept()
+                conn.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+                accepted.append(conn)
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+
+    accept_thread = threading.Thread(target=_accept_loop, daemon=True)
+    accept_thread.start()
+
+    try:
+        ctx = multiprocessing.get_context("fork")
+        heartbeat_ticks = ctx.Value("i", 0)
+        publish_done = ctx.Value("i", 0)
+        proc = ctx.Process(
+            target=_child_run,
+            args=(opts, pub_port, pull_port, heartbeat_ticks, publish_done),
+            daemon=True,
+        )
+        proc.start()
+        time.sleep(1.5)
+        baseline = heartbeat_ticks.value
+        samples = []
+        for _ in range(20):
+            samples.append(heartbeat_ticks.value)
+            time.sleep(0.1)
+        progress = samples[-1] - baseline
+
+        proc.join(timeout=10)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+
+        assert progress >= 20, (
+            f"Direct-call publish wedged outer loop: progress={progress}, "
+            f"baseline={baseline}, samples={samples}"
+        )
+    finally:
+        stop_accept.set()
+        try:
+            listener.close()
+        except OSError:
+            pass
+        for c in accepted:
+            try:
+                c.close()
+            except OSError:
+                pass
+        accept_thread.join(timeout=5)

--- a/tests/pytests/functional/transport/tcp/test_deadlock_repro.py
+++ b/tests/pytests/functional/transport/tcp/test_deadlock_repro.py
@@ -1,0 +1,249 @@
+"""
+Regression / repro test for issue #69986 -- MWorker deadlock via nested
+SyncWrapper in ``salt.transport.tcp.PublishServer.publish`` when
+``salt.utils.event.SaltEvent.fire_event`` is called from a running
+asyncio loop (the MWorker ``request_handler`` scenario).
+
+Structured as a subprocess-driven smoke test: the actual deadlock is
+run in a child ``multiprocessing.Process`` so the parent can enforce a
+hard wall-clock kill on a wedged child (a thread-based pytest-timeout
+cannot unwind a ``threading.Thread.join()`` on the outer asyncio
+loop's thread, which is exactly the deadlock we are proving).
+
+Repro model
+-----------
+
+Production symptom: every MWorker deadlocks with two threads pinned in
+``threading.Thread.join()`` inside nested ``SyncWrapper._wrap`` frames::
+
+    request_handler asyncio loop  (MWorker._handle_payload etc.)
+      -> MasterEvent.fire_event(...)      (_run_io_loop_sync=True)
+        -> self.pusher.publish(msg)         # SyncWrapper(PublishServer)
+             _wrap sees running loop => spawn thread + thread.join()
+             thread runs PublishServer.publish(msg) via IOLoop.run_sync
+               -> self.pub_sock.send(payload)   # SyncWrapper(_TCPPubServerPublisher)
+                    _wrap sees running loop => spawn thread + thread.join()
+                    thread runs _TCPPubServerPublisher.send via IOLoop.run_sync
+                      -> await self.stream.write(pack)
+
+When ``stream.write`` stalls (kernel TCP send buffer full because the
+puller stopped reading -- the exact #66282 scenario), the inner
+``run_sync`` never returns, so the middle ``thread.join()`` blocks, so
+the outer ``thread.join()`` blocks.  The outer ``thread.join()`` runs
+inside an ``async def`` on the MWorker's request-handler loop, so that
+loop is fully wedged.
+
+Repro technique
+---------------
+
+1. Bind a dumb loopback listener that accepts but never reads.
+   ``SO_RCVBUF`` is shrunk so the kernel TCP window closes quickly.
+2. In a child process, construct a ``MasterEvent`` (which builds the
+   ``SyncWrapper(PublishServer)`` pusher exactly like MWorker does).
+3. Fire ``event.fire_event(...)`` from inside an ``async def`` task.
+4. Run a heartbeat task on the same outer loop.
+
+Signal: on unpatched ``origin/3008.x`` the heartbeat freezes because
+the outer loop is pinned by ``asynchronous.py:260 wrap ->
+thread.join()``.  On the correct fix the heartbeat keeps ticking (the
+fire_event fast path fires-and-forgets on the running loop, no
+thread.join()).
+
+Run::
+
+    /home/dan/src/salt/venv310/bin/pytest \\
+        tests/pytests/functional/transport/tcp/test_deadlock_repro.py -x -v
+"""
+
+import multiprocessing
+import socket
+import threading
+import time
+
+import pytest
+
+
+def _find_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _child_run(opts, sock_dir, heartbeat_ticks, publish_done):
+    """
+    Runs in the child process.  Mirrors the MWorker call shape:
+    ``MasterEvent.fire_event`` from inside an ``async def``, on a
+    loop that also runs a heartbeat task.
+    """
+    import asyncio
+
+    import salt.utils.event
+
+    event = salt.utils.event.get_master_event(opts, sock_dir=sock_dir, listen=False)
+
+    async def _heartbeat(stop_event):
+        while not stop_event.is_set():
+            with heartbeat_ticks.get_lock():
+                heartbeat_ticks.value += 1
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=0.05)
+            except asyncio.TimeoutError:
+                pass
+
+    async def _publish():
+        # 256KB payloads * 50 iterations; the fixture below shrinks
+        # the receiver's SO_RCVBUF to 4KB so the kernel TCP window
+        # closes within the first few iterations.  On unpatched code
+        # the SyncWrapper wedge fires on the very first fire_event.
+        for i in range(50):
+            event.fire_event({"i": i, "pad": "x" * 262144}, tag=f"repro/{i}")
+            await asyncio.sleep(0.02)  # yield outer loop
+        publish_done.value = 1
+
+    async def _main():
+        # Kick off both tasks and let them run for the full sample
+        # window (~6s).  Do NOT cancel heartbeat early on
+        # ``_publish``'s completion -- the parent's sample window is
+        # what times the test out.
+        stop = asyncio.Event()
+        hb = asyncio.create_task(_heartbeat(stop))
+        await asyncio.sleep(0.1)
+        pub_task = asyncio.create_task(_publish())
+        try:
+            # Give the parent time to sample heartbeat during and
+            # after ``_publish``.  6s covers the parent's 1.5s
+            # baseline + 2s sample + margin.
+            await asyncio.sleep(6.0)
+        finally:
+            stop.set()
+            pub_task.cancel()
+            hb.cancel()
+            try:
+                await asyncio.wait_for(hb, timeout=1)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    asyncio.run(_main())
+
+
+@pytest.mark.timeout(90, method="thread")
+def test_fire_event_async_context_does_not_wedge_outer_loop(tmp_path):
+    """
+    Repro for #69986.
+
+    Runs the offending call sequence in a child process:
+    ``MasterEvent.fire_event`` from an ``async def`` while a
+    heartbeat task ticks on the same loop.  Parent samples the shared
+    heartbeat counter and asserts progress.
+
+    Failure signature on unpatched ``origin/3008.x``:
+      * heartbeat stops ticking within the first publish call because
+        the outer asyncio loop is pinned at
+        ``asynchronous.py:260 wrap -> thread.join()``.
+
+    Success signature on the correct fix:
+      * heartbeat keeps ticking (>=20 ticks in a 2s window).
+    """
+    pull_port = _find_free_port()
+    pub_port = _find_free_port()
+    sock_dir = str(tmp_path)
+    opts = {
+        "ipc_mode": "tcp",
+        "ipc_write_buffer": 0,
+        "publish_port": pub_port,
+        "tcp_master_pub_port": pub_port,
+        "tcp_master_pull_port": pull_port,
+        "master_ip": "127.0.0.1",
+        "transport": "tcp",
+        "id": "test-master",
+        "sock_dir": sock_dir,
+        "order_masters": False,
+        "publish_signing_algorithm": "PKCS1v15-SHA1",
+        "acceptance_wait_time": 1,
+        "acceptance_wait_time_max": 1,
+        "loop_interval": 1,
+        "max_event_size": 2 * 1024 * 1024,
+        "tcp_keepalive": True,
+        "tcp_keepalive_idle": 300,
+        "tcp_keepalive_cnt": -1,
+        "tcp_keepalive_intvl": -1,
+    }
+
+    # Dumb pull listener: accept but never read, shrink recv buffer.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+    listener.bind(("127.0.0.1", pull_port))
+    listener.listen(16)
+
+    stop_accept = threading.Event()
+    accepted = []
+
+    def _accept_loop():
+        while not stop_accept.is_set():
+            try:
+                listener.settimeout(0.5)
+                conn, _ = listener.accept()
+                conn.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+                accepted.append(conn)
+            except TimeoutError:
+                continue
+            except OSError:
+                break
+
+    accept_thread = threading.Thread(
+        target=_accept_loop, name="dumb-pull-acceptor", daemon=True
+    )
+    accept_thread.start()
+
+    try:
+        ctx = multiprocessing.get_context("fork")
+        heartbeat_ticks = ctx.Value("i", 0)
+        publish_done = ctx.Value("i", 0)
+        proc = ctx.Process(
+            target=_child_run,
+            args=(opts, sock_dir, heartbeat_ticks, publish_done),
+            daemon=True,
+        )
+        proc.start()
+
+        # Give the child time to boot and start heartbeat + publish.
+        time.sleep(1.5)
+        baseline = heartbeat_ticks.value
+
+        # Sample every 100ms for 2s to see if heartbeat is still
+        # progressing WHILE publish is running (or wedged).
+        samples = []
+        for _ in range(20):
+            samples.append(heartbeat_ticks.value)
+            time.sleep(0.1)
+        progress = samples[-1] - baseline
+
+        proc.join(timeout=10)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+
+        assert progress >= 20, (
+            f"Outer asyncio loop wedged during fire_event (issue #69986): "
+            f"heartbeat progressed only {progress} ticks in 2s while "
+            f"SaltEvent.fire_event held the loop via nested SyncWrapper "
+            f"thread.join(). baseline={baseline} samples={samples}"
+        )
+    finally:
+        stop_accept.set()
+        try:
+            listener.close()
+        except OSError:
+            pass
+        for c in accepted:
+            try:
+                c.close()
+            except OSError:
+                pass
+        accept_thread.join(timeout=5)

--- a/tests/pytests/unit/utils/event/test_fire_event_async_context.py
+++ b/tests/pytests/unit/utils/event/test_fire_event_async_context.py
@@ -37,17 +37,23 @@ def test_publish_server_publish_not_in_async_methods():
     )
 
 
-def test_tcp_pub_server_publisher_send_not_in_async_methods():
+def test_publish_server_has_async_pubs_cache():
     """
-    ``_TCPPubServerPublisher.async_methods`` must not list ``send``
-    or ``connect``/``_connect`` either -- the same wedge applies to
-    the inner SyncWrapper used by ``PublishServer.connect()``.
+    ``PublishServer`` must carry a per-loop ``_async_pubs``
+    WeakKeyDictionary so ``publish`` on a running loop can use a raw
+    ``_TCPPubServerPublisher`` bound to that loop, rather than the
+    SyncWrapper-based ``self.pub_sock`` whose IOStream is tied to a
+    different loop (loop-mismatch hang, #69986).
     """
-    for name in ("send", "connect", "_connect"):
-        assert name not in salt.transport.tcp._TCPPubServerPublisher.async_methods, (
-            f"_TCPPubServerPublisher.async_methods must not contain "
-            f"{name!r} -- see #69986."
-        )
+    import weakref
+
+    inst = salt.transport.tcp.PublishServer(
+        {}, pub_host="127.0.0.1", pub_port=0, pull_host="127.0.0.1", pull_port=0
+    )
+    try:
+        assert isinstance(inst._async_pubs, weakref.WeakKeyDictionary)
+    finally:
+        inst.close()
 
 
 class FakeCoroPusher:

--- a/tests/pytests/unit/utils/event/test_fire_event_async_context.py
+++ b/tests/pytests/unit/utils/event/test_fire_event_async_context.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for the ``SaltEvent.fire_event`` async-context handling
+added for #69986.
+
+The fix removes ``publish`` from ``PublishServer.async_methods`` (and
+``send`` / ``connect`` / ``_connect`` from
+``_TCPPubServerPublisher.async_methods``) so ``SyncWrapper`` exposes
+the raw async coroutine methods rather than the wedging sync
+``_wrap`` form.  ``SaltEvent.fire_event`` (a sync method) then
+detects the coroutine return value and either schedules it on the
+running loop (async context) or drives it through the SyncWrapper's
+owned ``io_loop.run_sync`` (sync context).
+
+These are unit-scale checks with no sockets or subprocess; the
+functional repro that catches the actual production deadlock lives at
+``tests/pytests/functional/transport/tcp/test_deadlock_repro.py``.
+"""
+
+import asyncio
+
+import pytest
+
+import salt.transport.tcp
+import salt.utils.event
+
+
+def test_publish_server_publish_not_in_async_methods():
+    """
+    Regression for #69986: ``publish`` must NOT be in
+    ``PublishServer.async_methods``.  Adding it back would put the
+    ``SyncWrapper._wrap`` sync form (which does ``thread.join()``
+    inside async callers) between callers and the coroutine.
+    """
+    assert "publish" not in salt.transport.tcp.PublishServer.async_methods, (
+        "PublishServer.async_methods must not contain 'publish' -- see "
+        "#69986; the sync _wrap form wedges the caller's asyncio loop."
+    )
+
+
+def test_tcp_pub_server_publisher_send_not_in_async_methods():
+    """
+    ``_TCPPubServerPublisher.async_methods`` must not list ``send``
+    or ``connect``/``_connect`` either -- the same wedge applies to
+    the inner SyncWrapper used by ``PublishServer.connect()``.
+    """
+    for name in ("send", "connect", "_connect"):
+        assert name not in salt.transport.tcp._TCPPubServerPublisher.async_methods, (
+            f"_TCPPubServerPublisher.async_methods must not contain "
+            f"{name!r} -- see #69986."
+        )
+
+
+class FakeCoroPusher:
+    """
+    Stand-in for a raw ``PublishServer`` (post-fix): ``publish``
+    returns a real coroutine so ``fire_event`` exercises its
+    ``iscoroutine`` handling branch.
+    """
+
+    def __init__(self):
+        self.published = []
+        self.io_loop = None  # not used on the async-context path
+
+    async def publish(self, msg, **_kw):
+        self.published.append((msg, asyncio.get_running_loop()))
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def event_opts(tmp_path):
+    return {
+        "id": "test-master",
+        "sock_dir": str(tmp_path),
+        "transport": "tcp",
+        "ipc_mode": "tcp",
+        "publish_signing_algorithm": "PKCS1v15-SHA1",
+        "max_event_size": 1048576,
+    }
+
+
+def _new_event(event_opts, tmp_path):
+    return salt.utils.event.SaltEvent(
+        "master",
+        sock_dir=str(tmp_path),
+        opts=event_opts,
+        listen=False,
+    )
+
+
+def test_fire_event_async_context_schedules_coroutine_on_running_loop(
+    event_opts, tmp_path
+):
+    """
+    When ``pusher.publish`` returns a coroutine and ``fire_event`` is
+    called from a running loop, ``fire_event`` must schedule the
+    coroutine on THAT loop (not the wedging SyncWrapper thread+join).
+    """
+    event = _new_event(event_opts, tmp_path)
+    fake_pusher = FakeCoroPusher()
+    event.pusher = fake_pusher
+    event.cpush = True
+
+    async def _run():
+        loop = asyncio.get_running_loop()
+        ret = event.fire_event({"payload": "async"}, tag="unit/async")
+        # Give the scheduled task a chance to run.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        return ret, loop
+
+    try:
+        ret, loop = asyncio.run(_run())
+        assert ret is True
+        assert len(fake_pusher.published) == 1
+        _, task_loop = fake_pusher.published[0]
+        assert task_loop is loop, (
+            "coroutine must run on the caller's running loop, not on a "
+            "SyncWrapper's owned loop."
+        )
+    finally:
+        event.destroy()
+
+
+def test_fire_event_async_context_does_not_block_caller(event_opts, tmp_path):
+    """
+    ``fire_event`` from async context is fire-and-forget: the sync
+    method must return immediately even if the underlying coroutine
+    never resolves.  If it accidentally ``await``-blocked (via any
+    hidden ``thread.join``), this test would hang.
+    """
+
+    class NeverResolvingPusher:
+        io_loop = None
+
+        async def publish(self, msg, **_kw):
+            await asyncio.Event().wait()  # never completes
+
+        def close(self):
+            pass
+
+    event = _new_event(event_opts, tmp_path)
+    event.pusher = NeverResolvingPusher()
+    event.cpush = True
+
+    async def _run():
+        ret = event.fire_event({"payload": "nowait"}, tag="unit/nowait")
+        # Don't yield -- prove fire_event returned synchronously.
+        return ret
+
+    try:
+        assert asyncio.run(_run()) is True
+    finally:
+        event.destroy()
+
+
+def test_fire_event_sync_context_drives_coroutine_via_pusher_loop(event_opts, tmp_path):
+    """
+    When called with no running loop, ``fire_event`` must drive the
+    returned coroutine via the SyncWrapper's owned ``io_loop.run_sync``
+    so the send actually completes (not silently dropped).
+    """
+    driven = {"called": False}
+
+    class SyncPusher:
+        published = []
+
+        class _FakeIOLoop:
+            @staticmethod
+            def run_sync(fn):
+                # Consume the coroutine returned by fn so we exercise
+                # the sync-context branch without a real Tornado loop.
+                driven["called"] = True
+                coro = fn()
+                try:
+                    coro.send(None)
+                except StopIteration:
+                    pass
+                except Exception:  # pylint: disable=broad-except
+                    pass
+                return None
+
+        io_loop = _FakeIOLoop()
+
+        async def publish(self, msg, **_kw):
+            SyncPusher.published.append(msg)
+
+        def close(self):
+            pass
+
+    event = _new_event(event_opts, tmp_path)
+    event.pusher = SyncPusher()
+    event.cpush = True
+
+    try:
+        assert event.fire_event({"payload": "sync"}, tag="unit/sync") is True
+        assert driven["called"] is True
+        assert len(SyncPusher.published) == 1
+    finally:
+        event.destroy()


### PR DESCRIPTION
## Summary
- Bypass nested SyncWrapper in ``PublishServer.publish`` when in async context
- Cache raw ``_TCPPubServerPublisher`` per running loop via ``WeakKeyDictionary``
- Invalidate on ``StreamClosedError`` both proactively and reactively

Fixes #69986

## Test plan
- [ ] `salt.transport.tcp` unit tests pass
- [ ] Master survives sustained ``fire_event`` load without wedging (validated in local 10-min stress bench)

## Related PRs
- 3006.x back-port: `dwoz/fix/bug1-syncwrapper-3006.x` (pending, needs review before opening due to substantial adaptation)