### PR TITLE
Fix module.run: positional arg for defaulted param raises 'multiple values'

### DIFF
--- a/changelog/69919.fixed.md
+++ b/changelog/69919.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``module.run`` raising ``got multiple values for argument`` when a positional argument was passed for a target function parameter that also has a default value.

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -118,6 +118,11 @@ def call_function(salt_function, *args, **kwargs):
                     # the kwargs list to be run.
                     function_kwargs.update(funcset)
     function_args.reverse()
+    # Drop any keyword-defaulted params already satisfied positionally,
+    # otherwise they'd be passed twice (once positionally, once via their
+    # stale default in function_kwargs).
+    for arg_name in argspec.args[: len(function_args)]:
+        function_kwargs.pop(arg_name, None)
     # Add kwargs passed as kwargs :)
     function_kwargs.update(kwargs)
     for arg in expected_args:

--- a/tests/pytests/unit/states/test_module.py
+++ b/tests/pytests/unit/states/test_module.py
@@ -510,6 +510,24 @@ def test_call_function_ordered_and_named_args():
         ) == (1, 2, 3, (), {})
 
 
+def test_call_function_positional_arg_with_default():
+    """
+    Regression test for issue 69919: passing a positional arg for a
+    parameter that also has a default value used to raise
+    "got multiple values for argument" because the default value stayed
+    in the keyword arguments alongside the positional one.
+    """
+
+    def rand_str(size=9999999, hash_type=None):
+        return (size, hash_type)
+
+    with patch.dict(module.__salt__, {"test.rand_str": rand_str}, clear=True):
+        assert module._call_function("test.rand_str", func_args=[999]) == (999, None)
+        assert module._call_function(
+            "test.rand_str", func_args=[999, "sha256"]
+        ) == (999, "sha256")
+
+
 def test_get_result():
     """
     Test _get_result routine when function returned result or retcode in it's results or in changes:


### PR DESCRIPTION
## Summary
Fixes #69919.

`module.run` (and anything else routed through `salt.utils.functools.call_function()`) crashed with `got multiple values for argument 'size'` when a positional argument was passed for a target-function parameter that also has a default value:

```
$ salt-call state.single module.run foo 'test.rand_str=[999]'
[ERROR   ] 'test.rand_str' failed: rand_str() got multiple values for argument 'size'
```

**Root cause**: `call_function()` pre-seeds `function_kwargs` with every defaulted parameter's default value up front, then appends raw positional list items to `function_args` without removing the corresponding key from `function_kwargs`. A parameter satisfied positionally that also happens to have a default (e.g. `size` in `test.rand_str`) ended up passed both positionally and via its stale default keyword — a genuine `TypeError`-equivalent collision.

**Fix**: once `function_args` is finalized, strip any `argspec.args` entries already covered positionally out of `function_kwargs` before merging in explicit kwargs and dict-style keyword items from the args list. This keeps the "kwargs win last" and missing-argument validation semantics intact.

## Test plan
- [x] Added `test_call_function_positional_arg_with_default` in `tests/pytests/unit/states/test_module.py`, reproducing the exact issue scenario.
- [x] `pytest tests/pytests/unit/states/test_module.py -v` — 24 passed.
- [x] `pytest tests/pytests/unit/modules/test_mine.py -v` (other caller of `call_function`) — 18 passed, no regressions.
- [x] Manually verified the fix against the reported repro shape (positional-only, positional+dict-kwarg, dict-kwarg-only, required-arg-missing-error cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)