### PR TITLE
nightlies dashboard: pair rerun XML + release-asset fallback for salt-version

### DIFF
--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -26,9 +26,17 @@ os="unknown"). Failure to parse never aborts dashboard generation.
 
 Test outcomes are classified per <testcase>:
   - failed:  has <failure> or <error>
-  - flaky:   passed but has <rerunFailure>/<rerunError> children (i.e. the
-             initial attempt failed but a pytest-rerunfailures retry passed).
-             The overall run stays green -- these still deserve visibility.
+  - flaky:   either
+             (a) passed but has <rerunFailure>/<rerunError> children
+                 (pytest-rerunfailures embeds retry outcomes inline), or
+             (b) failed in the main JUnit file but the sibling
+                 test-results-<X>-rerun.xml re-ran the same (classname, name)
+                 and it passed or was skipped. This is Salt CI's convention:
+                 the initial pytest process emits failures; a follow-up
+                 pytest --last-failed run uploads a `-rerun.xml`, and the
+                 overall pipeline is considered green when the rerun clears
+                 the failure. Ignoring the rerun would show green nightlies
+                 with false "failed" counts.
   - skipped: has <skipped>
   - passed:  none of the above
 
@@ -93,9 +101,34 @@ def _classify_testcase(tc: ET.Element) -> str:
     if tc.find("skipped") is not None:
         return "skipped"
     # rerunFailure / rerunError present but no final failure => flaky pass
+    # (pytest-rerunfailures embeds the retry outcomes inside a single testcase).
     if tc.find("rerunFailure") is not None or tc.find("rerunError") is not None:
         return "flaky"
     return "passed"
+
+
+def _pair_xml_files(artifact_dir: Path):
+    """Group XML files in artifact_dir into (main_xml, rerun_xml_or_none) pairs.
+
+    Salt CI re-runs failed tests separately and uploads a sibling
+    `test-results-<X>-rerun.xml` alongside the initial `test-results-<X>.xml`.
+    Walking `*.xml` naively would count the retried tests twice and record
+    every original failure even when the rerun made the overall job succeed.
+    """
+    mains: dict = {}
+    reruns: dict = {}
+    for xml in artifact_dir.rglob("*.xml"):
+        name = xml.name
+        if name.endswith("-rerun.xml"):
+            reruns[name[: -len("-rerun.xml")]] = xml
+        elif name.endswith(".xml"):
+            mains[name[: -len(".xml")]] = xml
+    for base, main in mains.items():
+        yield main, reruns.get(base)
+    # Rerun files without a matching main are unusual; count them standalone.
+    for base, rerun in reruns.items():
+        if base not in mains:
+            yield rerun, None
 
 
 def parse_junit_counts(junit_dir: Path) -> dict:
@@ -134,28 +167,43 @@ def parse_junit_counts(junit_dir: Path) -> dict:
             chunk = "unknown"
             slug = "unknown"
 
-        for xml_path in artifact_dir.rglob("*.xml"):
+        for main_xml, rerun_xml in _pair_xml_files(artifact_dir):
+            # Build (classname, name) -> classification map from the rerun
+            # file first; then when we see a `failed` in the main file whose
+            # (classname, name) also appears in the rerun with a non-failed
+            # outcome, reclassify it as `flaky` -- the retry succeeded (or
+            # was skipped due to an environmental condition), which is why
+            # Salt CI considers the pipeline green.
+            rerun_outcomes: dict = {}
+            if rerun_xml is not None:
+                try:
+                    rroot = ET.parse(rerun_xml).getroot()
+                except ET.ParseError:
+                    rroot = None
+                if rroot is not None:
+                    for tc in rroot.iter("testcase"):
+                        key = (tc.get("classname") or "", tc.get("name") or "")
+                        rerun_outcomes[key] = _classify_testcase(tc)
+
             try:
-                root = ET.parse(xml_path).getroot()
+                root = ET.parse(main_xml).getroot()
             except ET.ParseError:
                 continue
-            if root.tag == "testsuites":
-                suites = root.findall("testsuite")
-            elif root.tag == "testsuite":
-                suites = [root]
-            else:
-                continue
-            for ts in suites:
-                for tc in ts.findall("testcase"):
-                    outcome = _classify_testcase(tc)
-                    totals["tests"] += 1
-                    totals[outcome] += 1
-                    by_bucket[(chunk, slug)]["tests"] += 1
-                    by_bucket[(chunk, slug)][outcome] += 1
-                    cls = tc.get("classname") or ""
-                    name = tc.get("name") or ""
-                    if cls or name:
-                        unique_ids.add((cls, name))
+            for tc in root.iter("testcase"):
+                outcome = _classify_testcase(tc)
+                key = (tc.get("classname") or "", tc.get("name") or "")
+                if outcome == "failed" and key in rerun_outcomes:
+                    rer = rerun_outcomes[key]
+                    if rer in ("passed", "skipped"):
+                        outcome = "flaky"
+                    # rer == "failed" -> keep as failed
+                totals["tests"] += 1
+                totals[outcome] += 1
+                by_bucket[(chunk, slug)]["tests"] += 1
+                by_bucket[(chunk, slug)][outcome] += 1
+                cls, name = key
+                if cls or name:
+                    unique_ids.add(key)
 
     return {
         "totals": {**totals, "unique": len(unique_ids)},

--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -146,11 +146,12 @@ jobs:
       - name: extract salt version from a built package name
 
         id: salt-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Try to derive the salt version (e.g. 3008.2+205.g46fc3b1fb4) from any
-          # built rpm/deb filename. Best-effort — dashboard tolerates "unknown".
-          # Example: salt-3008.2+205.g46fc3b1fb4-0.x86_64.rpm
           # Derive the salt version (e.g. 3008.2+205.g46fc3b1fb4) from a built
           # artifact filename. Prefer the source tarball / onedir tarball because
           # those carry the bare upstream version; the rpm/deb regex used to trip
@@ -162,37 +163,63 @@ jobs:
           #   salt-<VER>-onedir-*.tar.xz              (onedir bundle)
           #   salt-<VER>-<REL>.<arch>.rpm             (rpm — strip -<REL>.arch)
           #   salt_<VER>-<REL>_<arch>.deb             (deb — strip -<REL>_arch)
+          #
+          # actions/download-artifact@v4 silently drops artifacts past some
+          # per-run limit on the larger branches (observed: 3006.x nightly with
+          # 700 artifacts on the run, only 305 materialised under
+          # nightly-artifacts/, and every `salt-*` package artifact was among
+          # the dropped ones). If none of the local file probes find a version,
+          # fall back to reading the just-created GitHub Release's asset list —
+          # gh release view returns the authoritative filenames.
+          probe_from_file() {
+            local f="$1"
+            local n
+            n=$(basename "$f")
+            # Try each shape in order.
+            for pat in \
+              's|^salt-\(.*\)-onedir-.*|\1|p' \
+              's|^salt-\(.*\)\.tar\.gz$|\1|p' \
+              's|^salt-\(.*\)-[0-9]*\.[^.]*\.rpm$|\1|p' \
+              's|^salt_\(.*\)-[0-9]*_[^_]*\.deb$|\1|p'; do
+              local v
+              v=$(echo "$n" | sed -n "$pat")
+              if [ -n "$v" ]; then
+                echo "$v"
+                return
+              fi
+            done
+          }
+
           version=""
-          # 1. source tarball
-          f=$(find nightly-artifacts -type f -name 'salt-*.tar.gz' ! -name '*onedir*' ! -name '*docs*' 2>/dev/null | head -1)
-          if [ -n "$f" ]; then
-            version=$(basename "$f" | sed -n 's|^salt-\(.*\)\.tar\.gz$|\1|p')
-          fi
-          # 2. onedir tarball
-          if [ -z "$version" ]; then
-            f=$(find nightly-artifacts -type f -name 'salt-*-onedir-*.tar.xz' 2>/dev/null | head -1)
-            if [ -n "$f" ]; then
-              version=$(basename "$f" | sed -n 's|^salt-\(.*\)-onedir-.*|\1|p')
-            fi
-          fi
-          # 3. rpm — strip trailing `-<REL>.<arch>.rpm`. Match only the top-level
-          # `salt-<VER>-<REL>.<arch>.rpm`, not `salt-api-*`, `salt-master-*`, ...
-          if [ -z "$version" ]; then
-            f=$(find nightly-artifacts -type f -name 'salt-*.rpm' \
+          # Local probes (order: sdist, onedir, rpm, deb).
+          for f in \
+            "$(find nightly-artifacts -type f -name 'salt-*.tar.gz' ! -name '*onedir*' ! -name '*docs*' 2>/dev/null | head -1)" \
+            "$(find nightly-artifacts -type f -name 'salt-*-onedir-*.tar.xz' 2>/dev/null | head -1)" \
+            "$(find nightly-artifacts -type f -name 'salt-*.rpm' \
                   ! -name 'salt-api-*' ! -name 'salt-master-*' ! -name 'salt-minion-*' \
                   ! -name 'salt-cloud-*' ! -name 'salt-ssh-*' ! -name 'salt-syndic-*' \
-                  2>/dev/null | head -1)
+                  2>/dev/null | head -1)" \
+            "$(find nightly-artifacts -type f -name 'salt_*.deb' 2>/dev/null | head -1)"; do
             if [ -n "$f" ]; then
-              version=$(basename "$f" | sed -n 's|^salt-\(.*\)-[0-9]*\.[^.]*\.rpm$|\1|p')
+              version=$(probe_from_file "$f")
+              [ -n "$version" ] && break
             fi
-          fi
-          # 4. deb — strip trailing `-<REL>_<arch>.deb`
+          done
+
+          # Fallback: query the release we just created / that already exists.
           if [ -z "$version" ]; then
-            f=$(find nightly-artifacts -type f -name 'salt_*.deb' 2>/dev/null | head -1)
-            if [ -n "$f" ]; then
-              version=$(basename "$f" | sed -n 's|^salt_\(.*\)-[0-9]*_[^_]*\.deb$|\1|p')
+            echo "local artifact probe returned no version; falling back to 'gh release view $TAG'"
+            # jq: pick a top-level `salt-` asset (skip salt-api-*, salt-master-* etc).
+            asset=$(gh release view "$TAG" --repo "$REPO" --json assets \
+                    --jq '.assets[].name | select(test("^salt[-_]"))
+                          | select(test("^salt-(api|master|minion|cloud|ssh|syndic)-") | not)' \
+                    2>/dev/null | head -1 || true)
+            if [ -n "$asset" ]; then
+              echo "release asset chosen: $asset"
+              version=$(probe_from_file "$asset")
             fi
           fi
+
           version=${version:-unknown}
           echo "version=${version}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70054. Two independent problems observed on the first live 3006.x nightly on gh-pages (`salt_version: unknown, failed: 164, flaky: 0` &mdash; both wrong, workflow shipped green).

### 1. Rerun-XML pairing (`generate_nightly_dashboard.py`)

Salt CI reruns failed tests as a follow-up `pytest --last-failed` process that uploads its result as a sibling `test-results-<X>-rerun.xml` alongside `test-results-<X>.xml`. The previous parser walked `*.xml` naively:

- counted rerun testcases twice, AND
- recorded every original failure even when the retry cleared it.

That's why 3008.x showed 57 "failed" on a green run. Fix:

- `_pair_xml_files()` groups sibling XMLs by their base name.
- For a paired main+rerun, testcases that failed in main get reclassified as `flaky` if the same `(classname, name)` appears in the rerun with outcome `passed` or `skipped` (skipped is common when the rerun host has the fixture pre-installed).
- Rerun testcases are overrides, not new executions.

**Impact on 3008.x run 31852300826** (verified against the actual JUnit artifacts):

| | before | after |
|---|---|---|
| tests | 296,738 | 296,681 |
| failed | 57 | **0** |
| flaky | 0 | **57** |

### 2. Fallback for salt-version when download-artifact drops packages

`actions/download-artifact@v4` silently drops artifacts past some per-run limit on the larger branches. Real numbers from 3006.x nightly run 31852297649:

```
Found 700 artifact(s)
downloading all artifacts
Total of 305 artifact(s) downloaded
```

Every `salt-*` package artifact was among the ~400 dropped &mdash; so `find nightly-artifacts -name salt-*` came up empty and `salt_version` was recorded as `unknown` even though the release itself (created earlier in the same job) had the packages attached correctly.

Fix: after the local file probe, fall back to querying the just-created release's asset list via `gh release view $TAG --json assets` and run the same name&rarr;version regex on the authoritative asset name. Also consolidated the four sed-shape branches into a shared `probe_from_file` helper so both paths use identical logic.

Verified against real filenames on saltstack/salt-nightlies:

    salt-3008.2+206.gbc6d557fcb.tar.gz                     -> 3008.2+206.gbc6d557fcb
    salt-3008.2+206.gbc6d557fcb-onedir-linux-x86_64.tar.xz -> 3008.2+206.gbc6d557fcb
    salt-3008.2+206.gbc6d557fcb-0.x86_64.rpm               -> 3008.2+206.gbc6d557fcb
    salt_3008.2+206.gbc6d557fcb-1_amd64.deb                -> 3008.2+206.gbc6d557fcb

### Verification

- **Synthetic JUnit fixture** covers both flavours of flake:
  - a main `<failure>` paired with a rerun-pass &rarr; flaky
  - a testcase with inline `<rerunFailure>` child (pytest-rerunfailures) &rarr; flaky
  - Total = 3 (not 4): the rerun testcase overrides, doesn't add.
- **Real data**: re-parsed all 336 JUnit artifacts from run 31852300826 with the new code; totals match the workflow's own success signal.
- **Shell**: `probe_from_file` unit-tested against all four real filename shapes.

### Merge requirements

- Docs &mdash; N/A.
- Changelog &mdash; none added (workflow tooling only).
- Tests &mdash; no automated tests (dashboard script has no test harness).

### Commits signed with GPG?

No.