### PR TITLE
ci: skip on saltstack/salt-nightlies (duplicate of upstream CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
+    if: github.repository != 'saltstack/salt-nightlies'
     outputs:
       changed-files: ${{ steps.process-changed-files.outputs.changed-files }}
       salt-version: ${{ steps.setup-salt-version.outputs.salt-version }}

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -2,6 +2,13 @@
 
 <%- extends 'layout.yml.jinja' %>
 <%- set pre_commit_version = "4.3.0" %>
+<%- # Skip CI on the saltstack/salt-nightlies fork. The mirror workflow on
+    # that repo force-pushes branches from saltstack/salt, which would
+    # otherwise trigger ci.yml here to re-run the exact tests that just ran
+    # on saltstack/salt. Pure duplicate. Gates the prepare-workflow job;
+    # all downstream jobs cascade-skip via their `needs: prepare-workflow`.
+%>
+<%- set prepare_workflow_if_check = "github.repository != 'saltstack/salt-nightlies'" %>
 
 
 <%- block jobs %>


### PR DESCRIPTION
### What does this PR do?

Gates `ci.yml` so it does not run on the `saltstack/salt-nightlies` fork. The mirror workflow on that repo force-pushes branches from `saltstack/salt` daily; those pushes were triggering `ci.yml` here to re-run the exact same tests that already ran on `saltstack/salt` before the mirror. Pure duplicate, no additional signal, runner-minute cost.

### Fix

Add `prepare_workflow_if_check = "github.repository != 'saltstack/salt-nightlies'"` to `ci.yml.jinja`, which layout.yml.jinja already threads into an `if:` on the `prepare-workflow` job. All downstream CI jobs `needs: prepare-workflow`, so they cascade-skip cleanly.

Same `if:` is also added directly to the generated `ci.yml` for immediate effect — without that, the gate wouldn't take hold until the next `tools ci` template regeneration.

### On saltstack/salt

Zero behavior change. The gate condition is trivially true (`github.repository` is `saltstack/salt`, not `saltstack/salt-nightlies`).

### On saltstack/salt-nightlies (after mirror sync brings this in)

`ci.yml` prepare-workflow job skips. All downstream jobs cascade-skip. Runner minutes saved. Existing nightly-related workflows (`run-nightly.yml`, `nightly.yml`, `publish-nightly-release.yml`, `mirror-from-saltstack-salt.yaml`) are unaffected — they don't go through `ci.yml`.

### What issues does this PR fix or reference?

Follow-up in the salt-nightlies series (#70017 / #70026 / #70027 / #70028 / #70029 / #70030 / #70040). No linked issue.

### Follow-up (not in this PR)

If desired, similar treatment could gate other duplicate workflows on the fork: `scheduled.yml`, `staging.yml`, `doc-linkcheck.yml`, `backport.yml`, `dependabot-sync.yml`, `release.yml`. Each is independent; would be a separate PR.

### Merge requirements satisfied?

- [ ] Docs — N/A.
- [ ] Changelog — none added.
- [ ] Tests — none applicable (workflow gate).

### Commits signed with GPG?

No.