### PR TITLE
run-nightly: gate branch-dispatch job via vars.SKIP_RUN_NIGHTLY

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -46,7 +46,11 @@ jobs:
 
   trigger-branch-nightly-builds:
     name: Trigger Branch Workflows
-    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}
+    # Repo-level opt-out. Set `SKIP_RUN_NIGHTLY=true` on repos that should
+    # not dispatch nightlies — e.g. saltstack/salt, once nightlies run on
+    # saltstack/salt-nightlies. Without this, the daily cron above triggers
+    # nightly.yml on every branch here as a duplicate of the fork's builds.
+    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_RUN_NIGHTLY != 'true' }}
     runs-on: ubuntu-24.04
     needs:
       - workflow-requirements

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -2,11 +2,10 @@
 
 <%- extends 'layout.yml.jinja' %>
 <%- set pre_commit_version = "4.3.0" %>
-<%- # Repo-level opt-out. Set `SKIP_CI=true` on repos where ci.yml would
-    # otherwise re-run tests already run upstream (e.g. saltstack/salt-nightlies,
-    # whose mirror workflow force-pushes branches from saltstack/salt).
-    # Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`.
-%>
+{# Repo-level opt-out. Set `SKIP_CI=true` on repos where ci.yml would
+   otherwise re-run tests already run upstream (e.g. saltstack/salt-nightlies,
+   whose mirror workflow force-pushes branches from saltstack/salt).
+   Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`. #}
 <%- set prepare_workflow_if_check = "vars.SKIP_CI != 'true'" %>
 
 

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -5,8 +5,10 @@
 {# Repo-level opt-out. Set `SKIP_CI=true` on repos where ci.yml would
    otherwise re-run tests already run upstream (e.g. saltstack/salt-nightlies,
    whose mirror workflow force-pushes branches from saltstack/salt).
-   Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`. #}
-<%- set prepare_workflow_if_check = "vars.SKIP_CI != 'true'" %>
+   Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`.
+   Uses `|default(...)` so child templates that extend ci.yml.jinja (nightly,
+   scheduled, staging) can override with their own gate or disable it. #}
+<%- set prepare_workflow_if_check = prepare_workflow_if_check|default("vars.SKIP_CI != 'true'") %>
 
 
 <%- block jobs %>

--- a/.github/workflows/templates/nightly.yml.jinja
+++ b/.github/workflows/templates/nightly.yml.jinja
@@ -2,6 +2,12 @@
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("true") %>
 <%- set prepare_workflow_skip_test_suite = "${{ inputs.skip-salt-test-suite && ' --skip-tests' || '' }}" %>
 <%- set prepare_workflow_skip_pkg_test_suite = "${{ inputs.skip-salt-pkg-test-suite && ' --skip-pkg-tests' || '' }}" %>
+{#- Disable ci.yml.jinja's SKIP_CI gate on nightly.yml. Nightlies are
+    intentionally run on saltstack/salt-nightlies, which sets SKIP_CI=true
+    to silence duplicate ci.yml runs -- that same variable must not also
+    silence the nightlies themselves. -#}
+
+<%- set prepare_workflow_if_check = prepare_workflow_if_check|default(False) %>
 <%- extends 'ci.yml.jinja' %>
 
 <%- block name %>

--- a/.github/workflows/templates/scheduled.yml.jinja
+++ b/.github/workflows/templates/scheduled.yml.jinja
@@ -1,7 +1,6 @@
-<%- # Also gate on repo-level opt-out (`SKIP_SCHEDULED=true`). RUN_SCHEDULED_BUILDS=1
-    # is set on the salt-nightlies fork to enable run-nightly.yml, and that same
-    # override would otherwise let scheduled.yml re-run on the fork as a duplicate.
-%>
+{# Also gate on repo-level opt-out (`SKIP_SCHEDULED=true`). RUN_SCHEDULED_BUILDS=1
+   is set on the salt-nightlies fork to enable run-nightly.yml, and that same
+   override would otherwise let scheduled.yml re-run on the fork as a duplicate. #}
 <%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_SCHEDULED != 'true' }}" %>
 <%- set skip_test_coverage_check = "true" %>
 <%- extends 'ci.yml.jinja' %>


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70048. Regular nightlies (non-stress) currently fire on `saltstack/salt` every midnight UTC: the daily cron in `run-nightly.yml` dispatches `nightly.yml` on all four branches (3006.x, 3007.x, 3008.x, master). The `workflow-requirements` check gates on "not a fork + not private", which `saltstack/salt` satisfies, so `RUN_SCHEDULED_BUILDS` being unset doesn't stop it.

With nightlies now published from `saltstack/salt-nightlies` (mirror runs `nightly.yml` there and `publish-nightly-release.yml` ships the artifacts to a GitHub release), the nightly run on `saltstack/salt` is a pure duplicate.

### Fix

Add `vars.SKIP_RUN_NIGHTLY != 'true'` to the `trigger-branch-nightly-builds` job's `if:`. One gate blocks all four branch dispatches at the trigger point &mdash; no `nightly.yml` spin-up just to skip.

### Post-merge

Set `SKIP_RUN_NIGHTLY=true` on `saltstack/salt`.

Same repo-variable pattern as #70048. Behaviour is unchanged on any repo until the variable is set.

### Commits signed with GPG?

No.