### PR TITLE
Add Master Inodes (Disk Files) panel to stress-test dashboard (3008.x)

### DIFF
--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -229,41 +229,11 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "unit": "percent"
-        }
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 18
-      },
-      "id": 14,
-      "targets": [
-        {
-          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name)",
-          "legendFormat": "Master Inodes (% Used)",
-          "refId": "A"
-        }
-      ],
-      "title": "Master Inodes (% Used)",
-      "type": "timeseries"
-    },
-    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 18
       },
       "id": 105,
       "title": "Per-Master-Process Memory (RSS + PSS)",
@@ -286,7 +256,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 26
+        "y": 19
       },
       "id": 200,
       "targets": [
@@ -321,7 +291,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 26
+        "y": 19
       },
       "id": 201,
       "targets": [
@@ -356,7 +326,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 26
+        "y": 19
       },
       "id": 202,
       "targets": [
@@ -391,7 +361,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 32
+        "y": 25
       },
       "id": 203,
       "targets": [
@@ -426,7 +396,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 32
+        "y": 25
       },
       "id": 204,
       "targets": [
@@ -461,7 +431,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 32
+        "y": 25
       },
       "id": 205,
       "targets": [
@@ -496,7 +466,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 38
+        "y": 31
       },
       "id": 206,
       "targets": [
@@ -531,7 +501,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 38
+        "y": 31
       },
       "id": 207,
       "targets": [
@@ -566,7 +536,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 38
+        "y": 31
       },
       "id": 208,
       "targets": [
@@ -601,7 +571,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 37
       },
       "id": 209,
       "targets": [
@@ -636,7 +606,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 44
+        "y": 37
       },
       "id": 210,
       "targets": [
@@ -671,7 +641,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 44
+        "y": 37
       },
       "id": 211,
       "targets": [
@@ -706,7 +676,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 43
       },
       "id": 212,
       "targets": [
@@ -741,7 +711,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 43
       },
       "id": 213,
       "targets": [
@@ -764,7 +734,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 49
       },
       "id": 101,
       "title": "Minion 1",
@@ -787,7 +757,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 57
+        "y": 50
       },
       "id": 20,
       "targets": [
@@ -817,7 +787,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 57
+        "y": 50
       },
       "id": 21,
       "targets": [
@@ -847,7 +817,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 57
+        "y": 50
       },
       "id": 22,
       "targets": [
@@ -865,7 +835,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 57
       },
       "id": 102,
       "title": "Minion 2",
@@ -888,7 +858,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 65
+        "y": 58
       },
       "id": 30,
       "targets": [
@@ -918,7 +888,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 65
+        "y": 58
       },
       "id": 31,
       "targets": [
@@ -948,7 +918,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 65
+        "y": 58
       },
       "id": 32,
       "targets": [
@@ -966,7 +936,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 65
       },
       "id": 103,
       "title": "Minion 3",
@@ -989,7 +959,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 73
+        "y": 66
       },
       "id": 40,
       "targets": [
@@ -1019,7 +989,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 73
+        "y": 66
       },
       "id": 41,
       "targets": [
@@ -1049,7 +1019,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 73
+        "y": 66
       },
       "id": 42,
       "targets": [
@@ -1067,7 +1037,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 73
       },
       "id": 104,
       "title": "Salt API",
@@ -1090,7 +1060,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 81
+        "y": 74
       },
       "id": 50,
       "targets": [
@@ -1120,7 +1090,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 81
+        "y": 74
       },
       "id": 51,
       "targets": [
@@ -1150,7 +1120,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 81
+        "y": 74
       },
       "id": 52,
       "targets": [

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -827,7 +827,7 @@
           "refId": "A"
         }
       ],
-      "title": "Minion Inodes (Disk Files)",
+      "title": "Minion 1 Inodes (Disk Files)",
       "type": "timeseries"
     },
     {
@@ -928,7 +928,7 @@
           "refId": "A"
         }
       ],
-      "title": "Minion Inodes (Disk Files)",
+      "title": "Minion 2 Inodes (Disk Files)",
       "type": "timeseries"
     },
     {

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -199,11 +199,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name)",
+          "legendFormat": "Master Inodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Master Inodes (Disk Files)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 18
       },
       "id": 105,
       "title": "Per-Master-Process Memory (RSS + PSS)",
@@ -226,7 +256,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 12
+        "y": 19
       },
       "id": 200,
       "targets": [
@@ -261,7 +291,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 12
+        "y": 19
       },
       "id": 201,
       "targets": [
@@ -296,7 +326,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 12
+        "y": 19
       },
       "id": 202,
       "targets": [
@@ -331,7 +361,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 18
+        "y": 25
       },
       "id": 203,
       "targets": [
@@ -366,7 +396,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 18
+        "y": 25
       },
       "id": 204,
       "targets": [
@@ -401,7 +431,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 25
       },
       "id": 205,
       "targets": [
@@ -436,7 +466,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 24
+        "y": 31
       },
       "id": 206,
       "targets": [
@@ -471,7 +501,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 24
+        "y": 31
       },
       "id": 207,
       "targets": [
@@ -506,7 +536,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 24
+        "y": 31
       },
       "id": 208,
       "targets": [
@@ -541,7 +571,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 209,
       "targets": [
@@ -576,7 +606,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 30
+        "y": 37
       },
       "id": 210,
       "targets": [
@@ -611,7 +641,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 30
+        "y": 37
       },
       "id": 211,
       "targets": [
@@ -646,7 +676,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 36
+        "y": 43
       },
       "id": 212,
       "targets": [
@@ -681,7 +711,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 43
       },
       "id": 213,
       "targets": [
@@ -704,7 +734,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 49
       },
       "id": 101,
       "title": "Minion 1",
@@ -727,7 +757,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 43
+        "y": 50
       },
       "id": 20,
       "targets": [
@@ -757,7 +787,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 43
+        "y": 50
       },
       "id": 21,
       "targets": [
@@ -787,7 +817,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 43
+        "y": 50
       },
       "id": 22,
       "targets": [
@@ -805,7 +835,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 57
       },
       "id": 102,
       "title": "Minion 2",
@@ -828,7 +858,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 51
+        "y": 58
       },
       "id": 30,
       "targets": [
@@ -858,7 +888,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 51
+        "y": 58
       },
       "id": 31,
       "targets": [
@@ -888,7 +918,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 51
+        "y": 58
       },
       "id": 32,
       "targets": [
@@ -906,7 +936,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 65
       },
       "id": 103,
       "title": "Minion 3",
@@ -929,7 +959,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 66
       },
       "id": 40,
       "targets": [
@@ -959,7 +989,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 59
+        "y": 66
       },
       "id": 41,
       "targets": [
@@ -989,7 +1019,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 66
       },
       "id": 42,
       "targets": [
@@ -1007,7 +1037,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 73
       },
       "id": 104,
       "title": "Salt API",
@@ -1030,7 +1060,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 67
+        "y": 74
       },
       "id": 50,
       "targets": [
@@ -1060,7 +1090,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 67
+        "y": 74
       },
       "id": 51,
       "targets": [
@@ -1090,7 +1120,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 67
+        "y": 74
       },
       "id": 52,
       "targets": [

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -229,11 +229,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 14,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-master\"}) by (name)",
+          "legendFormat": "Master Inodes (% Used)",
+          "refId": "A"
+        }
+      ],
+      "title": "Master Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 25
       },
       "id": 105,
       "title": "Per-Master-Process Memory (RSS + PSS)",
@@ -256,7 +286,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 19
+        "y": 26
       },
       "id": 200,
       "targets": [
@@ -291,7 +321,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 19
+        "y": 26
       },
       "id": 201,
       "targets": [
@@ -326,7 +356,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 19
+        "y": 26
       },
       "id": 202,
       "targets": [
@@ -361,7 +391,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 25
+        "y": 32
       },
       "id": 203,
       "targets": [
@@ -396,7 +426,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 25
+        "y": 32
       },
       "id": 204,
       "targets": [
@@ -431,7 +461,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 25
+        "y": 32
       },
       "id": 205,
       "targets": [
@@ -466,7 +496,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "id": 206,
       "targets": [
@@ -501,7 +531,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 31
+        "y": 38
       },
       "id": 207,
       "targets": [
@@ -536,7 +566,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 31
+        "y": 38
       },
       "id": 208,
       "targets": [
@@ -571,7 +601,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 37
+        "y": 44
       },
       "id": 209,
       "targets": [
@@ -606,7 +636,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 37
+        "y": 44
       },
       "id": 210,
       "targets": [
@@ -641,7 +671,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 37
+        "y": 44
       },
       "id": 211,
       "targets": [
@@ -676,7 +706,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 43
+        "y": 50
       },
       "id": 212,
       "targets": [
@@ -711,7 +741,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 43
+        "y": 50
       },
       "id": 213,
       "targets": [
@@ -734,7 +764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 56
       },
       "id": 101,
       "title": "Minion 1",
@@ -757,7 +787,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 57
       },
       "id": 20,
       "targets": [
@@ -787,7 +817,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 57
       },
       "id": 21,
       "targets": [
@@ -817,7 +847,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 57
       },
       "id": 22,
       "targets": [
@@ -835,7 +865,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 64
       },
       "id": 102,
       "title": "Minion 2",
@@ -858,7 +888,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 58
+        "y": 65
       },
       "id": 30,
       "targets": [
@@ -888,7 +918,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 58
+        "y": 65
       },
       "id": 31,
       "targets": [
@@ -918,7 +948,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 58
+        "y": 65
       },
       "id": 32,
       "targets": [
@@ -936,7 +966,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 72
       },
       "id": 103,
       "title": "Minion 3",
@@ -959,7 +989,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 66
+        "y": 73
       },
       "id": 40,
       "targets": [
@@ -989,7 +1019,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 66
+        "y": 73
       },
       "id": 41,
       "targets": [
@@ -1019,7 +1049,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 66
+        "y": 73
       },
       "id": 42,
       "targets": [
@@ -1037,7 +1067,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 80
       },
       "id": 104,
       "title": "Salt API",
@@ -1060,7 +1090,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 74
+        "y": 81
       },
       "id": 50,
       "targets": [
@@ -1090,7 +1120,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 74
+        "y": 81
       },
       "id": 51,
       "targets": [
@@ -1120,7 +1150,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 74
+        "y": 81
       },
       "id": 52,
       "targets": [

--- a/tests/monitoring/render_panels.py
+++ b/tests/monitoring/render_panels.py
@@ -126,6 +126,12 @@ def _is_percentunit(unit_hint: str) -> bool:
     return unit_hint.lower() == "percentunit"
 
 
+def _is_percent(unit_hint: str) -> bool:
+    # Grafana's "percent" is already a 0-100 value (unlike "percentunit",
+    # a 0-1 ratio) -- distinct unit string, distinct handling below.
+    return unit_hint.lower() == "percent"
+
+
 def _is_count_unit(unit_hint: str) -> bool:
     return unit_hint.lower() == "short"
 
@@ -139,6 +145,7 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     unit_hint = panel.get("fieldConfig", {}).get("defaults", {}).get("unit") or ""
     is_bytes = _bytes_unit(unit_hint)
     is_percentunit = _is_percentunit(unit_hint)
+    is_percent = _is_percent(unit_hint)
     is_count = _is_count_unit(unit_hint)
 
     fig, ax = plt.subplots(figsize=(11, 4))
@@ -181,6 +188,16 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
         # are already in that ratio, so label explicitly to avoid confusing
         # "1.2" with "1.2% of the host" instead of 1.2 CPU cores.
         ax.set_ylabel("CPU cores (1.0 = 1 core)")
+    elif is_percent:
+        # Values are already 0-100 (unlike percentunit's 0-1), so no
+        # rescaling -- just label and fix the axis to the full 0-100
+        # range. Without an explicit ylim, matplotlib autoscales to the
+        # data's actual min/max; a series that hovers in a narrow band
+        # near 100 (e.g. 99.6-100.0) then gets zoomed in so tightly it
+        # renders as a flat line pinned to the top, hiding real
+        # movement instead of showing it's nearly saturated.
+        ax.set_ylabel("%")
+        ax.set_ylim(0, 100)
     elif is_count:
         # "short" also covers FD/process counts (Master & API Resource Usage)
         # alongside inode counts -- disambiguate from the panel title so the


### PR DESCRIPTION
## Summary

VCOPS-100030: Master, Minions, and API already have their resource panels on the stress-test Grafana dashboard, but Master had no inode/disk-file count panel even though all three Minions do. Adds "Master Inodes (Disk Files)", following the same `container_fs_inodes_total - container_fs_inodes_free` pattern already used for the Minion inode panels, scoped to the `salt-master` container.

Inserted as a new row directly below the existing Master row (Memory / CPU / FDs), before the Per-Master-Process section; every panel from the Per-Master-Process header onward cascade-shifts down by 7 grid units. 37 panels total, verified no gridPos overlaps.


## Test plan

- [x] Validated `salt_monitoring.json` is well-formed JSON with no gridPos overlaps (script-checked)
- [x] Confirm panel renders correctly via a stress-test workflow run against this branch

https://github.com/saltstack/salt/actions/runs/32295402330
New dashboard has introduced Inodes for master as well.