### PR TITLE
Fix pem_finger so PEM strings match file fingerprints

### DIFF
--- a/changelog/69970.fixed.md
+++ b/changelog/69970.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``pem_finger`` so a PEM key string fingerprints the same as the same key on disk. ``master_finger`` now matches ``salt-key -F``.

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -1178,7 +1178,7 @@ class AsyncAuth:
             if syndic_finger:
                 if (
                     salt.utils.crypt.pem_finger(
-                        m_pub_fn, sum_type=self.opts["hash_type"]
+                        path=m_pub_fn, sum_type=self.opts["hash_type"]
                     )
                     != syndic_finger
                 ):
@@ -1187,7 +1187,7 @@ class AsyncAuth:
             if self.opts.get("master_finger", False):
                 if (
                     salt.utils.crypt.pem_finger(
-                        m_pub_fn, sum_type=self.opts["hash_type"]
+                        path=m_pub_fn, sum_type=self.opts["hash_type"]
                     )
                     != self.opts["master_finger"]
                 ):
@@ -1556,7 +1556,9 @@ class AsyncAuth:
             "matches the fingerprint of the correct master and that "
             "this minion is not subject to a man-in-the-middle attack.",
             finger,
-            salt.utils.crypt.pem_finger(master_key, sum_type=self.opts["hash_type"]),
+            salt.utils.crypt.pem_finger(
+                path=master_key, sum_type=self.opts["hash_type"]
+            ),
         )
         sys.exit(42)
 

--- a/salt/utils/crypt.py
+++ b/salt/utils/crypt.py
@@ -94,21 +94,22 @@ def pem_finger(path=None, key=None, sum_type="sha256"):
     pem file, and the type of cryptographic hash to use. The default is SHA256.
     The fingerprint of the pem will be returned.
 
+    PEM input is normalized the same way for both ``path`` and ``key``: header
+    and footer lines are stripped, and CRLF line endings are treated as LF.
+    Non-PEM ``key`` values are hashed as-is.
+
     If neither a key nor a path are passed in, a blank string will be returned.
     """
     if not key:
-        if not os.path.isfile(path):
+        if not path or not os.path.isfile(path):
             return ""
-
         with salt.utils.files.fopen(path, "rb") as fp_:
-            key = b"".join([x for x in fp_.readlines() if x.strip()][1:-1])
-            # We should never have \r\n in a key file. This will cause the
-            # finger to be different even though the only difference is the line
-            # endings.
-            key = key.replace(b"\r\n", b"\n")
+            key = fp_.read()
 
     if not isinstance(key, bytes):
         key = key.encode("utf-8")
+
+    key = _fingerprint_key_bytes(key)
 
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ""
@@ -119,3 +120,25 @@ def pem_finger(path=None, key=None, sum_type="sha256"):
         else:
             finger += pre[ind]
     return finger.rstrip(":")
+
+
+def _fingerprint_key_bytes(key):
+    """
+    Return the bytes that should be hashed for a PEM fingerprint.
+
+    PEM armor (BEGIN/END lines) is stripped so a key string fingerprints the
+    same as the same key read from a file. Body newlines are kept, matching
+    historical ``path=`` behavior. Non-PEM data is returned unchanged.
+    """
+    # CRLF in a key file would change the fingerprint even though the only
+    # difference is the line endings.
+    normalized = key.replace(b"\r\n", b"\n")
+    pem_lines = [line for line in normalized.split(b"\n") if line.strip()]
+    if (
+        len(pem_lines) >= 2
+        and pem_lines[0].strip().startswith(b"-----BEGIN")
+        and pem_lines[-1].strip().startswith(b"-----END")
+    ):
+        # Keep a trailing newline on each body line (historical path= behavior).
+        return b"".join(line + b"\n" for line in pem_lines[1:-1])
+    return key

--- a/tests/pytests/unit/utils/test_crypt.py
+++ b/tests/pytests/unit/utils/test_crypt.py
@@ -6,6 +6,9 @@ import pytest
 
 import salt.utils.crypt
 
+EXPECTED_PEM_FINGER = "9b:42:66:92:8a:d1:b9:27:42:e0:6d:f3:12:c9:74:74:b0:e0:0e:42:83:87:62:ad:95:49:9d:6f:8e:d0:ed:35"
+EXPECTED_NON_PEM_FINGER = "dd:13:0a:84:9d:7b:29:e5:54:1b:05:d2:f7:f8:6a:4a:cd:4f:1e:c5:98:c1:c9:43:87:83:f5:6b:c4:f0:ff:80"
+
 
 @pytest.fixture
 def pub_key_data():
@@ -27,19 +30,29 @@ def test_pem_finger_file_line_endings(tmp_path, pub_key_data, line_ending):
     key_file = tmp_path / "master_crlf.pub"
     key_file.write_bytes(line_ending.join(pub_key_data).encode("utf-8"))
     finger = salt.utils.crypt.pem_finger(path=str(key_file))
-    assert (
-        finger
-        == "9b:42:66:92:8a:d1:b9:27:42:e0:6d:f3:12:c9:74:74:b0:e0:0e:42:83:87:62:ad:95:49:9d:6f:8e:d0:ed:35"
-    )
+    assert finger == EXPECTED_PEM_FINGER
 
 
 @pytest.mark.parametrize("key", [b"123abc", "123abc"])
 def test_pem_finger_key(key):
     finger = salt.utils.crypt.pem_finger(key=key)
-    assert (
-        finger
-        == "dd:13:0a:84:9d:7b:29:e5:54:1b:05:d2:f7:f8:6a:4a:cd:4f:1e:c5:98:c1:c9:43:87:83:f5:6b:c4:f0:ff:80"
-    )
+    assert finger == EXPECTED_NON_PEM_FINGER
+
+
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n"])
+@pytest.mark.parametrize("as_bytes", [False, True])
+def test_pem_finger_key_matches_path(tmp_path, pub_key_data, line_ending, as_bytes):
+    """PEM passed as key= must fingerprint the same as the same PEM on disk.
+
+    Regression for #69970: path= stripped PEM headers/footers while key= hashed
+    the raw string, so minions could reject a valid master_finger.
+    """
+    pem = line_ending.join(pub_key_data)
+    key_file = tmp_path / "master.pub"
+    key_file.write_bytes(pem.encode("utf-8"))
+    key = pem.encode("utf-8") if as_bytes else pem
+    assert salt.utils.crypt.pem_finger(path=str(key_file)) == EXPECTED_PEM_FINGER
+    assert salt.utils.crypt.pem_finger(key=key) == EXPECTED_PEM_FINGER
 
 
 def test_pem_finger_sha512():


### PR DESCRIPTION
### What does this PR do?
``path=`` stripped PEM headers while ``key=`` hashed the raw string, so ``master_finger`` from a key string did not match ``salt-key -F``.

### What issues does this PR fix or reference?
Fixes #69970

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
