### PR TITLE
nightlies dashboard: exclude skipped tests from tests + unique counts

### DIFF
--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -143,13 +143,18 @@ def parse_junit_counts(junit_dir: Path) -> dict:
         }
 
     Notes:
-      - `tests` counts every `<testcase>` occurrence across all JUnit files
-        (i.e. executions — the same logical test running on multiple OS
-        slugs / transports / FIPS variants each add to it).
+      - `tests` counts every `<testcase>` occurrence that actually ran --
+        passed, failed, or flaky. Skipped testcases are counted separately
+        under `skipped` and are NOT included in `tests` (they never
+        executed a test body; pytest skipped them due to a marker or
+        missing fixture). This matches how CI operators think of "tests
+        that ran" vs "tests that were collected but excluded".
+      - The same logical test running on multiple OS slugs / transports /
+        FIPS variants each add to `tests`.
       - `unique` is the deduplicated count of distinct `(classname, name)`
-        tuples across ALL artifacts. It is a top-level total only; the
-        per-bucket breakdown stays as executions since that maps cleanly
-        onto how CI is scheduled.
+        tuples across ALL artifacts (excluding skipped). It is a top-level
+        total only; the per-bucket breakdown stays as executions since
+        that maps cleanly onto how CI is scheduled.
     """
     totals = _empty_bucket()
     by_bucket: dict = defaultdict(_empty_bucket)
@@ -197,12 +202,15 @@ def parse_junit_counts(junit_dir: Path) -> dict:
                     if rer in ("passed", "skipped"):
                         outcome = "flaky"
                     # rer == "failed" -> keep as failed
-                totals["tests"] += 1
+                # `tests` = testcases that actually ran (passed/failed/flaky).
+                # Skipped are counted in the `skipped` bucket but not `tests`.
+                if outcome != "skipped":
+                    totals["tests"] += 1
+                    by_bucket[(chunk, slug)]["tests"] += 1
                 totals[outcome] += 1
-                by_bucket[(chunk, slug)]["tests"] += 1
                 by_bucket[(chunk, slug)][outcome] += 1
                 cls, name = key
-                if cls or name:
+                if outcome != "skipped" and (cls or name):
                     unique_ids.add(key)
 
     return {


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70054 / #70059. `tests` previously counted every `<testcase>` element including those with a `<skipped>` child, so a green run on 3006.x reported **313,078 tests** while **66,034 of them never actually executed a test body** (pytest marker/fixture skip). That muddies the primary CI-health signal on the dashboard: "we ran 313k tests" vs the more honest "we ran 247k".

### Fix

Redefine `tests` = passed + failed + flaky (testcases that actually ran to a real outcome). `skipped` stays as its own bucket and the detail table still shows all four columns. `unique` similarly excludes skipped so it reflects distinct `(classname, name)` tuples that produced a real result.

### Impact

Recomputed from the same JUnit data for 8/15 nightlies:

| branch | tests (before -> after) | unique (before -> after) | skipped |
|---|---|---|---|
| 3008.x | 296,681 -> 232,860 | 19,645 -> 19,181 | 63,821 |
| 3006.x | 313,078 -> 247,044 | 20,963 -> 19,392 | 66,034 |

Skipped counts unchanged. Failed / flaky counts unchanged.

### Compatibility

Old history.json entries used a different schema entirely; this change only affects entries written from this commit onward. Older rows render as before.

### Commits signed with GPG?

No.