### PR TITLE
Add process-level CPU metrics for Master/API (fd_exporter.py)

### DIFF
--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -155,12 +155,17 @@
       "id": 11,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}[1m])",
-          "legendFormat": "Master CPU",
+          "expr": "rate(salt_master_cpu_seconds_total[1m])",
+          "legendFormat": "Master Process CPU",
           "refId": "A"
+        },
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}[1m])",
+          "legendFormat": "Total Container CPU",
+          "refId": "B"
         }
       ],
-      "title": "Master CPU Usage",
+      "title": "Master CPU Usage (Process vs Container)",
       "type": "timeseries"
     },
     {
@@ -564,12 +569,17 @@
       "id": 51,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}[1m])",
-          "legendFormat": "API CPU",
+          "expr": "rate(salt_api_cpu_seconds_total[1m])",
+          "legendFormat": "API Process CPU",
           "refId": "A"
+        },
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{cpu=\"total\",container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-api\"}[1m])",
+          "legendFormat": "Total Container CPU",
+          "refId": "B"
         }
       ],
-      "title": "API CPU Usage",
+      "title": "API CPU Usage (Process vs Container)",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/srv/salt/fd_exporter.py
+++ b/tests/monitoring/srv/salt/fd_exporter.py
@@ -2,6 +2,8 @@
 import http.server
 import os
 
+_CLK_TCK = os.sysconf("SC_CLK_TCK")
+
 
 class FDHandler(http.server.BaseHTTPRequestHandler):
     def log_message(self, format, *args):
@@ -17,9 +19,11 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
             master_fds = 0
             master_procs = 0
             master_rss = 0
+            master_cpu = 0.0
             api_fds = 0
             api_procs = 0
             api_rss = 0
+            api_cpu = 0.0
 
             try:
                 # Iterate over /proc directly once for efficiency
@@ -48,23 +52,31 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
                             except (OSError, PermissionError):
                                 fd_count = 0
 
-                            # RSS Memory (from /proc/[pid]/stat, field 24 is RSS in pages)
+                            # RSS Memory (from /proc/[pid]/stat, field 24 is RSS in
+                            # pages) and CPU time (fields 14/15 are utime/stime, in
+                            # clock ticks -- same stat read as RSS, no extra syscall).
                             try:
                                 with open(f"/proc/{pid}/stat", encoding="utf-8") as f:
                                     stat = f.read().split()
                                     rss_pages = int(stat[23])
                                     rss_bytes = rss_pages * 4096  # Assuming 4KB pages
+                                    utime_ticks = int(stat[13])
+                                    stime_ticks = int(stat[14])
+                                    cpu_seconds = (utime_ticks + stime_ticks) / _CLK_TCK
                             except (OSError, ValueError, IndexError):
                                 rss_bytes = 0
+                                cpu_seconds = 0.0
 
                             if is_master:
                                 master_fds += fd_count
                                 master_procs += 1
                                 master_rss += rss_bytes
+                                master_cpu += cpu_seconds
                             if is_api:
                                 api_fds += fd_count
                                 api_procs += 1
                                 api_rss += rss_bytes
+                                api_cpu += cpu_seconds
                     except (FileNotFoundError, ProcessLookupError, PermissionError):
                         # Process died while we were reading it
                         continue
@@ -83,6 +95,10 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
                 "# HELP salt_master_rss_bytes RSS memory usage for master in bytes",
                 "# TYPE salt_master_rss_bytes gauge",
                 f"salt_master_rss_bytes {master_rss}",
+                "# HELP salt_master_cpu_seconds_total Cumulative user+system CPU "
+                "time for master processes, in seconds",
+                "# TYPE salt_master_cpu_seconds_total counter",
+                f"salt_master_cpu_seconds_total {master_cpu}",
                 "# HELP salt_api_open_fds Number of open file descriptors for salt-api",
                 "# TYPE salt_api_open_fds gauge",
                 f"salt_api_open_fds {api_fds}",
@@ -92,6 +108,10 @@ class FDHandler(http.server.BaseHTTPRequestHandler):
                 "# HELP salt_api_rss_bytes RSS memory usage for salt-api in bytes",
                 "# TYPE salt_api_rss_bytes gauge",
                 f"salt_api_rss_bytes {api_rss}",
+                "# HELP salt_api_cpu_seconds_total Cumulative user+system CPU "
+                "time for salt-api processes, in seconds",
+                "# TYPE salt_api_cpu_seconds_total counter",
+                f"salt_api_cpu_seconds_total {api_cpu}",
             ]
             self.wfile.write(("\n".join(lines) + "\n").encode())
         else:


### PR DESCRIPTION
## Summary

Follow-up from a review comment on #70091 (Daniel Wozniak). Master and API already have a process-vs-container split for memory (`salt_master_rss_bytes` / `salt_api_rss_bytes` vs `container_memory_rss`) and FD counts, but CPU only had the container-level number. This extends `fd_exporter.py` to collect process-level CPU too, following the existing pattern.

- `fd_exporter.py` already opens `/proc/{pid}/stat` per matched process to read RSS (field 24). This reads `utime`/`stime` (fields 14/15, clock ticks) from that same read and converts to seconds via `os.sysconf("SC_CLK_TCK")` — no extra syscall per process.
- New counters: `salt_master_cpu_seconds_total`, `salt_api_cpu_seconds_total`. Exposed as Prometheus counters (matching cAdvisor's `container_cpu_usage_seconds_total` counter semantics) so both go through `rate()` identically on the dashboard.
- Dashboard: panels 11 ("Master CPU Usage") and 51 ("API CPU Usage") become "... (Process vs Container)", each now plotting `rate(salt_*_cpu_seconds_total)` alongside the existing container-level `rate()`, mirroring panel 10's Master Memory RSS layout.

### Incidental fix

Panel 51's container-level query was copy-pasted from panel 11 and had been querying the `salt-master` container instead of `salt-api` since it was added. Fixed alongside, since leaving a known-wrong query next to the new process-level series would be worse than the noise of an unrelated one-line fix.

### Non-goal (explicitly scoped out)

No container-level FD panel is added. Investigated separately and ruled out: cAdvisor does not export any file-descriptor metric, so a container-level FD series isn't obtainable the same way memory/CPU are. Documented as a non-goal in VCOPS-109599's AC.

Jira: https://vmw-jira.broadcom.net/browse/VCOPS-109599

## Test plan

- [x] `pylint --rcfile=.pylintrc` against `fd_exporter.py` with the CI-pinned `pylint==3.1.1` + `saltpylint==2024.2.5` -- 10.00/10, no findings (verified locally in a throwaway venv since the repo's `lint-tests` pre-commit hook always installs `linux.lock`, which fails to build on macOS regardless of session variant -- unrelated to this change)
- [x] Dashboard JSON validated: well-formed, panel count/ids unchanged (21), only panels 11/51 modified
- [ ] Confirm new metrics render correctly via a stress-test workflow run against this branch