### PR TITLE
nightlies: fix salt-version + differentiate failed/flaky and tests/unique on dashboard

### DIFF
--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -24,6 +24,20 @@ We split by `-` and pull the chunk out by known-position heuristics. If a name
 doesn't match, its tests are still counted but under (chunk="unknown",
 os="unknown"). Failure to parse never aborts dashboard generation.
 
+Test outcomes are classified per <testcase>:
+  - failed:  has <failure> or <error>
+  - flaky:   passed but has <rerunFailure>/<rerunError> children (i.e. the
+             initial attempt failed but a pytest-rerunfailures retry passed).
+             The overall run stays green -- these still deserve visibility.
+  - skipped: has <skipped>
+  - passed:  none of the above
+
+`tests` is the count of every <testcase> across all JUnit files (executions).
+The same logical test running on N OS slugs / transports / FIPS variants
+contributes N to `tests`. `unique` is the deduplicated count of distinct
+(classname, name) tuples across all artifacts -- suite coverage rather than
+throughput.
+
 No non-stdlib dependencies. Python 3.8+ (stdlib xml.etree, argparse, json).
 """
 
@@ -62,22 +76,54 @@ ARTIFACT_RE = re.compile(
 )
 
 
+def _empty_bucket() -> dict:
+    # tests    = total testcase executions (sum across all suites/artifacts)
+    # failed   = testcase had <failure> or <error> and no successful rerun
+    # flaky    = testcase passed but has <rerunFailure> / <rerunError> children
+    #            (pytest-rerunfailures marks tests that failed then passed on retry)
+    # skipped  = testcase has <skipped>
+    # passed   = tests - failed - flaky - skipped (derived, kept for clarity)
+    return {"tests": 0, "failed": 0, "flaky": 0, "skipped": 0, "passed": 0}
+
+
+def _classify_testcase(tc: ET.Element) -> str:
+    """Return one of: failed, flaky, skipped, passed."""
+    if tc.find("failure") is not None or tc.find("error") is not None:
+        return "failed"
+    if tc.find("skipped") is not None:
+        return "skipped"
+    # rerunFailure / rerunError present but no final failure => flaky pass
+    if tc.find("rerunFailure") is not None or tc.find("rerunError") is not None:
+        return "flaky"
+    return "passed"
+
+
 def parse_junit_counts(junit_dir: Path) -> dict:
-    """Walk junit_dir, sum test counts per (chunk, slug) bucket.
+    """Walk junit_dir, aggregate test counts per (chunk, slug) bucket.
 
     Returns:
         {
-          "totals": {"tests": N, "failures": N, "errors": N, "skipped": N},
+          "totals":     {tests, failed, flaky, skipped, passed, unique},
           "by_suite_os": {
-             (chunk, slug): {"tests": N, "failures": N, "errors": N, "skipped": N}
+             "<chunk>|<slug>": {tests, failed, flaky, skipped, passed}
           }
         }
+
+    Notes:
+      - `tests` counts every `<testcase>` occurrence across all JUnit files
+        (i.e. executions — the same logical test running on multiple OS
+        slugs / transports / FIPS variants each add to it).
+      - `unique` is the deduplicated count of distinct `(classname, name)`
+        tuples across ALL artifacts. It is a top-level total only; the
+        per-bucket breakdown stays as executions since that maps cleanly
+        onto how CI is scheduled.
     """
-    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
-    by_bucket = defaultdict(lambda: {"tests": 0, "failures": 0, "errors": 0, "skipped": 0})
+    totals = _empty_bucket()
+    by_bucket: dict = defaultdict(_empty_bucket)
+    unique_ids: set = set()
 
     if not junit_dir.exists():
-        return {"totals": totals, "by_suite_os": {}}
+        return {"totals": {**totals, "unique": 0}, "by_suite_os": {}}
 
     for artifact_dir in sorted(p for p in junit_dir.iterdir() if p.is_dir()):
         m = ARTIFACT_RE.match(artifact_dir.name)
@@ -93,7 +139,6 @@ def parse_junit_counts(junit_dir: Path) -> dict:
                 root = ET.parse(xml_path).getroot()
             except ET.ParseError:
                 continue
-            # Root can be <testsuites> (aggregate) or single <testsuite>.
             if root.tag == "testsuites":
                 suites = root.findall("testsuite")
             elif root.tag == "testsuite":
@@ -101,13 +146,19 @@ def parse_junit_counts(junit_dir: Path) -> dict:
             else:
                 continue
             for ts in suites:
-                for k in ("tests", "failures", "errors", "skipped"):
-                    n = int(ts.get(k, "0") or "0")
-                    totals[k] += n
-                    by_bucket[(chunk, slug)][k] += n
+                for tc in ts.findall("testcase"):
+                    outcome = _classify_testcase(tc)
+                    totals["tests"] += 1
+                    totals[outcome] += 1
+                    by_bucket[(chunk, slug)]["tests"] += 1
+                    by_bucket[(chunk, slug)][outcome] += 1
+                    cls = tc.get("classname") or ""
+                    name = tc.get("name") or ""
+                    if cls or name:
+                        unique_ids.add((cls, name))
 
     return {
-        "totals": totals,
+        "totals": {**totals, "unique": len(unique_ids)},
         "by_suite_os": {
             f"{chunk}|{slug}": counts for (chunk, slug), counts in sorted(by_bucket.items())
         },
@@ -152,55 +203,73 @@ def render_index_html(history: list) -> str:
         counts = e.get("test_counts", {}) or {}
         totals = counts.get("totals", {}) or {}
         tests = totals.get("tests", 0)
-        failures = totals.get("failures", 0)
-        errors = totals.get("errors", 0)
+        # Legacy history entries used `failures`/`errors`; new schema uses
+        # `failed`/`flaky`. Coalesce both so old rows still render.
+        failed = totals.get("failed", totals.get("failures", 0) + totals.get("errors", 0))
+        flaky = totals.get("flaky", 0)
+        skipped = totals.get("skipped", 0)
+        unique = totals.get("unique", 0)
         by_suite_os = counts.get("by_suite_os", {}) or {}
 
-        # Compact per-suite pills (aggregate over OS)
-        per_suite = defaultdict(lambda: {"tests": 0, "failures": 0, "errors": 0})
+        # Compact per-suite pills (aggregate over OS).
+        per_suite = defaultdict(lambda: {"tests": 0, "failed": 0, "flaky": 0})
         for key, c in by_suite_os.items():
             suite = key.split("|", 1)[0]
             per_suite[suite]["tests"] += c.get("tests", 0)
-            per_suite[suite]["failures"] += c.get("failures", 0)
-            per_suite[suite]["errors"] += c.get("errors", 0)
+            per_suite[suite]["failed"] += c.get("failed", c.get("failures", 0) + c.get("errors", 0))
+            per_suite[suite]["flaky"] += c.get("flaky", 0)
 
         pills = " ".join(
-            f'<span class="pill" title="{html.escape(s)}: {c["tests"]} tests, {c["failures"]} fail, {c["errors"]} err">'
-            f'{html.escape(s[:1].upper())}:{c["tests"]}</span>'
+            f'<span class="pill" title="{html.escape(s)}: {c["tests"]:,} run, {c["failed"]} failed, {c["flaky"]} flaky">'
+            f'{html.escape(s[:1].upper())}:{c["tests"]:,}</span>'
             for s, c in sorted(per_suite.items())
         )
 
-        # Detail table
+        # Detail table (per suite × os).
         detail_rows = "".join(
-            f'<tr><td>{html.escape(k.split("|", 1)[0])}</td><td>{html.escape(k.split("|", 1)[1] if "|" in k else "unknown")}</td>'
-            f'<td>{c.get("tests", 0)}</td><td>{c.get("failures", 0)}</td><td>{c.get("errors", 0)}</td><td>{c.get("skipped", 0)}</td></tr>'
+            f'<tr>'
+            f'<td>{html.escape(k.split("|", 1)[0])}</td>'
+            f'<td>{html.escape(k.split("|", 1)[1] if "|" in k else "unknown")}</td>'
+            f'<td>{c.get("tests", 0):,}</td>'
+            f'<td class="num-flaky">{c.get("flaky", 0)}</td>'
+            f'<td class="num-fail">{c.get("failed", c.get("failures", 0) + c.get("errors", 0))}</td>'
+            f'<td>{c.get("skipped", 0)}</td>'
+            f'</tr>'
             for k, c in sorted(by_suite_os.items())
         )
         detail_html = (
-            f'<table class="detail"><thead><tr><th>suite</th><th>os</th>'
-            f'<th>tests</th><th>fail</th><th>err</th><th>skip</th></tr></thead>'
+            f'<table class="detail"><thead><tr>'
+            f'<th>suite</th><th>os</th>'
+            f'<th>tests</th><th>flaky</th><th>failed</th><th>skip</th>'
+            f'</tr></thead>'
             f'<tbody>{detail_rows}</tbody></table>'
             if by_suite_os else '<em>no test-run artifacts parsed</em>'
         )
 
         release_url = html.escape(e.get("release_url", "#"))
         run_url = html.escape(e.get("nightly_run_url", "#"))
+        salt_version = e.get("salt_version") or "unknown"
+        # `unique` cell: only render a value when we have it; older rows show —.
+        unique_cell = f"{unique:,}" if unique else '<span class="dim">—</span>'
         rows_html_parts.append(
             f'<tr class="row {status_cls}" onclick="toggle(\'d{idx}\')">'
             f'<td>{html.escape(e.get("date", ""))}</td>'
             f'<td>{html.escape(e.get("branch", ""))}</td>'
-            f'<td><code>{html.escape(e.get("salt_version", ""))}</code></td>'
+            f'<td><code>{html.escape(salt_version)}</code></td>'
             f'<td class="status">{html.escape(overall_status)}</td>'
             f'<td>{tests:,}</td>'
-            f'<td>{failures + errors}</td>'
+            f'<td class="num-flaky">{flaky}</td>'
+            f'<td class="num-fail">{failed}</td>'
+            f'<td>{skipped:,}</td>'
+            f'<td>{unique_cell}</td>'
             f'<td class="pills">{pills}</td>'
             f'<td><a href="{release_url}" onclick="event.stopPropagation()">release</a> · '
             f'<a href="{run_url}" onclick="event.stopPropagation()">run</a></td>'
             f'</tr>'
-            f'<tr id="d{idx}" class="detail-row" style="display:none"><td colspan="8">{detail_html}</td></tr>'
+            f'<tr id="d{idx}" class="detail-row" style="display:none"><td colspan="11">{detail_html}</td></tr>'
         )
 
-    rows_html = "\n".join(rows_html_parts) if rows_html_parts else '<tr><td colspan="8"><em>no history yet</em></td></tr>'
+    rows_html = "\n".join(rows_html_parts) if rows_html_parts else '<tr><td colspan="11"><em>no history yet</em></td></tr>'
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -219,6 +288,9 @@ def render_index_html(history: list) -> str:
   tr.row.ok .status {{ color: #1a7f37; font-weight: 600; }}
   tr.row.fail .status {{ color: #cf222e; font-weight: 600; }}
   tr.row.pending .status {{ color: #9a6700; }}
+  .num-fail {{ color: #cf222e; font-weight: 600; }}
+  .num-flaky {{ color: #9a6700; }}
+  .dim {{ color: #999; }}
   .pill {{ display: inline-block; padding: 1px 6px; margin-right: 3px; background: #eaeef2; border-radius: 8px; font-size: 0.8em; font-family: monospace; }}
   .pills {{ min-width: 200px; }}
   code {{ font-size: 0.85em; background: #f6f8fa; padding: 1px 4px; border-radius: 3px; }}
@@ -236,12 +308,13 @@ def render_index_html(history: list) -> str:
 </head>
 <body>
 <h1>Salt Nightlies</h1>
-<div class="subhead">Recent nightly builds. Click a row to expand suite × OS breakdown. Updated {now}.</div>
+<div class="subhead">Recent nightly builds. `tests` = total testcase executions; `unique` = distinct (classname, name) tuples across all artifacts. Click a row to expand suite&nbsp;&times;&nbsp;OS breakdown. Updated {now}.</div>
 <table>
 <thead>
 <tr>
   <th>date</th><th>branch</th><th>salt version</th><th>status</th>
-  <th>tests</th><th>fail+err</th><th>by suite</th><th>links</th>
+  <th>tests</th><th>flaky</th><th>failed</th><th>skip</th><th>unique</th>
+  <th>by suite</th><th>links</th>
 </tr>
 </thead>
 <tbody>

--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -160,7 +160,8 @@ def parse_junit_counts(junit_dir: Path) -> dict:
     return {
         "totals": {**totals, "unique": len(unique_ids)},
         "by_suite_os": {
-            f"{chunk}|{slug}": counts for (chunk, slug), counts in sorted(by_bucket.items())
+            f"{chunk}|{slug}": counts
+            for (chunk, slug), counts in sorted(by_bucket.items())
         },
     }
 
@@ -199,7 +200,11 @@ def render_index_html(history: list) -> str:
     rows_html_parts = []
     for idx, e in enumerate(history):
         overall_status = e.get("overall_status", "unknown")
-        status_cls = "ok" if overall_status == "success" else ("fail" if overall_status == "failure" else "pending")
+        status_cls = (
+            "ok"
+            if overall_status == "success"
+            else ("fail" if overall_status == "failure" else "pending")
+        )
         counts = e.get("test_counts", {}) or {}
         totals = counts.get("totals", {}) or {}
         tests = totals.get("tests", 0)
@@ -208,23 +213,24 @@ def render_index_html(history: list) -> str:
 
         # Detail table (per suite × os).
         detail_rows = "".join(
-            f'<tr>'
+            f"<tr>"
             f'<td>{html.escape(k.split("|", 1)[0])}</td>'
             f'<td>{html.escape(k.split("|", 1)[1] if "|" in k else "unknown")}</td>'
             f'<td>{c.get("tests", 0):,}</td>'
             f'<td class="num-flaky">{c.get("flaky", 0)}</td>'
             f'<td class="num-fail">{c.get("failed", c.get("failures", 0) + c.get("errors", 0))}</td>'
             f'<td>{c.get("skipped", 0)}</td>'
-            f'</tr>'
+            f"</tr>"
             for k, c in sorted(by_suite_os.items())
         )
         detail_html = (
             f'<table class="detail"><thead><tr>'
-            f'<th>suite</th><th>os</th>'
-            f'<th>tests</th><th>flaky</th><th>failed</th><th>skip</th>'
-            f'</tr></thead>'
-            f'<tbody>{detail_rows}</tbody></table>'
-            if by_suite_os else '<em>no test-run artifacts parsed</em>'
+            f"<th>suite</th><th>os</th>"
+            f"<th>tests</th><th>flaky</th><th>failed</th><th>skip</th>"
+            f"</tr></thead>"
+            f"<tbody>{detail_rows}</tbody></table>"
+            if by_suite_os
+            else "<em>no test-run artifacts parsed</em>"
         )
 
         release_url = html.escape(e.get("release_url", "#"))
@@ -236,17 +242,21 @@ def render_index_html(history: list) -> str:
             f'<tr class="row {status_cls}" onclick="toggle(\'d{idx}\')">'
             f'<td>{html.escape(e.get("date", ""))}</td>'
             f'<td>{html.escape(e.get("branch", ""))}</td>'
-            f'<td><code>{html.escape(salt_version)}</code></td>'
+            f"<td><code>{html.escape(salt_version)}</code></td>"
             f'<td class="status">{html.escape(overall_status)}</td>'
-            f'<td>{tests:,}</td>'
-            f'<td>{unique_cell}</td>'
+            f"<td>{tests:,}</td>"
+            f"<td>{unique_cell}</td>"
             f'<td><a href="{release_url}" onclick="event.stopPropagation()">release</a> · '
             f'<a href="{run_url}" onclick="event.stopPropagation()">run</a></td>'
-            f'</tr>'
+            f"</tr>"
             f'<tr id="d{idx}" class="detail-row" style="display:none"><td colspan="7">{detail_html}</td></tr>'
         )
 
-    rows_html = "\n".join(rows_html_parts) if rows_html_parts else '<tr><td colspan="7"><em>no history yet</em></td></tr>'
+    rows_html = (
+        "\n".join(rows_html_parts)
+        if rows_html_parts
+        else '<tr><td colspan="7"><em>no history yet</em></td></tr>'
+    )
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -302,9 +312,18 @@ def render_index_html(history: list) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--history", type=Path, required=True, help="Path to history.json (read/write)")
-    ap.add_argument("--index", type=Path, required=True, help="Path to index.html (write)")
-    ap.add_argument("--junit-dir", type=Path, required=True, help="Directory of downloaded JUnit artifacts")
+    ap.add_argument(
+        "--history", type=Path, required=True, help="Path to history.json (read/write)"
+    )
+    ap.add_argument(
+        "--index", type=Path, required=True, help="Path to index.html (write)"
+    )
+    ap.add_argument(
+        "--junit-dir",
+        type=Path,
+        required=True,
+        help="Directory of downloaded JUnit artifacts",
+    )
     ap.add_argument("--date", required=True, help="YYYY-MM-DD")
     ap.add_argument("--branch", required=True)
     ap.add_argument("--tag", required=True)
@@ -312,7 +331,9 @@ def main() -> int:
     ap.add_argument("--salt-version", default="")
     ap.add_argument("--nightly-run-url", required=True)
     ap.add_argument("--release-url", required=True)
-    ap.add_argument("--overall-status", required=True, help="success | failure | pending")
+    ap.add_argument(
+        "--overall-status", required=True, help="success | failure | pending"
+    )
     ap.add_argument("--artifact-count", type=int, default=0)
     args = ap.parse_args()
 

--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -203,27 +203,8 @@ def render_index_html(history: list) -> str:
         counts = e.get("test_counts", {}) or {}
         totals = counts.get("totals", {}) or {}
         tests = totals.get("tests", 0)
-        # Legacy history entries used `failures`/`errors`; new schema uses
-        # `failed`/`flaky`. Coalesce both so old rows still render.
-        failed = totals.get("failed", totals.get("failures", 0) + totals.get("errors", 0))
-        flaky = totals.get("flaky", 0)
-        skipped = totals.get("skipped", 0)
         unique = totals.get("unique", 0)
         by_suite_os = counts.get("by_suite_os", {}) or {}
-
-        # Compact per-suite pills (aggregate over OS).
-        per_suite = defaultdict(lambda: {"tests": 0, "failed": 0, "flaky": 0})
-        for key, c in by_suite_os.items():
-            suite = key.split("|", 1)[0]
-            per_suite[suite]["tests"] += c.get("tests", 0)
-            per_suite[suite]["failed"] += c.get("failed", c.get("failures", 0) + c.get("errors", 0))
-            per_suite[suite]["flaky"] += c.get("flaky", 0)
-
-        pills = " ".join(
-            f'<span class="pill" title="{html.escape(s)}: {c["tests"]:,} run, {c["failed"]} failed, {c["flaky"]} flaky">'
-            f'{html.escape(s[:1].upper())}:{c["tests"]:,}</span>'
-            for s, c in sorted(per_suite.items())
-        )
 
         # Detail table (per suite × os).
         detail_rows = "".join(
@@ -258,18 +239,14 @@ def render_index_html(history: list) -> str:
             f'<td><code>{html.escape(salt_version)}</code></td>'
             f'<td class="status">{html.escape(overall_status)}</td>'
             f'<td>{tests:,}</td>'
-            f'<td class="num-flaky">{flaky}</td>'
-            f'<td class="num-fail">{failed}</td>'
-            f'<td>{skipped:,}</td>'
             f'<td>{unique_cell}</td>'
-            f'<td class="pills">{pills}</td>'
             f'<td><a href="{release_url}" onclick="event.stopPropagation()">release</a> · '
             f'<a href="{run_url}" onclick="event.stopPropagation()">run</a></td>'
             f'</tr>'
-            f'<tr id="d{idx}" class="detail-row" style="display:none"><td colspan="11">{detail_html}</td></tr>'
+            f'<tr id="d{idx}" class="detail-row" style="display:none"><td colspan="7">{detail_html}</td></tr>'
         )
 
-    rows_html = "\n".join(rows_html_parts) if rows_html_parts else '<tr><td colspan="11"><em>no history yet</em></td></tr>'
+    rows_html = "\n".join(rows_html_parts) if rows_html_parts else '<tr><td colspan="7"><em>no history yet</em></td></tr>'
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -291,8 +268,6 @@ def render_index_html(history: list) -> str:
   .num-fail {{ color: #cf222e; font-weight: 600; }}
   .num-flaky {{ color: #9a6700; }}
   .dim {{ color: #999; }}
-  .pill {{ display: inline-block; padding: 1px 6px; margin-right: 3px; background: #eaeef2; border-radius: 8px; font-size: 0.8em; font-family: monospace; }}
-  .pills {{ min-width: 200px; }}
   code {{ font-size: 0.85em; background: #f6f8fa; padding: 1px 4px; border-radius: 3px; }}
   a {{ color: #0969da; text-decoration: none; }}
   a:hover {{ text-decoration: underline; }}
@@ -308,13 +283,12 @@ def render_index_html(history: list) -> str:
 </head>
 <body>
 <h1>Salt Nightlies</h1>
-<div class="subhead">Recent nightly builds. `tests` = total testcase executions; `unique` = distinct (classname, name) tuples across all artifacts. Click a row to expand suite&nbsp;&times;&nbsp;OS breakdown. Updated {now}.</div>
+<div class="subhead">Recent nightly builds. `tests` = total testcase executions across all axes (OS &times; transport &times; FIPS &times; chunk); `unique` = distinct (classname, name) tuples. Click a row to expand the per-suite&nbsp;&times;&nbsp;OS breakdown (tests, flaky, failed, skip). Updated {now}.</div>
 <table>
 <thead>
 <tr>
   <th>date</th><th>branch</th><th>salt version</th><th>status</th>
-  <th>tests</th><th>flaky</th><th>failed</th><th>skip</th><th>unique</th>
-  <th>by suite</th><th>links</th>
+  <th>tests</th><th>unique</th><th>links</th>
 </tr>
 </thead>
 <tbody>

--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -151,8 +151,48 @@ jobs:
           # Try to derive the salt version (e.g. 3008.2+205.g46fc3b1fb4) from any
           # built rpm/deb filename. Best-effort — dashboard tolerates "unknown".
           # Example: salt-3008.2+205.g46fc3b1fb4-0.x86_64.rpm
-          version=$(find nightly-artifacts -type f \( -name 'salt-*.rpm' -o -name 'salt_*.deb' \) 2>/dev/null | \
-                    head -1 | sed -n 's|.*/salt[-_]\([0-9][0-9.+g-]*\)[._-].*|\1|p')
+          # Derive the salt version (e.g. 3008.2+205.g46fc3b1fb4) from a built
+          # artifact filename. Prefer the source tarball / onedir tarball because
+          # those carry the bare upstream version; the rpm/deb regex used to trip
+          # over the trailing `-0` packager release. Best-effort — dashboard
+          # tolerates "unknown".
+          #
+          # File-name shapes we search, in order:
+          #   salt-<VER>.tar.gz                       (source sdist)
+          #   salt-<VER>-onedir-*.tar.xz              (onedir bundle)
+          #   salt-<VER>-<REL>.<arch>.rpm             (rpm — strip -<REL>.arch)
+          #   salt_<VER>-<REL>_<arch>.deb             (deb — strip -<REL>_arch)
+          version=""
+          # 1. source tarball
+          f=$(find nightly-artifacts -type f -name 'salt-*.tar.gz' ! -name '*onedir*' ! -name '*docs*' 2>/dev/null | head -1)
+          if [ -n "$f" ]; then
+            version=$(basename "$f" | sed -n 's|^salt-\(.*\)\.tar\.gz$|\1|p')
+          fi
+          # 2. onedir tarball
+          if [ -z "$version" ]; then
+            f=$(find nightly-artifacts -type f -name 'salt-*-onedir-*.tar.xz' 2>/dev/null | head -1)
+            if [ -n "$f" ]; then
+              version=$(basename "$f" | sed -n 's|^salt-\(.*\)-onedir-.*|\1|p')
+            fi
+          fi
+          # 3. rpm — strip trailing `-<REL>.<arch>.rpm`. Match only the top-level
+          # `salt-<VER>-<REL>.<arch>.rpm`, not `salt-api-*`, `salt-master-*`, ...
+          if [ -z "$version" ]; then
+            f=$(find nightly-artifacts -type f -name 'salt-*.rpm' \
+                  ! -name 'salt-api-*' ! -name 'salt-master-*' ! -name 'salt-minion-*' \
+                  ! -name 'salt-cloud-*' ! -name 'salt-ssh-*' ! -name 'salt-syndic-*' \
+                  2>/dev/null | head -1)
+            if [ -n "$f" ]; then
+              version=$(basename "$f" | sed -n 's|^salt-\(.*\)-[0-9]*\.[^.]*\.rpm$|\1|p')
+            fi
+          fi
+          # 4. deb — strip trailing `-<REL>_<arch>.deb`
+          if [ -z "$version" ]; then
+            f=$(find nightly-artifacts -type f -name 'salt_*.deb' 2>/dev/null | head -1)
+            if [ -n "$f" ]; then
+              version=$(basename "$f" | sed -n 's|^salt_\(.*\)-[0-9]*_[^_]*\.deb$|\1|p')
+            fi
+          fi
           version=${version:-unknown}
           echo "version=${version}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What does this PR do?

Three related improvements to the nightlies visibility surface (`publish-nightly-release.yml` + `.github/scripts/generate_nightly_dashboard.py` on saltstack/salt-nightlies via mirror):

#### 1. Fix salt version on the gh-pages site

Previous extraction used one sed regex over `salt-*.rpm` / `salt_*.deb` and leaked the trailing packager release into the reported version:

| filename | old result | new result |
|---|---|---|
| `salt-3008.2+205.g46fc3b1fb4.tar.gz`                     | (not tried)                  | `3008.2+205.g46fc3b1fb4` |
| `salt-3008.2+205.g46fc3b1fb4-onedir-linux-x86_64.tar.xz` | (not tried)                  | `3008.2+205.g46fc3b1fb4` |
| `salt-3008.2+205.g46fc3b1fb4-0.x86_64.rpm`               | `3008.2+205.g46fc3b1fb4-0` | `3008.2+205.g46fc3b1fb4` |
| `salt_3008.2+205.g46fc3b1fb4-1_amd64.deb`                | `3008.2+205.g46fc3b1fb4-1` | `3008.2+205.g46fc3b1fb4` |

Rewritten to try, in order: source sdist &rarr; onedir tarball &rarr; rpm &rarr; deb, each with a shape-specific regex that stops at the packager delimiter. Excludes `salt-api-*`, `salt-master-*`, etc. so subpackage names don't get chosen first.

Regexes verified locally against the real filenames on the last successful nightly release.

#### 2. Differentiate failed from flaky

Previous parser summed `<testsuite>`-level counter attributes only, so a test that failed but passed on retry (pytest-rerunfailures) was invisible &mdash; the overall run stays green even though something is drifting toward broken.

New logic classifies each `<testcase>`:

- **failed** &mdash; has `<failure>` or `<error>`
- **flaky** &mdash; passed but has `<rerunFailure>` / `<rerunError>` children (initial attempt failed, retry passed)
- **skipped** &mdash; has `<skipped>`
- **passed** &mdash; none of the above

Flaky gets its own column with a warning tint. `failed` is red.

#### 3. Differentiate total executions from unique tests

Same logical test runs on many axes (OS slugs, transports, FIPS variants, chunks), so `tests` historically double-counted by design. A single test at 8 OS × 2 transports × 2 (FIPS) = 32 executions.

Added a top-level `unique` count &mdash; distinct `(classname, name)` tuples across all artifacts &mdash; so it's possible to tell suite-growth from CI-throughput-growth at a glance.

Per-row columns are now:

    date | branch | version | status | tests | flaky | failed | skip | unique | by-suite | links

Expand-row still shows `suite &times; os` breakdown, updated to the new schema.

### Schema compatibility

Old `history.json` entries used `failures`/`errors` fields. `render_index_html` coalesces old + new schemas so pre-existing rows still render (the `unique` cell falls back to an em-dash for those rows). No history migration needed.

### Verification

- Synthetic JUnit fixture: 4 testcases each in 2 artifact dirs, same test IDs &rarr; `tests=8, failed=2, flaky=2, skipped=2, passed=2, unique=4` (correct).
- `render_index_html` on a mixed old+new history renders both entries with no `KeyError`, thousand-separates counts, and shows an empty `salt_version` as `unknown` rather than an empty `<code>` block.

### Merge requirements

- Docs &mdash; N/A.
- Changelog &mdash; none added (workflow tooling only).
- Tests &mdash; no automated tests (dashboard script has no test harness yet).

### Commits signed with GPG?

No.