### PR TITLE
doc: fix duplicated requirement and stale download source in salt-cloud Windows docs

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -28,7 +28,9 @@ Requirements
 A copy of the Salt Minion Windows installer must be present on the system on
 which Salt Cloud is running. See
 `Windows - Salt install guide <https://docs.saltproject.io/salt/install-guide/en/latest/topics/install-by-operating-system/windows.html>`_ for information about downloading
-and using the Salt Minion Windows installer.
+and using the Salt Minion Windows installer. The installer can also be
+downloaded directly from the
+`Salt Project download area <https://packages.broadcom.com/artifactory/saltproject-generic/windows/>`_.
 
 Optionally WinRM can be used instead of `winexe` if the python module `pywinrm`
 is available and WinRM is supported on the target Windows version. Information
@@ -37,15 +39,7 @@ on pywinrm can be found at the project home:
 * `pywinrm project home`__
 
 .. __: https://github.com/diyan/pywinrm
-
-Additionally, a copy of the Salt Minion Windows installer must be present on
-the system on which Salt Cloud is running. This installer may be downloaded
-from saltstack.com:
-
-* `SaltStack Download Area`__
-
-.. __: https://packages.broadcom.com/artifactory/saltproject-generic/windows/
-
+__
 .. _new-pywinrm:
 
 Self Signed Certificates with WinRM


### PR DESCRIPTION
### What does this PR do?

The Requirements section of the salt-cloud Windows docs states the Salt Minion
Windows installer requirement twice — the second time prefixed with
"Additionally", implying it's a separate requirement. It also says the installer
is downloaded "from saltstack.com" while the link directly beneath it points at
`packages.broadcom.com`.

Merges the two paragraphs and drops the stale domain reference, keeping both the
install-guide link and the direct download link.

Docs-only; no behaviour change and no changelog entry needed per the changelog docs.