### PR TITLE
publish-nightly-release: only accept salt-versions that start with a digit

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -172,10 +172,13 @@ jobs:
           # fall back to reading the just-created GitHub Release's asset list —
           # gh release view returns the authoritative filenames.
           probe_from_file() {
+            # A valid salt version always starts with a digit (e.g. 3008.2+206.gbc6d557fcb).
+            # Reject any captured group that doesn't, so subpackage names like
+            # `salt-debuginfo-...`, `salt-common-...`, `salt-dbg_...` -- which slip
+            # past the `-name` filter -- don't get returned as "version=debuginfo-...".
             local f="$1"
             local n
             n=$(basename "$f")
-            # Try each shape in order.
             for pat in \
               's|^salt-\(.*\)-onedir-.*|\1|p' \
               's|^salt-\(.*\)\.tar\.gz$|\1|p' \
@@ -183,10 +186,9 @@ jobs:
               's|^salt_\(.*\)-[0-9]*_[^_]*\.deb$|\1|p'; do
               local v
               v=$(echo "$n" | sed -n "$pat")
-              if [ -n "$v" ]; then
-                echo "$v"
-                return
-              fi
+              case "$v" in
+                [0-9]*) echo "$v"; return ;;
+              esac
             done
           }
 


### PR DESCRIPTION
### What does this PR do?

The `find`-based local probe filters out obvious subpackage names (`salt-api-*`, `salt-master-*`, ...) but the exclusion list has drifted: today's 3006.x publish extracted `debuginfo-3006.27+199.gbf939d384b` from `salt-debuginfo-*.rpm` because `debuginfo` wasn't listed. `salt-common`, `salt-dbg`, `salt-doc`, and any future subpackage have the same failure mode.

### Fix

Assert the invariant instead: **a valid salt version always starts with a digit**. Applied inside `probe_from_file` so both the local file probe AND the `gh release view` fallback share the guard.

### Verified

| filename | before | after |
|---|---|---|
| `salt-3006.27+199.gbf939d384b-0.x86_64.rpm`           | `3006.27+199.gbf939d384b`            | `3006.27+199.gbf939d384b` |
| `salt-debuginfo-3006.27+199.gbf939d384b-0.x86_64.rpm` | `debuginfo-3006.27+199.gbf939d384b`  | rejected |
| `salt-common_3006.27+199.gbf939d384b_amd64.deb`       | `common_3006.27+199.gbf939d384b`     | rejected |
| `salt-dbg_3006.27+199.gbf939d384b_amd64.deb`          | `dbg_3006.27+199.gbf939d384b`        | rejected |
| `salt-api-3006.27+199.gbf939d384b-0.x86_64.rpm`       | `api-3006.27+199.gbf939d384b`        | rejected |

When every probe returns empty we fall through to `unknown` — same behaviour as before, just no more sub-package-name-as-version.

### Commits signed with GPG?

No.