### PR TITLE
Add Fedora 43 to test CI, drop Fedora 40

### DIFF
--- a/changelog/67182.added.md
+++ b/changelog/67182.added.md
@@ -1,0 +1,1 @@
+Added Fedora 43 to test CI, and dropped Fedora 40, in accordance with Fedora OS support policy.

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -89,15 +89,15 @@ test-salt-listing:
       arch: arm64
       container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-13"
       enabled: false
-    - slug: fedora-40
-      display_name: "Fedora 40"
+    - slug: fedora-43
+      display_name: "Fedora 43"
       arch: x86_64
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-40"
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-43"
       enabled: true
-    - slug: fedora-40-arm64
-      display_name: "Fedora 40 Arm64"
+    - slug: fedora-43-arm64
+      display_name: "Fedora 43 Arm64"
       arch: arm64
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-40"
+      container: "ghcr.io/saltstack/salt-ci-containers/testing:fedora-43"
       enabled: false
     - slug: photonos-4
       display_name: "Photon OS 4"

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2743,7 +2743,7 @@ def test_get_yum_config(grains):
         # This one seems to be in all of them...
         # If this ever breaks in the future, we'll need to get more specific
         # than os_family
-        setting = "installonly_limit"
+        setting = "reposdir"
     result = yumpkg._get_yum_config()
     assert setting in result
 

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1509,7 +1509,10 @@ def test_yumpkg_group_installed_with_repo_options(
         assert not ret["changes"]
         expected = [yumpkg._yum(), "--quiet"]
         expected.extend(expected_cli_options)
-        expected.extend(("groupinfo", name))
+        if yumpkg._yum() == "dnf5":
+            expected.extend(("group", "info", name))
+        else:
+            expected.extend(("groupinfo", name))
         run_stdout.assert_called_once_with(
             expected,
             output_loglevel="trace",


### PR DESCRIPTION
### What does this PR do?
Bump the fedora test slug in cicd/shared-gh-workflows-context.yml from fedora-40 to fedora-43, per Fedora's OS support policy. Update test_get_yum_config to key off "reposdir" instead of "installonly_limit", since newer Fedora/RHEL yum configs no longer carry installonly_limit by default.

Note: requires a fedora-43 image in
ghcr.io/saltstack/salt-ci-containers/testing (tracked separately in saltstack/salt-ci-containers).

### What issues does this PR fix or reference?
Fixes #67182 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
