### PR TITLE
mirror-from-saltstack-salt: prune refs/pull/* to avoid HTTP 408 timeout

### DIFF
--- a/.github/workflows/mirror-from-saltstack-salt.yaml
+++ b/.github/workflows/mirror-from-saltstack-salt.yaml
@@ -61,6 +61,19 @@ jobs:
         run: |
           git clone --bare --mirror https://github.com/saltstack/salt.git upstream.git
 
+      - name: prune refs/pull/* before push
+        working-directory: upstream.git
+        run: |
+          # GitHub rejects any push to refs/pull/* (managed by GitHub itself,
+          # not writable). --mirror still enumerates them during negotiation,
+          # which for salt is thousands of PR head/merge refs — sole cause of
+          # HTTP 408 timeouts observed on first cron attempts. Prune locally
+          # so negotiation only covers real branches + tags.
+          before=$(git for-each-ref refs/pull/ | wc -l)
+          git for-each-ref 'refs/pull/*' --format='delete %(refname)' | git update-ref --stdin
+          after=$(git for-each-ref refs/pull/ | wc -l)
+          echo "refs/pull/ pruned: ${before} -> ${after}"
+
       - name: push --mirror to salt-nightlies
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70017 and #70026. Adds one step to `mirror-from-saltstack-salt.yaml` that prunes `refs/pull/*` from the local bare clone before `git push --mirror`.

### Why

Observed on the first real mirror runs (saltstack/salt-nightlies workflow run 31676009635, ~19m28s, and re-dispatch 31677410414, similar duration): `git push --mirror` takes ~19–20 minutes and ends with `HTTP 408` from GitHub, even when the destination is already fully in sync.

Root cause is `refs/pull/*` — GitHub rejects any push to those refs (they are managed by GitHub itself, not writable), but `--mirror` still enumerates them during the initial ref-negotiation handshake. For `saltstack/salt` this is thousands of PR head/merge refs, and the negotiation alone hits the HTTP timeout.

Master alignment verified even in the 408-ing runs (source and destination master SHAs matched afterward), so deleting `refs/pull/*` from the local clone is safe — they're rebuildable from GitHub's own state at any time.

### Fix

```bash
git for-each-ref 'refs/pull/*' --format='delete %(refname)' | git update-ref --stdin
```

Between `git clone --bare --mirror` and `git push --mirror`. Only real branches, tags, and notes negotiate.

### What issues does this PR fix or reference?

Follow-up to #70017 and #70026. No linked issue.

### Merge requirements satisfied?

- [ ] Docs — N/A.
- [ ] Changelog — none added.
- [ ] Tests — no automated tests; workflow is an Actions definition.

### Commits signed with GPG?

No.