### PR TITLE
fix: add find_spec to NaclImporter to suppress deprecated find_module warning [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -4,6 +4,7 @@ Salt package
 
 import asyncio
 import importlib
+import importlib.machinery
 import os
 import re
 import sys
@@ -86,6 +87,12 @@ class NaclImporter:
         if not NaclImporter.loading and module_name.startswith("nacl"):
             NaclImporter.loading = True
             return self
+        return None
+
+    def find_spec(self, module_name, package_path=None, target=None):
+        if not NaclImporter.loading and module_name.startswith("nacl"):
+            NaclImporter.loading = True
+            return importlib.machinery.ModuleSpec(module_name, self)
         return None
 
     def create_module(self, spec):


### PR DESCRIPTION
Fixes #70010

`find_module` is deprecated since Python 3.4 and removed in Python 3.12. This adds a `find_spec` method (PEP 451) that returns a `ModuleSpec` with `self` as the loader, matching the loader protocol already implemented by `create_module` and `exec_module`.

## Verification
- `find_module` is preserved for backward compatibility on Python < 3.4
- `find_spec` returns `ModuleSpec(module_name, self)` matching the `find_module` return logic
- `create_module` and `exec_module` already exist and handle the actual module loading