### PR TITLE
nightlies dashboard: add per-OS aggregate table to release expand-row

### DIFF
--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -267,6 +267,38 @@ def render_index_html(history: list) -> str:
         unique = totals.get("unique", 0)
         by_suite_os = counts.get("by_suite_os", {}) or {}
 
+        # Per-OS table: aggregate every "chunk|slug" bucket by the slug
+        # (i.e. sum all suite chunks that ran on the same OS).
+        per_os: dict = defaultdict(
+            lambda: {"tests": 0, "flaky": 0, "failed": 0, "skipped": 0}
+        )
+        for key, c in by_suite_os.items():
+            os_name = key.split("|", 1)[1] if "|" in key else "unknown"
+            per_os[os_name]["tests"] += c.get("tests", 0)
+            per_os[os_name]["flaky"] += c.get("flaky", 0)
+            per_os[os_name]["failed"] += c.get(
+                "failed", c.get("failures", 0) + c.get("errors", 0)
+            )
+            per_os[os_name]["skipped"] += c.get("skipped", 0)
+        per_os_rows = "".join(
+            f"<tr>"
+            f"<td>{html.escape(os_name)}</td>"
+            f'<td>{c["tests"]:,}</td>'
+            f'<td class="num-flaky">{c["flaky"]}</td>'
+            f'<td class="num-fail">{c["failed"]}</td>'
+            f'<td>{c["skipped"]:,}</td>'
+            f"</tr>"
+            for os_name, c in sorted(per_os.items())
+        )
+        per_os_html = (
+            f'<table class="detail"><thead><tr>'
+            f"<th>os</th><th>tests</th><th>flaky</th><th>failed</th><th>skip</th>"
+            f"</tr></thead>"
+            f"<tbody>{per_os_rows}</tbody></table>"
+            if per_os
+            else ""
+        )
+
         # Detail table (per suite × os).
         detail_rows = "".join(
             f"<tr>"
@@ -279,7 +311,7 @@ def render_index_html(history: list) -> str:
             f"</tr>"
             for k, c in sorted(by_suite_os.items())
         )
-        detail_html = (
+        detail_by_suite_html = (
             f'<table class="detail"><thead><tr>'
             f"<th>suite</th><th>os</th>"
             f"<th>tests</th><th>flaky</th><th>failed</th><th>skip</th>"
@@ -287,6 +319,16 @@ def render_index_html(history: list) -> str:
             f"<tbody>{detail_rows}</tbody></table>"
             if by_suite_os
             else "<em>no test-run artifacts parsed</em>"
+        )
+
+        detail_html = (
+            (
+                '<div class="detail-section-title">Per OS</div>' + per_os_html
+                if per_os_html
+                else ""
+            )
+            + '<div class="detail-section-title">Per suite &times; OS</div>'
+            + detail_by_suite_html
         )
 
         release_url = html.escape(e.get("release_url", "#"))
@@ -339,6 +381,7 @@ def render_index_html(history: list) -> str:
   a:hover {{ text-decoration: underline; }}
   .detail {{ margin: 0.5em 0 0.5em 1em; width: auto; font-size: 0.85em; }}
   .detail th, .detail td {{ border-bottom: 1px solid #f0f0f0; }}
+  .detail-section-title {{ margin: 0.75em 0 0.25em 1em; font-weight: 600; font-size: 0.85em; color: #57606a; }}
 </style>
 <script>
   function toggle(id) {{

--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -143,13 +143,18 @@ def parse_junit_counts(junit_dir: Path) -> dict:
         }
 
     Notes:
-      - `tests` counts every `<testcase>` occurrence across all JUnit files
-        (i.e. executions — the same logical test running on multiple OS
-        slugs / transports / FIPS variants each add to it).
+      - `tests` counts every `<testcase>` occurrence that actually ran --
+        passed, failed, or flaky. Skipped testcases are counted separately
+        under `skipped` and are NOT included in `tests` (they never
+        executed a test body; pytest skipped them due to a marker or
+        missing fixture). This matches how CI operators think of "tests
+        that ran" vs "tests that were collected but excluded".
+      - The same logical test running on multiple OS slugs / transports /
+        FIPS variants each add to `tests`.
       - `unique` is the deduplicated count of distinct `(classname, name)`
-        tuples across ALL artifacts. It is a top-level total only; the
-        per-bucket breakdown stays as executions since that maps cleanly
-        onto how CI is scheduled.
+        tuples across ALL artifacts (excluding skipped). It is a top-level
+        total only; the per-bucket breakdown stays as executions since
+        that maps cleanly onto how CI is scheduled.
     """
     totals = _empty_bucket()
     by_bucket: dict = defaultdict(_empty_bucket)
@@ -197,12 +202,15 @@ def parse_junit_counts(junit_dir: Path) -> dict:
                     if rer in ("passed", "skipped"):
                         outcome = "flaky"
                     # rer == "failed" -> keep as failed
-                totals["tests"] += 1
+                # `tests` = testcases that actually ran (passed/failed/flaky).
+                # Skipped are counted in the `skipped` bucket but not `tests`.
+                if outcome != "skipped":
+                    totals["tests"] += 1
+                    by_bucket[(chunk, slug)]["tests"] += 1
                 totals[outcome] += 1
-                by_bucket[(chunk, slug)]["tests"] += 1
                 by_bucket[(chunk, slug)][outcome] += 1
                 cls, name = key
-                if cls or name:
+                if outcome != "skipped" and (cls or name):
                     unique_ids.add(key)
 
     return {

--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -321,15 +321,24 @@ def render_index_html(history: list) -> str:
             else "<em>no test-run artifacts parsed</em>"
         )
 
-        detail_html = (
-            (
-                '<div class="detail-section-title">Per OS</div>' + per_os_html
-                if per_os_html
-                else ""
-            )
-            + '<div class="detail-section-title">Per suite &times; OS</div>'
-            + detail_by_suite_html
+        # Side-by-side: suite × OS on the left, per-OS on the right.
+        left_pane = (
+            '<div class="detail-pane">'
+            '<div class="detail-section-title">Per suite &times; OS</div>'
+            f"{detail_by_suite_html}"
+            "</div>"
         )
+        right_pane = (
+            (
+                '<div class="detail-pane">'
+                '<div class="detail-section-title">Per OS</div>'
+                f"{per_os_html}"
+                "</div>"
+            )
+            if per_os_html
+            else ""
+        )
+        detail_html = f'<div class="detail-flex">{left_pane}{right_pane}</div>'
 
         release_url = html.escape(e.get("release_url", "#"))
         run_url = html.escape(e.get("nightly_run_url", "#"))
@@ -379,9 +388,11 @@ def render_index_html(history: list) -> str:
   code {{ font-size: 0.85em; background: #f6f8fa; padding: 1px 4px; border-radius: 3px; }}
   a {{ color: #0969da; text-decoration: none; }}
   a:hover {{ text-decoration: underline; }}
-  .detail {{ margin: 0.5em 0 0.5em 1em; width: auto; font-size: 0.85em; }}
+  .detail {{ margin: 0.5em 0 0.5em 0; width: auto; font-size: 0.85em; }}
   .detail th, .detail td {{ border-bottom: 1px solid #f0f0f0; }}
-  .detail-section-title {{ margin: 0.75em 0 0.25em 1em; font-weight: 600; font-size: 0.85em; color: #57606a; }}
+  .detail-section-title {{ margin: 0.75em 0 0.25em 0; font-weight: 600; font-size: 0.85em; color: #57606a; }}
+  .detail-flex {{ display: flex; gap: 2em; align-items: flex-start; margin-left: 1em; flex-wrap: wrap; }}
+  .detail-pane {{ min-width: 20em; }}
 </style>
 <script>
   function toggle(id) {{


### PR DESCRIPTION
### What does this PR do?

Adds a smaller **per-OS-only** aggregate table above the existing per-(suite&nbsp;&times;&nbsp;OS) table in each release's expand-row. The suite&nbsp;&times;&nbsp;OS table is great for pinpointing a chunk-level regression, but not for spotting a flaky *host*. Now you can see both at a glance.

### Layout in the expand row

```
Per OS
os                    | tests    | flaky | failed | skip
photonos-5            | 18,144   | 22    | 0      | 4,733
photonos-4            | 15,548   | 14    | 0      | 5,407
amazonlinux-2         | 16,706   | 13    | 0      | 4,249
...

Per suite × OS
suite         | os                  | tests    | flaky | failed | skip
functional    | amazonlinux-2       | 3,497    | 1     | 0      | 1,215
functional    | amazonlinux-2023-arm64 | 3,497 | 1     | 0      | 1,196
...
```

Same columns as the existing detail table, minus the `suite` column. Alphabetical by OS.

### Implementation

Derived at render time from the existing `by_suite_os` bucket — **no history.json schema change**, so entries written before this commit also render the new table. Single-file diff in `.github/scripts/generate_nightly_dashboard.py`, one CSS rule for the section title.

### Verification

Verified on 3006.x nightly data (run 31852297649):
- 18 distinct OS slugs
- 70 (suite &times; OS) combinations
- sum of per-OS `tests` = `totals.tests` (247,044) &mdash; no double-counting or missing rows.

### Depends on

Stacks on #70060 (exclude skipped from `tests`/`unique` counts). Will auto-collapse once that merges.

### Commits signed with GPG?

No.