### PR TITLE
publish-nightly-release: checkout repo so dashboard generator is accessible

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -32,6 +32,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - name: checkout repo (needed for .github/scripts/generate_nightly_dashboard.py)
+        uses: actions/checkout@v4
+        with:
+          # Sparse-checkout just the script — the whole tree isn't needed.
+          sparse-checkout: |
+            .github/scripts/generate_nightly_dashboard.py
+          sparse-checkout-cone-mode: false
+
       - name: compute release tag
         id: tag
         env:


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70040 / #70044. Publish workflow runs on a bare ubuntu-22.04 runner without `actions/checkout`, so `.github/scripts/generate_nightly_dashboard.py` isn't in the workspace. Observed in run 31794063745 — the dashboard step failed with:

```
python3: can't open file '/home/runner/work/salt-nightlies/salt-nightlies/.github/scripts/generate_nightly_dashboard.py': [Errno 2] No such file or directory
```

### Fix

Add `actions/checkout@v4` as the first step of the publish job, using `sparse-checkout` for just the generator script — the rest of the repo isn't needed here (nightly artifacts come via `actions/download-artifact`, gh-pages checkout is done into a separate `site/` subdirectory).

### Merge requirements satisfied?

- [ ] Docs — N/A.
- [ ] Changelog — none added.
- [ ] Tests — no automated tests.

### Commits signed with GPG?

No.