### PR TITLE
[3006.x] Add onedir package test for libyaml-linked PyYAML

### DIFF
--- a/tests/pytests/pkg/integration/test_libyaml.py
+++ b/tests/pytests/pkg/integration/test_libyaml.py
@@ -54,6 +54,11 @@ def check_libyaml_file(tmp_path):
     "Windows/macOS already pick libyaml-linked wheels.",
 )
 def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyaml_file):
+    if install_salt.downgrade:
+        pytest.skip(
+            "Downgrade flavor tests against the pre-#69950 onedir; "
+            "libyaml is expected to be absent there."
+        )
     ret = install_salt.proc.run(
         *(python_script_bin + [str(check_libyaml_file)]),
         stdout=subprocess.PIPE,
@@ -70,6 +75,11 @@ def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyam
     "Windows/macOS already pick libyaml-linked wheels.",
 )
 def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path):
+    if install_salt.downgrade:
+        pytest.skip(
+            "Downgrade flavor tests against the pre-#69950 onedir; "
+            "libyaml is expected to be absent there."
+        )
     script_path = tmp_path / "check_yamlloader.py"
     script_path.write_text(
         textwrap.dedent(

--- a/tests/pytests/pkg/integration/test_libyaml.py
+++ b/tests/pytests/pkg/integration/test_libyaml.py
@@ -78,9 +78,9 @@ def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path)
         import yaml
         import salt.utils.yamlloader
 
-        assert salt.utils.yamlloader.SafeLoader is yaml.CSafeLoader, (
-            "salt.utils.yamlloader.SafeLoader fell back to pure-Python "
-            "SafeLoader (libyaml not linked)"
+        assert salt.utils.yamlloader.BaseLoader is yaml.CSafeLoader, (
+            "salt.utils.yamlloader.BaseLoader fell back to pure-Python "
+            "yaml.SafeLoader (libyaml not linked)"
         )
         sys.exit(0)
         """

--- a/tests/pytests/pkg/integration/test_libyaml.py
+++ b/tests/pytests/pkg/integration/test_libyaml.py
@@ -11,8 +11,8 @@ run time, so it works uniformly across the install / upgrade / downgrade
 package-test flavors:
 
 - install / post-upgrade: current onedir is on disk, expect libyaml present
-- post-downgrade: previous onedir is on disk. If that release predates the
-  fix, expect libyaml absent (documenting the pre-fix state so a silent
+- post-downgrade: previous onedir is on disk. That release predates the
+  fix, so expect libyaml absent (documenting the pre-fix state so a silent
   regression on the previous branch is still caught).
 """
 
@@ -20,12 +20,7 @@ import subprocess
 import sys
 import textwrap
 
-import packaging.version
 import pytest
-
-# First release that ships the libyaml-linked PyYAML wheel on Linux onedir.
-# Update if the fix is ever backported earlier.
-LIBYAML_FIX_LANDED_IN = packaging.version.Version("3006.28")
 
 
 @pytest.fixture
@@ -35,8 +30,9 @@ def python_script_bin(install_salt):
 
 @pytest.fixture
 def libyaml_expected(install_salt):
-    """True if the onedir currently on disk is expected to ship libyaml."""
-    return packaging.version.Version(install_salt.version) >= LIBYAML_FIX_LANDED_IN
+    """Current onedir (install/upgrade) ships libyaml; the previous release
+    (post-downgrade validation) predates PR #69950 and does not."""
+    return not install_salt.use_prev_version
 
 
 @pytest.fixture
@@ -85,14 +81,14 @@ def test_libyaml_matches_installed_version(
     )
     if libyaml_expected:
         assert ret.returncode == 0, (
-            f"libyaml expected present in salt {install_salt.version} "
-            f"(>= {LIBYAML_FIX_LANDED_IN}) but the probe failed:\n{ret.stderr}"
+            f"libyaml expected present in the current onedir but the probe "
+            f"failed:\n{ret.stderr}"
         )
     else:
         assert ret.returncode != 0, (
-            f"libyaml unexpectedly present in salt {install_salt.version} "
-            f"(pre-{LIBYAML_FIX_LANDED_IN}). If the fix was backported "
-            f"earlier, lower LIBYAML_FIX_LANDED_IN in this test."
+            "libyaml unexpectedly present in the previous-release onedir. "
+            "If PR #69950 was backported earlier than 3006.28, drop this "
+            "test's downgrade branch."
         )
 
 
@@ -125,14 +121,14 @@ def test_salt_yamlloader_matches_installed_version(
     )
     if libyaml_expected:
         assert ret.returncode == 0, (
-            f"salt.utils.yamlloader.BaseLoader should be yaml.CSafeLoader in "
-            f"salt {install_salt.version} (>= {LIBYAML_FIX_LANDED_IN}); "
-            f"it resolved to the pure-Python loader instead."
+            "salt.utils.yamlloader.BaseLoader should be yaml.CSafeLoader in "
+            "the current onedir; it resolved to the pure-Python loader "
+            "instead."
         )
     else:
         assert ret.returncode != 0, (
-            f"salt.utils.yamlloader.BaseLoader unexpectedly resolves to "
-            f"yaml.CSafeLoader in pre-{LIBYAML_FIX_LANDED_IN} "
-            f"salt {install_salt.version}. If the fix was backported "
-            f"earlier, lower LIBYAML_FIX_LANDED_IN in this test."
+            "salt.utils.yamlloader.BaseLoader unexpectedly resolves to "
+            "yaml.CSafeLoader in the previous-release onedir. If PR #69950 "
+            "was backported earlier than 3006.28, drop this test's downgrade "
+            "branch."
         )

--- a/tests/pytests/pkg/integration/test_libyaml.py
+++ b/tests/pytests/pkg/integration/test_libyaml.py
@@ -5,18 +5,38 @@ Regression cover for #69907 / PR #69950 (3006.x) and #69949 (3008.x):
 the Linux onedir build was source-compiling PyYAML under a relenv toolchain
 that has no libyaml, so `yaml.CSafeLoader`/`yaml.CSafeDumper` were absent
 and every YAML load fell back to the ~10-20x slower pure-Python parser.
+
+The test asserts the invariant that matches whatever salt is installed at
+run time, so it works uniformly across the install / upgrade / downgrade
+package-test flavors:
+
+- install / post-upgrade: current onedir is on disk, expect libyaml present
+- post-downgrade: previous onedir is on disk. If that release predates the
+  fix, expect libyaml absent (documenting the pre-fix state so a silent
+  regression on the previous branch is still caught).
 """
 
 import subprocess
 import sys
 import textwrap
 
+import packaging.version
 import pytest
+
+# First release that ships the libyaml-linked PyYAML wheel on Linux onedir.
+# Update if the fix is ever backported earlier.
+LIBYAML_FIX_LANDED_IN = packaging.version.Version("3006.28")
 
 
 @pytest.fixture
 def python_script_bin(install_salt):
     return install_salt.binary_paths["python"]
+
+
+@pytest.fixture
+def libyaml_expected(install_salt):
+    """True if the onedir currently on disk is expected to ship libyaml."""
+    return packaging.version.Version(install_salt.version) >= LIBYAML_FIX_LANDED_IN
 
 
 @pytest.fixture
@@ -53,12 +73,9 @@ def check_libyaml_file(tmp_path):
     reason="Only the Linux onedir build passes --no-binary=:all:; "
     "Windows/macOS already pick libyaml-linked wheels.",
 )
-def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyaml_file):
-    if install_salt.downgrade:
-        pytest.skip(
-            "Downgrade flavor tests against the pre-#69950 onedir; "
-            "libyaml is expected to be absent there."
-        )
+def test_libyaml_matches_installed_version(
+    install_salt, python_script_bin, check_libyaml_file, libyaml_expected
+):
     ret = install_salt.proc.run(
         *(python_script_bin + [str(check_libyaml_file)]),
         stdout=subprocess.PIPE,
@@ -66,7 +83,17 @@ def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyam
         check=False,
         universal_newlines=True,
     )
-    assert ret.returncode == 0, ret.stderr
+    if libyaml_expected:
+        assert ret.returncode == 0, (
+            f"libyaml expected present in salt {install_salt.version} "
+            f"(>= {LIBYAML_FIX_LANDED_IN}) but the probe failed:\n{ret.stderr}"
+        )
+    else:
+        assert ret.returncode != 0, (
+            f"libyaml unexpectedly present in salt {install_salt.version} "
+            f"(pre-{LIBYAML_FIX_LANDED_IN}). If the fix was backported "
+            f"earlier, lower LIBYAML_FIX_LANDED_IN in this test."
+        )
 
 
 @pytest.mark.skipif(
@@ -74,12 +101,9 @@ def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyam
     reason="Only the Linux onedir build passes --no-binary=:all:; "
     "Windows/macOS already pick libyaml-linked wheels.",
 )
-def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path):
-    if install_salt.downgrade:
-        pytest.skip(
-            "Downgrade flavor tests against the pre-#69950 onedir; "
-            "libyaml is expected to be absent there."
-        )
+def test_salt_yamlloader_matches_installed_version(
+    install_salt, python_script_bin, tmp_path, libyaml_expected
+):
     script_path = tmp_path / "check_yamlloader.py"
     script_path.write_text(
         textwrap.dedent(
@@ -88,11 +112,7 @@ def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path)
         import yaml
         import salt.utils.yamlloader
 
-        assert salt.utils.yamlloader.BaseLoader is yaml.CSafeLoader, (
-            "salt.utils.yamlloader.BaseLoader fell back to pure-Python "
-            "yaml.SafeLoader (libyaml not linked)"
-        )
-        sys.exit(0)
+        sys.exit(0 if salt.utils.yamlloader.BaseLoader is getattr(yaml, "CSafeLoader", None) else 1)
         """
         )
     )
@@ -103,4 +123,16 @@ def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path)
         check=False,
         universal_newlines=True,
     )
-    assert ret.returncode == 0, ret.stderr
+    if libyaml_expected:
+        assert ret.returncode == 0, (
+            f"salt.utils.yamlloader.BaseLoader should be yaml.CSafeLoader in "
+            f"salt {install_salt.version} (>= {LIBYAML_FIX_LANDED_IN}); "
+            f"it resolved to the pure-Python loader instead."
+        )
+    else:
+        assert ret.returncode != 0, (
+            f"salt.utils.yamlloader.BaseLoader unexpectedly resolves to "
+            f"yaml.CSafeLoader in pre-{LIBYAML_FIX_LANDED_IN} "
+            f"salt {install_salt.version}. If the fix was backported "
+            f"earlier, lower LIBYAML_FIX_LANDED_IN in this test."
+        )

--- a/tests/pytests/pkg/integration/test_libyaml.py
+++ b/tests/pytests/pkg/integration/test_libyaml.py
@@ -1,0 +1,96 @@
+"""
+Verify the onedir bundle ships a libyaml-linked PyYAML.
+
+Regression cover for #69907 / PR #69950 (3006.x) and #69949 (3008.x):
+the Linux onedir build was source-compiling PyYAML under a relenv toolchain
+that has no libyaml, so `yaml.CSafeLoader`/`yaml.CSafeDumper` were absent
+and every YAML load fell back to the ~10-20x slower pure-Python parser.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def python_script_bin(install_salt):
+    return install_salt.binary_paths["python"]
+
+
+@pytest.fixture
+def check_libyaml_file(tmp_path):
+    script_path = tmp_path / "check_libyaml.py"
+    script_path.write_text(
+        textwrap.dedent(
+            """
+        import sys
+        import yaml
+
+        assert hasattr(yaml, "CSafeLoader"), "yaml.CSafeLoader missing"
+        assert hasattr(yaml, "CSafeDumper"), "yaml.CSafeDumper missing"
+        assert hasattr(yaml, "CLoader"), "yaml.CLoader missing"
+        assert hasattr(yaml, "CDumper"), "yaml.CDumper missing"
+
+        import _yaml  # noqa: F401  # PyYAML C extension
+
+        loader = yaml.CSafeLoader("key: value\\n")
+        try:
+            data = loader.get_single_data()
+        finally:
+            loader.dispose()
+        assert data == {"key": "value"}, data
+        sys.exit(0)
+        """
+        )
+    )
+    return script_path
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Only the Linux onedir build passes --no-binary=:all:; "
+    "Windows/macOS already pick libyaml-linked wheels.",
+)
+def test_libyaml_bundled_in_onedir(install_salt, python_script_bin, check_libyaml_file):
+    ret = install_salt.proc.run(
+        *(python_script_bin + [str(check_libyaml_file)]),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Only the Linux onedir build passes --no-binary=:all:; "
+    "Windows/macOS already pick libyaml-linked wheels.",
+)
+def test_salt_yamlloader_uses_libyaml(install_salt, python_script_bin, tmp_path):
+    script_path = tmp_path / "check_yamlloader.py"
+    script_path.write_text(
+        textwrap.dedent(
+            """
+        import sys
+        import yaml
+        import salt.utils.yamlloader
+
+        assert salt.utils.yamlloader.SafeLoader is yaml.CSafeLoader, (
+            "salt.utils.yamlloader.SafeLoader fell back to pure-Python "
+            "SafeLoader (libyaml not linked)"
+        )
+        sys.exit(0)
+        """
+        )
+    )
+    ret = install_salt.proc.run(
+        *(python_script_bin + [str(script_path)]),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr


### PR DESCRIPTION
Follow-up to PR #69950 (3006.x) / #69949 (3008.x) — adds a package-level regression test so a slip back to a source-built PyYAML without libyaml (the class of bug reported in #69907) fails CI before release.

What it checks, from the shipped onedir python:
- `yaml.CSafeLoader`, `yaml.CSafeDumper`, `yaml.CLoader`, `yaml.CDumper` are all present
- `import _yaml` succeeds (PyYAML C extension is importable)
- `salt.utils.yamlloader.SafeLoader is yaml.CSafeLoader` — catches the case where the extension exists but Salt's shim is still resolving to the pure-Python loader
- Round-trips a trivial YAML doc through `CSafeLoader` to make sure the extension is functional, not just importable

Linux-only. Windows and macOS onedirs do not pass `--no-binary=:all:` to pip, so they already pick libyaml-linked wheels.