### PR TITLE
nightlies dashboard: dedupe re-uploaded JUnit artifact dirs

### DIFF
--- a/.github/scripts/generate_nightly_dashboard.py
+++ b/.github/scripts/generate_nightly_dashboard.py
@@ -163,8 +163,36 @@ def parse_junit_counts(junit_dir: Path) -> dict:
     if not junit_dir.exists():
         return {"totals": {**totals, "unique": 0}, "by_suite_os": {}}
 
-    for artifact_dir in sorted(p for p in junit_dir.iterdir() if p.is_dir()):
-        m = ARTIFACT_RE.match(artifact_dir.name)
+    # Dedupe re-run job artifact uploads. When a GH Actions test job is retried
+    # (either by the workflow's re-run of failed jobs, or by an operator
+    # clicking "Re-run failed jobs"), the second attempt uploads its JUnit
+    # results as a *new* artifact directory with the same
+    # (slug, transport, chunk, group) but a fresher <ts>. Walking both would
+    # double-count that chunk's tests. Keep only the highest-<ts> upload per
+    # (slug, transport, chunk, group). Dirs whose names don't match the schema
+    # are always kept (their content classification falls into the "unknown"
+    # bucket which we don't try to dedupe).
+    latest_dir: dict = {}
+    unmatched_dirs: list = []
+    for d in sorted(p for p in junit_dir.iterdir() if p.is_dir()):
+        m = ARTIFACT_RE.match(d.name)
+        if not m:
+            unmatched_dirs.append(d)
+            continue
+        key = (
+            m.group("slug"),
+            m.group("transport") or "",
+            m.group("chunk"),
+            m.group("group"),
+        )
+        ts = int(m.group("ts"))
+        existing = latest_dir.get(key)
+        if existing is None or ts > existing[0]:
+            latest_dir[key] = (ts, d, m)
+    ordered = [(d, m) for (_ts, d, m) in latest_dir.values()]
+    ordered += [(d, None) for d in unmatched_dirs]
+
+    for artifact_dir, m in ordered:
         if m:
             chunk = m.group("chunk")
             slug = m.group("slug")


### PR DESCRIPTION
### What does this PR do?

Follow-up to #70060 / #70061 / #70059. When a GitHub Actions test job is retried (either automatically or via "Re-run failed jobs"), the second attempt uploads its JUnit results as a **new** artifact directory that shares `(slug, transport, chunk, group)` with the first attempt but carries a fresher `<ts>` suffix in the directory name. `parse_junit_counts` walked both and double-counted that chunk's tests.

### Observed on 3008.x 2026-08-16

The windows-2025 zeromq scenarios chunk uploaded twice (`ts=1786840771` and `1786845195`, ~74 min apart). Against a static `head_sha` (3008.x didn't move between 8/15 and 8/16), the daily counts drifted:

| | 8/15 | 8/16 before fix | 8/16 after fix |
|---|---|---|---|
| tests | 232,860 | 232,865 | 232,861 |
| failed | 0 | 1 | 0 |
| flaky | 57 | 64 | 63 |
| skipped | 63,821 | 63,836 | 63,821 |

The phantom `failed=1` was from the first attempt of a shard that later passed on the second attempt; the older upload was overriding classification.

### Fix

Build a `{(slug, transport, chunk, group): (ts, dir)}` map, keep only the entry with the highest `ts`, then iterate the survivors. Dirs whose names don't match the schema are always kept (they land in the "unknown" bucket which we don't try to dedupe).

Single-file change to `.github/scripts/generate_nightly_dashboard.py`. No history.json schema change, no workflow change &mdash; previously-computed rows still render as-is; only entries computed after this merge will use the deduped view.

### Commits signed with GPG?

No.