### PR TITLE
fix: validate basicConstraints pathlen against issuer certificate

### DIFF
--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -1457,6 +1457,30 @@ def _create_basic_constraints(val, **kwargs):
             raise SaltInvocationError(
                 f"Invalid configuration for basicContraints: {err}"
             ) from err
+
+    # If this is a CA certificate and we have an issuer certificate, validate
+    # and default pathlen according to the issuer's BasicConstraints.
+    ca_crt = kwargs.get("ca_crt")
+    if val["ca"] and ca_crt is not None:
+        try:
+            issuer_bc_ext = ca_crt.extensions.get_extension_for_class(
+                cx509.BasicConstraints
+            )
+        except cx509.ExtensionNotFound:
+            issuer_bc_ext = None
+        if issuer_bc_ext is not None and issuer_bc_ext.value.ca:
+            issuer_pathlen = issuer_bc_ext.value.path_length
+            if issuer_pathlen is not None:
+                max_pathlen = issuer_pathlen - 1
+                if "pathlen" not in val:
+                    val["pathlen"] = max_pathlen
+                elif val["pathlen"] > max_pathlen:
+                    raise SaltInvocationError(
+                        f"basicConstraints pathlen must be at most one lower "
+                        f"than the issuer's pathlen ({max_pathlen}), "
+                        f"got {val['pathlen']}"
+                    )
+
     try:
         return (
             cx509.BasicConstraints(val["ca"], val.get("pathlen")),

--- a/tests/pytests/unit/utils/test_x509.py
+++ b/tests/pytests/unit/utils/test_x509.py
@@ -154,6 +154,53 @@ class TestCreateExtension:
             assert crit == critical
             ext.assert_called_once_with(*expected)
 
+    @staticmethod
+    def _ca_crt_with_pathlen(pathlen, ca=True):
+        ca_crt = Mock()
+        bc_ext = Mock()
+        bc_ext.value.ca = ca
+        bc_ext.value.path_length = pathlen
+        ca_crt.extensions.get_extension_for_class.return_value = bc_ext
+        return ca_crt
+
+    def test_create_basic_constraints_defaults_pathlen_from_issuer(self):
+        ca_crt = self._ca_crt_with_pathlen(3)
+        with patch("cryptography.x509.BasicConstraints", autospec=True) as ext:
+            _, crit = x509._create_extension(
+                "basicConstraints", {"ca": True}, ca_crt=ca_crt
+            )
+            assert crit is False
+            ext.assert_called_once_with(True, 2)
+
+    def test_create_basic_constraints_valid_pathlen(self):
+        ca_crt = self._ca_crt_with_pathlen(3)
+        with patch("cryptography.x509.BasicConstraints", autospec=True) as ext:
+            _, crit = x509._create_extension(
+                "basicConstraints", {"ca": True, "pathlen": 2}, ca_crt=ca_crt
+            )
+            ext.assert_called_once_with(True, 2)
+
+    def test_create_basic_constraints_pathlen_too_large(self):
+        ca_crt = self._ca_crt_with_pathlen(3)
+        with patch("cryptography.x509.BasicConstraints", autospec=True):
+            with pytest.raises(salt.exceptions.SaltInvocationError):
+                x509._create_extension(
+                    "basicConstraints", {"ca": True, "pathlen": 3}, ca_crt=ca_crt
+                )
+
+    def test_create_basic_constraints_issuer_without_pathlen(self):
+        ca_crt = self._ca_crt_with_pathlen(None)
+        with patch("cryptography.x509.BasicConstraints", autospec=True) as ext:
+            _, crit = x509._create_extension(
+                "basicConstraints", {"ca": True}, ca_crt=ca_crt
+            )
+            ext.assert_called_once_with(True, None)
+
+    def test_create_basic_constraints_without_issuer(self):
+        with patch("cryptography.x509.BasicConstraints", autospec=True) as ext:
+            _, crit = x509._create_extension("basicConstraints", {"ca": True})
+            ext.assert_called_once_with(True, None)
+
     @pytest.mark.parametrize(
         "val,expected,critical",
         [


### PR DESCRIPTION
## What does this PR do?

Fixes the `x509_v2` `basicConstraints` handling described in #70042:

1. **Validate** an explicit `pathlen`: when creating a CA certificate, `pathlen` must be at most one lower than the issuer certificate's `pathlen`. A too-large value now raises `SaltInvocationError` instead of silently producing an invalid certificate chain.

2. **Default** a missing `pathlen` to `issuer_pathlen - 1` instead of leaving it unset, which previously produced a CA certificate whose `pathlen` was not constrained to the issuer's hierarchy.

## Why is this needed?

Per RFC 5280 §4.2.1.9, a CA certificate's `pathLenConstraint` must not exceed the issuer's constraint minus one. The previous behavior issued certificates that violated the CA hierarchy without any warning.

## What changes?

- `salt/utils/x509.py`: `_create_basic_constraints()` now inspects the issuer certificate (`ca_crt`) when the certificate being created is a CA, gets the issuer's `BasicConstraints` extension, and either validates or defaults `pathlen` accordingly.
- `tests/pytests/unit/utils/test_x509.py`: new tests covering defaulting, validation, the too-large error case, issuer without `pathlen`, and the no-issuer case.

## Checklist

- [x] Tests added for the new behavior
- [x] Existing `test_create_basic_constraints` still passes (no issuer case is unchanged)

Signed-off-by: waterWang <waterWang@users.noreply.github.com>