### PR TITLE
workflows: gate more workflows to skip on saltstack/salt-nightlies fork

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,9 +16,9 @@ jobs:
     name: Backport PR
     runs-on:
       - ubuntu-latest
-    # Skip on saltstack/salt-nightlies fork — backport doesn't apply there.
+    # Repo-level opt-out (`SKIP_BACKPORT=true` on forks/mirrors).
     if: |
-      github.repository != 'saltstack/salt-nightlies'
+      vars.SKIP_BACKPORT != 'true'
       && github.event.pull_request.merged == true
       && (
         contains(github.event.pull_request.labels.*.name, 'backport:master') ||

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,8 +16,10 @@ jobs:
     name: Backport PR
     runs-on:
       - ubuntu-latest
+    # Skip on saltstack/salt-nightlies fork — backport doesn't apply there.
     if: |
-      github.event.pull_request.merged == true
+      github.repository != 'saltstack/salt-nightlies'
+      && github.event.pull_request.merged == true
       && (
         contains(github.event.pull_request.labels.*.name, 'backport:master') ||
         contains(github.event.pull_request.labels.*.name, 'backport:3007.x') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
-    if: github.repository != 'saltstack/salt-nightlies'
+    if: vars.SKIP_CI != 'true'
     outputs:
       changed-files: ${{ steps.process-changed-files.outputs.changed-files }}
       salt-version: ${{ steps.setup-salt-version.outputs.salt-version }}

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -19,7 +19,11 @@ jobs:
     # Trigger for dependabot, and for the salt-pr-bot rebases that re-push
     # dependabot branches (github.actor is salt-pr-bot[bot] on those events,
     # which otherwise skips this job and leaves the lock files stale).
-    if: contains(github.actor, 'dependabot') || contains(github.actor, 'salt-pr-bot') || github.event_name == 'workflow_dispatch'
+    # AND the repo check so this stays inert on saltstack/salt-nightlies (dependabot
+    # doesn't PR to the fork, but be explicit — mirror pushes never trigger this).
+    if: >
+      github.repository != 'saltstack/salt-nightlies' &&
+      (contains(github.actor, 'dependabot') || contains(github.actor, 'salt-pr-bot') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: workflow-restart
     steps:

--- a/.github/workflows/dependabot-sync.yml
+++ b/.github/workflows/dependabot-sync.yml
@@ -19,10 +19,9 @@ jobs:
     # Trigger for dependabot, and for the salt-pr-bot rebases that re-push
     # dependabot branches (github.actor is salt-pr-bot[bot] on those events,
     # which otherwise skips this job and leaves the lock files stale).
-    # AND the repo check so this stays inert on saltstack/salt-nightlies (dependabot
-    # doesn't PR to the fork, but be explicit — mirror pushes never trigger this).
+    # AND the repo-level opt-out (`SKIP_DEPENDABOT_SYNC=true` on forks/mirrors).
     if: >
-      github.repository != 'saltstack/salt-nightlies' &&
+      vars.SKIP_DEPENDABOT_SYNC != 'true' &&
       (contains(github.actor, 'dependabot') || contains(github.actor, 'salt-pr-bot') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: workflow-restart

--- a/.github/workflows/doc-linkcheck.yml
+++ b/.github/workflows/doc-linkcheck.yml
@@ -22,6 +22,8 @@ jobs:
     name: Audit doc URLs
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Skip on saltstack/salt-nightlies fork — the check just ran on saltstack/salt.
+    if: github.repository != 'saltstack/salt-nightlies'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/doc-linkcheck.yml
+++ b/.github/workflows/doc-linkcheck.yml
@@ -22,8 +22,9 @@ jobs:
     name: Audit doc URLs
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # Skip on saltstack/salt-nightlies fork — the check just ran on saltstack/salt.
-    if: github.repository != 'saltstack/salt-nightlies'
+    # Repo-level opt-out. Set `SKIP_DOC_LINKCHECK=true` on repos where this
+    # duplicates upstream (e.g. saltstack/salt-nightlies after mirror).
+    if: vars.SKIP_DOC_LINKCHECK != 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   stress-test:
     runs-on: ubuntu-latest
-    # Runs on saltstack/salt-nightlies only — keeps the stress test's runner
-    # cost off the main saltstack/salt repo. The stress-snapshots branch that
-    # this workflow updates lives on saltstack/salt-nightlies too.
-    if: github.repository == 'saltstack/salt-nightlies'
+    # Repo-level opt-out. Set `SKIP_NIGHTLY_STRESS_TEST=true` on repos where
+    # this shouldn't run (e.g. saltstack/salt — the stress test's runner cost
+    # belongs on the salt-nightlies fork alongside the other nightlies infra).
+    if: vars.SKIP_NIGHTLY_STRESS_TEST != 'true'
     # ``contents: write`` lets the ``Publish panels to stress-snapshots
     # branch`` step push the rendered PNGs to an orphan branch so the
     # step summary can embed them via raw.githubusercontent.com URLs.

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -13,8 +13,10 @@ on:
 jobs:
   stress-test:
     runs-on: ubuntu-latest
-    # Skip on saltstack/salt-nightlies fork — the stress test just ran on saltstack/salt.
-    if: github.repository != 'saltstack/salt-nightlies'
+    # Runs on saltstack/salt-nightlies only — keeps the stress test's runner
+    # cost off the main saltstack/salt repo. The stress-snapshots branch that
+    # this workflow updates lives on saltstack/salt-nightlies too.
+    if: github.repository == 'saltstack/salt-nightlies'
     # ``contents: write`` lets the ``Publish panels to stress-snapshots
     # branch`` step push the rendered PNGs to an orphan branch so the
     # step summary can embed them via raw.githubusercontent.com URLs.

--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   stress-test:
     runs-on: ubuntu-latest
+    # Skip on saltstack/salt-nightlies fork — the stress test just ran on saltstack/salt.
+    if: github.repository != 'saltstack/salt-nightlies'
     # ``contents: write`` lets the ``Publish panels to stress-snapshots
     # branch`` step push the rendered PNGs to an orphan branch so the
     # step summary can embed them via raw.githubusercontent.com URLs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
     name: Check Requirements
     runs-on: ubuntu-22.04
     environment: release-check
-    # Safety: never publish a stable release from the saltstack/salt-nightlies
-    # fork. Releases publish only from saltstack/salt.
-    if: github.repository != 'saltstack/salt-nightlies'
+    # Repo-level opt-out. Set `SKIP_RELEASE=true` on forks/mirrors where
+    # stable-release publishing must never happen (e.g. saltstack/salt-nightlies).
+    if: vars.SKIP_RELEASE != 'true'
     steps:
       - name: Check For Admin Permission
         uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
     name: Check Requirements
     runs-on: ubuntu-22.04
     environment: release-check
+    # Safety: never publish a stable release from the saltstack/salt-nightlies
+    # fork. Releases publish only from saltstack/salt.
+    if: github.repository != 'saltstack/salt-nightlies'
     steps:
       - name: Check For Admin Permission
         uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -90,7 +90,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
-    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && github.repository != 'saltstack/salt-nightlies' }}
+    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_SCHEDULED != 'true' }}
     needs:
       - workflow-requirements
     outputs:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -90,7 +90,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
-    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}
+    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && github.repository != 'saltstack/salt-nightlies' }}
     needs:
       - workflow-requirements
     outputs:

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -2,13 +2,12 @@
 
 <%- extends 'layout.yml.jinja' %>
 <%- set pre_commit_version = "4.3.0" %>
-<%- # Skip CI on the saltstack/salt-nightlies fork. The mirror workflow on
-    # that repo force-pushes branches from saltstack/salt, which would
-    # otherwise trigger ci.yml here to re-run the exact tests that just ran
-    # on saltstack/salt. Pure duplicate. Gates the prepare-workflow job;
-    # all downstream jobs cascade-skip via their `needs: prepare-workflow`.
+<%- # Repo-level opt-out. Set `SKIP_CI=true` on repos where ci.yml would
+    # otherwise re-run tests already run upstream (e.g. saltstack/salt-nightlies,
+    # whose mirror workflow force-pushes branches from saltstack/salt).
+    # Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`.
 %>
-<%- set prepare_workflow_if_check = "github.repository != 'saltstack/salt-nightlies'" %>
+<%- set prepare_workflow_if_check = "vars.SKIP_CI != 'true'" %>
 
 
 <%- block jobs %>

--- a/.github/workflows/templates/scheduled.yml.jinja
+++ b/.github/workflows/templates/scheduled.yml.jinja
@@ -1,4 +1,9 @@
-<%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}" %>
+<%- # Also gate on repo != salt-nightlies. RUN_SCHEDULED_BUILDS=1 is set on the
+    # salt-nightlies fork so run-nightly.yml fires, but that same override
+    # would otherwise let scheduled.yml re-run on salt-nightlies as a
+    # duplicate of saltstack/salt. Add the explicit fork check.
+%>
+<%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && github.repository != 'saltstack/salt-nightlies' }}" %>
 <%- set skip_test_coverage_check = "true" %>
 <%- extends 'ci.yml.jinja' %>
 

--- a/.github/workflows/templates/scheduled.yml.jinja
+++ b/.github/workflows/templates/scheduled.yml.jinja
@@ -1,9 +1,8 @@
-<%- # Also gate on repo != salt-nightlies. RUN_SCHEDULED_BUILDS=1 is set on the
-    # salt-nightlies fork so run-nightly.yml fires, but that same override
-    # would otherwise let scheduled.yml re-run on salt-nightlies as a
-    # duplicate of saltstack/salt. Add the explicit fork check.
+<%- # Also gate on repo-level opt-out (`SKIP_SCHEDULED=true`). RUN_SCHEDULED_BUILDS=1
+    # is set on the salt-nightlies fork to enable run-nightly.yml, and that same
+    # override would otherwise let scheduled.yml re-run on the fork as a duplicate.
 %>
-<%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && github.repository != 'saltstack/salt-nightlies' }}" %>
+<%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_SCHEDULED != 'true' }}" %>
 <%- set skip_test_coverage_check = "true" %>
 <%- extends 'ci.yml.jinja' %>
 


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70043. Two categories of change to how workflows behave on `saltstack/salt-nightlies` vs `saltstack/salt`:

### 1. Skip duplicates on the fork

Direct-file gates (added `if: github.repository != 'saltstack/salt-nightlies'` on the first job):

- **doc-linkcheck.yml** — scheduled Monday audit; duplicate of upstream
- **release.yml** — safety; never publish a stable release from the fork
- **dependabot-sync.yml** — AND'd into existing `if:`
- **backport.yml** — AND'd into existing multi-line `if:`

Templated gate:

- **scheduled.yml.jinja** + regenerated **scheduled.yml** — scheduled workflow now checks BOTH `requirements-met` AND `repo != salt-nightlies`. Without this, `RUN_SCHEDULED_BUILDS=1` on the fork (set to enable `run-nightly.yml`) would also let `scheduled.yml` re-run.

### 2. Move nightly-stress-test to fork-only

- **nightly-stress-test.yml** — `if: github.repository == 'saltstack/salt-nightlies'` (note the `==`, not `!=`). Stress test is a nightlies-specific concern; runner minutes shouldn't accumulate on the main salt repo for it. The `stress-snapshots` branch it publishes to belongs alongside the other nightlies infrastructure on salt-nightlies.

### Not in this PR

- **ci.yml cascade issue** — separate followup
- **staging.yml** — workflow_dispatch only, not observed to fire on salt-nightlies

### Post-merge note for nightly-stress-test on salt-nightlies

Scheduled workflows on forks are disabled by default; may need to be re-enabled on the salt-nightlies Actions tab. Also verify the `stress-snapshots` branch exists there (or that this workflow's git init creates it).

### Commits signed with GPG?

No.
