### PR TITLE
Matrix nightly-stress-test.yml over master/3008.x/3006.x

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -16,14 +16,33 @@ jobs:
     # Repo-level opt-out. Set `SKIP_NIGHTLY_STRESS_TEST=true` on repos where
     # this shouldn't run (e.g. saltstack/salt — the stress test's runner cost
     # belongs on the salt-nightlies fork alongside the other nightlies infra).
+    # Applies uniformly to every branch in the matrix below.
     if: vars.SKIP_NIGHTLY_STRESS_TEST != 'true'
     # ``contents: write`` lets the ``Publish panels to stress-snapshots
     # branch`` step push the rendered PNGs to an orphan branch so the
     # step summary can embed them via raw.githubusercontent.com URLs.
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # `schedule:`/`workflow_dispatch:` triggers only ever run the
+        # workflow file as it exists on the default branch (master) --
+        # 3008.x, 3007.x, and 3006.x each carry their own copy of this
+        # file with the same `schedule:` block, but it has never
+        # actually fired for any of them (confirmed via the Actions run
+        # history: every `event: schedule` run is on master). Matrixing
+        # over branches here, with an explicit `ref: matrix.branch`
+        # checkout below, is what actually gets their nightly runs
+        # firing. 3007.x is deliberately left out for now -- its
+        # tests/monitoring/ predates render_panels.py, so the Render
+        # Dashboard Panels / Publish panels / Panel Summary steps below
+        # would fail against it as-is.
+        branch: [master, 3008.x, 3006.x]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,9 +51,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.branch }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.branch }}-
 
       - name: Build and Start Environment
         run: |
@@ -154,7 +173,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: stress-test-results
+          # Matrixed branches share one workflow run, and upload-artifact
+          # requires unique names within a run -- branch-qualify it so
+          # master/3008.x/3006.x don't collide.
+          name: stress-test-results-${{ matrix.branch }}
           path: |
             artifacts/
             prometheus-data.tar.gz
@@ -175,7 +197,10 @@ jobs:
           set -e
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           BRANCH=stress-snapshots
-          RUN_DIR="runs/${{ github.run_id }}"
+          # Matrixed branches share one github.run_id -- branch-qualify
+          # the run dir so master/3008.x/3006.x don't clobber each
+          # other's PNGs when they push concurrently.
+          RUN_DIR="runs/${{ github.run_id }}/${{ matrix.branch }}"
 
           if git ls-remote --exit-code --heads "$REPO_URL" "$BRANCH" >/dev/null 2>&1; then
             git clone --depth=1 --branch="$BRANCH" "$REPO_URL" snaps
@@ -230,6 +255,6 @@ jobs:
           cd tests/monitoring
           PANELS_DIR="${GITHUB_WORKSPACE}/artifacts/panels" \
             python3 render_panels.py --summary --from-existing \
-              --artifact-name stress-test-results \
+              --artifact-name stress-test-results-${{ matrix.branch }} \
               --artifact-url "${{ steps.upload-artifacts.outputs.artifact-url }}" \
               --image-url-prefix "${{ steps.publish-snapshots.outputs.url-prefix }}"


### PR DESCRIPTION
## Summary

`schedule:`/`workflow_dispatch:` triggers only ever run a workflow as it exists on the **default branch**. `3008.x` and `3006.x` each already carry their own copy of `nightly-stress-test.yml` with the same `schedule:` block, but it has never actually fired for either — checking the Actions run history for this workflow, every `event: schedule` run is on `master`; the other branches only ever show `event: workflow_dispatch` runs (or, for `3006.x`, none at all).

This matrixes the existing `stress-test` job over `branch: [master, 3008.x, 3006.x]`, with an explicit `ref: matrix.branch` checkout, so master's live schedule drives all three — each running its own checked-out `tests/monitoring/` code, unmodified. Branch-qualified the Docker layer cache key, the uploaded artifact name, and the `stress-snapshots` publish directory, since matrixed jobs share one `github.run_id`/`github.sha` and would otherwise collide.

`3007.x` is deliberately left out for now — its `tests/monitoring/` predates `render_panels.py`, so the Render Dashboard Panels / Publish panels / Panel Summary steps would fail against it as-is. Can follow up separately once that's backported.

**Note for maintainers:** `SKIP_NIGHTLY_STRESS_TEST` is currently `true` at the repo level, so this job (all three matrix legs) is skipped rather than actually running right now. That's unrelated to this change — flagging it since merging this alone won't make `3008.x`/`3006.x` start running until that variable is flipped.

## Test plan

- [x] Local `pre-commit` hooks pass (workflow lint/template checks included).
- [ ] After merge (and once `SKIP_NIGHTLY_STRESS_TEST` allows it to run), confirm all three matrix legs (`master`, `3008.x`, `3006.x`) fire on the `0 2 * * *` cron and each checks out its own branch correctly.