### PR TITLE
Add opt-in cgroup-aware minion_memory_headroom / minion_memory_max (#69884)

### DIFF
--- a/changelog/69884.added.md
+++ b/changelog/69884.added.md
@@ -1,0 +1,1 @@
+Added opt-in ``minion_memory_headroom`` and ``minion_memory_max`` minion config options with cgroup v1 / v2 detection so the queue-admission memory check can be tuned on large hosts and cgroup-limited minions. Defaults preserve the existing 95%-of-system-RAM behavior.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3330,6 +3330,70 @@ processed as slots become available. ``-1`` is the default and disables the limi
 
     process_count_max: -1
 
+.. conf_minion:: minion_memory_headroom
+
+``minion_memory_headroom``
+--------------------------
+
+.. versionadded:: 3006.28
+
+Default: ``None``
+
+Required free memory the minion must be able to allocate before it will start
+another job. When set, the minion queue admission check compares this against
+the reference "total memory available to this minion" (see
+:conf_minion:`minion_memory_max`) instead of the built-in 95%-of-system-RAM
+rule.
+
+Accepts either a percentage string (``"5%"``) or an absolute size
+(``"5G"``, ``"500M"``, ``"5368709120"``, or a raw int of bytes).
+
+When unset, the minion preserves the legacy behavior of pausing queue
+processing when system-wide RAM usage exceeds 95%. Setting this opt is the
+recommended way to give the minion useful headroom guidance on very large
+hosts (where 5% of RAM is many GB) or on cgroup-limited minions.
+
+The reference memory used to evaluate the percentage / absolute check is
+resolved in this order:
+
+1. ``minion_memory_max`` if set.
+2. cgroup v2 ``memory.max`` if the minion process is confined by a v2
+   cgroup with a finite limit.
+3. cgroup v1 ``memory.limit_in_bytes`` if the minion process is confined by
+   a v1 memory cgroup with a finite limit.
+4. ``psutil.virtual_memory().total`` (system-wide RAM).
+
+.. code-block:: yaml
+
+    minion_memory_headroom: 5%
+
+.. code-block:: yaml
+
+    minion_memory_headroom: 500M
+
+.. conf_minion:: minion_memory_max
+
+``minion_memory_max``
+---------------------
+
+.. versionadded:: 3006.28
+
+Default: ``None``
+
+Explicit override for the reference "total memory available to this minion"
+used by :conf_minion:`minion_memory_headroom`. Accepts an absolute size
+(``"2G"``, ``"1073741824"``, or a raw int of bytes).
+
+When unset, the reference is auto-detected from cgroup v2 / v1 memory limits
+(when the minion process is confined by a cgroup) and finally falls back to
+``psutil.virtual_memory().total``. Set this opt to pin the reference on
+hosts where cgroup detection is unavailable or where the operator wants to
+enforce a lower cap than the cgroup allows.
+
+.. code-block:: yaml
+
+    minion_memory_max: 2G
+
 .. _minion-logging-settings:
 
 Minion Logging Settings

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -301,6 +301,15 @@ VALID_OPTS = immutabletypes.freeze(
         "multiprocessing": bool,
         # Maximum number of concurrently active processes at any given point in time
         "process_count_max": int,
+        # Opt-in memory-headroom guard for queue admission. Accepts a
+        # percentage string ("5%") or an absolute size ("5G", "500M", int
+        # bytes). None preserves the legacy 5%-of-system-RAM behavior.
+        "minion_memory_headroom": (str, int, type(None)),
+        # Optional explicit override for the reference "total memory" used
+        # by the headroom guard. Accepts int bytes or a size string. When
+        # unset the reference is auto-detected from cgroup v2 / v1 limits,
+        # falling back to system-wide RAM.
+        "minion_memory_max": (str, int, type(None)),
         # Whether or not the salt minion should run scheduled mine updates
         "mine_enabled": bool,
         # Whether or not scheduled mine updates should be accompanied by a job return for the job cache
@@ -1187,6 +1196,8 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "autosign_timeout": 120,
         "multiprocessing": True,
         "process_count_max": -1,
+        "minion_memory_headroom": None,
+        "minion_memory_max": None,
         "mine_enabled": True,
         "mine_return_job": False,
         "mine_interval": 60,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -61,6 +61,7 @@ import salt.utils.process
 import salt.utils.schedule
 import salt.utils.ssdp
 import salt.utils.state
+import salt.utils.stringutils
 import salt.utils.user
 import salt.utils.zeromq
 from salt._compat import ipaddress
@@ -91,6 +92,16 @@ try:
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
+
+# Paths for cgroup-aware memory-limit detection. Module-level so tests can
+# monkeypatch to a synthetic cgroup filesystem laid out under tmp_path.
+_CGROUP_PROC_PATH = "/proc/self/cgroup"
+_CGROUP_FS_ROOT = "/sys/fs/cgroup"
+# cgroup v1 kernel "no limit" sentinel is (LONG_MAX / PAGE_SIZE) * PAGE_SIZE,
+# i.e. ~9.22 EB. We compare against 2**62 (~4.6 EB) which is comfortably
+# above any real limit but below the sentinel — anything at or above this
+# is treated as "unlimited".
+_CGROUP_V1_UNLIMITED_THRESHOLD = 1 << 62
 
 try:
     import resource
@@ -483,6 +494,215 @@ def service_name():
     Return the proper service name based on platform
     """
     return "salt_minion" if "bsd" in sys.platform else "salt-minion"
+
+
+def _read_cgroup_file(path):
+    """
+    Read a cgroup pseudo-file. Return the stripped contents on success or
+    ``None`` on any error. Cgroup files are stable on Linux; we intentionally
+    swallow every failure (missing file, permission denied, non-Linux host,
+    exotic mount layout) and let the caller fall back to system-wide memory.
+    """
+    try:
+        with salt.utils.files.fopen(path, "r") as fh:
+            return fh.read().strip()
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+
+
+def _parse_self_cgroup(content):
+    """
+    Parse ``/proc/self/cgroup`` content. Return a tuple
+    ``(v2_path, v1_memory_path)`` where each element is a string starting
+    with ``/`` or ``None`` if that hierarchy isn't present.
+
+    v2 line format:  ``0::/system.slice/salt-minion.service``
+    v1 line format:  ``5:memory:/system.slice/salt-minion.service``
+    """
+    v2_path = None
+    v1_memory_path = None
+    if not content:
+        return v2_path, v1_memory_path
+    for line in content.splitlines():
+        parts = line.split(":", 2)
+        if len(parts) != 3:
+            continue
+        hierarchy_id, controllers, cgroup_path = parts
+        if hierarchy_id == "0" and controllers == "":
+            v2_path = cgroup_path or "/"
+        elif "memory" in controllers.split(","):
+            v1_memory_path = cgroup_path or "/"
+    return v2_path, v1_memory_path
+
+
+def _detect_cgroup_memory(proc_path=None, fs_root=None):
+    """
+    Detect the memory limit and current usage that apply to this process
+    via cgroups.
+
+    Returns ``(limit_bytes, used_bytes, source)`` where ``source`` is
+    ``"cgroup-v2"``, ``"cgroup-v1"``, or ``None``. When no cgroup limit
+    applies (unified hierarchy reports ``"max"``, v1 reports the unlimited
+    sentinel, or the files can't be read) returns ``(None, None, None)``.
+
+    Any I/O or parse failure is logged at DEBUG and swallowed — this helper
+    must never raise into the caller.
+    """
+    proc_path = proc_path or _CGROUP_PROC_PATH
+    fs_root = fs_root or _CGROUP_FS_ROOT
+    content = _read_cgroup_file(proc_path)
+    if content is None:
+        log.debug(
+            "No cgroup information at %s; skipping cgroup memory detection", proc_path
+        )
+        return None, None, None
+    v2_path, v1_memory_path = _parse_self_cgroup(content)
+
+    # Prefer cgroup v2 (unified hierarchy) when both are present. On a
+    # v1 host the v2 line will be absent; on a hybrid host the v2 line
+    # exists but has no controllers, in which case v2 memory files simply
+    # won't be found and we'll fall through to v1.
+    if v2_path is not None:
+        max_str = _read_cgroup_file(
+            os.path.join(fs_root, v2_path.lstrip("/"), "memory.max")
+        )
+        if max_str is not None:
+            if max_str == "max":
+                log.debug("cgroup v2 memory.max is 'max' (unlimited)")
+            else:
+                try:
+                    limit = int(max_str)
+                except ValueError:
+                    log.debug("Unparseable cgroup v2 memory.max: %r", max_str)
+                else:
+                    current_str = _read_cgroup_file(
+                        os.path.join(fs_root, v2_path.lstrip("/"), "memory.current")
+                    )
+                    try:
+                        current = int(current_str) if current_str is not None else 0
+                    except ValueError:
+                        current = 0
+                    return limit, current, "cgroup-v2"
+
+    if v1_memory_path is not None:
+        v1_base = os.path.join(fs_root, "memory", v1_memory_path.lstrip("/"))
+        limit_str = _read_cgroup_file(os.path.join(v1_base, "memory.limit_in_bytes"))
+        if limit_str is not None:
+            try:
+                limit = int(limit_str)
+            except ValueError:
+                log.debug("Unparseable cgroup v1 memory.limit_in_bytes: %r", limit_str)
+            else:
+                if limit >= _CGROUP_V1_UNLIMITED_THRESHOLD:
+                    log.debug(
+                        "cgroup v1 memory.limit_in_bytes is at unlimited sentinel: %s",
+                        limit,
+                    )
+                else:
+                    usage_str = _read_cgroup_file(
+                        os.path.join(v1_base, "memory.usage_in_bytes")
+                    )
+                    try:
+                        used = int(usage_str) if usage_str is not None else 0
+                    except ValueError:
+                        used = 0
+                    return limit, used, "cgroup-v1"
+
+    return None, None, None
+
+
+def _parse_size_opt(value):
+    """
+    Parse a size expressed as int-bytes or a string (``"5G"``, ``"500M"``,
+    or plain digits). Return an int number of bytes, or ``None`` on any
+    parse failure. Zero and negatives are treated as invalid.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # bool is a subclass of int — reject to avoid True->1-byte surprise.
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = int(text)
+        if parsed > 0:
+            return parsed
+    except ValueError:
+        pass
+    bytes_ = salt.utils.stringutils.human_to_bytes(text)
+    return bytes_ if bytes_ > 0 else None
+
+
+def _headroom_to_bytes(value, reference):
+    """
+    Convert a ``minion_memory_headroom`` opt to an absolute byte count
+    relative to ``reference``. Accepts a percentage string (``"5%"``), a
+    size string / int (``"500M"``, ``5368709120``), or ``None``. Returns
+    ``None`` on any parse failure or when ``value`` is ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip().endswith("%"):
+        text = value.strip()[:-1].strip()
+        try:
+            pct = float(text)
+        except ValueError:
+            log.debug("Unparseable percentage in minion_memory_headroom: %r", value)
+            return None
+        if not 0 < pct <= 100:
+            log.debug("minion_memory_headroom percentage out of range: %r", value)
+            return None
+        return int(reference * pct / 100.0)
+    bytes_ = _parse_size_opt(value)
+    if bytes_ is None:
+        log.debug("Unparseable minion_memory_headroom: %r", value)
+    return bytes_
+
+
+def _resolve_memory_reference(max_opt):
+    """
+    Resolve the reference "total memory available to this minion" and the
+    current used bytes.
+
+    Precedence:
+        1. ``minion_memory_max`` config (int bytes or size string).
+        2. cgroup v2 ``memory.max`` (with ``memory.current`` for used).
+        3. cgroup v1 ``memory.limit_in_bytes`` (with ``memory.usage_in_bytes``).
+        4. ``psutil.virtual_memory().total`` (with ``.used``).
+
+    Returns ``(reference_bytes, used_bytes, source)`` where ``source`` is
+    one of ``"config"``, ``"cgroup-v2"``, ``"cgroup-v1"``, ``"system"``.
+    """
+    import psutil  # local import mirrors the caller's guarded pattern
+
+    if max_opt is not None:
+        configured = _parse_size_opt(max_opt)
+        if configured is not None:
+            vm = psutil.virtual_memory()
+            # If the operator's cap is <= system total we assume they're
+            # describing a per-process cap and use it as the reference; we
+            # still need a "used" number so we consult cgroup usage first
+            # (accurate for the process) then fall back to system used.
+            cg_limit, cg_used, cg_source = _detect_cgroup_memory()
+            if cg_source is not None:
+                used = cg_used
+            else:
+                used = vm.used
+            return configured, used, "config"
+        log.debug("Unparseable minion_memory_max: %r", max_opt)
+
+    cg_limit, cg_used, cg_source = _detect_cgroup_memory()
+    if cg_source is not None:
+        return cg_limit, cg_used, cg_source
+
+    vm = psutil.virtual_memory()
+    return vm.total, vm.used, "system"
 
 
 class MinionBase:
@@ -2255,6 +2475,21 @@ class Minion(MinionBase):
         """
         Check if we have enough memory to start a new process.
         Returns True if we have headroom, False otherwise.
+
+        The reference "total memory" and the required headroom can both be
+        tuned via minion config:
+
+        * ``minion_memory_max`` — explicit override for the reference total
+          (int bytes or a size string like ``"5G"``).
+        * ``minion_memory_headroom`` — required free headroom, either a
+          percentage of the reference (``"5%"``) or an absolute size
+          (``"5G"`` / ``"500M"`` / int bytes).
+
+        When neither opt is set the check preserves the legacy behavior
+        (``psutil.virtual_memory().percent > 95``) byte-for-byte. When an
+        opt is set the reference is resolved from
+        ``minion_memory_max`` > cgroup v2 > cgroup v1 >
+        ``psutil.virtual_memory().total``.
         """
         if not HAS_PSUTIL:
             return True
@@ -2262,11 +2497,44 @@ class Minion(MinionBase):
         try:
             import psutil
 
-            mem = psutil.virtual_memory()
-            if mem.percent > 95:
+            headroom_opt = self.opts.get("minion_memory_headroom")
+            max_opt = self.opts.get("minion_memory_max")
+
+            if headroom_opt is None and max_opt is None:
+                # Legacy fast path — no config, no cgroup lookup, no
+                # behavior change on upgrade.
+                mem = psutil.virtual_memory()
+                if mem.percent > 95:
+                    log.warning(
+                        "Memory limit reached (Used: %s%%). Pausing queue processing.",
+                        mem.percent,
+                    )
+                    return False
+                return True
+
+            reference, used, source = _resolve_memory_reference(max_opt)
+            headroom_bytes = _headroom_to_bytes(headroom_opt, reference)
+            if headroom_bytes is None:
+                # Parse failure already logged at DEBUG; fall back to a
+                # 5% headroom on the resolved reference so operator intent
+                # (they asked for cgroup-aware behavior) is honored.
+                headroom_bytes = int(reference * 0.05)
+
+            log.debug(
+                "Memory headroom check: source=%s reference=%s used=%s headroom=%s",
+                source,
+                reference,
+                used,
+                headroom_bytes,
+            )
+            if used + headroom_bytes > reference:
                 log.warning(
-                    "Memory limit reached (Used: %s%%). Pausing queue processing.",
-                    mem.percent,
+                    "Memory limit reached (Used: %s of %s, headroom: %s, source: %s). "
+                    "Pausing queue processing.",
+                    used,
+                    reference,
+                    headroom_bytes,
+                    source,
                 )
                 return False
         except Exception:  # pylint: disable=broad-exception-caught

--- a/tests/pytests/scenarios/minion_memory_headroom/conftest.py
+++ b/tests/pytests/scenarios/minion_memory_headroom/conftest.py
@@ -1,0 +1,65 @@
+"""
+Scenario fixtures for the ``minion_memory_headroom`` opt-in configurable
+queue-admission memory check (issue #69884). Each test parametrizes on the
+minion-config overrides so a fresh minion is booted per scenario, proving
+end-to-end that the loader accepts the new opts and the minion runs with
+them in effect.
+"""
+
+import pytest
+from saltfactories.utils import random_string
+
+from tests.conftest import FIPS_TESTRUN
+
+
+@pytest.fixture(scope="package")
+def salt_master(salt_factories):
+    factory = salt_factories.salt_master_daemon(
+        random_string("mem-headroom-master-"),
+        overrides={
+            "open_mode": True,
+            "fips_mode": FIPS_TESTRUN,
+            "publish_signing_algorithm": (
+                "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+            ),
+        },
+    )
+    with factory.started():
+        yield factory
+
+
+def _minion_overrides(extra=None):
+    overrides = {
+        "fips_mode": FIPS_TESTRUN,
+        "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+        "signing_algorithm": "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1",
+    }
+    if extra:
+        overrides.update(extra)
+    return overrides
+
+
+@pytest.fixture(scope="function")
+def minion_with_opts(salt_master, request):
+    """
+    Boot a fresh minion for the current test with the caller-supplied
+    ``minion_memory_headroom`` / ``minion_memory_max`` overrides applied.
+
+    Use like:
+
+        @pytest.mark.parametrize(
+            "minion_with_opts",
+            [{"minion_memory_headroom": "5G"}],
+            indirect=True,
+        )
+        def test_something(minion_with_opts):
+            salt_call = minion_with_opts.salt_call_cli()
+            ...
+    """
+    overrides = _minion_overrides(getattr(request, "param", None))
+    factory = salt_master.salt_minion_daemon(
+        random_string("mem-headroom-minion-"),
+        overrides=overrides,
+    )
+    with factory.started():
+        yield factory

--- a/tests/pytests/scenarios/minion_memory_headroom/test_minion_memory_headroom.py
+++ b/tests/pytests/scenarios/minion_memory_headroom/test_minion_memory_headroom.py
@@ -1,0 +1,178 @@
+"""
+End-to-end scenario tests for the opt-in ``minion_memory_headroom`` /
+``minion_memory_max`` minion config options and the runtime path through
+``salt.minion.Minion._has_memory_headroom``.
+
+These complement the unit-level matrix in
+``tests/pytests/unit/test_minion_memory_headroom.py`` (which mocks psutil
+and injects a synthetic cgroupfs). Here we boot a real minion daemon with
+each opt combination and drive the check via subprocess evaluation of the
+minion's on-disk config, proving the loader accepts the new opts and the
+runtime code path returns the expected value.
+
+See issue https://github.com/saltstack/salt/issues/69884.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def _run_headroom_eval(config_path):
+    """
+    Spawn a subprocess in the same Python interpreter that pytest is running
+    under, load the minion config from ``config_path``, construct an
+    ``SMinion``, and print the JSON-serialisable result of
+    ``_has_memory_headroom()``.
+
+    Returns the string printed (``"True"`` or ``"False"``). Raises with the
+    subprocess stderr on any failure so debugging is straightforward.
+    """
+    # ``_has_memory_headroom`` is defined on ``Minion`` (not ``SMinion``)
+    # and only reads ``self.opts``. Rather than constructing a full
+    # ``Minion`` (which requires master connectivity and a running loop),
+    # bind the unbound method to a ``SimpleNamespace`` carrying the loaded
+    # opts. This exercises the exact code path the running minion daemon
+    # takes: it loads the config from disk via ``salt.config.minion_config``
+    # and calls ``Minion._has_memory_headroom``.
+    script = textwrap.dedent(
+        f"""
+        import types
+        import salt.config
+        import salt.minion
+        opts = salt.config.minion_config({config_path!r})
+        stub = types.SimpleNamespace(opts=opts)
+        print(salt.minion.Minion._has_memory_headroom(stub))
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"headroom-eval subprocess failed (rc={result.returncode})\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result.stdout.strip().splitlines()[-1]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: opts round-trip through the config loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "minion_with_opts",
+    [{"minion_memory_headroom": "5G", "minion_memory_max": "10G"}],
+    indirect=True,
+    ids=["headroom-5g-max-10g"],
+)
+def test_config_round_trip(minion_with_opts):
+    """
+    Boot a minion with the new opts in its config file, then use
+    ``salt-call --local config.get`` to read them back. Proves the loader
+    accepts both opts (i.e. they're in ``VALID_OPTS``) and that they
+    survive the write-file / read-file round trip.
+    """
+    salt_call = minion_with_opts.salt_call_cli()
+    ret = salt_call.run("--local", "config.get", "minion_memory_headroom")
+    assert ret.returncode == 0, ret
+    assert ret.data == "5G"
+
+    ret = salt_call.run("--local", "config.get", "minion_memory_max")
+    assert ret.returncode == 0, ret
+    assert ret.data == "10G"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: default preserved end-to-end (no upgrade drift)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "minion_with_opts",
+    [{}],
+    indirect=True,
+    ids=["defaults"],
+)
+def test_default_preserved(minion_with_opts):
+    """
+    With neither ``minion_memory_headroom`` nor ``minion_memory_max`` set,
+    the runtime check must return the legacy ``psutil.virtual_memory()
+    .percent > 95`` verdict. On any test host that has more than 5% RAM
+    free (a safe assumption) the result is True.
+    """
+    # Runtime path: legacy branch. Any healthy CI host has >5% RAM free.
+    result = _run_headroom_eval(minion_with_opts.config_file)
+    assert result == "True"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: config override forces a deterministic-True result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "minion_with_opts",
+    [
+        {
+            # 1 EB pinned as reference; 1% headroom (~10 PB). No matter
+            # what the actual system usage looks like, used+headroom
+            # is nowhere near 1 EB, so the check must return True.
+            "minion_memory_max": 1 << 60,
+            "minion_memory_headroom": "1%",
+        }
+    ],
+    indirect=True,
+    ids=["huge-max-tiny-percent"],
+)
+def test_config_override_deterministic_true(minion_with_opts):
+    """
+    With ``minion_memory_max = 1 EB`` and ``minion_memory_headroom = "1%"``
+    the runtime check is guaranteed to return True regardless of actual
+    system memory pressure. Proves the config path drives real
+    ``_has_memory_headroom()`` behavior.
+    """
+    result = _run_headroom_eval(minion_with_opts.config_file)
+    assert result == "True"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: config override forces a deterministic-False result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "minion_with_opts",
+    [
+        {
+            # 1 KB pinned as reference; 100% headroom means "reserve
+            # everything". used + headroom > reference is guaranteed
+            # (unless the process has literally 0 bytes RSS, which is
+            # impossible).
+            "minion_memory_max": 1024,
+            "minion_memory_headroom": "100%",
+        }
+    ],
+    indirect=True,
+    ids=["tiny-max-full-percent"],
+)
+def test_config_override_deterministic_false(minion_with_opts):
+    """
+    With ``minion_memory_max = 1 KB`` and ``minion_memory_headroom = "100%"``
+    the runtime check is guaranteed to return False. Proves the config
+    path can actually block queue admission when the operator asks it to.
+    """
+    result = _run_headroom_eval(minion_with_opts.config_file)
+    assert result == "False"

--- a/tests/pytests/unit/test_minion_memory_headroom.py
+++ b/tests/pytests/unit/test_minion_memory_headroom.py
@@ -1,0 +1,350 @@
+"""
+Tests for the configurable / cgroup-aware ``_has_memory_headroom`` guard on
+the minion queue-admission hot path. See issue #69884.
+"""
+
+import types
+
+import pytest
+
+import salt.minion
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cgroup_fs(tmp_path, monkeypatch):
+    """
+    Lay out a synthetic ``/proc/self/cgroup`` + cgroupfs under ``tmp_path``
+    and monkey-patch the module-level path constants so the detection helper
+    reads from it.
+
+    Returns a callable ``lay(version, limit, current=0, cgroup_path=...)``.
+    Callers may invoke it multiple times; later calls overwrite the layout.
+    """
+    proc_dir = tmp_path / "proc" / "self"
+    proc_dir.mkdir(parents=True)
+    proc_cgroup = proc_dir / "cgroup"
+    fs_root = tmp_path / "sys" / "fs" / "cgroup"
+    fs_root.mkdir(parents=True)
+
+    monkeypatch.setattr(salt.minion, "_CGROUP_PROC_PATH", str(proc_cgroup))
+    monkeypatch.setattr(salt.minion, "_CGROUP_FS_ROOT", str(fs_root))
+
+    def _lay(version, limit, current=0, cgroup_path="/salt.slice/salt-minion.service"):
+        if version == "v2":
+            proc_cgroup.write_text(f"0::{cgroup_path}\n")
+            unit_dir = fs_root / cgroup_path.lstrip("/")
+            unit_dir.mkdir(parents=True, exist_ok=True)
+            limit_str = "max" if limit == "max" else str(limit)
+            (unit_dir / "memory.max").write_text(limit_str + "\n")
+            (unit_dir / "memory.current").write_text(str(current) + "\n")
+        elif version == "v1":
+            proc_cgroup.write_text(
+                f"5:memory:{cgroup_path}\n2:cpu,cpuacct:{cgroup_path}\n"
+            )
+            unit_dir = fs_root / "memory" / cgroup_path.lstrip("/")
+            unit_dir.mkdir(parents=True, exist_ok=True)
+            (unit_dir / "memory.limit_in_bytes").write_text(str(limit) + "\n")
+            (unit_dir / "memory.usage_in_bytes").write_text(str(current) + "\n")
+        elif version == "none":
+            # cgroupfs exists but /proc/self/cgroup missing entirely
+            if proc_cgroup.exists():
+                proc_cgroup.unlink()
+        else:
+            raise ValueError(f"unknown cgroup version: {version}")
+
+    return _lay
+
+
+@pytest.fixture
+def no_cgroup(tmp_path, monkeypatch):
+    """Point the cgroup constants at paths that do not exist."""
+    monkeypatch.setattr(
+        salt.minion, "_CGROUP_PROC_PATH", str(tmp_path / "nonexistent-cgroup")
+    )
+    monkeypatch.setattr(
+        salt.minion, "_CGROUP_FS_ROOT", str(tmp_path / "nonexistent-fs-root")
+    )
+
+
+def _minion(opts):
+    """Return a stand-in with just enough surface for ``_has_memory_headroom``."""
+    return types.SimpleNamespace(opts=opts)
+
+
+# ---------------------------------------------------------------------------
+# Parser / helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseSizeOpt:
+    def test_none(self):
+        assert salt.minion._parse_size_opt(None) is None
+
+    def test_bool_rejected(self):
+        # bool is a subclass of int — must not silently mean 1 byte.
+        assert salt.minion._parse_size_opt(True) is None
+        assert salt.minion._parse_size_opt(False) is None
+
+    def test_int(self):
+        assert salt.minion._parse_size_opt(5368709120) == 5368709120
+
+    def test_zero_and_negative_rejected(self):
+        assert salt.minion._parse_size_opt(0) is None
+        assert salt.minion._parse_size_opt(-1) is None
+
+    def test_string_digits(self):
+        assert salt.minion._parse_size_opt("5368709120") == 5368709120
+
+    def test_string_g(self):
+        assert salt.minion._parse_size_opt("5G") == 5 * (1024**3)
+
+    def test_string_m(self):
+        assert salt.minion._parse_size_opt("500M") == 500 * (1024**2)
+
+    def test_empty_string(self):
+        assert salt.minion._parse_size_opt("") is None
+        assert salt.minion._parse_size_opt("   ") is None
+
+    def test_garbage(self):
+        assert salt.minion._parse_size_opt("garbage") is None
+
+
+class TestHeadroomToBytes:
+    def test_none(self):
+        assert salt.minion._headroom_to_bytes(None, 1024) is None
+
+    def test_percent_5(self):
+        # 5% of 2 GB
+        assert salt.minion._headroom_to_bytes("5%", 2 * (1024**3)) == int(
+            2 * (1024**3) * 0.05
+        )
+
+    def test_percent_100(self):
+        assert salt.minion._headroom_to_bytes("100%", 1000) == 1000
+
+    def test_percent_zero_rejected(self):
+        assert salt.minion._headroom_to_bytes("0%", 1000) is None
+
+    def test_percent_over_100_rejected(self):
+        assert salt.minion._headroom_to_bytes("101%", 1000) is None
+
+    def test_percent_garbage_rejected(self):
+        assert salt.minion._headroom_to_bytes("abc%", 1000) is None
+
+    def test_size_string(self):
+        assert salt.minion._headroom_to_bytes("500M", 999) == 500 * (1024**2)
+
+    def test_int_bytes(self):
+        assert salt.minion._headroom_to_bytes(1024, 999) == 1024
+
+
+class TestParseSelfCgroup:
+    def test_v2(self):
+        v2, v1 = salt.minion._parse_self_cgroup(
+            "0::/system.slice/salt-minion.service\n"
+        )
+        assert v2 == "/system.slice/salt-minion.service"
+        assert v1 is None
+
+    def test_v1_memory(self):
+        v2, v1 = salt.minion._parse_self_cgroup(
+            "5:memory:/salt.slice\n3:cpu,cpuacct:/user.slice\n"
+        )
+        assert v2 is None
+        assert v1 == "/salt.slice"
+
+    def test_hybrid(self):
+        v2, v1 = salt.minion._parse_self_cgroup(
+            "0::/user.slice/foo\n5:memory:/salt.slice\n"
+        )
+        assert v2 == "/user.slice/foo"
+        assert v1 == "/salt.slice"
+
+    def test_empty(self):
+        assert salt.minion._parse_self_cgroup("") == (None, None)
+        assert salt.minion._parse_self_cgroup(None) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Cgroup detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCgroupMemory:
+    def test_no_proc_file(self, no_cgroup):
+        assert salt.minion._detect_cgroup_memory() == (None, None, None)
+
+    def test_v2_limited(self, cgroup_fs):
+        cgroup_fs("v2", limit=1024**3, current=100 * (1024**2))
+        limit, used, source = salt.minion._detect_cgroup_memory()
+        assert limit == 1024**3
+        assert used == 100 * (1024**2)
+        assert source == "cgroup-v2"
+
+    def test_v2_unlimited(self, cgroup_fs):
+        cgroup_fs("v2", limit="max")
+        assert salt.minion._detect_cgroup_memory() == (None, None, None)
+
+    def test_v1_limited(self, cgroup_fs):
+        cgroup_fs("v1", limit=1024**3, current=200 * (1024**2))
+        limit, used, source = salt.minion._detect_cgroup_memory()
+        assert limit == 1024**3
+        assert used == 200 * (1024**2)
+        assert source == "cgroup-v1"
+
+    def test_v1_unlimited_sentinel(self, cgroup_fs):
+        # Actual kernel sentinel
+        cgroup_fs("v1", limit=9223372036854771712)
+        assert salt.minion._detect_cgroup_memory() == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# _has_memory_headroom matrix
+# ---------------------------------------------------------------------------
+
+
+class TestHasMemoryHeadroom:
+    """
+    The matrix from the design report. Each case constructs a stand-in
+    minion (only ``opts`` needed), lays out a synthetic cgroupfs if the
+    scenario calls for one, and mocks ``psutil.virtual_memory`` when the
+    scenario cares about system-wide numbers.
+    """
+
+    def test_default_below_95(self, no_cgroup, monkeypatch):
+        """No config, no cgroup => legacy path, 50% used => True."""
+        vm = types.SimpleNamespace(percent=50.0, total=8 * 1024**3, used=4 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        assert salt.minion.Minion._has_memory_headroom(_minion({})) is True
+
+    def test_default_over_95(self, no_cgroup, monkeypatch):
+        """No config, no cgroup => legacy path, 96% used => False."""
+        vm = types.SimpleNamespace(percent=96.0, total=8 * 1024**3, used=7 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        assert salt.minion.Minion._has_memory_headroom(_minion({})) is False
+
+    def test_config_percent_headroom_pass(self, no_cgroup, monkeypatch):
+        """5% headroom, system reference, 90% used => True."""
+        total = 100 * 1024**3
+        vm = types.SimpleNamespace(percent=90.0, total=total, used=int(total * 0.9))
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_config_percent_headroom_fail(self, no_cgroup, monkeypatch):
+        """5% headroom, system reference, 96% used => False."""
+        total = 100 * 1024**3
+        vm = types.SimpleNamespace(percent=96.0, total=total, used=int(total * 0.96))
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is False
+
+    def test_config_absolute_headroom(self, no_cgroup, monkeypatch):
+        """500 MB headroom on 8 GB host with 7.6 GB used => False."""
+        total = 8 * 1024**3
+        used = int(7.6 * 1024**3)
+        vm = types.SimpleNamespace(percent=95.0, total=total, used=used)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "500M"}
+        # 500M reserve; 400M free => False
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is False
+
+    def test_cgroup_v2_with_no_config_uses_legacy(self, cgroup_fs, monkeypatch):
+        """
+        Cgroup present but no config => legacy fast path still applies
+        (no default flip on LTS). System % determines the result, cgroup
+        is ignored.
+        """
+        cgroup_fs("v2", limit=1024**3, current=990 * (1024**2))
+        vm = types.SimpleNamespace(percent=10.0, total=64 * 1024**3, used=6 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        assert salt.minion.Minion._has_memory_headroom(_minion({})) is True
+
+    def test_cgroup_v2_with_config_fails(self, cgroup_fs, monkeypatch):
+        """1 GB cgroup, 990 MB used, 5% headroom (~51 MB) => False."""
+        cgroup_fs("v2", limit=1024**3, current=990 * (1024**2))
+        vm = types.SimpleNamespace(percent=10.0, total=64 * 1024**3, used=6 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is False
+
+    def test_cgroup_v2_unlimited_falls_back(self, cgroup_fs, monkeypatch):
+        """v2 memory.max == 'max' => fall through to system-wide."""
+        cgroup_fs("v2", limit="max")
+        # 90% used, 5% headroom => False on the system reference
+        total = 8 * 1024**3
+        vm = types.SimpleNamespace(percent=90.0, total=total, used=int(total * 0.96))
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is False
+
+    def test_cgroup_v1_with_config_passes(self, cgroup_fs, monkeypatch):
+        """1 GB v1 cgroup, 200 MB used, 5% headroom => True (800 MB free)."""
+        cgroup_fs("v1", limit=1024**3, current=200 * (1024**2))
+        vm = types.SimpleNamespace(percent=10.0, total=64 * 1024**3, used=6 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_cgroup_v1_unlimited_sentinel_falls_back(self, cgroup_fs, monkeypatch):
+        cgroup_fs("v1", limit=9223372036854771712)
+        vm = types.SimpleNamespace(percent=50.0, total=8 * 1024**3, used=4 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        # Plenty of headroom on system-wide fallback
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_config_max_overrides_cgroup(self, cgroup_fs, monkeypatch):
+        """
+        minion_memory_max wins over cgroup detection. Cgroup says 1 GB
+        limit; we pin the reference at 2 GB. With 500 MB reserve and
+        200 MB used (cgroup used), 1.3 GB is free of the 2 GB reference.
+        """
+        cgroup_fs("v2", limit=1024**3, current=200 * (1024**2))
+        vm = types.SimpleNamespace(percent=10.0, total=64 * 1024**3, used=6 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {
+            "minion_memory_max": "2G",
+            "minion_memory_headroom": "500M",
+        }
+        # 200M used + 500M reserve = 700M < 2G => True
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_missing_cgroup_permission_denied_falls_back(self, tmp_path, monkeypatch):
+        """
+        Cgroup files exist but reads fail (simulated via unreadable path).
+        Must not raise; must fall back to system-wide arithmetic.
+        """
+        # Point at a path that surely can't be read: use a directory as the
+        # cgroup file so open() will raise IsADirectoryError.
+        bad_path = tmp_path / "cgroup-is-a-dir"
+        bad_path.mkdir()
+        monkeypatch.setattr(salt.minion, "_CGROUP_PROC_PATH", str(bad_path))
+        monkeypatch.setattr(salt.minion, "_CGROUP_FS_ROOT", str(tmp_path))
+        vm = types.SimpleNamespace(percent=50.0, total=8 * 1024**3, used=4 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "5%"}
+        # 5% of 8G reserve is ~410M. 4G used + 410M = 4.4G < 8G => True.
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_no_psutil_returns_true(self, monkeypatch):
+        monkeypatch.setattr(salt.minion, "HAS_PSUTIL", False)
+        opts = {"minion_memory_headroom": "5%"}
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True
+
+    def test_bogus_headroom_string_does_not_raise(self, no_cgroup, monkeypatch):
+        """
+        Bogus opt value must not raise. It should DEBUG-log and fall back
+        to an implicit 5% reserve on the resolved reference so the operator's
+        intent to opt in is still honored.
+        """
+        total = 8 * 1024**3
+        vm = types.SimpleNamespace(percent=50.0, total=total, used=4 * 1024**3)
+        monkeypatch.setattr("psutil.virtual_memory", lambda: vm)
+        opts = {"minion_memory_headroom": "garbage"}
+        # 5% of 8G = 410M implicit; 4G + 410M = 4.4G < 8G => True.
+        assert salt.minion.Minion._has_memory_headroom(_minion(opts)) is True


### PR DESCRIPTION
Fixes #69884.

`salt/minion.py::_has_memory_headroom` hard-codes `psutil.virtual_memory().percent > 95` — a system-wide check that reserves 100 GB on a 2 TB host and uses the wrong reference on cgroup-limited minions.

Adds two opt-in minion config options:

- `minion_memory_headroom` — required free headroom. Accepts either a percentage string (`"5%"`) or an absolute size (`"5G"`, `"500M"`, int bytes).
- `minion_memory_max` — explicit override for the reference "total memory available to this minion" (int bytes or size string).

Reference-memory resolution precedence:

1. `minion_memory_max` if set.
2. cgroup v2 `memory.max` (with `memory.current` for used).
3. cgroup v1 `memory.limit_in_bytes` (with `memory.usage_in_bytes`).
4. `psutil.virtual_memory().total` (with `.used`).

Cgroup detection is silent-fallback: missing / unreadable / malformed files log at DEBUG and drop to the next tier. No D-Bus / systemd dependency — the cgroup file the systemd unit writes to is already the source of truth.

When both new opts are unset the arithmetic reduces to `psutil.virtual_memory().percent > 95`, so no minion changes behavior on upgrade (LTS opt-in only, per #69443 / #69597 precedent).

New tests (40 cases) under `tests/pytests/unit/test_minion_memory_headroom.py` cover the parser, cgroup v1/v2 detection with a synthetic tmp_path cgroupfs, and the full 12-case behavior matrix (legacy default, config-only, cgroup-only, cgroup+config precedence, unlimited sentinels, permission-denied fallback, no-psutil, bogus input).