### PR TITLE
Pin Cython<3.3 for pyzmq source-build compat (master)

### DIFF
--- a/changelog/70120.fixed.md
+++ b/changelog/70120.fixed.md
@@ -1,0 +1,1 @@
+Pin Cython<3.3 for pyzmq source builds broken by Cython 3.3.0.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,14 @@ setuptools >= 78.1.1
 # propagates to PEP 517 build envs since pip 22.1, so capping here keeps
 # build envs on the pre-split 9.x series for every source build.
 setuptools-scm < 10
+# Cap Cython < 3.3 in PEP 517 build envs. Cython 3.3.0 (2026-08-22) rejects
+# variable redeclarations that pyzmq 27.1.0's zmq/backend/cython/_zmq.py
+# still emits (``'hint' redeclared`` at :357, ``'c_addr' redeclared`` at
+# :1112), breaking every ``--no-binary=:all:`` onedir build that source-builds
+# pyzmq. pyzmq's own ``pyproject.toml`` pulls ``Cython>=3.1.1`` unpinned;
+# PIP_CONSTRAINT propagates to PEP 517 build envs on pip <26.2, so pinning
+# here keeps pyzmq's isolated build env on the Cython 3.2 line.
+Cython < 3.3
 # pip 25.2 is the version that relenv's onedir ships with, and that
 # tools/pkg/build.py downloads + patches in pkg/patches/pip-urllib3/.
 # Bumping past 25.2 here causes the noxfile bootstrap pip install in


### PR DESCRIPTION
## What broke

Cython 3.3.0 was published to PyPI on 2026-08-22. It rejects variable
redeclarations that ``pyzmq==27.1.0``'s ``zmq/backend/cython/_zmq.py`` still
emits:

```
zmq/backend/cython/_zmq.py:357:8: 'hint' redeclared
zmq/backend/cython/_zmq.py:1112:12: 'c_addr' redeclared
error: subprocess-exited-with-error
Building wheel for pyzmq (pyproject.toml): finished with status 'error'
ERROR: Failed building wheel for pyzmq
```

pyzmq's own ``pyproject.toml`` declares ``build-system.requires =
["Cython>=3.1.1"]`` unpinned, so its isolated PEP 517 build env picks up
Cython 3.3.0.

Salt's onedir build sets ``--no-binary=:all:`` (with a small allow-list) on
Linux and macOS so that native deps link against the relenv toolchain. That
policy forces a pyzmq source build on every Linux/macOS × Python 3.10..3.14
target, so every onedir/RPM/DEB build broke.

## Fix

Add ``Cython < 3.3`` to ``requirements/constraints.txt``. ``tools/pkg/build.py``
sets ``PIP_CONSTRAINT=requirements/constraints.txt`` for every ``pip install``
that source-builds onedir deps, and ``PIP_CONSTRAINT`` still propagates to
PEP 517 build envs on pip <26.2 (pip 26.1.2, which the current onedir ships,
emits a deprecation warning but still applies it). This caps pyzmq's build
env on the Cython 3.2 line, unblocking the source build.

## Scope

Build-tooling only. No runtime deps, no ``pyzmq`` version change, no
``noxfile.py``/workflow changes. Cython is not a Salt runtime dep; it only
appears as a transitive PEP 517 build requirement of source-built C
extensions.

## Cross-branch

Same fix applied on every active branch:

- 3006.x: (sibling PR - update after merge)
- 3007.x: (sibling PR - update after merge)
- 3008.x: #70118
- master: this PR

## Verification

- ``pre-commit run --files requirements/constraints.txt changelog/*.fixed.md``: clean
- Requirements-lock hooks all pass; no lock regen needed (Cython is not in any runtime lock)