### PR TITLE
[3008.x] Fix MWorkerQueue anon_pipes leak on pooled ROUTER (#69987)

### DIFF
--- a/changelog/69987.fixed.md
+++ b/changelog/69987.fixed.md
@@ -1,0 +1,1 @@
+Fix ``MWorkerQueue`` accumulating dead-peer state under sustained connect/disconnect churn. The pooled ``RequestServer`` ROUTER now sets ZMTP heartbeat, TCP keepalive, ``ROUTER_HANDOVER``, and a ``LINGER`` timeout so libzmq detects and reaps dead peers instead of retaining them in ``_anonymous_pipes``.

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -632,7 +632,23 @@ class RequestServer(salt.transport.base.DaemonizedRequestServer):
         # Create frontend ROUTER socket (minions connect here)
         self.uri = "tcp://{interface}:{ret_port}".format(**self.opts)
         self.clients = context.socket(zmq.ROUTER)
-        self.clients.setsockopt(zmq.LINGER, 1)
+        # PATCH: match the non-pooled ``zmq_device`` socket options exactly.
+        # The pooled path was only setting ``LINGER=1``, ``IPV4ONLY``, and
+        # ``BACKLOG`` -- missing ZMTP heartbeat, TCP keepalive, and
+        # ROUTER_HANDOVER.  Without heartbeat / keepalive, libzmq only
+        # reaps dead peers when the OS default TCP keepalive fires
+        # (~2h15m on Linux), so anon_pipes / out_pipes entries for
+        # long-gone peers accumulate without bound (observed 1000+
+        # stuck TCP conns / 9+ GB RSS under sustained CLI + salt-api
+        # churn).
+        self.clients.setsockopt(zmq.LINGER, 1000)
+        if hasattr(zmq, "ROUTER_HANDOVER"):
+            self.clients.setsockopt(zmq.ROUTER_HANDOVER, 1)
+        _set_zmq_heartbeat(self.clients, self.opts)
+        self.clients.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.clients.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 60)
+        self.clients.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 15)
+        self.clients.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
         if self.opts["ipv6"] is True and hasattr(zmq, "IPV4ONLY"):
             self.clients.setsockopt(zmq.IPV4ONLY, 0)
         self.clients.setsockopt(zmq.BACKLOG, self.opts.get("zmq_backlog", 1000))


### PR DESCRIPTION
## Summary
- Add ZMTP heartbeat (30s IVL, 60s TTL/TIMEOUT) on ``zmq_device_pooled`` ROUTER
- Add TCP keepalive (60s idle, 30s interval, 3 count)
- Add ``ROUTER_HANDOVER`` so new conn from same identity replaces stale
- Bump ``LINGER`` from 1 -> 1000 ms so in-flight replies survive teardown

Only applies to 3008.x -- 3006.x's ``zmq_device`` already got the equivalent fix in ``569db36f49f`` and ``zmq_device_pooled`` doesn't exist there.

Fixes #69987

## Test plan
- [ ] Local stress bench: MWQ RSS stable over 45+ min
- [ ] gdb walk of ``router_t::_anonymous_pipes`` stays bounded