### PR TITLE
Fix/salt cloud windows docs

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -58,9 +58,9 @@ on pywinrm can be found at the project home:
 
 Additionally, a copy of the Salt Minion Windows installer must be present on
 the system on which Salt Cloud is running. This installer may be downloaded
-from saltstack.com:
+from the Salt Project download area:
 
-* `SaltStack Download Area`__
+* `Salt Project Download Area`__
 
 .. __: https://packages.broadcom.com/artifactory/saltproject-generic/windows/
 


### PR DESCRIPTION
Retargets #70015 at `3006.x` per @twangboy's review.

The Requirements section says the Salt Minion Windows installer is downloaded
"from saltstack.com", while the link directly beneath it points at
`packages.broadcom.com`. Updates the wording and the link label to match.

Note this is smaller than #70015. On `master` the same paragraph is also
duplicated — the requirement is stated once earlier with the install-guide link,
then again here prefixed with "Additionally". That duplication doesn't exist on
`3006.x`, so this PR only fixes the stale domain reference. Happy to keep the
master PR open for the duplication, or handle it however you'd prefer.

Docs-only.