### PR TITLE
Preserve keyword-only defaults in namespaced_function and alias_function

### DIFF
--- a/changelog/69901.fixed.md
+++ b/changelog/69901.fixed.md
@@ -1,0 +1,1 @@
+Fixed `salt.utils.functools.namespaced_function` and `alias_function` dropping keyword-only argument defaults (`__kwdefaults__`), which made calling the copied function without those keyword arguments raise `TypeError`.

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -61,6 +61,10 @@ def namespaced_function(function, global_dict, defaults=None, preserve_context=N
         closure=function.__closure__,
     )
     new_namespaced_function.__dict__.update(function.__dict__)
+    # types.FunctionType does not accept keyword-only defaults, so copy them
+    # over explicitly; otherwise calling the clone without those keyword
+    # arguments raises TypeError even though the original had defaults.
+    new_namespaced_function.__kwdefaults__ = function.__kwdefaults__
     return new_namespaced_function
 
 
@@ -76,6 +80,10 @@ def alias_function(fun, name, doc=None):
         fun.__closure__,
     )
     alias_fun.__dict__.update(fun.__dict__)
+    # types.FunctionType does not accept keyword-only defaults, so copy them
+    # over explicitly; otherwise calling the alias without those keyword
+    # arguments raises TypeError even though the original had defaults.
+    alias_fun.__kwdefaults__ = fun.__kwdefaults__
 
     if doc and isinstance(doc, str):
         alias_fun.__doc__ = doc

--- a/tests/pytests/unit/utils/test_functools.py
+++ b/tests/pytests/unit/utils/test_functools.py
@@ -19,7 +19,7 @@ def test_namespaced_function_preserves_kwdefaults():
     )
     assert cloned.__kwdefaults__ == _func_with_kwonly_default.__kwdefaults__
     # Would raise "missing 1 required keyword-only argument: 'baz'" without the fix
-    assert cloned("a") == ("a", (), "default")
+    assert cloned("a") == ("a", (), "default")  # pylint: disable=not-callable
 
 
 def test_alias_function_preserves_kwdefaults():
@@ -27,8 +27,6 @@ def test_alias_function_preserves_kwdefaults():
     alias_function must preserve keyword-only argument defaults so that calling
     the alias without those keyword arguments does not raise TypeError.
     """
-    aliased = salt.utils.functools.alias_function(
-        _func_with_kwonly_default, "aliased"
-    )
+    aliased = salt.utils.functools.alias_function(_func_with_kwonly_default, "aliased")
     assert aliased.__kwdefaults__ == _func_with_kwonly_default.__kwdefaults__
-    assert aliased("a") == ("a", (), "default")
+    assert aliased("a") == ("a", (), "default")  # pylint: disable=not-callable

--- a/tests/pytests/unit/utils/test_functools.py
+++ b/tests/pytests/unit/utils/test_functools.py
@@ -1,0 +1,34 @@
+"""
+Unit tests for salt.utils.functools
+"""
+
+import salt.utils.functools
+
+
+def _func_with_kwonly_default(bar=None, *args, baz="default"):
+    return (bar, args, baz)
+
+
+def test_namespaced_function_preserves_kwdefaults():
+    """
+    namespaced_function must preserve keyword-only argument defaults so that
+    calling the clone without those keyword arguments does not raise TypeError.
+    """
+    cloned = salt.utils.functools.namespaced_function(
+        _func_with_kwonly_default, globals()
+    )
+    assert cloned.__kwdefaults__ == _func_with_kwonly_default.__kwdefaults__
+    # Would raise "missing 1 required keyword-only argument: 'baz'" without the fix
+    assert cloned("a") == ("a", (), "default")
+
+
+def test_alias_function_preserves_kwdefaults():
+    """
+    alias_function must preserve keyword-only argument defaults so that calling
+    the alias without those keyword arguments does not raise TypeError.
+    """
+    aliased = salt.utils.functools.alias_function(
+        _func_with_kwonly_default, "aliased"
+    )
+    assert aliased.__kwdefaults__ == _func_with_kwonly_default.__kwdefaults__
+    assert aliased("a") == ("a", (), "default")


### PR DESCRIPTION
### What does this PR do?

Fixes #69901.

`salt.utils.functools.namespaced_function` and `alias_function` both rebuild a function with `types.FunctionType`, passing `argdefs=fn.__defaults__` but nothing for `__kwdefaults__`. The constructor has no parameter for keyword-only defaults, so the copy loses them. Calling the copy without those keyword arguments then raises `TypeError` even though the original had defaults:

```python
from salt.utils.functools import namespaced_function

def foo(bar=None, *_, baz=None):
    pass

namespaced_function(foo, globals())()
# TypeError: foo() missing 1 required keyword-only argument: 'baz'
```

Setting `__kwdefaults__` on the new function object in both helpers restores the defaults.

### Tests

Added `tests/pytests/unit/utils/test_functools.py` covering both helpers: each asserts `__kwdefaults__` is carried over and that the copy is callable without the keyword-only argument. Both assertions fail against the current code and pass with the change.

I could not run the full salt suite on my machine (Windows, no salt runtime), so I verified by executing the patched `salt/utils/functools.py` directly with the two salt-internal imports stubbed; both copies keep `__kwdefaults__` and are callable. The new unit test is standard and should run cleanly in CI.

### Changelog

Added `changelog/69901.fixed.md`.