### PR TITLE
Bump packaged pip to 26.2 and relenv to 0.22.22 (CVE-2026-44432)

### DIFF
--- a/changelog/70109.fixed.md
+++ b/changelog/70109.fixed.md
@@ -1,1 +1,3 @@
 Updated the pip shipped in Salt's packaged onedir builds from 26.1.2 to 26.2. This fixes CVE-2026-44432 (urllib3 decompression-bomb bypass), since pip 26.2 vendors a fixed urllib3 2.7.0.
+
+pip 26.2 also completed its deprecation of applying `PIP_CONSTRAINT` to PEP 517 build environments, so ``tools/pkg/build.py`` now also sets `PIP_BUILD_CONSTRAINT` wherever it sets `PIP_CONSTRAINT`, keeping build-time dependencies (e.g. the `Cython<3.3` pin needed for pyzmq) constrained during onedir/package builds.

--- a/changelog/70109.fixed.md
+++ b/changelog/70109.fixed.md
@@ -1,0 +1,1 @@
+Updated the pip shipped in Salt's packaged onedir builds from 26.1.2 to 26.2. This fixes CVE-2026-44432 (urllib3 decompression-bomb bypass), since pip 26.2 vendors a fixed urllib3 2.7.0.

--- a/pkg/macos/install_salt.sh
+++ b/pkg/macos/install_salt.sh
@@ -134,6 +134,7 @@ if [ -f "$BUILD_DIR/bin/distro" ]; then
     rm -f "$PIP_LOG"
 else
     cat "$PIP_LOG"
+    rm -f "$PIP_LOG"
     _failure
 fi
 

--- a/pkg/macos/install_salt.sh
+++ b/pkg/macos/install_salt.sh
@@ -127,10 +127,13 @@ fi
 # Install Requirements into the Python Environment
 #-------------------------------------------------------------------------------
 _msg "Installing Salt requirements"
-$PIP_BIN install -r "$REQ_FILE" > /dev/null 2>&1
+PIP_LOG="$(mktemp)"
+$PIP_BIN install -r "$REQ_FILE" > "$PIP_LOG" 2>&1
 if [ -f "$BUILD_DIR/bin/distro" ]; then
     _success
+    rm -f "$PIP_LOG"
 else
+    cat "$PIP_LOG"
     _failure
 fi
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,7 +19,7 @@ setuptools >= 78.1.1
 # build envs on the pre-split 9.x series for every source build.
 setuptools-scm < 10
 # This pin is for the dev/lint tooling venvs only -- tools/pkg/build.py
-# pins the packaged/shipped pip independently (currently 26.1.2) and is
+# pins the packaged/shipped pip independently (currently 26.2) and is
 # unaffected by this value. Bumping past 25.2 here causes the noxfile
 # bootstrap pip install in the lint-pre-commit hook to upgrade the
 # just-installed 25.2 inside the pre-commit hook venv on Python 3.14,

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -30,6 +30,22 @@ log = logging.getLogger(__name__)
 _DOWNLOADED_PIP_WHEEL: pathlib.Path | None = None
 
 
+def _set_pip_constraint_env(env: dict[str, str]) -> None:
+    """
+    Point PIP_CONSTRAINT, and its PEP 517 build-env counterpart
+    PIP_BUILD_CONSTRAINT, at requirements/constraints.txt.
+
+    pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
+    environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
+    the replacement for constraining build-time dependencies such as
+    Cython.
+    """
+    env["PIP_CONSTRAINT"] = str(
+        tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
+    )
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
+
+
 def _download_pip_wheel(ctx: Context) -> pathlib.Path:
     """
     Download pip==26.2 into a temporary directory and return the path to
@@ -151,14 +167,7 @@ def debian(
             env_args.append(f"--prepend-path={cargo_home_bin}")
 
     env = os.environ.copy()
-    env["PIP_CONSTRAINT"] = str(
-        tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
-    )
-    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
-    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
-    # the replacement for constraining build-time dependencies such as
-    # Cython.
-    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
+    _set_pip_constraint_env(env)
 
     ctx.run("ln", "-sf", "pkg/debian/", ".")
     debuild_flags = ["-uc", "-us"]
@@ -241,14 +250,7 @@ def rpm(
             os.environ[key] = value
 
     env = os.environ.copy()
-    env["PIP_CONSTRAINT"] = str(
-        tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
-    )
-    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
-    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
-    # the replacement for constraining build-time dependencies such as
-    # Cython.
-    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
+    _set_pip_constraint_env(env)
     spec_file = checkout / "pkg" / "rpm" / "salt.spec"
     ctx.run(
         "rpmbuild", "-bb", f"--define=_salt_src {checkout}", str(spec_file), env=env
@@ -760,15 +762,11 @@ def onedir_dependencies(
     )
     _check_pkg_build_files_exist(ctx, requirements_file=requirements_file)
 
-    env["PIP_CONSTRAINT"] = str(
-        tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
-    )
-    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
-    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
-    # the replacement for constraining build-time dependencies such as
-    # Cython, which matters here since install_args enables
-    # --no-binary=:all: for several platforms.
-    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
+    # This matters here since install_args enables --no-binary=:all: for
+    # several platforms, which makes PIP_BUILD_CONSTRAINT (rather than just
+    # PIP_CONSTRAINT) the one that actually constrains build-time
+    # dependencies such as Cython.
+    _set_pip_constraint_env(env)
     ctx.run(
         str(python_bin),
         "-m",
@@ -1042,14 +1040,7 @@ def salt_onedir(
         embed_dir.mkdir(parents=True, exist_ok=True)
 
     # download new virtualenv embedded wheels
-    env["PIP_CONSTRAINT"] = str(
-        tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
-    )
-    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
-    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
-    # the replacement for constraining build-time dependencies such as
-    # Cython.
-    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
+    _set_pip_constraint_env(env)
     # Download setuptools and wheel normally; pip is handled separately below
     # so that the pinned version is used instead of whatever PyPI resolves.
     ctx.run(
@@ -1061,6 +1052,7 @@ def salt_onedir(
         "wheel",
         "--dest",
         str(embed_dir),
+        env=env,
     )
     # Copy the pinned pip wheel into the embed directory so that virtualenv
     # seeds new environments with it.

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -154,6 +154,11 @@ def debian(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
+    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
+    # the replacement for constraining build-time dependencies such as
+    # Cython.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
 
     ctx.run("ln", "-sf", "pkg/debian/", ".")
     debuild_flags = ["-uc", "-us"]
@@ -239,6 +244,11 @@ def rpm(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
+    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
+    # the replacement for constraining build-time dependencies such as
+    # Cython.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     spec_file = checkout / "pkg" / "rpm" / "salt.spec"
     ctx.run(
         "rpmbuild", "-bb", f"--define=_salt_src {checkout}", str(spec_file), env=env
@@ -753,6 +763,12 @@ def onedir_dependencies(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
+    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
+    # the replacement for constraining build-time dependencies such as
+    # Cython, which matters here since install_args enables
+    # --no-binary=:all: for several platforms.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     ctx.run(
         str(python_bin),
         "-m",
@@ -766,11 +782,15 @@ def onedir_dependencies(
     # Install the pinned pip version instead of leaving relenv's bundled
     # copy in place. --force-reinstall is required because relenv ships
     # with pip pre-installed, so without it pip would skip the install as
-    # "already satisfied". PIP_CONSTRAINT is dropped for this single call
-    # because requirements/constraints.txt pins pip to an older version for
-    # the dev/lint tooling, which would conflict with the newer pip
-    # explicitly requested here.
-    pip_env = {k: v for k, v in env.items() if k != "PIP_CONSTRAINT"}
+    # "already satisfied". PIP_CONSTRAINT/PIP_BUILD_CONSTRAINT are dropped
+    # for this single call because requirements/constraints.txt pins pip to
+    # an older version for the dev/lint tooling, which would conflict with
+    # the newer pip explicitly requested here.
+    pip_env = {
+        k: v
+        for k, v in env.items()
+        if k not in ("PIP_CONSTRAINT", "PIP_BUILD_CONSTRAINT")
+    }
     ctx.run(
         str(python_bin),
         "-m",
@@ -1025,6 +1045,11 @@ def salt_onedir(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # pip >= 26.2 no longer applies PIP_CONSTRAINT to PEP 517 build
+    # environments (the gone_in="26.2" deprecation); PIP_BUILD_CONSTRAINT is
+    # the replacement for constraining build-time dependencies such as
+    # Cython.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     # Download setuptools and wheel normally; pip is handled separately below
     # so that the pinned version is used instead of whatever PyPI resolves.
     ctx.run(

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -32,29 +32,30 @@ _DOWNLOADED_PIP_WHEEL: pathlib.Path | None = None
 
 def _download_pip_wheel(ctx: Context) -> pathlib.Path:
     """
-    Download pip==26.1.2 into a temporary directory and return the path to
+    Download pip==26.2 into a temporary directory and return the path to
     the wheel. The result is cached for the lifetime of the current process
     so subsequent calls are free.
 
-    pip 26.1.2 vendors urllib3 2.6.3, which already contains upstream fixes
-    for CVE-2025-66418 and CVE-2026-21441 -- no patching is needed.
+    pip 26.2 vendors urllib3 2.7.0, which already contains upstream fixes
+    for CVE-2025-66418, CVE-2026-21441, and CVE-2026-44432 -- no patching
+    is needed.
     """
     global _DOWNLOADED_PIP_WHEEL
     if _DOWNLOADED_PIP_WHEEL is not None:
         return _DOWNLOADED_PIP_WHEEL
 
     tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="salt-pip-download-"))
-    ctx.info("Downloading pip==26.1.2 ...")
+    ctx.info("Downloading pip==26.2 ...")
     # Drop PIP_CONSTRAINT for this single call: requirements/constraints.txt
     # pins pip to an older version for the dev/lint tooling venvs, which
-    # would conflict with explicitly requesting pip==26.1.2 here.
+    # would conflict with explicitly requesting pip==26.2 here.
     download_env = {k: v for k, v in os.environ.items() if k != "PIP_CONSTRAINT"}
     ctx.run(
         sys.executable,
         "-m",
         "pip",
         "download",
-        "pip==26.1.2",
+        "pip==26.2",
         "--no-deps",
         "--dest",
         str(tmpdir),
@@ -777,7 +778,7 @@ def onedir_dependencies(
         "install",
         "--force-reinstall",
         "--no-deps",
-        "pip==26.1.2",
+        "pip==26.2",
         env=pip_env,
     )
     ctx.run(


### PR DESCRIPTION
### What does this PR do?
Updates the pip wheel Salt's onedir build downloads and ships for virtualenv seeding from 26.1.2 to 26.2, which vendors urllib3 2.7.0 and fixes CVE-2026-44432 (a decompression-bomb bypass in urllib3 2.6.0-2.6.3). The earlier 25.2 -> 26.1.2 bump (#69853/#69852) only got urllib3 to 2.6.3.

Also bumps relenv 0.22.18 -> 0.22.22, since pip 26.2 changed the signature of InstallRequirement.install() (added a script_executable kwarg) and 0.22.18's compatibility patch for that doesn't fully cover it. relenv 0.22.22 introspects pip's actual signature instead of assuming a fixed shape.

- tools/pkg/build.py: bump pip==26.1.2 -> pip==26.2 in _download_pip_wheel() and onedir_dependencies(), update docstring/comments
- requirements/constraints.txt: update comment reference only; the dev/lint pip == 25.2 pin is unrelated and unchanged
- cicd/shared-gh-workflows-context.yml: relenv_version 0.22.18 ->
  0.22.22
- .github/workflows/{ci,nightly,staging,scheduled}.yml: regenerated from templates to pick up the relenv version bump
- changelog/70109.fixed.md: add changelog entry

### What issues does this PR fix or reference?
Fixes #70109

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
