### PR TITLE
fix: make `get_encoding` parameter in `load_pubkey` actually work instead of being a no-op

### DIFF
--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -1132,6 +1132,8 @@ def load_pubkey(pk, get_encoding=False):
                 ed448.Ed448PublicKey,
             ),
         ):
+            if get_encoding:
+                return pk, None, None
             return pk
         raise SaltInvocationError(
             f"Passed object is not a public key, but {pk.__class__.__name__}"
@@ -1139,13 +1141,19 @@ def load_pubkey(pk, get_encoding=False):
     pk = load_file_or_bytes(pk)
     if PEM_BEGIN in pk:
         try:
-            return serialization.load_pem_public_key(pk)
+            pk = serialization.load_pem_public_key(pk)
+            if get_encoding:
+                return pk, "pem", None
+            return pk
         except ValueError as err:
             raise PubDeserializationError(
                 "Could not load PEM-encoded public key."
             ) from err
     try:
-        return serialization.load_der_public_key(pk)
+        pk = serialization.load_der_public_key(pk)
+        if get_encoding:
+            return pk, "der", None
+        return pk
     except ValueError as err:
         raise PubDeserializationError("Could not load DER-encoded public key.") from err
 


### PR DESCRIPTION
### Problem

`salt.utils.x509.load_pubkey` accepts a `get_encoding` parameter but never uses it — it's a no-op. The parameter is documented as controlling whether the function returns the encoding type alongside the loaded key, but every return path ignores it.

### Changes

Add `get_encoding` handling to `load_pubkey`, mirroring the same pattern used by `load_privkey` and `load_cert`:

1. **Already a key object** (`hasattr(pk, "public_bytes")`): return `(pk, None, None)` when `get_encoding=True`
2. **PEM-encoded**: return `(pk, "pem", None)` when `get_encoding=True`
3. **DER-encoded**: return `(pk, "der", None)` when `get_encoding=True`

Without `get_encoding` (default `False`), behavior is unchanged — returns the key object alone.

### Verification

- `load_pubkey(pk, get_encoding=True)` now returns `(key, "pem", None)` for PEM input
- `load_pubkey(pk, get_encoding=True)` now returns `(key, "der", None)` for DER input
- `load_pubkey(pk, get_encoding=False)` (default) returns `key` only — no breaking change

Fixes #70046