### PR TITLE
Add percentage-based Inode (Disk Files) panels for Minion 1/2/3

### DIFF
--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -300,11 +300,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 23,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)",
+          "legendFormat": "Minion 1 Inodes %",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 1 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 26
       },
       "id": 102,
       "title": "Minion 2",
@@ -327,7 +357,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 20
+        "y": 27
       },
       "id": 30,
       "targets": [
@@ -357,7 +387,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 20
+        "y": 27
       },
       "id": 31,
       "targets": [
@@ -387,7 +417,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 20
+        "y": 27
       },
       "id": 32,
       "targets": [
@@ -401,11 +431,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "id": 33,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)",
+          "legendFormat": "Minion 2 Inodes %",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 2 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 41
       },
       "id": 103,
       "title": "Minion 3",
@@ -428,7 +488,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 28
+        "y": 42
       },
       "id": 40,
       "targets": [
@@ -458,7 +518,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 28
+        "y": 42
       },
       "id": 41,
       "targets": [
@@ -488,7 +548,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 28
+        "y": 42
       },
       "id": 42,
       "targets": [
@@ -502,11 +562,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 49
+      },
+      "id": 43,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)",
+          "legendFormat": "Minion 3 Inodes %",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 3 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 56
       },
       "id": 104,
       "title": "Salt API",
@@ -529,7 +619,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 36
+        "y": 57
       },
       "id": 50,
       "targets": [
@@ -559,7 +649,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 57
       },
       "id": 51,
       "targets": [
@@ -589,7 +679,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 57
       },
       "id": 52,
       "targets": [


### PR DESCRIPTION
## Summary

Follow-up from a review comment on #70091 (Daniel Wozniak): the existing Minion Inode (Disk Files) panels show absolute inode counts; a percentage-used view "seems more intuitive." Daniel's own conclusion was "Both are probably useful," so this adds percentage as new, separate panels rather than replacing the absolute-count ones.

- New panels: "Minion 1/2/3 Inodes (% Used)" (ids 23/33/43), each `unit: percent`, inserted as its own row right after the corresponding minion's existing Inode panel.
- Expression per panel: `100 * (inodes_total - inodes_free) / inodes_total`, scoped to that minion's container via cAdvisor's `container_fs_inodes_total` / `container_fs_inodes_free`.
- All following sections cascade-shifted down (+7 per insertion) to avoid gridPos overlap; verified: 24 panels total, valid JSON, no overlaps.

### Why a separate panel instead of a second series on the existing one

Checked `render_panels.py`: each panel renders on a single shared matplotlib axis with one unit applied to the whole panel (no per-series unit/scale support). An absolute inode count (potentially thousands) and a 0-100 percentage on the same axis would make the percentage line unreadable, so percentage is a standalone panel.

### Scope note

Master's Inode panel (panel id 13, VCOPS-100030 / #70091) isn't touched here — that PR hasn't landed on `master` yet, so the panel doesn't exist on this branch. Adding the same percentage treatment to Master is tracked as a follow-up in VCOPS-109598, to be done once #70091 merges.

Jira: https://vmw-jira.broadcom.net/browse/VCOPS-109598

## Test plan

- [x] Validated `salt_monitoring.json` is well-formed JSON with no gridPos overlaps (script-checked)
- [ ] Confirm panels render correctly via a stress-test workflow run against this branch