### PR TITLE
fix: use pwd.getpwuid for shell grain instead of SHELL env var

### DIFF
--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -23,11 +23,13 @@ def shell():
     if salt.utils.platform.is_windows():
         env_var = "COMSPEC"
         default = r"C:\Windows\system32\cmd.exe"
-    else:
-        env_var = "SHELL"
-        default = "/bin/sh"
-
-    return {"shell": os.environ.get(env_var, default)}
+        return {"shell": os.environ.get(env_var, default)}
+    try:
+        import pwd
+        shell = pwd.getpwuid(os.getuid()).pw_shell
+        return {"shell": shell or "/bin/sh"}
+    except (ImportError, KeyError, AttributeError):
+        return {"shell": "/bin/sh"}
 
 
 def config():


### PR DESCRIPTION
### Problem

When running `cmd.run`, the default shell behaves inconsistently depending on how the command is executed:

- `salt-call cmd.run 'echo $0 - $SHELL'` → `/bin/bash - /bin/bash` (local execution)
- `salt $HOSTNAME cmd.run 'echo $0 - $SHELL'` → `/bin/sh -` (remote execution via minion)

The `shell` grain also shows the same inconsistency:

- `salt-call grains.get shell` → `/bin/bash`
- `salt $HOSTNAME grains.get shell` → `/bin/sh`

### Root Cause

`salt/grains/extra.py`'s `shell()` function uses `os.environ.get("SHELL", "/bin/sh")` to determine the default shell. The `$SHELL` environment variable is set to the user's login shell when running locally via `salt-call`, but is not set in the salt minion daemon process running remotely, causing it to fall back to `/bin/sh`.

### Fix

Replace the `os.environ.get("SHELL", "/bin/sh")` call with `pwd.getpwuid(os.getuid()).pw_shell`, which reads the user's configured login shell from `/etc/passwd` instead of the environment variable. This value is consistent regardless of the execution context.

### Changes

- `salt/grains/extra.py`: Use `pwd.getpwuid(os.getuid()).pw_shell` for the `shell()` grain on Unix systems
- Falls back to `/bin/sh` if `pwd` is unavailable or the shell entry is empty
- Windows behavior unchanged (still uses `COMSPEC` environment variable)

### Verification

- `pwd` is a standard library module available on all Unix systems
- `pwd.getpwuid()` returns the user's shell from `/etc/passwd`, which is the same value regardless of how the process was started
- The `shell()` function already handles Windows separately via `salt.utils.platform.is_windows()`

Fixes #70021