### PR TITLE
fix postgres module to use `config.get`

### DIFF
--- a/changelog/69971.fixed.md
+++ b/changelog/69971.fixed.md
@@ -1,0 +1,1 @@
+Made postgres module to use config.get instead of relying on config.option

--- a/changelog/69971.fixed.md
+++ b/changelog/69971.fixed.md
@@ -1,1 +1,2 @@
-Made postgres module to use config.get instead of relying on config.option
+- Made postgres module to use config.get instead of relying on config.option
+- Made tests for postgres module to ensure nested keys are used and backwardly compatible

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -140,9 +140,9 @@ def _find_pg_binary(util):
 
     Helper function to locate various psql related binaries
     """
-    pg_bin_dir = __salt__["config.option"](
-        "postgres.bins_dir", default=__salt__["config.get"]("postgres:bins_dir")
-    )
+    pg_bin_dir = __salt__["config.option"]("postgres.bins_dir") or __salt__[
+        "config.get"
+    ]("postgres:bins_dir")
     if pg_bin_dir:
         util_bin = salt.utils.path.which(os.path.join(pg_bin_dir, util))
         if util_bin:
@@ -155,20 +155,14 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
     Helper function to call psql, because the password requirement
     makes this too much code to be repeated in each function below
     """
-    kwargs = {
-        "reset_system_locale": False,
-        "clean_env": True,
-        "timeout": __salt__["config.option"](
-            "postgres.timeout",
-            default=__salt__["config.get"](
-                "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
-            ),
-        ),
-    }
+    timeout = __salt__["config.option"]("postgres.timeout") or __salt__["config.get"](
+        "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+    )
+    kwargs = {"reset_system_locale": False, "clean_env": True, "timeout": timeout}
     if runas is None:
         if not host:
-            host = __salt__["config.option"](
-                "postgres.host", default=__salt__["config.get"]("postgres:host")
+            host = __salt__["config.option"]("postgres.host") or __salt__["config.get"](
+                "postgres:host"
             )
         if not host or host.startswith("/"):
             if "FreeBSD" in __grains__["os_family"]:
@@ -185,8 +179,8 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
         kwargs["runas"] = runas
 
     if password is None:
-        password = __salt__["config.option"](
-            "postgres.pass", default=__salt__["config.get"]("postgres:pass")
+        password = __salt__["config.option"]("postgres.pass") or __salt__["config.get"](
+            "postgres:pass"
         )
     if password is not None:
         pgpassfile = salt.utils.files.mkstemp(text=True)
@@ -268,16 +262,11 @@ def _run_initdb(
             __salt__["file.chown"](pgpassfile, runas, "")
         cmd.extend([f"--pwfile={pgpassfile}"])
 
-    kwargs = dict(
-        runas=runas,
-        clean_env=True,
-        timeout=__salt__["config.option"](
-            "postgres.timeout",
-            default=__salt__["config.get"](
-                "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
-            ),
-        ),
+    timeout = __salt__["config.option"]("postgres.timeout") or __salt__["config.get"](
+        "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
     )
+
+    kwargs = dict(runas=runas, clean_env=True, timeout=timeout)
     cmdstr = shlex.join(cmd)
     ret = __salt__["cmd.run_all"](cmdstr, python_shell=False, **kwargs)
 
@@ -356,22 +345,21 @@ def _connection_defaults(user=None, host=None, port=None, maintenance_db=None):
     values assigned to missing values.
     """
     if not user:
-        user = __salt__["config.option"](
-            "postgres.user", default=__salt__["config.get"]("postgres:user")
+        user = __salt__["config.option"]("postgres.user") or __salt__["config.get"](
+            "postgres:user"
         )
     if not host:
-        host = __salt__["config.option"](
-            "postgres.user", default=__salt__["config.get"]("postgres:host")
+        host = __salt__["config.option"]("postgres.host") or __salt__["config.get"](
+            "postgres:host"
         )
     if not port:
-        port = __salt__["config.option"](
-            "postgres.port", default=__salt__["config.get"]("postgres:port")
+        port = __salt__["config.option"]("postgres.port") or __salt__["config.get"](
+            "postgres:port"
         )
     if not maintenance_db:
         maintenance_db = __salt__["config.option"](
-            "postgres.maintenance_db",
-            default=__salt__["config.get"]("postgres:maintenance_db"),
-        )
+            "postgres.maintenance_db"
+        ) or __salt__["config.get"]("postgres:maintenance_db")
 
     return (user, host, port, maintenance_db)
 

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -140,7 +140,9 @@ def _find_pg_binary(util):
 
     Helper function to locate various psql related binaries
     """
-    pg_bin_dir = __salt__["config.option"]("postgres.bins_dir")
+    pg_bin_dir = __salt__["config.option"](
+        "postgres.bins_dir", default=__salt__["config.get"]("postgres:bins_dir")
+    )
     if pg_bin_dir:
         util_bin = salt.utils.path.which(os.path.join(pg_bin_dir, util))
         if util_bin:
@@ -157,12 +159,17 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
         "reset_system_locale": False,
         "clean_env": True,
         "timeout": __salt__["config.option"](
-            "postgres.timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+            "postgres.timeout",
+            default=__salt__["config.get"](
+                "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+            ),
         ),
     }
     if runas is None:
         if not host:
-            host = __salt__["config.option"]("postgres.host")
+            host = __salt__["config.option"](
+                "postgres.host", default=__salt__["config.get"]("postgres:host")
+            )
         if not host or host.startswith("/"):
             if "FreeBSD" in __grains__["os_family"]:
                 runas = "postgres"
@@ -178,7 +185,9 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
         kwargs["runas"] = runas
 
     if password is None:
-        password = __salt__["config.option"]("postgres.pass")
+        password = __salt__["config.option"](
+            "postgres.pass", default=__salt__["config.get"]("postgres:pass")
+        )
     if password is not None:
         pgpassfile = salt.utils.files.mkstemp(text=True)
         with salt.utils.files.fopen(pgpassfile, "w") as fp_:
@@ -263,7 +272,10 @@ def _run_initdb(
         runas=runas,
         clean_env=True,
         timeout=__salt__["config.option"](
-            "postgres.timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+            "postgres.timeout",
+            default=__salt__["config.get"](
+                "postgres:timeout", default=_DEFAULT_COMMAND_TIMEOUT_SECS
+            ),
         ),
     )
     cmdstr = shlex.join(cmd)
@@ -344,13 +356,22 @@ def _connection_defaults(user=None, host=None, port=None, maintenance_db=None):
     values assigned to missing values.
     """
     if not user:
-        user = __salt__["config.option"]("postgres.user")
+        user = __salt__["config.option"](
+            "postgres.user", default=__salt__["config.get"]("postgres:user")
+        )
     if not host:
-        host = __salt__["config.option"]("postgres.host")
+        host = __salt__["config.option"](
+            "postgres.user", default=__salt__["config.get"]("postgres:host")
+        )
     if not port:
-        port = __salt__["config.option"]("postgres.port")
+        port = __salt__["config.option"](
+            "postgres.port", default=__salt__["config.get"]("postgres:port")
+        )
     if not maintenance_db:
-        maintenance_db = __salt__["config.option"]("postgres.maintenance_db")
+        maintenance_db = __salt__["config.option"](
+            "postgres.maintenance_db",
+            default=__salt__["config.get"]("postgres:maintenance_db"),
+        )
 
     return (user, host, port, maintenance_db)
 

--- a/tests/pytests/unit/modules/test_postgres.py
+++ b/tests/pytests/unit/modules/test_postgres.py
@@ -72,6 +72,7 @@ def configure_loader_modules():
         postgres: {
             "__grains__": {"os_family": "Linux"},
             "__salt__": {
+                "config.get": MagicMock(),
                 "config.option": MagicMock(),
                 "cmd.run_all": MagicMock(),
                 "file.chown": MagicMock(),
@@ -186,9 +187,81 @@ def test_has_privileges_with_function(get_test_privileges_list_function_csv):
         )
 
 
+def test__connection_defaults():
+    """
+    test to ensure toplevel keys for connection defaults are backwards compatible
+    """
+
+    def config_option(key, default=None):
+        if key in config:
+            return config[key]
+        return default
+
+    config_option_mock = MagicMock(side_effect=config_option)
+    postgres_opts = {
+        "config.get": configmod.get,
+        "config.option": config_option_mock,
+    }
+    config = {
+        "postgres.user": "user",
+        "postgres.host": "host",
+        "postgres.port": 9999,
+        "postgres.maintenance_db": "maintenance_db",
+    }
+
+    with patch.dict(postgres.__salt__, postgres_opts):
+        with patch.dict(configmod.__opts__, config):
+            result = postgres._connection_defaults()
+            assert result == ("user", "host", 9999, "maintenance_db")
+            assert config_option_mock.call_count == 4
+
+
+def test__connection_defaults_nested():
+    """
+    test to ensure nested keys for connection defaults work
+    """
+
+    def config_get(key, default=None, delimiter=":"):
+        current_config_level = config
+        for split_key in key.split(delimiter):
+            if split_key in current_config_level:
+                current_config_level = current_config_level[split_key]
+            else:
+                return default
+        if current_config_level == config:
+            return default
+        return current_config_level
+
+    def config_option(key, default=None):
+        if key in config:
+            return config[key]
+        return default
+
+    config_get_mock = MagicMock(side_effect=config_get)
+    postgres_opts = {
+        "config.get": config_get_mock,
+        "config.option": MagicMock(side_effect=config_option),
+    }
+    config = {
+        "postgres": {
+            "user": "user",
+            "host": "host",
+            "port": 9999,
+            "maintenance_db": "maintenance_db",
+        },
+    }
+
+    with patch.dict(postgres.__salt__, postgres_opts):
+        with patch.dict(configmod.__opts__, config):
+            result = postgres._connection_defaults()
+            assert result == ("user", "host", 9999, "maintenance_db")
+            assert config_get_mock.call_count == 4
+
+
 def test__runpsql_with_timeout():
     cmd_run_mock = MagicMock()
     postgres_opts = {
+        "config.get": configmod.get,
         "config.option": configmod.option,
         "cmd.run_all": cmd_run_mock,
     }
@@ -200,11 +273,14 @@ def test__runpsql_with_timeout():
     }
     with patch.dict(postgres.__salt__, postgres_opts):
         with patch.dict(
-            configmod.__opts__, {"postgres.timeout": 60, "postgres.pass": None}
+            configmod.__opts__,
+            {"postgres.timeout": 60, "postgres.pass": None, "postgres": {"pass": None}},
         ):
             postgres._run_psql("fakecmd", runas="saltuser")
             cmd_run_mock.assert_called_with("fakecmd", timeout=60, **kwargs)
-        with patch.dict(configmod.__opts__, {"postgres.pass": None}):
+        with patch.dict(
+            configmod.__opts__, {"postgres.pass": None, "postgres": {"pass": None}}
+        ):
             postgres._run_psql("fakecmd", runas="saltuser")
             cmd_run_mock.assert_called_with("fakecmd", timeout=0, **kwargs)
 
@@ -212,6 +288,7 @@ def test__runpsql_with_timeout():
 def test__run_initdb_with_timeout():
     cmd_run_mock = MagicMock(return_value={})
     postgres_opts = {
+        "config.get": configmod.get,
         "config.option": configmod.option,
         "cmd.run_all": cmd_run_mock,
     }
@@ -224,11 +301,18 @@ def test__run_initdb_with_timeout():
     with patch.dict(postgres.__salt__, postgres_opts):
         with patch.object(postgres, "_find_pg_binary", return_value="/fake/path"):
             with patch.dict(
-                configmod.__opts__, {"postgres.timeout": 60, "postgres.pass": None}
+                configmod.__opts__,
+                {
+                    "postgres.timeout": 60,
+                    "postgres.pass": None,
+                    "postgres": {"pass": None},
+                },
             ):
                 postgres._run_initdb("fakename", runas="saltuser")
                 cmd_run_mock.assert_called_with(cmd_str, timeout=60, **kwargs)
-            with patch.dict(configmod.__opts__, {"postgres.pass": None}):
+            with patch.dict(
+                configmod.__opts__, {"postgres.pass": None, "postgres": {"pass": None}}
+            ):
                 postgres._run_initdb("fakename", runas="saltuser")
                 cmd_run_mock.assert_called_with(cmd_str, timeout=0, **kwargs)
 
@@ -2663,6 +2747,34 @@ def test_find_pg_binary_bins_dir_preferred_over_path():
     assert result == "/usr/pgsql-15/bin/psql"
 
 
+def test_find_pg_binary_bins_dir_nested_preferred_over_path():
+    """
+    When postgres.bins_dir is configured (nested), _find_pg_binary should return
+    the binary from bins_dir even when a psql binary is also present on the
+    system PATH (GitHub issue #53190).
+    """
+
+    def which_side_effect(path):
+        if path == "/usr/pgsql-15/bin/psql":
+            return "/usr/pgsql-15/bin/psql"
+        if path == "psql":
+            return "/usr/bin/psql"
+        return None
+
+    def config_option(key, default=None, **kwargs):
+        return default
+
+    with patch.dict(
+        postgres.__salt__,
+        {
+            "config.get": MagicMock(return_value="/usr/pgsql-15/bin"),
+            "config.option": MagicMock(side_effect=config_option),
+        },
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/pgsql-15/bin/psql"
+
+
 def test_find_pg_binary_bins_dir_used_when_not_on_path():
     """
     When postgres.bins_dir is configured and psql is not on the system PATH,
@@ -2682,6 +2794,31 @@ def test_find_pg_binary_bins_dir_used_when_not_on_path():
     assert result == "/usr/pgsql-15/bin/psql"
 
 
+def test_find_pg_binary_bins_dir_nested_used_when_not_on_path():
+    """
+    When postgres.bins_dir is configured (nested) and psql is not on the system
+    PATH, _find_pg_binary should still find the binary via bins_dir.
+    """
+
+    def which_side_effect(path):
+        if path == "/usr/pgsql-15/bin/psql":
+            return "/usr/pgsql-15/bin/psql"
+        return None
+
+    def config_option(key, default=None, **kwargs):
+        return default
+
+    with patch.dict(
+        postgres.__salt__,
+        {
+            "config.get": MagicMock(return_value="/usr/pgsql-15/bin"),
+            "config.option": MagicMock(side_effect=config_option),
+        },
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/pgsql-15/bin/psql"
+
+
 def test_find_pg_binary_falls_back_to_path_when_bins_dir_not_set():
     """
     When postgres.bins_dir is not configured, _find_pg_binary should fall
@@ -2690,6 +2827,26 @@ def test_find_pg_binary_falls_back_to_path_when_bins_dir_not_set():
     with patch.dict(
         postgres.__salt__,
         {"config.option": MagicMock(return_value=None)},
+    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/psql")):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/bin/psql"
+
+
+def test_find_pg_binary_falls_back_to_path_when_bins_dir_nested_not_set():
+    """
+    When postgres.bins_dir is not configured (nested), _find_pg_binary should
+    fall back to the system PATH (regression guard).
+    """
+
+    def config_option(key, default=None, **kwargs):
+        return default
+
+    with patch.dict(
+        postgres.__salt__,
+        {
+            "config.get": MagicMock(return_value="/usr/pgsql-15/bin"),
+            "config.option": MagicMock(side_effect=config_option),
+        },
     ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/psql")):
         result = postgres._find_pg_binary("psql")
     assert result == "/usr/bin/psql"
@@ -2714,6 +2871,31 @@ def test_find_pg_binary_falls_back_to_path_when_not_in_bins_dir():
     assert result == "/usr/bin/psql"
 
 
+def test_find_pg_binary_falls_back_to_path_when_not_in_bins_dir_nested():
+    """
+    When postgres.bins_dir is configured (nested) but the binary is not found
+    there, _find_pg_binary should fall back to the system PATH.
+    """
+
+    def which_side_effect(path):
+        if path == "psql":
+            return "/usr/bin/psql"
+        return None
+
+    def config_option(key, default=None, **kwargs):
+        return default
+
+    with patch.dict(
+        postgres.__salt__,
+        {
+            "config.get": MagicMock(return_value="/usr/pgsql-15/bin"),
+            "config.option": MagicMock(side_effect=config_option),
+        },
+    ), patch("salt.utils.path.which", side_effect=which_side_effect):
+        result = postgres._find_pg_binary("psql")
+    assert result == "/usr/bin/psql"
+
+
 def test_find_pg_binary_returns_none_when_not_found_anywhere():
     """
     When psql cannot be found in bins_dir or on the system PATH,
@@ -2722,6 +2904,26 @@ def test_find_pg_binary_returns_none_when_not_found_anywhere():
     with patch.dict(
         postgres.__salt__,
         {"config.option": MagicMock(return_value="/usr/pgsql-15/bin")},
+    ), patch("salt.utils.path.which", MagicMock(return_value=None)):
+        result = postgres._find_pg_binary("psql")
+    assert result is None
+
+
+def test_find_pg_binary_returns_none_when_not_found_anywhere_nested():
+    """
+    When psql cannot be found in bins_dir (nested) or on the system PATH,
+    _find_pg_binary should return None so the caller can handle the error.
+    """
+
+    def config_option(key, default=None, **kwargs):
+        return default
+
+    with patch.dict(
+        postgres.__salt__,
+        {
+            "config.get": MagicMock(return_value="/usr/pgsql-15/bin"),
+            "config.option": MagicMock(side_effect=config_option),
+        },
     ), patch("salt.utils.path.which", MagicMock(return_value=None)):
         result = postgres._find_pg_binary("psql")
     assert result is None


### PR DESCRIPTION
### What does this PR do?
Modifies the postgres execution module to respect the configuration set by changing all calls from `config.option` to `config.get` and setting the string delimiters to colons.

As noted in the related issue I opened:
```
# salt-call config.option

Passed invalid arguments: option() missing 1 required positional argument: 'value'.

Usage:

Returns the setting for the specified config value. The priority for
matches is the same as in :py:func:`config.get <salt.modules.config.get>`,
only this function does not recurse into nested data structures. Another
difference between this function and :py:func:`config.get
<salt.modules.config.get>` is that it comes with a set of "sane defaults".
To view these, you can run the following command:
```

It seems like `config.option` is just the wrong function to use and `config.get` is the correct one.

Before this fix:
```
# salt-call postgres.psql_query "SELECT current_user, session_user;"
local:
    |_
      ----------
      current_user:
          postgres
      session_user:
          postgres
```

After:

```
# salt-call postgres.psql_query "SELECT current_user, session_user;"
local:
    |_
      ----------
      current_user:
          salt_admin
      session_user:
          salt_admin
```

### What issues does this PR fix or reference?
Fixes #69971 

### Previous Behavior
postgres module was not respecting the configuration set in either the pillars or minion configuration file.

### New Behavior
postgres module now respects configuration values.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->