### PR TITLE
[Draft] 3008.x: rename nightly-stress-test.yml to run-stress-test.yml, add branch input

### DIFF
--- a/.github/workflows/run-stress-test.yml
+++ b/.github/workflows/run-stress-test.yml
@@ -1,10 +1,12 @@
-name: Nightly Stress Test
+name: Run Stress Test
 
 on:
-  schedule:
-    - cron: '0 2 * * *' # 2 AM UTC
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch'
+        required: true
+        default: '3008.x'
       duration:
         description: Stress test duration (GitHub-hosted runner caps at 6h)
         required: true
@@ -43,6 +45,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,9 +55,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ inputs.branch }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ inputs.branch }}-
 
       - name: Build and Start Environment
         run: |
@@ -82,8 +86,8 @@ jobs:
         # profile.  ``worker_threads`` sizes the MWorker pool and lets
         # a run sweep the parallelism / RSS trade-off.
         env:
-          ENABLE_METRICS: ${{ github.event.inputs.enable_metrics || 'false' }}
-          WORKER_THREADS: ${{ github.event.inputs.worker_threads || '5' }}
+          ENABLE_METRICS: ${{ inputs.enable_metrics || 'false' }}
+          WORKER_THREADS: ${{ inputs.worker_threads || '5' }}
         run: |
           cd tests/monitoring
           need_restart=0
@@ -171,7 +175,7 @@ jobs:
           STRESS_PID=$!
 
           # Default to 30m if not workflow_dispatch
-          DURATION="${{ github.event.inputs.duration || '0.5h' }}"
+          DURATION="${{ inputs.duration || '0.5h' }}"
           echo "Running stress test for $DURATION..."
 
           # Use sleep with suffix support (m, h)
@@ -226,7 +230,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: stress-test-results
+          name: stress-test-results-${{ inputs.branch }}
           path: |
             artifacts/
             prometheus-data.tar.gz
@@ -247,7 +251,7 @@ jobs:
           set -e
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           BRANCH=stress-snapshots
-          RUN_DIR="runs/${{ github.run_id }}"
+          RUN_DIR="runs/${{ github.run_id }}/${{ inputs.branch }}"
 
           if git ls-remote --exit-code --heads "$REPO_URL" "$BRANCH" >/dev/null 2>&1; then
             git clone --depth=1 --branch="$BRANCH" "$REPO_URL" snaps
@@ -302,6 +306,6 @@ jobs:
           cd tests/monitoring
           PANELS_DIR="${GITHUB_WORKSPACE}/artifacts/panels" \
             python3 render_panels.py --summary --from-existing \
-              --artifact-name stress-test-results \
+              --artifact-name stress-test-results-${{ inputs.branch }} \
               --artifact-url "${{ steps.upload-artifacts.outputs.artifact-url }}" \
               --image-url-prefix "${{ steps.publish-snapshots.outputs.url-prefix }}"


### PR DESCRIPTION
## Summary

Part of VCOPS-100029 (run a stress test against a specific PR/branch on demand). Companion to #70087 (master), which adds a `nightly-stress-test.yml` dispatcher on master that fires this branch's own copy of the (renamed) workflow nightly via `workflow_dispatch --ref 3008.x`, matching the `--ref matrix.branch` pattern already used by `run-nightly.yml`'s `trigger-branch-nightly-builds` job.

- Renamed `nightly-stress-test.yml` -> `run-stress-test.yml` (drops the dead `schedule:` trigger -- GitHub only honors `schedule:` off the repo's default branch, so it never fired on this branch anyway).
- Added a required `branch` input (default `3008.x`), used to `checkout` the actual code under test -- lets this be invoked against an arbitrary branch/PR, not just this one.
- Kept this branch's own `enable_metrics` / `worker_threads` inputs and `Configure salt-master` step as-is (not merged/aligned with master's simpler copy -- intentionally left divergent per-branch).
- Branch-qualified the Docker cache key, uploaded artifact name, and `stress-snapshots` run dir with `inputs.branch`, matching master's copy.

## Test plan

- [x] Local `pre-commit` hooks pass.
- [ ] After merge, confirm `workflow_dispatch` (manually, and via the master dispatcher once #70087 merges) runs successfully against this branch.