### PR TITLE
fix: defer NDB/IPDB construction in network_settings beacon to first use

### DIFF
--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -17,11 +17,9 @@ try:
     from pyroute2 import NDB
     from pyroute2.ndb.compat import ipdb_interfaces_view
 
-    IP = NDB()
     HAS_PYROUTE2 = True
     HAS_NDB = True
 except ImportError:
-    IP = None
     HAS_NDB = False
     HAS_PYROUTE2 = False
 
@@ -29,11 +27,9 @@ except ImportError:
 try:
     from pyroute2 import IPDB
 
-    if IP is None:
-        IP = IPDB()
-        HAS_PYROUTE2 = True
+    HAS_IPDB = True
 except ImportError:
-    IP = None
+    HAS_IPDB = False
 
 
 log = logging.getLogger(__name__)
@@ -69,6 +65,20 @@ ATTRS = [
 
 LAST_STATS = {}
 
+# Key under which the lazily-created NDB/IPDB handle is cached in the
+# loader's ``__context__`` so that it survives beacon module reloads.
+_NDB_CONTEXT_KEY = "network_settings.ndb_handle"
+
+# The NDB/IPDB handle is deliberately NOT constructed here.  Salt's
+# LazyLoader re-executes beacon modules whenever the beacon loader is
+# rebuilt (grain refresh, saltutil.sync_beacons, highstate).  Constructing
+# the handle at import time would spawn a new thread, netlink socket and
+# in-memory SQLite database on every reload, orphaning the previous
+# instances whose receiver threads then run for the life of the process
+# (see #70036).  Creation is deferred to first use in :func:`beacon` and
+# cached in __context__, which the loader preserves across reloads.
+IP = None
+
 
 class Hashabledict(dict):
     """
@@ -85,6 +95,36 @@ def __virtual__():
     err_msg = "pyroute2 library is missing"
     log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
     return False, err_msg
+
+
+def _get_ip():
+    """
+    Return the shared NDB/IPDB handle, creating it on first use.
+
+    The handle is cached in the loader's ``__context__`` (which survives
+    beacon module reloads) so that at most one instance exists per
+    process, regardless of how many times the beacon is re-executed.
+
+    .. versionchanged:: 3009
+        The NDB/IPDB handle is now created lazily instead of at import
+        time, and cached in ``__context__``.  See #70036.
+    """
+    global IP
+    if IP is not None:
+        return IP
+    context = globals().get("__context__", {})
+    if context:
+        cached = context.get(_NDB_CONTEXT_KEY)
+        if cached is not None:
+            IP = cached
+            return IP
+    if HAS_NDB:
+        IP = NDB()
+    elif HAS_IPDB:
+        IP = IPDB()
+    if context:
+        context[_NDB_CONTEXT_KEY] = IP
+    return IP
 
 
 def validate(config):
@@ -187,7 +227,8 @@ def beacon(config):
 
     coalesce = False
 
-    _stats = _copy_interfaces_info(ipdb_interfaces_view(IP) if HAS_NDB else IP.by_name)
+    ip = _get_ip()
+    _stats = _copy_interfaces_info(ipdb_interfaces_view(ip) if HAS_NDB else ip.by_name)
 
     if not LAST_STATS:
         LAST_STATS = _stats

--- a/tests/pytests/unit/beacons/test_network_settings.py
+++ b/tests/pytests/unit/beacons/test_network_settings.py
@@ -195,15 +195,14 @@ def test_interface_dict_fields_new():
 @pytest.fixture
 def reset_ip_global():
     """
-    Ensure the module-level IP handle is reset between tests so that
-    tests checking lazy initialization are independent.
+    Ensure the module-level IP handle and __context__ cache are reset
+    between the lazy-initialization tests.
     """
-    original_ip = network_settings.IP
-    original_context = network_settings.globals().get("__context__", {})
     yield
-    network_settings.IP = original_ip
-    if original_context:
-        original_context.pop(network_settings._NDB_CONTEXT_KEY, None)
+    network_settings.IP = None
+    context = network_settings.globals().get("__context__")
+    if isinstance(context, dict):
+        context.pop(network_settings._NDB_CONTEXT_KEY, None)
 
 
 def test_ip_not_constructed_at_import(reset_ip_global):
@@ -222,13 +221,12 @@ def test_get_ip_caches_instance_in_context(reset_ip_global):
     _get_ip() creates the handle once and caches it in __context__, so a
     second call returns the same instance without constructing a new one.
     """
-    context = network_settings.globals().get("__context__", {})
+    context = {"__pid__": 12345}
     with patch.object(network_settings, "IP", None), patch.object(
         network_settings, "HAS_NDB", True
-    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())):
-        # Ensure cached handle is absent
-        context.pop(network_settings._NDB_CONTEXT_KEY, None)
-
+    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())), patch.object(
+        network_settings, "__context__", context
+    ):
         ip1 = network_settings._get_ip()
         ip2 = network_settings._get_ip()
 
@@ -245,15 +243,17 @@ def test_get_ip_reuses_cached_context_handle(reset_ip_global):
     beacon loader generation), _get_ip() reuses it instead of constructing
     a new NDB instance.
     """
-    context = network_settings.globals().get("__context__", {})
+    context = {"__pid__": 12345}
     cached = MockIPClass()
     context[network_settings._NDB_CONTEXT_KEY] = cached
     with patch.object(network_settings, "IP", None), patch.object(
         network_settings, "HAS_NDB", True
-    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())):
+    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())), patch.object(
+        network_settings, "__context__", context
+    ):
         ip = network_settings._get_ip()
 
         assert ip is cached
         # No new NDB was constructed -- the cached handle was reused
         network_settings.NDB.assert_not_called()
-        network_settings.IP is cached
+        assert network_settings.IP is cached

--- a/tests/pytests/unit/beacons/test_network_settings.py
+++ b/tests/pytests/unit/beacons/test_network_settings.py
@@ -190,3 +190,70 @@ def test_interface_dict_fields_new():
         view = ipdb_interfaces_view(ndb)
         for attr in network_settings.ATTRS:
             assert attr in view["lo"]
+
+
+@pytest.fixture
+def reset_ip_global():
+    """
+    Ensure the module-level IP handle is reset between tests so that
+    tests checking lazy initialization are independent.
+    """
+    original_ip = network_settings.IP
+    original_context = network_settings.globals().get("__context__", {})
+    yield
+    network_settings.IP = original_ip
+    if original_context:
+        original_context.pop(network_settings._NDB_CONTEXT_KEY, None)
+
+
+def test_ip_not_constructed_at_import(reset_ip_global):
+    """
+    The NDB/IPDB handle must not be created at module import time.
+
+    See #70036: constructing it eagerly leaks one instance (thread, netlink
+    socket, in-memory SQLite database) per beacon loader refresh.
+    """
+    # IP starts as None; it is only created on first use inside beacon().
+    assert network_settings.IP is None
+
+
+def test_get_ip_caches_instance_in_context(reset_ip_global):
+    """
+    _get_ip() creates the handle once and caches it in __context__, so a
+    second call returns the same instance without constructing a new one.
+    """
+    context = network_settings.globals().get("__context__", {})
+    with patch.object(network_settings, "IP", None), patch.object(
+        network_settings, "HAS_NDB", True
+    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())):
+        # Ensure cached handle is absent
+        context.pop(network_settings._NDB_CONTEXT_KEY, None)
+
+        ip1 = network_settings._get_ip()
+        ip2 = network_settings._get_ip()
+
+        assert ip1 is ip2
+        # Only one NDB instance was constructed
+        network_settings.NDB.assert_called_once()
+        # It is cached in the loader context
+        assert context.get(network_settings._NDB_CONTEXT_KEY) is ip1
+
+
+def test_get_ip_reuses_cached_context_handle(reset_ip_global):
+    """
+    If a handle is already cached in __context__ (e.g. from a previous
+    beacon loader generation), _get_ip() reuses it instead of constructing
+    a new NDB instance.
+    """
+    context = network_settings.globals().get("__context__", {})
+    cached = MockIPClass()
+    context[network_settings._NDB_CONTEXT_KEY] = cached
+    with patch.object(network_settings, "IP", None), patch.object(
+        network_settings, "HAS_NDB", True
+    ), patch.object(network_settings, "NDB", MagicMock(return_value=MockIPClass())):
+        ip = network_settings._get_ip()
+
+        assert ip is cached
+        # No new NDB was constructed -- the cached handle was reused
+        network_settings.NDB.assert_not_called()
+        network_settings.IP is cached


### PR DESCRIPTION
### Problem

Constructing `NDB()` (or `IPDB()`) at module import time leaks one instance per beacon loader refresh: Salt's LazyLoader re-executes beacon modules whenever the loader is rebuilt (grain refresh, `saltutil.sync_beacons`, highstate), and each re-execution spawns a new NDB with its own thread, netlink socket and in-memory SQLite database. Nothing retains a reference to the previous instance, so its receiver thread runs for the life of the process.

Threads accumulate indefinitely, and every leaked thread processes every netlink neighbour event, contending on the GIL — so minion CPU rises steadily with uptime until the service is restarted, even on minions that do **not** configure the `network_settings` beacon at all (the leak happens at import, not at execution).

### Changes

1. **Defer NDB()/IPDB() construction to first use** inside `beacon()`, cached in a new `_get_ip()` helper. A beacon that is not configured now creates no resources at import time.

2. **Cache the handle in the loader's `__context__`**, which survives beacon module reloads, so that at most one NDB/IPDB instance is created per process regardless of how many times the beacon is re-executed.

3. **Fix the secondary IPDB bug**: the legacy IPDB fallback `except ImportError: IP = None` no longer exists (the handle is now lazily constructed), so a working NDB handle can no longer be wiped by a failed IPDB import.

### Testing

Existing tests continue to pass (they use `patch.object(network_settings, "IP", MockIPClass)`, which is compatible with `_get_ip()` returning the patched value).

Fixes #70036