### PR TITLE
[3006.x] Disable pip's periodic version check in salt-pip (#70024)

### DIFF
--- a/changelog/70024.fixed.md
+++ b/changelog/70024.fixed.md
@@ -1,0 +1,1 @@
+Set ``PIP_DISABLE_PIP_VERSION_CHECK=1`` in ``salt-pip`` so every invocation no longer triggers pip's periodic "A new release of pip is available" HTTPS check against a packager-pinned onedir pip. Operators can opt back in by exporting ``PIP_DISABLE_PIP_VERSION_CHECK=0``.

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -624,6 +624,12 @@ def _pip_environment(env, extras):
         new_env["PYTHONPATH"] = f"{extras}{os.pathsep}{env['PYTHONPATH']}"
     else:
         new_env["PYTHONPATH"] = extras
+    # Suppress pip's periodic "A new release of pip is available" check.
+    # The onedir bundles a packager-pinned pip, so the outbound HTTPS
+    # round-trip is pure noise (and a proxy-config gotcha; cf. #69910).
+    # setdefault so operators can opt back in with
+    # PIP_DISABLE_PIP_VERSION_CHECK=0 in the environment.
+    new_env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
     return new_env
 
 

--- a/tests/pytests/functional/cli/test_salt_pip.py
+++ b/tests/pytests/functional/cli/test_salt_pip.py
@@ -1,11 +1,12 @@
 import os
+import pathlib
 
 import pytest
 
 import salt.scripts
 import salt.utils.platform
 from tests.conftest import CODE_DIR
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 def test_within_onedir_env(shell):
@@ -29,3 +30,80 @@ def test_outside_onedir_env(capsys):
             salt.scripts.salt_pip()
     captured = capsys.readouterr()
     assert "'salt-pip' is only meant to be used from a Salt onedir." in captured.err
+
+
+def _run_salt_pip_capturing_subprocess(tmp_path, monkeypatch, env_overrides):
+    """
+    Drive ``salt.scripts.salt_pip`` end-to-end while stubbing out the
+    actual ``python -m pip`` invocation. Returns the ``env`` mapping
+    that ``salt_pip`` handed to ``subprocess.run``.
+
+    ``env_overrides`` is applied to ``os.environ`` via ``monkeypatch``
+    *before* ``salt_pip`` runs so the test controls whether
+    ``PIP_DISABLE_PIP_VERSION_CHECK`` is already set by the "operator".
+    """
+    # Scrub any inherited copy of the var first, then apply overrides.
+    monkeypatch.delenv("PIP_DISABLE_PIP_VERSION_CHECK", raising=False)
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+
+    # Force a deterministic argv so _pip_args stays a no-op.
+    monkeypatch.setattr("sys.argv", ["salt-pip", "--version"])
+
+    # Pretend we're inside an onedir; the path only feeds the
+    # ``extras-X.Y`` string appended to PYTHONPATH.
+    fake_relenv = pathlib.Path(tmp_path)
+    fake_subprocess_result = MagicMock()
+    fake_subprocess_result.returncode = 0
+
+    recorded = {}
+
+    def fake_run(command, shell, check, env):
+        recorded["command"] = command
+        recorded["env"] = env
+        return fake_subprocess_result
+
+    with patch("salt.scripts._get_onedir_env_path", return_value=fake_relenv), patch(
+        "salt.config.minion_config", return_value={"user": None}
+    ), patch("salt.utils.user.get_user", return_value="root"), patch(
+        "salt.scripts.subprocess.run", side_effect=fake_run
+    ):
+        with pytest.raises(SystemExit) as exc:
+            salt.scripts.salt_pip()
+
+    assert exc.value.code == 0
+    assert "command" in recorded, "subprocess.run was never invoked"
+    return recorded
+
+
+def test_salt_pip_subprocess_gets_disable_version_check_env(tmp_path, monkeypatch):
+    """
+    Regression test for #70024, end-to-end.
+
+    Drive ``salt.scripts.salt_pip`` with a stubbed ``subprocess.run`` and
+    assert the ``env`` dict handed to the child ``python -m pip`` process
+    has ``PIP_DISABLE_PIP_VERSION_CHECK=1``. This catches a future
+    refactor that stopped routing ``salt_pip`` through
+    ``_pip_environment`` — the unit test on ``_pip_environment`` alone
+    would still pass in that case.
+    """
+    recorded = _run_salt_pip_capturing_subprocess(
+        tmp_path, monkeypatch, env_overrides={}
+    )
+    assert recorded["env"].get("PIP_DISABLE_PIP_VERSION_CHECK") == "1"
+
+
+def test_salt_pip_subprocess_respects_operator_override(tmp_path, monkeypatch):
+    """
+    Regression test for #70024, end-to-end.
+
+    If an operator has already exported ``PIP_DISABLE_PIP_VERSION_CHECK=0``
+    (i.e., they want pip's periodic version check back), ``salt-pip``
+    must not stomp on it.
+    """
+    recorded = _run_salt_pip_capturing_subprocess(
+        tmp_path,
+        monkeypatch,
+        env_overrides={"PIP_DISABLE_PIP_VERSION_CHECK": "0"},
+    )
+    assert recorded["env"].get("PIP_DISABLE_PIP_VERSION_CHECK") == "0"

--- a/tests/pytests/unit/test_scripts.py
+++ b/tests/pytests/unit/test_scripts.py
@@ -58,6 +58,37 @@ def test_pip_environment_pypath_win():
     )
 
 
+def test_pip_environment_disables_version_check():
+    """
+    Regression test for #70024.
+
+    ``salt-pip`` shells out to ``python -m pip`` under a packager-pinned
+    onedir pip; pip's periodic "A new release of pip is available" check
+    is pure noise and a proxy-config gotcha (cf. #69910). ``_pip_environment``
+    must inject ``PIP_DISABLE_PIP_VERSION_CHECK=1`` into the child's env.
+    """
+    extras = "/tmp/footest"
+    env = {"HOME": "/home/dwoz"}
+    pipenv = _pip_environment(env, extras)
+    assert "PIP_DISABLE_PIP_VERSION_CHECK" not in env
+    assert pipenv["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
+
+
+def test_pip_environment_respects_operator_override():
+    """
+    Regression test for #70024.
+
+    Operators must be able to re-enable pip's periodic version check by
+    exporting ``PIP_DISABLE_PIP_VERSION_CHECK=0`` before invoking
+    ``salt-pip``. ``_pip_environment`` uses ``setdefault`` so a caller's
+    explicit setting wins over the salt-pip default.
+    """
+    extras = "/tmp/footest"
+    env = {"HOME": "/home/dwoz", "PIP_DISABLE_PIP_VERSION_CHECK": "0"}
+    pipenv = _pip_environment(env, extras)
+    assert pipenv["PIP_DISABLE_PIP_VERSION_CHECK"] == "0"
+
+
 def test_pip_args_not_installing():
     extras = "/tmp/footest"
     args = ["list"]


### PR DESCRIPTION
Fixes #70024

`salt-pip` shells out to `python -m pip` against a packager-pinned onedir pip, so pip's periodic "A new release of pip is available" HTTPS check is pure noise and a proxy-config gotcha (cf. #69910). `salt/modules/pip.py` already suppresses it on 6 code paths; salt-pip should too.

Sets `PIP_DISABLE_PIP_VERSION_CHECK=1` in `_pip_environment` via `setdefault` (env-var, not argv) so user-passed pip subcommands stay untouched and operators can opt back in by exporting `PIP_DISABLE_PIP_VERSION_CHECK=0`.

Regression tests in `tests/pytests/unit/test_scripts.py`. Merge-forward will propagate to 3007.x/3008.x/master.