### PR TITLE
Add mirror and publish-nightly-release workflows for salt-nightlies fork

### DIFF
--- a/.github/workflows/mirror-from-saltstack-salt.yaml
+++ b/.github/workflows/mirror-from-saltstack-salt.yaml
@@ -1,0 +1,73 @@
+name: mirror from saltstack/salt
+
+# Multi-branch mirror from saltstack/salt into saltstack/salt-nightlies.
+# Lives in saltstack/salt but is GATED to only execute on saltstack/salt-nightlies,
+# so upstream salt never tries to mirror itself. Runs before the daily nightly
+# window so the branches carry the latest code when run-nightly.yml fires.
+#
+# The file must live in salt (not just salt-nightlies) because git push --mirror
+# would otherwise delete it from salt-nightlies on the first sync (--mirror
+# prunes any refs/files that don't exist upstream).
+#
+# Uses `git push --mirror` to copy ALL refs (branches + tags), pruning
+# deleted refs. Idempotent — no-op when there are no upstream changes.
+#
+# Prereqs on salt-nightlies:
+#   - Repo variable `RUN_SCHEDULED_BUILDS=1` (enables run-nightly.yml despite fork check)
+#   - Secret `MIRROR_TOKEN` — a PAT / fine-grained token with `contents: write` and
+#     `workflows: write` scope on salt-nightlies. Needed because GITHUB_TOKEN cannot
+#     push workflow file changes; a mirror by definition touches .github/workflows.
+#     Alternative: a GitHub App with the same scope, using
+#     actions/create-github-app-token@v1 to mint a token per run.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # 23:30 UTC — 30 minutes before run-nightly.yml (00:00 UTC) so mirrored
+    # branches are up-to-date when the nightly scheduler fires.
+    - cron: '30 23 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-from-saltstack-salt
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    # HARD GATE: only run on the nightlies fork. On saltstack/salt this workflow
+    # is dormant — the cron fires but no work is done.
+    if: github.repository == 'saltstack/salt-nightlies'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: install git
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git
+
+      - name: configure git
+        run: |
+          git config --global user.name "salt-nightlies-mirror-bot"
+          git config --global user.email "salt-nightlies-mirror-bot@users.noreply.github.com"
+
+      - name: clone bare from upstream
+        run: |
+          git clone --bare --mirror https://github.com/saltstack/salt.git upstream.git
+
+      - name: push --mirror to salt-nightlies
+        env:
+          MIRROR_TOKEN: ${{ secrets.MIRROR_TOKEN }}
+        working-directory: upstream.git
+        run: |
+          # Point origin at this repo, authenticated with MIRROR_TOKEN
+          git remote set-url origin "https://x-access-token:${MIRROR_TOKEN}@github.com/${{ github.repository }}.git"
+          # --mirror pushes all refs (branches, tags, notes) and prunes deleted ones
+          git push --mirror origin
+
+      - name: summary
+        if: always()
+        run: |
+          echo "Mirrored saltstack/salt -> ${{ github.repository }}"
+          echo "Next: run-nightly.yml (00:00 UTC) will fire on the freshly-mirrored branches."

--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -1,0 +1,120 @@
+name: Publish Nightly Release
+
+# Publishes a GitHub Release containing all artifacts produced by nightly.yml.
+# Lives in saltstack/salt but is GATED to only execute on saltstack/salt-nightlies,
+# so upstream salt keeps building nightlies without also publishing releases here.
+#
+# Triggered by workflow_run: nightly.yml completed. Downloads that run's GHA
+# artifacts and attaches them to a new release tagged
+# `nightly-YYYY-MM-DD-<branch>`. Skipped if the tag already exists (idempotent
+# for re-runs on the same day/branch).
+
+on:
+  workflow_run:
+    workflows: ["Nightly"]
+    types: [completed]
+
+permissions:
+  contents: write   # to create releases + push tags
+  actions: read     # to download artifacts from the triggering run
+
+concurrency:
+  group: publish-nightly-release-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # HARD GATE: only run on the nightlies fork, and only if the triggering
+    # nightly.yml run succeeded. On saltstack/salt this workflow is dormant.
+    if: >
+      github.repository == 'saltstack/salt-nightlies' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: compute release tag
+        id: tag
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          # Sanitize branch (turn slashes into dashes for a valid tag component).
+          branch_tag=$(printf '%s' "${BRANCH}" | tr '/' '-')
+          date=$(date -u +%Y-%m-%d)
+          tag="nightly-${date}-${branch_tag}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "computed tag=${tag}"
+
+      - name: check if release already exists (idempotent skip)
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view "${{ steps.tag.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "already-exists=true" >> "$GITHUB_OUTPUT"
+            echo "release ${{ steps.tag.outputs.tag }} already exists — skipping to avoid overwriting"
+          else
+            echo "already-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: download all artifacts from the triggering nightly.yml run
+        if: steps.check.outputs.already-exists != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          path: nightly-artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true
+
+      - name: list assets to publish
+        if: steps.check.outputs.already-exists != 'true'
+        run: |
+          set -euo pipefail
+          echo "=== files under nightly-artifacts/ ==="
+          find nightly-artifacts -type f | sort
+          echo "=== filtered assets (release-ready formats only) ==="
+          find nightly-artifacts -type f \
+            \( -name '*.rpm' -o -name '*.deb' -o -name '*.msi' -o -name '*.exe' \
+               -o -name '*.pkg' -o -name '*.tar.xz' -o -name '*.tar.gz' \
+               -o -name '*onedir*.zip' -o -name '*onedir*.xz' \) | sort > /tmp/assets.txt
+          echo "count: $(wc -l < /tmp/assets.txt)"
+          cat /tmp/assets.txt
+
+      - name: create release with all assets
+        if: steps.check.outputs.already-exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          BRANCH: ${{ steps.tag.outputs.branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          notes=$(cat <<EOF
+          Nightly build from branch \`${BRANCH}\` at commit \`${HEAD_SHA}\`.
+
+          Source workflow run: ${RUN_URL}
+
+          Assets in this release are unsigned nightly builds. Not intended for production.
+          EOF
+          )
+          # Read asset list (blank line if empty) and pass each file as a positional arg.
+          if [ ! -s /tmp/assets.txt ]; then
+            echo "::warning::no release-format assets found in nightly-artifacts/. Creating an empty release for record-keeping."
+            gh release create "${TAG}" \
+              --repo "${{ github.repository }}" \
+              --target "${HEAD_SHA}" \
+              --title "Nightly ${TAG}" \
+              --notes "${notes}" \
+              --prerelease
+          else
+            # xargs to pass all asset paths as arguments to gh release create
+            xargs -a /tmp/assets.txt gh release create "${TAG}" \
+              --repo "${{ github.repository }}" \
+              --target "${HEAD_SHA}" \
+              --title "Nightly ${TAG}" \
+              --notes "${notes}" \
+              --prerelease
+          fi


### PR DESCRIPTION
### What does this PR do?

Adds two GitHub Actions workflows that support publishing nightly builds via a `saltstack/salt-nightlies` fork of this repo:

- **`.github/workflows/mirror-from-saltstack-salt.yaml`** — daily cron (23:30 UTC) that pulls all branches and tags from `saltstack/salt` into the fork via `git clone --bare --mirror` + `git push --mirror`. Runs 30 minutes before the existing `run-nightly.yml` cron so mirrored branches carry the latest code when nightly builds fire.

- **`.github/workflows/publish-nightly-release.yml`** — triggered by `workflow_run` on `Nightly` completion. Downloads the run's build artifacts (`.rpm`/`.deb`/`.msi`/`.exe`/`.pkg`/`.tar.xz`/`.zip`) and publishes them as a prerelease tagged `nightly-YYYY-MM-DD-<branch>`, targeting the existing `head_sha` (no release commit, no changelog mutation). Downstream consumers can then pull via `gh release download` following the same pattern used for stable releases.

Both workflows are HARD-GATED with `if: github.repository == 'saltstack/salt-nightlies'` — they are DORMANT when the workflow files exist on `saltstack/salt`. They only execute after being mirrored to the fork.

### What issues does this PR fix or reference?

N/A — new capability, no existing issue.

### Previous Behavior

Nightly builds via `nightly.yml` produce artifacts as GitHub Actions run artifacts (~90 day retention). No mechanism today publishes them as GitHub releases for downstream consumers.

### New Behavior

On `saltstack/salt` itself: **no change**. Both new workflows exist on disk but are gated to do nothing.

On a `saltstack/salt-nightlies` fork (which needs one-time setup: `RUN_SCHEDULED_BUILDS=1` variable, `MIRROR_TOKEN` secret):

1. 23:30 UTC — mirror workflow syncs branches/tags from `saltstack/salt`.
2. 00:00 UTC — existing `run-nightly.yml` fires, triggers `nightly.yml` for each branch (fork check overridden by `RUN_SCHEDULED_BUILDS=1`).
3. On each `Nightly` completion — publish workflow downloads artifacts and creates prerelease `nightly-YYYY-MM-DD-<branch>`.

### Merge requirements satisfied?

- [ ] Docs — N/A, no user-facing docs affected.
- [ ] Changelog — none added; happy to add a towncrier entry (e.g. `<PR#>.added.md`) once PR number is assigned if maintainers require.
- [ ] Tests — no automated tests; workflows are Actions definitions. Test plan below.

### Test plan

- Merge and confirm both workflows appear in the Actions tab on `saltstack/salt` but do not fire (gated).
- Fork setup on `saltstack/salt-nightlies` (repo variable + secret + seed mirror), then manually dispatch each workflow to verify behavior end-to-end.

### Commits signed with GPG?

No.

### Notes for maintainers

- No changes to any existing workflow, template, or code.
- `MIRROR_TOKEN` requires `workflows:write` because a full mirror will touch `.github/workflows/` files; `GITHUB_TOKEN` cannot push workflow file changes.
- Publish workflow uses `--target ${HEAD_SHA}` so the tag points at the existing commit; no `git commit` on the fork.