### PR TITLE
[3008.x] Fix PubServer wedge on slow TCP subscriber (#69988)

### DIFF
--- a/changelog/69988.fixed.md
+++ b/changelog/69988.fixed.md
@@ -1,0 +1,1 @@
+Fix master ``PubServer`` wedge caused by a single slow TCP subscriber. Rewrote ``publish_payload`` to fire-and-forget writes with a per-subscriber ``publish_drain_timeout`` (default 5s). Slow subscribers are closed and removed instead of blocking every subsequent publish.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -554,6 +554,11 @@ VALID_OPTS = immutabletypes.freeze(
         # Set the zeromq high water mark on the publisher interface.
         # http://api.zeromq.org/3-2:zmq-setsockopt
         "pub_hwm": int,
+        # Per-subscriber timeout (seconds) for the TCP PubServer to drain
+        # a single publish write.  Subscribers that don't drain within
+        # this window are closed and removed to keep publish_payload
+        # from wedging on a slow peer.  See #69988.
+        "publish_drain_timeout": float,
         # IPC buffer size
         # Refs https://github.com/saltstack/salt/issues/34215
         "ipc_write_buffer": int,
@@ -1531,6 +1536,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "publish_port": 4505,
         "zmq_backlog": 1000,
         "pub_hwm": 1000,
+        "publish_drain_timeout": 5.0,
         "auth_mode": 1,
         "user": _MASTER_USER,
         "worker_threads": 5,

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1364,6 +1364,31 @@ class PubServer(tornado.tcpserver.TCPServer):
 
         return _cb
 
+    def _discard_slow_client(self, client, reason=""):
+        """
+        Close and forget a subscriber whose write future didn't drain in
+        the ``publish_drain_timeout``.  Idempotent -- ``client.close``
+        tolerates double-close, and ``set.discard`` is a no-op on absent
+        entries.
+        """
+        if client not in self.clients and getattr(client, "_slow_closed", False):
+            return
+        client._slow_closed = True
+        log.warning(
+            "Publisher discarding slow subscriber %s (%s)",
+            client.address,
+            reason,
+        )
+        try:
+            self.remove_presence_callback(client)
+        except Exception:  # pylint: disable=broad-except
+            pass
+        self.clients.discard(client)
+        try:
+            client.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     def handle_stream(self, stream, address):
         cert = None
         try:
@@ -1445,20 +1470,56 @@ class PubServer(tornado.tcpserver.TCPServer):
         )
         payload = salt.transport.frame.frame_msg(package)
         to_remove = []
-        # Start writes to every targeted client concurrently so a single
-        # slow subscriber can't stall delivery to the rest of the fleet.
-        # See https://github.com/saltstack/salt/issues/66282 — sequential
-        # ``yield client.stream.write(...)`` was clogging the event
-        # publisher loop, growing per-client write buffers and eventually
-        # wedging the master.
-        write_futures = []
+
+        def _make_drain_task(client):
+            """
+            PATCH: drain a subscriber's write future in a fire-and-forget
+            asyncio task with a bounded per-subscriber timeout.
+
+            Previously ``publish_payload`` awaited each client's write
+            future sequentially.  A single slow subscriber (kernel TCP
+            send buffer full) made ``await future`` never resolve; every
+            subsequent broadcast piled up more pending publish_payload
+            coroutines all blocked on the same subscriber, wedging EP's
+            io_loop.  With EP not draining ``master_event_pull.ipc``,
+            MWorker's ``fire_event`` -> ``stream.write`` blocked in the
+            kernel; SyncWrapper's ``thread.join()`` never returned and
+            every MWorker deadlocked, which in turn wedged MWQ's DEALER
+            send() and cascaded down to minion request timeouts and TCP
+            churn.
+
+            Fire-and-forget with a timeout means ``publish_payload``
+            returns immediately after queueing writes.  Slow subscribers
+            drain in their own tasks.  If a subscriber can't drain in
+            ``publish_drain_timeout`` seconds, it is closed and removed
+            from ``self.clients`` -- fixes the wedge; the peer can
+            reconnect and try again.
+            """
+            drain_timeout = self.opts.get("publish_drain_timeout", 5.0)
+
+            async def _drain(fut):
+                try:
+                    await asyncio.wait_for(fut, timeout=drain_timeout)
+                except tornado.iostream.StreamClosedError:
+                    self._discard_slow_client(client, reason="stream closed")
+                except asyncio.TimeoutError:
+                    self._discard_slow_client(
+                        client, reason=f"drain timeout {drain_timeout}s"
+                    )
+                except Exception as exc:  # pylint: disable=broad-except
+                    log.warning("Publisher drain to %s failed: %s", client.address, exc)
+                    self._discard_slow_client(client, reason=str(exc))
+
+            return _drain
+
         if topic_list:
             for topic in topic_list:
                 sent = False
                 for client in list(self.clients):
                     if topic == client.id_:
                         try:
-                            write_futures.append((client, client.stream.write(payload)))
+                            fut = client.stream.write(payload)
+                            asyncio.ensure_future(_make_drain_task(client)(fut))
                             sent = True
                         except tornado.iostream.StreamClosedError:
                             to_remove.append(client)
@@ -1467,14 +1528,10 @@ class PubServer(tornado.tcpserver.TCPServer):
         else:
             for client in list(self.clients):
                 try:
-                    write_futures.append((client, client.stream.write(payload)))
+                    fut = client.stream.write(payload)
+                    asyncio.ensure_future(_make_drain_task(client)(fut))
                 except tornado.iostream.StreamClosedError:
                     to_remove.append(client)
-        for client, future in write_futures:
-            try:
-                await future
-            except tornado.iostream.StreamClosedError:
-                to_remove.append(client)
         for client in to_remove:
             log.debug(
                 "Subscriber at %s has disconnected from publisher", client.address


### PR DESCRIPTION
## Summary
- Rewrite ``PubServer.publish_payload`` to use fire-and-forget writes with per-subscriber timeout
- Add ``_discard_slow_client`` helper that closes + removes subscribers that don't drain
- New master opt ``publish_drain_timeout`` (default 5.0 seconds)
- Complements existing concurrent-write commit ``73c6970351b``

Fixes #69988

## Test plan
- [ ] Slow-subscriber unit test (fake stream that never resolves write future)
- [ ] Master survives 10-min stress bench without wedging

## Related PRs
- 3006.x back-port: `dwoz/fix/bug3-slow-subscriber-3006.x` (uses tornado ``gen.with_timeout`` + ``io_loop.spawn_callback`` instead of ``asyncio.ensure_future``)