### PR TITLE
Retry chocolatey installer download on transient HTTP errors in test fixture

### DIFF
--- a/tests/pytests/functional/states/test_chocolatey_latest.py
+++ b/tests/pytests/functional/states/test_chocolatey_latest.py
@@ -2,13 +2,18 @@
 Functional tests for chocolatey state
 """
 
+import logging
 import os
 import pathlib
+import time
 
 import pytest
 
 import salt.utils.path
 import salt.utils.win_reg
+from salt.exceptions import MinionError
+
+log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
@@ -16,6 +21,23 @@ pytestmark = [
     pytest.mark.slow_test,
     pytest.mark.destructive_test,
 ]
+
+# HTTP status codes and error substrings that indicate a transient failure of
+# the Chocolatey Community Repository (proxy/CDN blips, rate limits, TCP
+# resets). Matched against the ``MinionError`` message text raised by
+# ``cp.get_url`` — that is the only signal available to the fixture.
+_TRANSIENT_HTTP_MARKERS = (
+    "HTTP 502",
+    "HTTP 503",
+    "HTTP 504",
+    "HTTP 429",
+    "Connection reset",
+    "Connection aborted",
+    "Connection refused",
+    "Read timed out",
+    "timed out",
+    "Temporary failure",
+)
 
 
 @pytest.fixture(scope="module")
@@ -37,11 +59,46 @@ def chocolatey_mod(modules):
     choco_dir = choco_pkg.parent / "choco_dir"
     choco_script = choco_dir / "tools" / "chocolateyInstall.ps1"
 
+    def _download_installer(attempts=5, base_delay=2, max_delay=30):
+        # The Chocolatey Community Repository (community.chocolatey.org)
+        # intermittently returns HTTP 5xx/429 from its CDN, which breaks
+        # nightly CI runs whose only crime is timing. Retry with exponential
+        # backoff on those transient errors before giving up. See failing
+        # nightly runs for context:
+        #   https://github.com/saltstack/salt-nightlies/actions/runs/32316673545
+        #   https://github.com/saltstack/salt-nightlies/actions/runs/32200698572
+        last_error = None
+        for attempt in range(1, attempts + 1):
+            try:
+                modules.cp.get_url(path=url, dest=str(choco_pkg))
+                return
+            except MinionError as exc:
+                message = str(exc)
+                if not any(marker in message for marker in _TRANSIENT_HTTP_MARKERS):
+                    raise
+                last_error = exc
+                if attempt == attempts:
+                    break
+                delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+                log.warning(
+                    "Transient error fetching chocolatey installer (attempt "
+                    "%d/%d): %s; retrying in %ds",
+                    attempt,
+                    attempts,
+                    message,
+                    delay,
+                )
+                time.sleep(delay)
+        pytest.skip(
+            "Chocolatey Community Repository unavailable after "
+            f"{attempts} attempts: {last_error}"
+        )
+
     def install():
         # Install Chocolatey 1.2.1
 
         # Download Package
-        modules.cp.get_url(path=url, dest=str(choco_pkg))
+        _download_installer()
 
         # Unzip Package
         modules.archive.unzip(


### PR DESCRIPTION
### What does this PR do?
Hardens the `chocolatey_mod` module-scoped fixture in
`tests/pytests/functional/states/test_chocolatey_latest.py` so that the
Windows nightly `functional zeromq 3` jobs stop failing every time the
Chocolatey Community Repository (community.chocolatey.org) returns a
transient HTTP 5xx / 429 from its CDN.

Two-layer fix, both applied:

1. Retry the `cp.get_url` call for the installer nupkg with exponential
   backoff (up to 5 attempts, cap ~30s per sleep) on the transient
   markers: `HTTP 502/503/504/429`, connection resets, read timeouts.
2. If retries exhaust, `pytest.skip` with a message naming the failure
   count and the last error. This is **not** a `skipif` at collection
   time hiding a Salt bug — it fires only when the external service is
   genuinely down, and the tests literally cannot run without the
   installer download.

### What issues does this PR fix or reference?
No open issue — surfaced by the nightly job failure:

- https://github.com/saltstack/salt-nightlies/actions/runs/32316673545 (2026-08-20)
- https://github.com/saltstack/salt-nightlies/actions/runs/32200698572 (2026-08-19)

Both nights, both Windows 2022 and Windows 2025, the
`Test Salt / Windows <year> functional zeromq 3` job failed at
`chocolatey_mod` fixture setup with:

```
salt.exceptions.MinionError: Error: HTTP 504: Gateway Timeout reading /api/v2/package/chocolatey/
```

### Previous Behavior
Any transient blip from community.chocolatey.org made the fixture
raise on the first call, erroring all five tests
(`test_installed_latest`, `test_installed_version`,
`test_installed_version_existing_capitalization`, `test_uninstalled`,
`test_upgraded`) at setup.

### New Behavior
Transient HTTP errors are retried with backoff; if the service is
still down after the retry budget is exhausted, the tests are skipped
at runtime with a clear message rather than reported as errors.

### Merge-forward
This will merge forward to 3007.x / 3008.x / master via the standard
merge-forward branches. No sibling PRs.

### Test-only change
This is a test-fixture hardening only. No production Salt code is
touched, so no changelog fragment. A regression test for this class of
fix is impractical — it would require simulating community.chocolatey.org
returning HTTP 504.

### Merge requirements satisfied?
- [x] Docs (n/a — test infrastructure)
- [x] Changelog (n/a — test-only fixture change)
- [x] Tests written/updated (this is a test fixture change)

### Commits signed with GPG?
Yes
