### PR TITLE
publish-nightly-release: dashboard should update even when release already exists

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: download all artifacts from the triggering nightly.yml run
-        if: steps.check.outputs.already-exists != 'true'
+
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
@@ -69,7 +69,7 @@ jobs:
           merge-multiple: true
 
       - name: list assets to publish
-        if: steps.check.outputs.already-exists != 'true'
+
         run: |
           set -euo pipefail
           echo "=== files under nightly-artifacts/ ==="
@@ -125,7 +125,7 @@ jobs:
       # reflects the new release. See .github/scripts/generate_nightly_dashboard.py.
       # -----------------------------------------------------------------
       - name: download JUnit test-run artifacts from nightly.yml
-        if: steps.check.outputs.already-exists != 'true'
+
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -136,7 +136,7 @@ jobs:
           merge-multiple: false
 
       - name: extract salt version from a built package name
-        if: steps.check.outputs.already-exists != 'true'
+
         id: salt-version
         run: |
           set -euo pipefail
@@ -150,7 +150,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: checkout gh-pages branch into ./site (create if missing)
-        if: steps.check.outputs.already-exists != 'true'
+
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: regenerate history.json + index.html
-        if: steps.check.outputs.already-exists != 'true'
+
         env:
           TAG: ${{ steps.tag.outputs.tag }}
           BRANCH: ${{ steps.tag.outputs.branch }}
@@ -195,7 +195,7 @@ jobs:
             --artifact-count "${asset_count}"
 
       - name: commit + push gh-pages
-        if: steps.check.outputs.already-exists != 'true'
+
         working-directory: site
         run: |
           set -euo pipefail


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70040. `publish-nightly-release.yml`'s dashboard steps inherited `if: steps.check.outputs.already-exists != 'true'` — the same gate that skips release-create when a release for the day/branch already exists. That's wrong for the dashboard: the dashboard should reflect every nightly.yml completion, and the generator already handles same-tag entries by replacing them.

### Observed on saltstack/salt-nightlies

Publish-nightly-release run 31784972054 fired after nightly.yml 31781506651 completed. But `nightly-2026-08-14-3008.x` had been created earlier in the day by a natural cron cycle, so the release-create step correctly skipped — and every subsequent step (including dashboard generation) skipped too. Result: run exited in 9s, `gh-pages` unchanged.

### Fix

Only `create release with all assets` isn't idempotent — creating an existing release fails, so it correctly needs the gate. All other steps (download artifacts, list assets, download junit, extract salt version, checkout gh-pages, regenerate dashboard, commit + push) can safely re-run:

- Downloads overwrite the same directory
- List-assets regenerates /tmp/assets.txt
- Dashboard generator's history logic: `history = [e for e in history if e.get("tag") != args.tag]; history.append(entry)`

Drop the gate from every non-release step. Small change (7 lines).

### What issues does this PR fix or reference?

Follow-up to #70040. No linked issue.

### Merge requirements satisfied?

- [ ] Docs — N/A.
- [ ] Changelog — none added.
- [ ] Tests — no automated tests.

### Commits signed with GPG?

No.