### PR TITLE
Add percentage-based Inode (Disk Files) panels for Minion 1/2/3 (3008.x)

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -11,6 +11,7 @@ on:
         default: '0.5h'
         type: choice
         options:
+          - '10m'
           - '0.5h'
           - '1h'
           - '1.5h'

--- a/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
+++ b/tests/monitoring/grafana/provisioning/dashboards/salt_monitoring.json
@@ -801,11 +801,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 50
+      },
+      "id": 23,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-1\"}) by (name)",
+          "legendFormat": "Minion 1 Inodes (% Used)",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 1 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 57
       },
       "id": 102,
       "title": "Minion 2",
@@ -828,7 +858,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 51
+        "y": 58
       },
       "id": 30,
       "targets": [
@@ -858,7 +888,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 51
+        "y": 58
       },
       "id": 31,
       "targets": [
@@ -888,7 +918,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 51
+        "y": 58
       },
       "id": 32,
       "targets": [
@@ -902,11 +932,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 65
+      },
+      "id": 33,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-2\"}) by (name)",
+          "legendFormat": "Minion 2 Inodes (% Used)",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 2 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 72
       },
       "id": 103,
       "title": "Minion 3",
@@ -929,7 +989,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 73
       },
       "id": 40,
       "targets": [
@@ -959,7 +1019,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 59
+        "y": 73
       },
       "id": 41,
       "targets": [
@@ -989,7 +1049,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 73
       },
       "id": 42,
       "targets": [
@@ -1003,11 +1063,41 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 80
+      },
+      "id": 43,
+      "targets": [
+        {
+          "expr": "100 * (sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name) - sum(container_fs_inodes_free{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)) / sum(container_fs_inodes_total{container_label_com_docker_compose_project=\"monitoring\",container_label_com_docker_compose_service=\"salt-minion-3\"}) by (name)",
+          "legendFormat": "Minion 3 Inodes (% Used)",
+          "refId": "A"
+        }
+      ],
+      "title": "Minion 3 Inodes (% Used)",
+      "type": "timeseries"
+    },
+    {
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 87
       },
       "id": 104,
       "title": "Salt API",
@@ -1030,7 +1120,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 67
+        "y": 88
       },
       "id": 50,
       "targets": [
@@ -1060,7 +1150,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 67
+        "y": 88
       },
       "id": 51,
       "targets": [
@@ -1090,7 +1180,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 67
+        "y": 88
       },
       "id": 52,
       "targets": [

--- a/tests/monitoring/render_panels.py
+++ b/tests/monitoring/render_panels.py
@@ -126,6 +126,12 @@ def _is_percentunit(unit_hint: str) -> bool:
     return unit_hint.lower() == "percentunit"
 
 
+def _is_percent(unit_hint: str) -> bool:
+    # Grafana's "percent" is already a 0-100 value (unlike "percentunit",
+    # a 0-1 ratio) -- distinct unit string, distinct handling below.
+    return unit_hint.lower() == "percent"
+
+
 def _is_count_unit(unit_hint: str) -> bool:
     return unit_hint.lower() == "short"
 
@@ -139,6 +145,7 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
     unit_hint = panel.get("fieldConfig", {}).get("defaults", {}).get("unit") or ""
     is_bytes = _bytes_unit(unit_hint)
     is_percentunit = _is_percentunit(unit_hint)
+    is_percent = _is_percent(unit_hint)
     is_count = _is_count_unit(unit_hint)
 
     fig, ax = plt.subplots(figsize=(11, 4))
@@ -181,6 +188,16 @@ def render_panel(panel: dict, end_ts: float) -> plt.Figure | None:
         # are already in that ratio, so label explicitly to avoid confusing
         # "1.2" with "1.2% of the host" instead of 1.2 CPU cores.
         ax.set_ylabel("CPU cores (1.0 = 1 core)")
+    elif is_percent:
+        # Values are already 0-100 (unlike percentunit's 0-1), so no
+        # rescaling -- just label and fix the axis to the full 0-100
+        # range. Without an explicit ylim, matplotlib autoscales to the
+        # data's actual min/max; a series that hovers in a narrow band
+        # near 100 (e.g. 99.6-100.0) then gets zoomed in so tightly it
+        # renders as a flat line pinned to the top, hiding real
+        # movement instead of showing it's nearly saturated.
+        ax.set_ylabel("%")
+        ax.set_ylim(0, 100)
     elif is_count:
         # "short" also covers FD/process counts (Master & API Resource Usage)
         # alongside inode counts -- disambiguate from the panel title so the


### PR DESCRIPTION
## Summary

- New panels: "Minion 1/2/3 Inodes (% Used)" (ids 23/33/43), each `unit: percent`, inserted as its own row right after the corresponding minion's existing panel row.
- Expression per panel: `100 * (inodes_total - inodes_free) / inodes_total`, scoped to that minion's container via cAdvisor's `container_fs_inodes_total` / `container_fs_inodes_free`.
- All following sections cascade-shifted down (+7 per insertion) to avoid gridPos overlap; verified: 39 panels total, valid JSON, no overlaps.

### Why a separate panel instead of a second series on the existing one

Checked `render_panels.py` on this branch: each panel renders on a single shared matplotlib axis with one unit applied to the whole panel (no per-series unit/scale support). An absolute inode count and a 0-100 percentage on the same axis would make the percentage line unreadable, so percentage is a standalone panel.


## Note


## Test plan

- [x] Validated `salt_monitoring.json` is well-formed JSON with no gridPos overlaps (script-checked)
- [ ] Confirm panels render correctly via a stress-test workflow run against this branch