### PR TITLE
Add pythonrelease and pythonrelease_info grains

### DIFF
--- a/changelog/59594.added.md
+++ b/changelog/59594.added.md
@@ -1,0 +1,5 @@
+Added ``pythonrelease`` and ``pythonrelease_info`` grains, which follow the
+``<foo>release`` / ``<foo>release_info`` convention already used by grains such
+as ``osrelease`` / ``osrelease_info``. ``pythonrelease`` is the dotted version
+string (for example ``3.11.0``) and ``pythonrelease_info`` is the equivalent
+list. The existing list-valued ``pythonversion`` grain is unchanged.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3175,7 +3175,19 @@ def pythonversion():
     """
     # Provides:
     #   pythonversion
-    return {"pythonversion": list(sys.version_info)}
+    #   pythonrelease
+    #   pythonrelease_info
+    #
+    # ``pythonversion`` is a list rather than a dotted string, which is
+    # inconsistent with the ``<foo>release`` / ``<foo>release_info`` pair used
+    # by the other version grains (e.g. ``osrelease`` / ``osrelease_info``).
+    # ``pythonrelease`` and ``pythonrelease_info`` follow that convention;
+    # ``pythonversion`` is kept unchanged for backwards compatibility.
+    return {
+        "pythonversion": list(sys.version_info),
+        "pythonrelease": platform.python_version(),
+        "pythonrelease_info": list(sys.version_info),
+    }
 
 
 def pythonpath():

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -4475,6 +4475,27 @@ def test_pythonversion():
     assert ret["pythonversion"] == python_version
 
 
+def test_pythonrelease():
+    """
+    test pythonrelease and pythonrelease_info
+
+    These follow the ``<foo>release`` / ``<foo>release_info`` convention used
+    by the other version grains, unlike the older list-valued
+    ``pythonversion`` grain which is retained for backwards compatibility.
+    """
+    ret = core.pythonversion()
+
+    assert "pythonrelease" in ret
+    assert ret["pythonrelease"] == platform.python_version()
+    # dotted major.minor.micro, matching the shape of e.g. osrelease
+    assert ret["pythonrelease"] == "{}.{}.{}".format(*sys.version_info[:3])
+
+    assert "pythonrelease_info" in ret
+    assert ret["pythonrelease_info"] == [*sys.version_info]
+    # the pre-existing grain keeps working and stays in sync
+    assert ret["pythonrelease_info"] == ret["pythonversion"]
+
+
 @pytest.mark.skip_unless_on_linux
 def test_get_machine_id():
     """


### PR DESCRIPTION
## What does this PR do?

Adds `pythonrelease` and `pythonrelease_info` grains.

## What issues does this PR fix or reference?

Fixes #59594

## Background

`pythonversion` is a list rather than a dotted string:

```
pythonversion:
    - 3
    - 11
    - 0
    - final
    - 0
```

which breaks the `<foo>release` / `<foo>release_info` convention the other version grains follow (`osrelease` is `7.9.2009` with `osrelease_info` carrying the tuple; likewise `kernelrelease`).

The issue suggested adding `pythonrelease` / `pythonrelease_info` and deprecating `pythonversion` at some documented future point. This PR does **only the additive half** — it deliberately does not touch or deprecate `pythonversion`, so it carries no backwards-compatibility risk. The deprecation is a separate decision for the maintainers.

## Result

```
pythonversion:      [3, 12, 3, 'final', 0]   # unchanged
pythonrelease:      '3.12.3'
pythonrelease_info: [3, 12, 3, 'final', 0]
```

`pythonrelease` uses `platform.python_version()`, which is defined as `major.minor.micro` and so matches the shape of `osrelease`.

## Tests written?

Yes — added `test_pythonrelease` to `tests/pytests/unit/grains/test_core.py`, asserting the dotted form matches both `platform.python_version()` and `major.minor.micro`, that `pythonrelease_info` matches `sys.version_info`, and that it stays in sync with the pre-existing `pythonversion` grain.

Verified locally:

- Both `test_pythonversion` (pre-existing, confirming the old grain is untouched) and the new `test_pythonrelease` pass against the real `salt.grains.core` module.
- Checked the two other tests that reference this grain — `tests/pytests/integration/modules/grains/test_module.py` and `tests/pytests/pkg/integration/test_salt_grains.py` — both assert *membership* (`assert grain in ret.data`) rather than an exact grain set, so adding grains does not affect them.
- `black==24.2.0` (the version pinned in `.pre-commit-config.yaml`) reports both changed files unchanged.

I was not able to run the full `tests/pytests/unit/grains/test_core.py` suite locally — the `salt-factories` conftest setup didn't complete in this environment — so CI is the real check on the rest of that file.

## Commits signed with GPG?

No