### PR TITLE
Fix file.managed omitting mode from changes when creating a file

### DIFF
--- a/changelog/69969.fixed.md
+++ b/changelog/69969.fixed.md
@@ -1,0 +1,1 @@
+Fixed file.managed not including mode (and user/group) in changes when creating a new file, making created-file permissions unauditable from state output

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -6224,8 +6224,30 @@ def check_file_meta(
     except CommandExecutionError:
         lstats = {}
 
+    def _add_file_meta_changes(changes_dict, stats_data=None):
+        """
+        Record the requested user/group/mode into ``changes_dict`` for a file
+        that is being created. When a value was not passed explicitly, fall
+        back to ``stats_data`` (the ``stats()`` result for ``name``) so that
+        inherited permissions are still reported. Ownership and mode are not
+        tracked on Windows, so nothing is recorded there.
+        """
+        if salt.utils.platform.is_windows():
+            return
+        target_user = user or (stats_data.get("user") if stats_data else None)
+        target_group = group or (stats_data.get("group") if stats_data else None)
+        target_mode = mode or (stats_data.get("mode") if stats_data else None)
+        for key, val in (
+            ("user", target_user),
+            ("group", target_group),
+            ("mode", target_mode),
+        ):
+            if val is not None:
+                changes_dict[key] = val
+
     if not lstats and not new_file_diff:
         changes["newfile"] = name
+        _add_file_meta_changes(changes, lstats)
         if any([ignore_ordering, ignore_whitespace, ignore_comment_characters]):
             return True, changes
         return changes
@@ -6323,6 +6345,7 @@ def check_file_meta(
                 changes["diff"] = differences
 
     if not lstats:
+        _add_file_meta_changes(changes, lstats)
         return changes
 
     if not salt.utils.platform.is_windows():

--- a/tests/pytests/unit/modules/file/test_file_check.py
+++ b/tests/pytests/unit/modules/file/test_file_check.py
@@ -51,6 +51,86 @@ def get_link_perms():
     return "0755"
 
 
+@pytest.mark.skip_on_windows(
+    reason="File ownership and modes are not checked on Windows"
+)
+@pytest.mark.parametrize("new_file_diff", [False, True])
+def test_check_file_meta_new_file_reports_permissions(tmp_path, new_file_diff):
+    path = tmp_path / "file-that-does-not-exist"
+    assert not path.exists()
+    filename = str(path)
+
+    ret = filemod.check_file_meta(
+        filename,
+        None,
+        None,
+        None,
+        "test-user",
+        "test-group",
+        "0640",
+        None,
+        None,
+        new_file_diff=new_file_diff,
+    )
+
+    expected = {"user": "test-user", "group": "test-group", "mode": "0640"}
+    if not new_file_diff:
+        expected["newfile"] = filename
+    assert ret == expected
+
+
+@pytest.mark.skip_on_windows(
+    reason="File ownership and modes are not checked on Windows"
+)
+def test_check_file_meta_new_file_preserves_ignore_return_shape(tmp_path):
+    filename = str(tmp_path / "file-that-does-not-exist")
+
+    ret = filemod.check_file_meta(
+        filename,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "0640",
+        None,
+        None,
+        ignore_ordering=True,
+    )
+
+    assert ret == (True, {"newfile": filename, "mode": "0640"})
+
+
+@pytest.mark.skip_on_windows(
+    reason="File ownership and modes are not checked on Windows"
+)
+@pytest.mark.parametrize("new_file_diff", [False, True])
+def test_check_file_meta_new_file_reports_partial_permissions(tmp_path, new_file_diff):
+    """
+    Only the values that were requested are reported. Leaving user/group as the
+    Salt/OS default (``None``) must not add spurious keys to the changes.
+    """
+    filename = str(tmp_path / "file-that-does-not-exist")
+
+    ret = filemod.check_file_meta(
+        filename,
+        None,
+        None,
+        None,
+        None,
+        None,
+        "0640",
+        None,
+        None,
+        new_file_diff=new_file_diff,
+    )
+
+    expected = {"mode": "0640"}
+    if not new_file_diff:
+        expected["newfile"] = filename
+    assert ret == expected
+
+
 @pytest.mark.skip_on_windows(reason="os.symlink is not available on Windows")
 def test_check_file_meta_follow_symlinks(a_link, tfile):
     user = getpass.getuser()


### PR DESCRIPTION
## Summary
- `check_file_meta()` in `salt/modules/file.py` has two early-return points that fire when the target file does not yet exist (`lstats` falsy). Both skipped the entire mode/user/group comparison block, so `file.managed` only ever reported `{'newfile': name}` (test=True) or a diff (real run) when *creating* a file — never the mode being applied. When the file already existed, mode/user/group changes were reported correctly.
- This makes it impossible to audit, from state output alone, what permissions a newly-created file will get (e.g. `mode: '0600'` vs an unspecified umask-derived mode produce byte-identical `changes`).
- Fix: on the new-file paths, report the requested `mode`/`user`/`group` directly (there's nothing to diff against), guarded the same way as the existing-file case (skipped on Windows). Both early-return points are updated so behavior is consistent regardless of `new_file_diff`.

Fixes #69969

## Test plan
- [x] Added unit tests in `tests/pytests/unit/modules/file/test_file_check.py` covering a nonexistent target path with `mode`/`user`/`group` specified, for both `new_file_diff=True/False`, and for the `ignore_ordering`/tuple-return path.
- [x] Verified existing-file behavior is unchanged (no regression).
- [x] Added `changelog/69969.fixed.md`.

Note: ran `pytest tests/pytests/unit/modules/file/test_file_check.py` on Windows; the OS-gated tests (`skip_on_windows`) skip there since mode/user/group aren't applicable on Windows — the fix's logic was additionally verified directly against `check_file_meta()` with `salt.utils.platform.is_windows()` patched to `False`, confirming the new/existing-file paths behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)