### PR TITLE
fix: prevent KeyError in zonecfg _is_globalzone when __grains__ lacks 'kernel'

### DIFF
--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -83,7 +83,7 @@ def _is_globalzone():
     """
     Check if we are running in the globalzone
     """
-    if not __grains__["kernel"] == "SunOS":
+    if not __grains__.get("kernel", "") == "SunOS":
         return False
 
     zonename = __salt__["cmd.run_all"]("zonename")


### PR DESCRIPTION
### Fixes #70020

## Root Cause

`_is_globalzone()` in `salt/modules/zonecfg.py` accesses `__grains__["kernel"]` 
directly without checking if the key exists. When `__grains__` does not contain 
a `kernel` key (e.g., on non-SunOS systems where grains haven't been populated 
in that context), a `KeyError: 'kernel'` is raised during module loading.

This causes the error message:
```
Exception raised when processing __virtual__ function for 
salt.loaded.int.module.zonecfg. Module will not be loaded: 'kernel'
```

## Fix

Use `__grains__.get("kernel", "")` instead of `__grains__["kernel"]` to safely 
handle the case where the grain key is absent. The function already returns 
`False` when the kernel is not `"SunOS"`, so an empty string default preserves 
the same behavior.
