### PR TITLE
Pin Cython<3.3 for pyzmq source-build compat (3007.x)

### DIFF
--- a/changelog/70119.fixed.md
+++ b/changelog/70119.fixed.md
@@ -1,0 +1,1 @@
+Pin Cython<3.3 for pyzmq source builds broken by Cython 3.3.0.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,13 @@ setuptools >= 78.1.1
 # build envs on the pre-split 9.x series for every source build.
 setuptools-scm < 10
 pip == 26.0.1
+# pyzmq 25.1.2 / 27.1.0 (both used across Salt onedirs) build from source under
+# ``--no-binary=:all:`` and pull Cython unpinned via PEP 517. Cython 3.3.0
+# (2026-08-22) rejects the redeclarations at zmq/backend/cython/_zmq.py:357
+# (``hint``) and :1112 (``c_addr``). PIP_CONSTRAINT propagates to PEP 517
+# build envs, so capping Cython here keeps pyzmq source builds green until
+# pyzmq ships a fix.
+Cython < 3.3
 markdown-it-py < 3.0.0; python_version == "3.9"
 # myst-docutils 4.x (the latest supporting Python 3.10) requires
 # markdown-it-py ~=3.0; the 5.x line that pairs with markdown-it-py 4.x


### PR DESCRIPTION
## What broke
Cython 3.3.0 (published to PyPI 2026-08-22) rejects two variable redeclarations in pyzmq's Cython source:

```
zmq/backend/cython/_zmq.py:357:8: 'hint' redeclared
zmq/backend/cython/_zmq.py:1112:12: 'c_addr' redeclared
```

pyzmq's `[build-system].requires` pulls `cython` unpinned, so every PEP 517 source build of pyzmq (`--no-binary=:all:` onedir path in `tools/pkg/build.py`) pulls Cython 3.3.0 and fails. `PIP_CONSTRAINT` is already set to `requirements/constraints.txt` and (per pip docs) still propagates to PEP 517 build envs on pip <26.2.

## Fix
Add `Cython < 3.3` to `requirements/constraints.txt`. Build tooling only — no runtime deps or lock files change (Cython is a build-only dep, uv-pip-compile does not record it).

## Scope
- `requirements/constraints.txt`: +7 lines (comment + pin)
- `changelog/70119.fixed.md`

No runtime code touched.

## Cross-branch
Same fix on all active branches:
- 3006.x: sibling PR TBD
- 3007.x: this PR (#70119)
- 3008.x: sibling PR TBD
- master: sibling PR TBD