### PR TITLE
Pin Cython<3.3 for pyzmq source-build compat (3008.x)

### DIFF
--- a/changelog/70118.fixed.md
+++ b/changelog/70118.fixed.md
@@ -1,0 +1,1 @@
+Pin Cython<3.3 for pyzmq source builds broken by Cython 3.3.0.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -46,3 +46,10 @@ markdown-it-py < 4.0.0; python_version == "3.10"
 jsonschema < 4; python_version == "3.11"
 bcrypt < 5; python_version == "3.11"
 junos-eznc < 2.7; python_version == "3.11"
+# Cython 3.3.0 (2026-08-22) rejects the ``hint`` and ``c_addr`` redeclarations
+# in pyzmq 27.1.0's ``zmq/backend/cython/_zmq.py`` and fails to emit ``_zmq.c``,
+# breaking every source build of pyzmq (onedir Linux/macOS use
+# ``--no-binary=:all:``). PIP_CONSTRAINT propagates into pyzmq's PEP 517 build
+# env, so capping Cython here keeps the pyzmq wheel compiling until pyzmq
+# ships a Cython 3.3-compatible release.
+Cython < 3.3


### PR DESCRIPTION
## What broke

Cython 3.3.0 (released 2026-08-22) rejects redeclarations that pyzmq 27.1.0's `zmq/backend/cython/_zmq.py` currently emits at lines 357 (`hint`) and 1112 (`c_addr`). Every Salt onedir source build of pyzmq (`--no-binary=:all:` on Linux/macOS) fails during the Cython `_zmq.c` generation step. Cross-branch: seen on 3006.x/3007.x/3008.x/master starting at Cython's PyPI publish time.

## Fix

Add `Cython < 3.3` to `requirements/constraints.txt`. `PIP_CONSTRAINT` propagates into pyzmq's PEP 517 isolated build env (see `tools/pkg/build.py` and `noxfile.py`), so this caps the Cython the build env installs without touching pyzmq's own `pyproject.toml`. Cap is removable when pyzmq ships a Cython 3.3-compatible release.

## Scope

Build-tooling only. No runtime deps changed. No lockfile regeneration needed (Cython is a PEP 517 build dep and is not present in any `requirements/static/**.lock`).

## Sibling PRs

Same fix on the other supported branches (populated once all four are open):
- 3006.x: TBD
- 3007.x: TBD
- 3008.x: this PR
- master: TBD

## Test plan

- [ ] Onedir Linux/macOS build jobs succeed past the pyzmq wheel step.
- [ ] Cython version pulled into pyzmq's PEP 517 build env logs as < 3.3.