### PR TITLE
fix: defer fetch request when repo is not yet initialized during GitProvider init

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1350,6 +1350,19 @@ class GitProvider:
     def fetch_request_check(self):
         fetch_request = salt.utils.path.join(self._salt_working_dir, "fetch_request")
         if os.path.isfile(fetch_request):
+            if getattr(self, "repo", None) is None:
+                # The repo has not yet been initialized (e.g. we are being
+                # called from GitProvider.__init__ before the provider's
+                # init_remote() has run). Leave the fetch request in place
+                # so that a later call to this method (e.g. from checkout())
+                # can honor it once self.repo exists.
+                log.debug(
+                    "Fetch request present for %s remote '%s', but repo is "
+                    "not yet initialized; deferring",
+                    self.role,
+                    self.id,
+                )
+                return False
             log.debug("Fetch request: %s", self._salt_working_dir)
             try:
                 os.remove(fetch_request)


### PR DESCRIPTION
Fixes #70081

## Summary

During `GitProvider.__init__()`, `fetch_request_check()` is called (line 531) *before* the provider subclass has had a chance to call `init_remote()`. If a `fetch_request` file happens to exist in the salt working dir at this point (e.g. left over from a prior run), the code path:

```
fetch_request_check() -> self.fetch() -> self._fetch()
```

immediately accesses `self.repo.remotes[0]` (Pygit2 `_fetch`, and GitPython `_fetch` both do this). But `self.repo` is only set later, inside `init_remote()`, which the subclasses call *after* `super().__init__()` returns. The result is an intermittent `AttributeError: 'Pygit2' object has no attribute 'repo'` (or `'GitPython'`) that makes git_pillar/gitfs highstates fail every few runs.

## Fix

In `fetch_request_check()`, check `getattr(self, "repo", None)`. If the repo is not yet initialized, return `False` **without removing the fetch_request file** — the file is preserved so the next call to `fetch_request_check()` (from `checkout()`, by which time `self.repo` exists) processes it.

- Applies to both `Pygit2` and `GitPython` providers.
- `GitCLI` is unaffected (its `_fetch()` shells out to the git binary and never touches `self.repo`).

## Tests

- `tests/pytests/functional/utils/gitfs/test_gitfs.py`
- `tests/pytests/functional/utils/gitfs/test_pillar.py`
