### PR TITLE
Fix silent truncation of large HTTP downloads in cp/fileclient

### DIFF
--- a/changelog/69916.fixed.md
+++ b/changelog/69916.fixed.md
@@ -1,0 +1,17 @@
+Fixed large HTTP(S) downloads (over 100MiB) via `cp.cache_file`/
+`fileclient.get_url` being silently truncated, which could leave
+`winrepo_ng` installers (and other large `salt://`-adjacent HTTP
+downloads) incomplete without raising an error. Tornado's HTTPClient
+enforces a default `max_buffer_size` of 100MiB independently of
+`max_body_size`; when a server doesn't send a `Content-Length` header,
+Salt read the response until the connection closed, hitting that limit
+and truncating the download. `max_buffer_size` is now passed alongside
+`max_body_size` so both track the `http_max_body` option.
+
+`fileclient.get_url` now also compares the number of bytes received
+against any advertised `Content-Length` and raises a clear error
+instead of caching a partial file if they don't match, and the
+`requests` backend now streams responses via `iter_content` and
+catches `requests.exceptions.RequestException`, so a connection
+dropped mid-download is reported the same way as other HTTP errors
+instead of crashing with an unhandled exception.

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -685,7 +685,21 @@ class Client:
             #   both content encoding and etag are found.
             write_body = [None, False, None, None]
 
+            # Content-Length of the final (non-redirect) response, used to
+            # detect truncated downloads. See #69916: some HTTP client
+            # configurations can silently stop reading a streamed response
+            # partway through without raising an error.
+            content_length = [None]
+            bytes_received = [0]
+
             def on_header(hdr):
+                if write_body[0] and content_length[0] is None:
+                    header_name, _, header_value = hdr.partition(":")
+                    if header_name.strip().lower() == "content-length":
+                        try:
+                            content_length[0] = int(header_value.strip())
+                        except ValueError:
+                            pass
                 if write_body[1] is not False and (
                     write_body[2] is None or (use_etag and write_body[3] is None)
                 ):
@@ -760,6 +774,7 @@ class Client:
 
                 def on_chunk(chunk):
                     if write_body[0]:
+                        bytes_received[0] += len(chunk)
                         if write_body[2]:
                             chunk = chunk.decode(write_body[2])
                         result.append(chunk)
@@ -774,6 +789,7 @@ class Client:
 
                 def on_chunk(chunk):
                     if write_body[0]:
+                        bytes_received[0] += len(chunk)
                         destfp.write(chunk)
 
             # ETag is only used for refetch. Cached file and previous ETag
@@ -808,6 +824,18 @@ class Client:
             if "handle" not in query:
                 raise MinionError(
                     "Error: {} reading {}".format(query["error"], url_data.path)
+                )
+            if content_length[0] is not None and bytes_received[0] != content_length[0]:
+                if not no_cache and destfp is not None:
+                    destfp.close()
+                    destfp = None
+                    with contextlib.suppress(OSError):
+                        os.remove(dest_tmp)
+                raise MinionError(
+                    "Failed to download {}: expected {} bytes but received "
+                    "{} bytes (truncated download)".format(
+                        url, content_length[0], bytes_received[0]
+                    )
                 )
             if no_cache:
                 if write_body[2]:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -78,6 +78,9 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 USERAGENT = f"Salt/{salt.version.__version__}"
+# Chunk size used when streaming a response body through the ``requests``
+# backend (see #69916).
+REQUESTS_CHUNK_SIZE = 1024 * 1024
 
 
 def __decompressContent(coding, pgctnt):
@@ -423,44 +426,65 @@ def query(
                     cert,
                 )
 
-        if formdata:
-            if not formdata_fieldname:
-                ret["error"] = "formdata_fieldname is required when formdata=True"
-                log.error(ret["error"])
-                return ret
-            result = sess.request(
-                method,
-                url,
-                params=params,
-                files={formdata_fieldname: (formdata_filename, io.StringIO(data))},
-                **req_kwargs,
+        if formdata and not formdata_fieldname:
+            ret["error"] = "formdata_fieldname is required when formdata=True"
+            log.error(ret["error"])
+            return ret
+
+        try:
+            if formdata:
+                result = sess.request(
+                    method,
+                    url,
+                    params=params,
+                    files={formdata_fieldname: (formdata_filename, io.StringIO(data))},
+                    **req_kwargs,
+                )
+            else:
+                result = sess.request(
+                    method, url, params=params, data=data, **req_kwargs
+                )
+            result.raise_for_status()
+            if stream is True:
+                # fake a HTTP response header
+                header_callback(f"HTTP/1.0 {result.status_code} MESSAGE")
+                # Stream the response in chunks instead of buffering the
+                # entire body in memory at once via result.content, so
+                # large downloads (e.g. winrepo installers) don't need to
+                # fit in RAM. See #69916.
+                for chunk in result.iter_content(chunk_size=REQUESTS_CHUNK_SIZE):
+                    if chunk:
+                        streaming_callback(chunk)
+                return {
+                    "handle": result,
+                }
+
+            if handle is True:
+                return {
+                    "handle": result,
+                    "body": result.content,
+                }
+
+            log.debug(
+                "Final URL location of Response: %s",
+                sanitize_url(result.url, hide_fields),
             )
-        else:
-            result = sess.request(method, url, params=params, data=data, **req_kwargs)
-        result.raise_for_status()
-        if stream is True:
-            # fake a HTTP response header
-            header_callback(f"HTTP/1.0 {result.status_code} MESSAGE")
-            # fake streaming the content
-            streaming_callback(result.content)
-            return {
-                "handle": result,
-            }
 
-        if handle is True:
-            return {
-                "handle": result,
-                "body": result.content,
-            }
-
-        log.debug(
-            "Final URL location of Response: %s", sanitize_url(result.url, hide_fields)
-        )
-
-        result_status_code = result.status_code
-        result_headers = result.headers
-        result_text = result.content
-        result_cookies = result.cookies
+            result_status_code = result.status_code
+            result_headers = result.headers
+            result_text = result.content
+            result_cookies = result.cookies
+        except requests.exceptions.RequestException as exc:
+            # Surface connection-level failures (e.g. a server closing the
+            # connection before delivering the full response, as can
+            # happen with large downloads) the same way the tornado
+            # backend surfaces HTTP errors, instead of letting the
+            # exception propagate unhandled out of http.query(). See
+            # #69916.
+            ret["status"] = getattr(getattr(exc, "response", None), "status_code", None)
+            ret["error"] = str(exc)
+            log.debug("Cannot perform 'http.query': %s - %s", url_full, ret["error"])
+            return ret
         result_text = _decode_result_text(
             result_text, backend, decode_body=decode_body, result=result
         )
@@ -627,11 +651,22 @@ def query(
         req_kwargs = salt.utils.data.decode(req_kwargs, to_str=True)
 
         try:
+            # < --- START do not merge these settings to other branches START ---> #
+            # 3006.x uses vendored salt.ext.tornado + a blocking HTTPClient.
+            # 3007.x+ uses system Tornado + SyncWrapper(AsyncHTTPClient), so
+            # the equivalent max_buffer_size fix must be applied there
+            # separately (see #69916). Tornado's IOStream defaults
+            # max_buffer_size to 100MiB independently of max_body_size; with
+            # a streaming_callback and no Content-Length response header,
+            # Tornado silently truncates the download at that limit instead
+            # of raising an error. Pass max_buffer_size alongside
+            # max_body_size so both track the http_max_body opt.
             download_client = (
-                HTTPClient(max_body_size=max_body)
+                HTTPClient(max_body_size=max_body, max_buffer_size=max_body)
                 if supports_max_body_size
-                else HTTPClient()
+                else HTTPClient(max_buffer_size=max_body)
             )
+            # < --- END do not merge these settings to other branches END ---> #
             result = download_client.fetch(url_full, **req_kwargs)
         except salt.ext.tornado.httpclient.HTTPError as exc:
             ret["status"] = exc.code

--- a/tests/pytests/functional/test_fileclient_get_url_large_file.py
+++ b/tests/pytests/functional/test_fileclient_get_url_large_file.py
@@ -1,0 +1,167 @@
+"""
+Integration-style regression tests for
+https://github.com/saltstack/salt/issues/69916.
+
+Unlike the unit tests in ``tests/pytests/unit/utils/test_http.py`` and
+``tests/pytests/unit/fileclient/test_fileclient.py`` (which exercise
+``salt.utils.http.query`` and ``salt.fileclient.Client.get_url`` in
+isolation, mocking the other), these tests drive
+``salt.fileclient.Client.get_url`` end-to-end against a real HTTP
+server with nothing mocked, to confirm the whole download pipeline
+(fileclient -> salt.utils.http.query -> a real socket -> the minion's
+file cache on disk) actually delivers large files intact for both the
+``tornado`` and ``requests`` backends.
+"""
+
+import hashlib
+import os
+import socketserver
+import threading
+from http.server import BaseHTTPRequestHandler
+
+import pytest
+
+import salt.fileclient as fileclient
+import salt.utils.files
+from salt.exceptions import MinionError
+
+# This bug (#69916) is specifically about winrepo_ng downloads on
+# Windows, so make sure these tests actually run there too.
+pytestmark = [pytest.mark.windows_whitelisted]
+
+
+class _CloseWithoutContentLengthHandler(BaseHTTPRequestHandler):
+    """
+    Serves ``body`` with no ``Content-Length`` header, forcing the
+    client to read until the connection is closed. This is the framing
+    that triggered Tornado's silent truncation at its default
+    ``max_buffer_size`` (100MiB) prior to the fix for #69916.
+    """
+
+    body = b""
+
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.end_headers()
+        try:
+            self.wfile.write(self.body)
+        except OSError:
+            # Client gave up; nothing left to do.
+            pass
+
+    def log_message(self, *args):  # pylint: disable=arguments-differ
+        pass
+
+
+class _TruncatedContentLengthHandler(BaseHTTPRequestHandler):
+    """
+    Advertises the full size of ``body`` via ``Content-Length``, but
+    only sends half of it before dropping the connection, simulating a
+    server-side failure partway through a download.
+    """
+
+    body = b""
+
+    def do_GET(self):  # noqa: N802
+        truncated_at = len(self.body) // 2
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(self.body)))
+        self.end_headers()
+        try:
+            self.wfile.write(self.body[:truncated_at])
+        except OSError:
+            pass
+        self.connection.close()
+
+    def log_message(self, *args):  # pylint: disable=arguments-differ
+        pass
+
+
+@pytest.fixture(scope="module")
+def large_body():
+    # Comfortably larger than Tornado's 100MiB default max_buffer_size
+    # so a truncation would be reliably detected. Built from a
+    # repeating, non-constant pattern (rather than all-zero/all-'x'
+    # bytes) so that a regression which corrupts data without changing
+    # its length wouldn't slip past a naive size-only check.
+    pattern = bytes(range(256))
+    size = 101 * 1024 * 1024
+    reps, remainder = divmod(size, len(pattern))
+    return pattern * reps + pattern[:remainder]
+
+
+def _start_server(handler_cls, body):
+    handler = type("Handler", (handler_cls,), {"body": body})
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+    return httpd, server_thread, f"http://127.0.0.1:{port}/largefile.bin"
+
+
+@pytest.mark.slow_test
+@pytest.mark.parametrize("backend", ["tornado", "requests"])
+def test_get_url_large_file_no_content_length_not_truncated(
+    tmp_path, large_body, backend
+):
+    """
+    A minion downloading a large (>100MiB) file from a server that
+    doesn't send a Content-Length header (as can happen with
+    winrepo_ng HTTP servers) must receive and cache the entire file
+    instead of having it silently truncated.
+    """
+    httpd, server_thread, url = _start_server(
+        _CloseWithoutContentLengthHandler, large_body
+    )
+    try:
+        dest = str(tmp_path / "downloaded.bin")
+        client = fileclient.Client(
+            {"cachedir": str(tmp_path / "cache"), "backend": backend}
+        )
+
+        result = client.get_url(url, dest)
+
+        assert result == dest
+        assert os.path.getsize(dest) == len(large_body)
+        with salt.utils.files.fopen(dest, "rb") as fp_:
+            downloaded = fp_.read()
+        assert (
+            hashlib.sha256(downloaded).digest() == hashlib.sha256(large_body).digest()
+        )
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=5)
+
+
+@pytest.mark.slow_test
+@pytest.mark.parametrize("backend", ["tornado", "requests"])
+def test_get_url_truncated_content_length_raises_cleanly(tmp_path, large_body, backend):
+    """
+    If a server advertises a Content-Length but the connection drops
+    before delivering that many bytes, both backends detect the broken
+    connection themselves (before get_url's own Content-Length check
+    ever runs) and get_url must surface that as a clean MinionError
+    instead of the underlying tornado/requests exception propagating
+    unhandled -- notably for the ``requests`` backend, which used to
+    crash here with an unhandled ``ChunkedEncodingError``/
+    ``IncompleteRead`` prior to the fix for #69916. Either way, the
+    partial download must not be promoted to ``dest``.
+    """
+    httpd, server_thread, url = _start_server(
+        _TruncatedContentLengthHandler, large_body
+    )
+    try:
+        dest = str(tmp_path / "downloaded.bin")
+        client = fileclient.Client(
+            {"cachedir": str(tmp_path / "cache"), "backend": backend}
+        )
+
+        with pytest.raises(MinionError):
+            client.get_url(url, dest)
+
+        assert not os.path.exists(dest)
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=5)

--- a/tests/pytests/integration/modules/test_cp.py
+++ b/tests/pytests/integration/modules/test_cp.py
@@ -2,6 +2,12 @@
 Integration tests for the cp execution module.
 """
 
+import hashlib
+import os
+import socketserver
+import threading
+from http.server import BaseHTTPRequestHandler
+
 import pytest
 
 import salt.utils.files
@@ -48,3 +54,92 @@ def test_get_template_with_imported_context(
     with salt.utils.files.fopen(str(dest), "r") as fp_:
         rendered = salt.utils.stringutils.to_unicode(fp_.read())
     assert "bar" in rendered
+
+
+# Comfortably larger than Tornado's 100MiB (104857600 byte) default
+# max_buffer_size, so a truncated download would be reliably detected.
+_LARGE_DOWNLOAD_SIZE = 101 * 1024 * 1024
+# Deterministic, cheap-to-regenerate payload so the expected hash can be
+# computed independently of the server that streams it.
+_LARGE_DOWNLOAD_PATTERN = bytes(range(256))
+
+
+def _expected_large_download_sha256():
+    digest = hashlib.sha256()
+    remaining = _LARGE_DOWNLOAD_SIZE
+    while remaining:
+        chunk = _LARGE_DOWNLOAD_PATTERN[: min(len(_LARGE_DOWNLOAD_PATTERN), remaining)]
+        digest.update(chunk)
+        remaining -= len(chunk)
+    return digest.hexdigest()
+
+
+class _NoContentLengthHandler(BaseHTTPRequestHandler):
+    """
+    Serves ``_LARGE_DOWNLOAD_SIZE`` bytes of a deterministic pattern with no
+    ``Content-Length`` header, forcing the client to read until the
+    connection is closed, same as e.g. a winrepo installer served without
+    that header.
+    """
+
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.end_headers()
+        remaining = _LARGE_DOWNLOAD_SIZE
+        while remaining:
+            chunk = _LARGE_DOWNLOAD_PATTERN[
+                : min(len(_LARGE_DOWNLOAD_PATTERN), remaining)
+            ]
+            try:
+                self.wfile.write(chunk)
+            except OSError:
+                return
+            remaining -= len(chunk)
+
+    def log_message(self, *args):  # pylint: disable=arguments-differ
+        pass
+
+
+@pytest.fixture
+def no_content_length_webserver():
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), _NoContentLengthHandler)
+    port = httpd.server_address[1]
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/large-file"
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=5)
+
+
+@pytest.mark.slow_test
+@pytest.mark.windows_whitelisted
+def test_cache_file_large_http_download_without_content_length_not_truncated(
+    salt_call_cli, no_content_length_webserver
+):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69916
+
+    ``cp.cache_file`` (used by ``win_pkg`` to download winrepo installers,
+    among others) must not silently truncate downloads at Tornado's 100MiB
+    default ``max_buffer_size`` when the server doesn't send a
+    ``Content-Length`` header.
+    """
+    ret = salt_call_cli.run("cp.cache_file", no_content_length_webserver, _timeout=120)
+    assert ret.returncode == 0, ret
+    cached_path = ret.data
+    assert cached_path, ret
+
+    assert os.path.getsize(cached_path) == _LARGE_DOWNLOAD_SIZE, (
+        f"Expected {_LARGE_DOWNLOAD_SIZE} bytes but got "
+        f"{os.path.getsize(cached_path)}; the download was truncated "
+        "(see #69916)"
+    )
+
+    digest = hashlib.sha256()
+    with salt.utils.files.fopen(cached_path, "rb") as fp_:
+        for chunk in iter(lambda: fp_.read(1024 * 1024), b""):
+            digest.update(chunk)
+    assert digest.hexdigest() == _expected_large_download_sha256()

--- a/tests/pytests/unit/fileclient/test_fileclient.py
+++ b/tests/pytests/unit/fileclient/test_fileclient.py
@@ -10,6 +10,7 @@ import pytest
 
 import salt.utils.files
 from salt import fileclient
+from salt.exceptions import MinionError
 from tests.support.mock import AsyncMock, MagicMock, Mock, patch
 
 log = logging.getLogger(__name__)
@@ -263,6 +264,34 @@ def test_setstate(file_client, mocked_opts):
     mocked_opts["fake_opt"] = "fake"
     file_client.__setstate__({"opts": mocked_opts})
     assert file_client.opts == mocked_opts
+
+
+def test_get_url_raises_on_truncated_content_length(tmp_path):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69916
+
+    If the server advertises a ``Content-Length`` but delivers fewer bytes
+    than that, ``get_url`` must not silently write the truncated data to
+    the minion's file cache; it should clean up the partial download and
+    raise a clear error instead.
+    """
+    dest = os.path.join(tmp_path, "downloaded_file")
+
+    def fake_query(url, stream, streaming_callback, header_callback, **kwargs):
+        header_callback("HTTP/1.1 200 OK")
+        header_callback("Content-Length: 1000")
+        header_callback("")
+        streaming_callback(b"x" * 500)
+        return {"handle": object()}
+
+    client = fileclient.Client({"cachedir": str(tmp_path)})
+
+    with patch("salt.utils.http.query", side_effect=fake_query):
+        with pytest.raises(MinionError, match="truncated"):
+            client.get_url("http://example.com/file", dest)
+
+    assert not os.path.exists(dest)
+    assert not os.path.exists(f"{dest}.part")
 
 
 def test_get_url_with_hash(client_opts):

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -1,4 +1,7 @@
+import socketserver
+import threading
 import urllib
+from http.server import BaseHTTPRequestHandler
 
 import pytest
 import requests
@@ -187,6 +190,150 @@ def test_query_tornado_httperror_no_response():
     assert ret.get("status") == 599
     assert "Timeout while connecting" in ret.get("error", "")
     assert "body" not in ret
+
+
+class _CloseWithoutContentLengthHandler(BaseHTTPRequestHandler):
+    """
+    Serves a response of a given size with no Content-Length header,
+    forcing the client to read until the connection is closed.
+    """
+
+    response_size = 0
+
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.end_headers()
+        remaining = self.response_size
+        chunk = b"x" * (1024 * 1024)
+        while remaining:
+            to_write = chunk[: min(len(chunk), remaining)]
+            try:
+                self.wfile.write(to_write)
+            except OSError:
+                # Client gave up (e.g. it hit a read buffer limit); nothing
+                # left to do but stop serving this request.
+                return
+            remaining -= len(to_write)
+
+    def log_message(self, *args):  # pylint: disable=arguments-differ
+        pass
+
+
+@pytest.mark.slow_test
+def test_query_tornado_no_content_length_large_body_not_truncated():
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69916
+
+    Tornado's ``SimpleAsyncHTTPClient`` enforces a default ``max_buffer_size``
+    of 100MiB independently of ``max_body_size``/``http_max_body``. When a
+    server does not send a ``Content-Length`` header (forcing Salt to read
+    until the connection closes), downloads larger than 100MiB were silently
+    truncated at ~100MiB instead of completing or raising an error.
+    """
+    # Comfortably larger than Tornado's 100MiB (104857600 byte) default
+    # max_buffer_size, so a truncation would be reliably detected.
+    response_size = 101 * 1024 * 1024
+
+    handler = type(
+        "Handler",
+        (_CloseWithoutContentLengthHandler,),
+        {"response_size": response_size},
+    )
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+
+    received = []
+
+    def on_chunk(chunk):
+        received.append(chunk)
+
+    try:
+        ret = http.query(
+            f"http://127.0.0.1:{port}/",
+            backend="tornado",
+            stream=True,
+            streaming_callback=on_chunk,
+            opts={},
+        )
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=5)
+
+    assert "error" not in ret, ret.get("error")
+    total_received = sum(len(chunk) for chunk in received)
+    assert total_received == response_size, (
+        f"Expected {response_size} bytes but received {total_received}; "
+        "the download was truncated (see #69916)"
+    )
+
+
+class _TruncatedContentLengthHandler(BaseHTTPRequestHandler):
+    """
+    Serves half of the advertised Content-Length and then drops the
+    connection, simulating a mid-download failure.
+    """
+
+    body = b""
+
+    def do_GET(self):  # noqa: N802
+        truncated_at = len(self.body) // 2
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(self.body)))
+        self.end_headers()
+        self.wfile.write(self.body[:truncated_at])
+        self.connection.close()
+
+    def log_message(self, *args):  # pylint: disable=arguments-differ
+        pass
+
+
+def test_query_requests_connection_error_returns_error_dict():
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69916
+
+    The ``requests`` backend is the documented workaround for the Tornado
+    ``max_buffer_size`` truncation bug, but unlike the ``tornado`` backend it
+    did not catch connection errors: when a server closed the connection
+    before delivering the full ``Content-Length``, the underlying
+    ``requests`` exception propagated unhandled out of ``http.query()``
+    instead of being reported the same way the ``tornado`` backend reports
+    HTTP errors (via the returned dict's ``error``/``status`` keys).
+    """
+    handler = type(
+        "Handler", (_TruncatedContentLengthHandler,), {"body": b"x" * (256 * 1024)}
+    )
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+
+    received = []
+
+    def on_chunk(chunk):
+        received.append(chunk)
+
+    def on_header(hdr):
+        pass
+
+    try:
+        ret = http.query(
+            f"http://127.0.0.1:{port}/",
+            backend="requests",
+            stream=True,
+            streaming_callback=on_chunk,
+            header_callback=on_header,
+            opts={},
+        )
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=5)
+
+    assert "handle" not in ret
+    assert ret.get("error")
 
 
 def test_parse_cookie_header():


### PR DESCRIPTION
### What does this PR do?
Tornado's HTTPClient enforces a default max_buffer_size of 100MiB independently of max_body_size. When a server doesn't send a Content-Length header (as some winrepo_ng HTTP servers don't), Salt read the response until the connection closed and silently truncated downloads over 100MiB instead of raising an error. Pass max_buffer_size alongside max_body_size so both track http_max_body.

Also harden fileclient.get_url() to compare bytes received against any advertised Content-Length and raise MinionError on mismatch instead of caching a partial file, and fix the requests backend to stream via iter_content() and catch RequestException so connection failures surface as clean errors instead of unhandled exceptions.

### What issues does this PR fix or reference?
Fixes #69916

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
