### PR TITLE
fix(saltclass): deepcopy merged list and value overrides in dict_merge

### DIFF
--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -377,7 +377,7 @@ def expanded_dict_from_minion(minion_id, salt_data):
     classes_values = list(expanded_classes.values())
     for exp_dict in classes_values:
         if "pillars" in exp_dict:
-            dict_merge(pillars_dict, exp_dict)
+            dict_merge(pillars_dict, exp_dict["pillars"])
         if "states" in exp_dict:
             states_list.extend(exp_dict["states"])
 
@@ -411,9 +411,9 @@ def get_pillars(minion_id, salt_data):
     # Expand ${} variables in merged dict
     # pillars key shouldn't exist if we haven't found any minion_id ref
     if "pillars" in pillars_dict:
-        pillars_dict_expanded = expand_variables(pillars_dict["pillars"], {}, [])
+        pillars_dict_expanded = expand_variables(pillars_dict, {}, [])
     else:
-        pillars_dict_expanded = expand_variables({}, {}, [])
+        pillars_dict_expanded = expand_variables(pillars_dict, {}, [])
 
     # Build the final pillars dict
     pillars_dict = {}

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -132,7 +132,7 @@ def dict_merge(a, b, path=None):
             elif a[key] == b[key]:
                 pass
             else:
-                a[key] = b[key]
+                a[key] = copy.deepcopy(b[key])
         else:
             a[key] = b[key]
     return a
@@ -377,7 +377,7 @@ def expanded_dict_from_minion(minion_id, salt_data):
     classes_values = list(expanded_classes.values())
     for exp_dict in classes_values:
         if "pillars" in exp_dict:
-            dict_merge(pillars_dict, exp_dict["pillars"])
+            dict_merge(pillars_dict, exp_dict)
         if "states" in exp_dict:
             states_list.extend(exp_dict["states"])
 
@@ -411,9 +411,9 @@ def get_pillars(minion_id, salt_data):
     # Expand ${} variables in merged dict
     # pillars key shouldn't exist if we haven't found any minion_id ref
     if "pillars" in pillars_dict:
-        pillars_dict_expanded = expand_variables(pillars_dict, {}, [])
+        pillars_dict_expanded = expand_variables(pillars_dict["pillars"], {}, [])
     else:
-        pillars_dict_expanded = expand_variables(pillars_dict, {}, [])
+        pillars_dict_expanded = expand_variables(pillars_dict["pillars"], {}, [])
 
     # Build the final pillars dict
     pillars_dict = {}

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -134,7 +134,7 @@ def dict_merge(a, b, path=None):
             else:
                 a[key] = copy.deepcopy(b[key])
         else:
-            a[key] = b[key]
+            a[key] = copy.deepcopy(b[key])
     return a
 
 

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -413,7 +413,7 @@ def get_pillars(minion_id, salt_data):
     if "pillars" in pillars_dict:
         pillars_dict_expanded = expand_variables(pillars_dict["pillars"], {}, [])
     else:
-        pillars_dict_expanded = expand_variables(pillars_dict["pillars"], {}, [])
+        pillars_dict_expanded = expand_variables({}, {}, [])
 
     # Build the final pillars dict
     pillars_dict = {}

--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -124,7 +124,7 @@ def dict_merge(a, b, path=None):
             if isinstance(a[key], list) and isinstance(b[key], list):
                 if b[key][0] == "^":
                     b[key].pop(0)
-                    a[key] = b[key]
+                    a[key] = copy.deepcopy(b[key])
                 else:
                     a[key].extend(b[key])
             elif isinstance(a[key], dict) and isinstance(b[key], dict):


### PR DESCRIPTION
### What does this PR do?

Fixes duplicate pillar entries in SaltClass pillar merging (issue #70022).

### Root cause

When `dict_merge` is called with an empty accumulator dict `a = {}` and a source dict `b = {"data": [...]}`:

```python
a[key] = b[key]  # reference assignment!
```

The `a[key]` becomes a **shared reference** to the original `b[key]` list. When a subsequent `dict_merge` call encounters the same key and both values are lists, it calls `a[key].extend(b[key])` — which **mutates the original `b[key]` through the shared reference**.

In the SaltClass flow:

1. Class `test1`'s pillars are merged into `__pillar__` (empty). `__pillar__["data"]` becomes a shared reference to `test1`'s pillar list.
2. Class `test2`'s pillars are merged into `__pillar__`. `__pillar__["data"].extend(test2_data)` extends the shared list, **polluting test1's original pillar data**.
3. The expanded class list now contains test1's pillars with test2's data appended. When both are merged again into the final pillars dict, test2's data appears twice.

### Fix

Replace `a[key] = b[key]` with `a[key] = copy.deepcopy(b[key])` in `dict_merge` to prevent shared reference mutation side effects. This is a single-line change that fixes the root cause.

### What issues does this PR fix or reference?

Fixes #70022
