### PR TITLE
fix(deltaproxy): log sub-proxy init failures at ERROR level instead of INFO [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -384,7 +384,7 @@ async def post_master_init(self, master):
                     _id, uid, self.opts, self.proxy, self.utils
                 )
             except Exception as exc:  # pylint: disable=broad-except
-                log.info(
+                log.error(
                     "An exception occured during initialization for %s, skipping: %s",
                     _id,
                     exc,
@@ -405,7 +405,7 @@ async def post_master_init(self, master):
                     )
 
     if _failed:
-        log.info("Following sub proxies failed %s", _failed)
+        log.error("The following sub proxies failed to initialize: %s", _failed)
     self.ready = True
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes saltstack/salt#70072

When a deltaproxy control minion initializes its sub-proxies **sequentially** (the default), an exception during a sub-proxy's initialization is caught and logged at **INFO** level. With the default `log_level: warning`, a failure that permanently disables a minion produces **zero visible log output** — the sub-proxy silently disappears.

The parallel startup path handles this correctly (logs at ERROR + re-raises). This PR brings the sequential path in line:

1. Per-proxy failure: `log.info` → `log.error`
2. Summary of failed proxies: `log.info` → `log.error`

## Problem Details

From the issue: after upgrading a production master from 3007.14 to 3008.2, all 21 sub-proxies failed to initialize (netmiko_px proxy module removed from core in 3008). The service showed `active (running)`, logs contained nothing, and the fleet was silently unmanaged for four days.

## What does this PR do NOT change?

No behavior change — only the log level of existing failure messages, matching the parallel-startup branch.

## Testing

- Manual verification on the code: the two `log.info` calls in `salt/metaproxy/deltaproxy.py` `post_master_init` (sequential branch) are now `log.error`.
- No functional code path changed.