### PR TITLE
mirror-from-saltstack-salt: override remote.origin.mirror to allow scoped refspecs

### DIFF
--- a/.github/workflows/mirror-from-saltstack-salt.yaml
+++ b/.github/workflows/mirror-from-saltstack-salt.yaml
@@ -92,7 +92,13 @@ jobs:
           # with --prune to remove refs deleted on salt. Anything else on
           # salt-nightlies — including nightly-YYYY-MM-DD-<branch> tags created
           # by publish-nightly-release.yml — is left alone.
-          git push --prune origin \
+          #
+          # `-c remote.origin.mirror=false` is required: `git clone --bare --mirror`
+          # above sets remote.origin.mirror=true in the local config, which makes
+          # `git push` implicitly use --mirror, which fatals when combined with
+          # refspecs ("--mirror can't be combined with refspecs"). Inline override
+          # avoids modifying the config.
+          git -c remote.origin.mirror=false push --prune origin \
             '+refs/heads/*:refs/heads/*' \
             '+refs/tags/v*:refs/tags/v*'
 


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70029. `git clone --bare --mirror` (added in #70017) sets `remote.origin.mirror=true` in the local config. That makes every subsequent `git push origin ...` implicitly add `--mirror`, which is incompatible with explicit refspecs — the push fatals with:

```
fatal: --mirror can't be combined with refspecs
```

Observed on the first cron dispatch after #70029 merged (saltstack/salt-nightlies workflow run 31692368445 exited 128).

### Fix

Pass `-c remote.origin.mirror=false` inline on the push:

```bash
git -c remote.origin.mirror=false push --prune origin \
  '+refs/heads/*:refs/heads/*' \
  '+refs/tags/v*:refs/tags/v*'
```

`--no-mirror` flag doesn't override `remote.<name>.mirror` per git's precedence — only an explicit `-c` config override does.

### Verification

Locally reproduced the failure with the workflow's exact clone flags, then confirmed the fix pushes in ~2 seconds:

```
$ git config --get remote.origin.mirror
true

$ git push --prune origin '+refs/heads/*:refs/heads/*'
fatal: --mirror can't be combined with refspecs

$ git -c remote.origin.mirror=false push --prune origin '+refs/heads/*:refs/heads/*'
Everything up-to-date  (in ~2s)
```

### What issues does this PR fix or reference?

Follow-up to #70029 (and the earlier #70017 / #70026 / #70027 / #70028 series).

### Commits signed with GPG?

No.