### PR TITLE
Fix synchronous batch timeout tracking

### DIFF
--- a/changelog/70018.fixed.md
+++ b/changelog/70018.fixed.md
@@ -1,0 +1,4 @@
+Fixed synchronous batch mode releasing slots after the timeout window while
+the return iterator was still tracking a running job. Synchronous batches now
+wait for a return or an iterator-reported timeout before dispatching another
+minion.

--- a/salt/utils/batch_state.py
+++ b/salt/utils/batch_state.py
@@ -214,11 +214,12 @@ def progress_batch(state, new_returns=None, *, now=None, timed_out=None):
        each minion from ``active`` to ``failed`` with reason
        ``"timeout"``.  The sync driver uses this to surface timeouts
        detected externally by ``cmd_iter_no_block``'s own clock.
-    4. Internal timeout sweep — move minions whose ``active`` dispatch
-       time exceeds ``now - (timeout + gather_job_timeout)`` to
-       ``failed`` with reason ``"timeout"``.  The async driver relies
-       on this; the sync driver reports the same minions externally,
-       so this is idempotent in practice.
+    4. For master-driven async batches, perform an internal timeout sweep:
+       move minions whose ``active`` dispatch time exceeds
+       ``now - (timeout + gather_job_timeout)`` to ``failed`` with reason
+       ``"timeout"``.  Sync CLI batches rely on their LocalClient iterator,
+       which probes ``saltutil.find_job`` and reports completed timeouts via
+       the ``timed_out`` argument above.
     5. Prune expired entries from ``state["wait"]`` (entries with
        timestamp ``<= now``).
     6. If not halted, pop from ``pending`` up to
@@ -295,16 +296,23 @@ def progress_batch(state, new_returns=None, *, now=None, timed_out=None):
                 state["wait"].append(now + bwait)
 
     # ---- 4. Internal timeout sweep -------------------------------------
-    _t = state.get("timeout")
-    _g = state.get("gather_job_timeout")
-    timeout_window = (60 if _t is None else _t) + (10 if _g is None else _g)
-    for minion_id, dispatch_ts in list(state["active"].items()):
-        if now - dispatch_ts >= timeout_window:
-            del state["active"][minion_id]
-            state["failed"][minion_id] = "timeout"
-            timed_out_minions.append(minion_id)
-            if bwait:
-                state["wait"].append(now + bwait)
+    # Master-driven async batches do not have a LocalClient iterator to
+    # determine whether a minion's job is still running, so they need a
+    # wall-clock safety timeout.  Sync CLI batches do have that iterator;
+    # it probes saltutil.find_job and reports a timeout through ``timed_out``
+    # only after the job is no longer running.  Applying this sweep to the
+    # sync driver releases its batch slot while the job is still active.
+    if state.get("driver") == "master":
+        _t = state.get("timeout")
+        _g = state.get("gather_job_timeout")
+        timeout_window = (60 if _t is None else _t) + (10 if _g is None else _g)
+        for minion_id, dispatch_ts in list(state["active"].items()):
+            if now - dispatch_ts >= timeout_window:
+                del state["active"][minion_id]
+                state["failed"][minion_id] = "timeout"
+                timed_out_minions.append(minion_id)
+                if bwait:
+                    state["wait"].append(now + bwait)
 
     # ---- 4. Prune expired wait stamps ----------------------------------
     if state["wait"]:

--- a/tests/pytests/unit/cli/test_batch.py
+++ b/tests/pytests/unit/cli/test_batch.py
@@ -547,6 +547,61 @@ def test_run_batch_wait_delays_next_dispatch(batch):
     assert spin_sleeps[0] >= 1
 
 
+def test_run_waits_for_live_iterator_past_timeout_window(batch):
+    """
+    A synchronous batch must not free a slot merely because the master's
+    timeout window elapsed while the return iterator is still tracking the
+    job.
+
+    The ``None`` values model an iterator which has not received the job
+    return yet (including while ``saltutil.find_job`` reports it as running).
+    """
+    batch.opts = {
+        "batch": "1",
+        "timeout": 5,
+        "fun": "test.ping",
+        "arg": [],
+        "gather_job_timeout": 10,
+    }
+    batch.gather_minions = MagicMock(
+        return_value=[["m1", "m2"], [], []],
+    )
+
+    first_returned = False
+    dispatches = []
+
+    def _make_iter(minions, *args, **kwargs):
+        nonlocal first_returned
+        targets = list(minions)
+        dispatches.append((targets, first_returned))
+
+        def _ret_iter():
+            nonlocal first_returned
+            if targets == ["m1"]:
+                # Batch._poll_iterators consumes at most six empty polls per
+                # pass. Keep this iterator alive across two passes so the
+                # clock can advance beyond timeout + gather_job_timeout.
+                for _ in range(12):
+                    yield None
+                first_returned = True
+                yield {"m1": {"ret": True, "retcode": 0, "failed": False}}
+            else:
+                yield {"m2": {"ret": True, "retcode": 0, "failed": False}}
+
+        return _ret_iter()
+
+    batch.local.cmd_iter_no_block = MagicMock(side_effect=_make_iter)
+
+    # create_batch_state and the first dispatch occur at t=1. Subsequent
+    # progress checks are beyond the 15-second timeout window.
+    clock = iter([1.0, 1.0, 17.0])
+    with patch("salt.cli.batch.time.time", side_effect=lambda: next(clock, 17.0)):
+        ret = list(Batch.run(batch))
+
+    assert len(ret) == 2
+    assert dispatches == [(["m1"], False), (["m2"], True)]
+
+
 def test_run_does_not_write_to_master_cachedir(batch):
     """
     Regression test for issue #69418.

--- a/tests/pytests/unit/utils/batch_state/test_conformance.py
+++ b/tests/pytests/unit/utils/batch_state/test_conformance.py
@@ -20,7 +20,7 @@ import importlib
 
 import pytest
 
-from salt.utils.batch_state import progress_batch
+from salt.utils.batch_state import create_batch_state, progress_batch
 from tests.pytests.unit.utils.batch_state.batch_state_scenarios import SCENARIOS
 
 SYNC_TEST_MODULE = "tests.pytests.unit.cli.test_batch"
@@ -79,3 +79,36 @@ def test_scenario(scenario):
                 f"  expected: {expected_value}\n"
                 f"  got:      {state[field]}"
             )
+
+
+def test_sync_batch_waits_for_iterator_timeout():
+    """
+    A synchronous batch must not release a slot based only on elapsed time.
+
+    Its LocalClient iterator probes ``saltutil.find_job`` while a job is
+    running and reports an actual timeout through the ``timed_out`` argument.
+    """
+    state = create_batch_state(
+        {"batch": 1, "timeout": 5, "gather_job_timeout": 10},
+        ["m1", "m2"],
+        "JID",
+        driver="cli",
+        now=1.0,
+    )
+
+    action = progress_batch(state, now=1.0)
+    assert action.publish == ["m1"]
+
+    # The old internal sweep expired the slot after 15 seconds even when the
+    # iterator had confirmed that the minion's job was still running.
+    action = progress_batch(state, now=17.0)
+    assert action.publish == []
+    assert state["active"] == {"m1": 1.0}
+    assert state["pending"] == ["m2"]
+    assert state["failed"] == {}
+
+    # Iterator exhaustion remains authoritative for synchronous timeouts.
+    action = progress_batch(state, now=18.0, timed_out=["m1"])
+    assert action.publish == ["m2"]
+    assert state["active"] == {"m2": 18.0}
+    assert state["failed"] == {"m1": "timeout"}


### PR DESCRIPTION
### What does this PR do?

Restricts the shared batch state machine's internal wall-clock timeout sweep to
master-driven asynchronous batches.

The synchronous CLI driver already has an authoritative `LocalClient` return
iterator. That iterator probes `saltutil.find_job` and stays alive while a job
is running, then reports a timeout through the existing `timed_out` input when
tracking ends without a return. Applying a second wall-clock sweep to the CLI
driver releases its slot prematurely and allows the next sub-batch to start
while the original job is still running.

### What issues does this PR fix or reference?

Fixes #70018

### Previous Behavior

After `timeout + gather_job_timeout`, a synchronous batch moved an active
minion to `failed` and dispatched another minion even if the return iterator
was still tracking the running job.

### New Behavior

Synchronous batches keep a slot occupied until the return iterator yields the
minion result or exhausts and reports a timeout. Master-driven asynchronous
batches retain their existing internal wall-clock timeout.

### Regression tests

- A state-machine test verifies that elapsed wall-clock time alone cannot free
  a CLI batch slot and that an explicit iterator timeout still can.
- A `Batch.run()` test keeps a synthetic return iterator alive beyond the
  timeout window and verifies that the next sub-batch is dispatched only after
  the first result arrives.
- Both tests fail against the previous logic and pass with this change.
- All 43 tests in the affected unit-test files pass.

### Merge requirements satisfied?

- [x] Docs (state-machine documentation updated)
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No
