### PR TITLE
[3008.x] Fix master-cluster peer traffic honoring cluster_pool_port (#69877)

### DIFF
--- a/changelog/69877.fixed.md
+++ b/changelog/69877.fixed.md
@@ -1,0 +1,1 @@
+Fix master-cluster peer traffic honoring ``cluster_pool_port`` instead of falling back to hardcoded ``55596``; ``cluster_port`` accepted as deprecated alias with a warning.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -260,7 +260,7 @@ changed to the filesystem location shared between peers in the cluster.
     cluster_pki_dir: /my/gluster/share/pki
 
 
-.. conf_master:: cluster_port
+.. conf_master:: cluster_pool_port
 
 ``cluster_pool_port``
 ---------------------

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -1568,7 +1568,7 @@ class MasterPubServerChannel:
         if opts.get("cluster_id"):
             # Cluster mode: Use TCP-based transport for peer communication while
             # preserving normal local IPC behavior for internal processes.
-            port = opts.get("cluster_port", 55596)
+            port = opts["cluster_pool_port"]
             pull_path = os.path.join(opts["sock_dir"], "master_event_pull.ipc")
             pub_path = os.path.join(opts["sock_dir"], "master_event_pub.ipc")
             bind_host = opts.get("interface", "127.0.0.1")
@@ -1684,7 +1684,7 @@ class MasterPubServerChannel:
             )
 
             aio_loop = salt.utils.asynchronous.aioloop(self.io_loop)
-            port = self.opts.get("cluster_port", 55596)
+            port = self.opts["cluster_pool_port"]
 
             # One pusher per remote host.  Do not use ``build_peer_pushers`` here:
             # discover-reply appends duplicate hosts to ``opts["cluster_peers"]`` and
@@ -2892,7 +2892,7 @@ class MasterPubServerChannel:
 
         # Cluster-specific peer communication (separate from local IPC)
         if self.opts.get("cluster_id"):
-            self.tcp_master_pool_port = self.opts.get("cluster_port", 55596)
+            self.tcp_master_pool_port = self.opts["cluster_pool_port"]
             self.auth_errors = collections.defaultdict(collections.deque)
             self.peer_map = {}
 

--- a/salt/cluster/consensus/service.py
+++ b/salt/cluster/consensus/service.py
@@ -611,7 +611,7 @@ class RaftService:
 
         pusher = self._peer_pushers.get(addr)
         if pusher is None:
-            port = self.opts.get("cluster_port", 55596)
+            port = self.opts["cluster_pool_port"]
             pusher = salt.transport.tcp.PublishServer(
                 self.opts,
                 pull_host=addr,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -4369,6 +4369,21 @@ def apply_master_config(overrides=None, defaults=None):
     opts["__fs_update"] = True
 
     _adjust_log_file_override(overrides, defaults["log_file"])
+    # Soft-deprecation alias: the master-cluster Raft rewrite (introduced in
+    # 3008.0) accidentally read the peer-pool port from ``cluster_port``
+    # instead of the documented ``cluster_pool_port``. ``cluster_port`` was
+    # never registered in ``VALID_OPTS``/``DEFAULT_MASTER_OPTS``, so any
+    # operator who happened to set it silently overrode nothing. If an
+    # operator explicitly set ``cluster_port`` (and not
+    # ``cluster_pool_port``), honor their intent by aliasing it across, and
+    # warn that the alias will be removed in a future release. See #69877.
+    if "cluster_port" in overrides and "cluster_pool_port" not in overrides:
+        log.warning(
+            "The 'cluster_port' master opt is deprecated and will be "
+            "removed in Argon+1 / Potassium; use 'cluster_pool_port' "
+            "instead."
+        )
+        overrides["cluster_pool_port"] = overrides["cluster_port"]
     if overrides:
         opts.update(overrides)
     # `keep_acl_in_token` will be forced to True when using external authentication

--- a/tests/pytests/scenarios/cluster_kind/conftest.py
+++ b/tests/pytests/scenarios/cluster_kind/conftest.py
@@ -400,7 +400,7 @@ def _master_pod_manifest(name, image, headless_fqdn, expected_peers, namespace):
                     "ports": [
                         {"name": "ret", "containerPort": 4506},
                         {"name": "pub", "containerPort": 4505},
-                        {"name": "cluster-pool", "containerPort": 55596},
+                        {"name": "cluster-pool", "containerPort": 4520},
                     ],
                     # Three probes per the 2026 Kubernetes guidance for
                     # consensus-based services (etcd's lesson: liveness
@@ -485,7 +485,7 @@ def _headless_service_manifest(namespace):
             "ports": [
                 {"name": "ret", "port": 4506},
                 {"name": "pub", "port": 4505},
-                {"name": "cluster-pool", "port": 55596},
+                {"name": "cluster-pool", "port": 4520},
             ],
             "publishNotReadyAddresses": True,
         },

--- a/tests/pytests/unit/channel/test_master_cluster_port.py
+++ b/tests/pytests/unit/channel/test_master_cluster_port.py
@@ -1,0 +1,80 @@
+"""
+Regression tests for https://github.com/saltstack/salt/issues/69877.
+
+The Raft rewrite for master clustering accidentally read the peer-pool port
+from ``cluster_port`` instead of the documented ``cluster_pool_port``.
+``cluster_port`` was never registered in ``VALID_OPTS``/``DEFAULT_MASTER_OPTS``,
+so ``.get("cluster_port", 55596)`` silently fell back to the hardcoded literal
+``55596`` on every master, ignoring the operator's ``cluster_pool_port``
+setting. This module locks in that ``MasterPubServerChannel.factory`` binds
+the pool puller to ``opts["cluster_pool_port"]``.
+"""
+
+import salt.channel.server
+from tests.support.mock import patch
+
+
+def _cluster_opts(**overrides):
+    opts = {
+        "cluster_id": "test-cluster",
+        "cluster_peers": [],
+        "cluster_pool_port": 4520,
+        "sock_dir": "/tmp/does-not-matter",
+        "interface": "127.0.0.1",
+        "publish_port": 4505,
+    }
+    opts.update(overrides)
+    return opts
+
+
+def test_master_pub_server_channel_factory_uses_cluster_pool_port():
+    """
+    ``MasterPubServerChannel.factory`` in cluster mode must bind the peer
+    pool puller to ``opts["cluster_pool_port"]``, not the hardcoded 55596
+    that the pre-fix code fell back to.
+    """
+    opts = _cluster_opts(cluster_pool_port=4520)
+
+    with patch("salt.transport.tcp.PublishServer") as pub_server, patch.object(
+        salt.channel.server.MasterPubServerChannel, "__init__", return_value=None
+    ):
+        salt.channel.server.MasterPubServerChannel.factory(opts)
+
+    assert pub_server.called
+    call_kwargs = pub_server.call_args.kwargs
+    assert call_kwargs["pull_port"] == 4520
+    assert call_kwargs["pull_port"] != 55596
+
+
+def test_master_pub_server_channel_factory_honours_non_default_pool_port():
+    """
+    A non-default ``cluster_pool_port`` must be honored end-to-end. Before
+    the fix this returned 55596 regardless of the operator's setting.
+    """
+    opts = _cluster_opts(cluster_pool_port=6520)
+
+    with patch("salt.transport.tcp.PublishServer") as pub_server, patch.object(
+        salt.channel.server.MasterPubServerChannel, "__init__", return_value=None
+    ):
+        salt.channel.server.MasterPubServerChannel.factory(opts)
+
+    assert pub_server.call_args.kwargs["pull_port"] == 6520
+
+
+def test_master_pub_server_channel_factory_ignores_cluster_port_key():
+    """
+    ``cluster_port`` is not a valid opt at the channel layer -- the alias
+    lives in ``apply_master_config``, so once opts land at the factory the
+    key must have been translated to ``cluster_pool_port``. If a caller
+    passes ``cluster_port`` here, the factory must NOT fall back to it or
+    to 55596; ``cluster_pool_port`` is the only source of truth.
+    """
+    opts = _cluster_opts(cluster_pool_port=4520)
+    opts["cluster_port"] = 55596  # stale/typo -- must be ignored
+
+    with patch("salt.transport.tcp.PublishServer") as pub_server, patch.object(
+        salt.channel.server.MasterPubServerChannel, "__init__", return_value=None
+    ):
+        salt.channel.server.MasterPubServerChannel.factory(opts)
+
+    assert pub_server.call_args.kwargs["pull_port"] == 4520

--- a/tests/pytests/unit/cluster/consensus/test_raft_membership.py
+++ b/tests/pytests/unit/cluster/consensus/test_raft_membership.py
@@ -358,7 +358,7 @@ class TestMaxVotersCap:
         opts = salt.config.master_config("/dev/null")
         opts["interface"] = "127.0.0.1"
         opts["cluster_peers"] = ["127.0.0.2"]
-        opts["cluster_port"] = 55597
+        opts["cluster_pool_port"] = 55597
         opts["cachedir"] = tmpdir
         opts["cluster_max_voters"] = 3
 
@@ -420,7 +420,7 @@ class TestMaxVotersCap:
         opts = salt.config.master_config("/dev/null")
         opts["interface"] = my_addr
         opts["cluster_peers"] = list(peer_addrs)
-        opts["cluster_port"] = 55596
+        opts["cluster_pool_port"] = 55596
         opts["cachedir"] = tmpdir
         if max_voters is not None:
             opts["cluster_max_voters"] = max_voters
@@ -554,7 +554,7 @@ class TestNotifyPeerJoined:
         opts = salt.config.master_config("/dev/null")
         opts["interface"] = "127.0.0.1"
         opts["cluster_peers"] = ["127.0.0.2"]
-        opts["cluster_port"] = 55596
+        opts["cluster_pool_port"] = 55596
         opts["cachedir"] = tmpdir
 
         loop = asyncio.new_event_loop()

--- a/tests/pytests/unit/cluster/consensus/test_voter_health.py
+++ b/tests/pytests/unit/cluster/consensus/test_voter_health.py
@@ -243,7 +243,7 @@ class TestOperatorOverride:
         opts = salt.config.master_config("/dev/null")
         opts["interface"] = "127.0.0.1"
         opts["cluster_peers"] = ["127.0.0.2", "127.0.0.3"]
-        opts["cluster_port"] = 55596
+        opts["cluster_pool_port"] = 55596
         opts["cachedir"] = tmpdir
         opts["cluster_min_voters"] = 2
 

--- a/tests/pytests/unit/config/test_master_config.py
+++ b/tests/pytests/unit/config/test_master_config.py
@@ -1,3 +1,5 @@
+import logging
+
 import salt.config
 from tests.support.mock import MagicMock, patch
 
@@ -72,6 +74,44 @@ def test_apply_for_cluster():
     assert isinstance(opts["cluster_peers"], list)
     opts["cluster_peers"].sort()
     assert ["127.0.0.1", "127.0.0.3"] == opts["cluster_peers"]
+
+
+def test_cluster_port_alias_warns_and_aliases_cluster_pool_port(caplog):
+    """
+    Regression for https://github.com/saltstack/salt/issues/69877.
+
+    The Raft rewrite for master clustering accidentally read the peer-pool
+    port from an undocumented ``cluster_port`` opt instead of the
+    documented ``cluster_pool_port``. ``apply_master_config`` now accepts
+    ``cluster_port`` as a soft-deprecated alias: it copies the value into
+    ``cluster_pool_port`` (if the caller did not set that explicitly) and
+    emits a deprecation warning.
+    """
+    defaults = salt.config.DEFAULT_MASTER_OPTS.copy()
+    overrides = {"cluster_port": 6520}
+
+    with caplog.at_level(logging.WARNING, logger="salt.config"):
+        opts = salt.config.apply_master_config(overrides, defaults)
+
+    assert opts["cluster_pool_port"] == 6520
+    assert any(
+        "cluster_port" in rec.message and "deprecated" in rec.message
+        for rec in caplog.records
+    ), f"expected deprecation warning; got: {[r.message for r in caplog.records]}"
+
+
+def test_cluster_pool_port_wins_over_cluster_port_alias():
+    """
+    If both ``cluster_port`` and ``cluster_pool_port`` are set, the
+    documented ``cluster_pool_port`` wins -- the alias is a soft landing
+    for operators who happened to pick up the buggy name, not a co-equal
+    setting.
+    """
+    defaults = salt.config.DEFAULT_MASTER_OPTS.copy()
+    overrides = {"cluster_port": 55596, "cluster_pool_port": 6520}
+
+    opts = salt.config.apply_master_config(overrides, defaults)
+    assert opts["cluster_pool_port"] == 6520
 
 
 def test___cli_path_is_expanded():


### PR DESCRIPTION
Fixes #69877.

**Root cause.** The Raft rewrite (3008.0+) reads the peer-pool port from `opts.get("cluster_port", 55596)` at four sites, but the documented option is `cluster_pool_port` (registered in `VALID_OPTS`/`DEFAULT_MASTER_OPTS` by #67999). `cluster_port` was never a valid opt, so every master silently fell back to the hardcoded literal `55596`, ignoring the operator's `cluster_pool_port` setting. Both sender and receiver made the same mistake so the cluster still worked — but on the wrong port.

**Fix (Option 3 from analysis).** Rename the four call sites to `opts["cluster_pool_port"]`, and add a soft-deprecation alias in `apply_master_config`: if an operator explicitly set `cluster_port` (and not `cluster_pool_port`), copy the value across and emit a deprecation warning. Alias scheduled for removal in Argon+1 / Potassium.

Also swaps the same wrong-name in existing test collateral (`test_raft_membership.py`, `test_voter_health.py`, `cluster_kind` k8s conftest which was opening `55596` on the pod + service), fixes a stray `.. conf_master:: cluster_port` label in `doc/ref/configuration/master.rst`, and adds regression tests for both the factory-level port binding and the deprecation alias.

Cross-reference: #69540 (draft, master-cluster reference topologies) already asserts `cluster_pool_port` / `4520` in `test_haproxy_documented_config.py` — this PR delivers the code fix that makes that contract hold.

Merge-forward pipeline carries this to `master`; `3007.x` is unaffected (post-#69622 revert).