### PR TITLE
mirror-from-saltstack-salt: fix prune pattern (was matching nothing)

### DIFF
--- a/.github/workflows/mirror-from-saltstack-salt.yaml
+++ b/.github/workflows/mirror-from-saltstack-salt.yaml
@@ -70,7 +70,7 @@ jobs:
           # HTTP 408 timeouts observed on first cron attempts. Prune locally
           # so negotiation only covers real branches + tags.
           before=$(git for-each-ref refs/pull/ | wc -l)
-          git for-each-ref 'refs/pull/*' --format='delete %(refname)' | git update-ref --stdin
+          git for-each-ref refs/pull/ --format='delete %(refname)' | git update-ref --stdin
           after=$(git for-each-ref refs/pull/ | wc -l)
           echo "refs/pull/ pruned: ${before} -> ${after}"
 


### PR DESCRIPTION
### What does this PR do?

One-character fix to the prune step added in #70027. The pattern `'refs/pull/*'` used with `git for-each-ref` matches **zero** refs — the `*` wildcard is treated as a literal, not a glob, in `for-each-ref` pattern arguments. The prune was a no-op, `refs/pull/*` still enumerated on push, and the HTTP 408 problem #70027 was meant to solve was still happening.

Correct syntax is the prefix without wildcard: `refs/pull/`. Same form already used in the `before` and `after` count lines directly adjacent.

### Verification

Verified locally against a fresh `git clone --bare --mirror` of `saltstack/salt`:

**With buggy pattern** (current merged version of #70027):
```
$ git for-each-ref 'refs/pull/*' | wc -l
0
$ git for-each-ref refs/pull/ | wc -l
48905
```

**With fix**:
```
$ git for-each-ref refs/pull/ --format='delete %(refname)' | git update-ref --stdin
refs/pull/ pruned: 48905 -> 0
$ time git push --mirror ...salt-nightlies.git
Everything up-to-date
real    0m0.686s
```

### Impact if not merged

The salt-nightlies mirror cron will fail nightly with HTTP 408 (same as before #70027 attempted a fix). The mirror still achieves ref sync at the git level (verified — master SHAs matched on both sides after the 408), so it's a workflow-ergonomics and runtime issue, not a data-correctness one. But nightly runs will always appear red.

### Merge requirements satisfied?

- [ ] Docs — N/A.
- [ ] Changelog — none added.
- [ ] Tests — no automated tests; workflow is an Actions definition.

### Commits signed with GPG?

No.