### PR TITLE
Pin Cython<3.3 for pyzmq source-build compat (3006.x)

### DIFF
--- a/changelog/70121.fixed.md
+++ b/changelog/70121.fixed.md
@@ -1,0 +1,1 @@
+Pin Cython<3.3 for pyzmq source builds broken by Cython 3.3.0.

--- a/noxfile.py
+++ b/noxfile.py
@@ -262,6 +262,11 @@ def _upgrade_pip_setuptools_and_wheel(session, upgrade=True):
 
     env = os.environ.copy()
     env["PIP_CONSTRAINT"] = str(REPO_ROOT / "requirements" / "constraints.txt")
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     install_command = [
         "python",
         "-m",
@@ -293,6 +298,11 @@ def _install_requirements(
     # Install requirements
     env = os.environ.copy()
     env["PIP_CONSTRAINT"] = str(REPO_ROOT / "requirements" / "constraints.txt")
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
 
     requirements_file = _get_pip_requirements_file(
         session, requirements_type=requirements_type
@@ -324,6 +334,11 @@ def _install_coverage_requirement(session):
     if SKIP_REQUIREMENTS_INSTALL is False:
         env = os.environ.copy()
         env["PIP_CONSTRAINT"] = str(REPO_ROOT / "requirements" / "constraints.txt")
+        # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+        # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+        # constraints file via PIP_BUILD_CONSTRAINT so entries like
+        # ``Cython < 3.3`` reach pyzmq's source build.
+        env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
         coverage_requirement = COVERAGE_REQUIREMENT
         if coverage_requirement is None:
             coverage_requirement = "coverage==7.3.1"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,3 +31,12 @@ markdown-it-py < 4.0.0; python_version == "3.10"
 jsonschema < 4; python_version == "3.11"
 bcrypt < 5; python_version == "3.11"
 junos-eznc < 2.7; python_version == "3.11"
+# Cython 3.3.0 (released 2026-08-22) tightened its parser and rejects
+# variable redeclarations in pyzmq 27.1.0's zmq/backend/cython/_zmq.py
+# (`hint` at :357 and `c_addr` at :1112). pyzmq is source-built under
+# the relenv toolchain (see --no-binary=:all: in tools/pkg/build.py),
+# so pip resolves Cython fresh from PyPI in the isolated PEP-517 build
+# env. This constraint must also be exported via PIP_BUILD_CONSTRAINT
+# because PIP_CONSTRAINT stopped applying to build-isolation deps in
+# pip 26.x (deprecated in 26.1, enforced in 26.2).
+Cython < 3.3

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -138,6 +138,11 @@ def debian(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
 
     ctx.run("ln", "-sf", "pkg/debian/", ".")
     ctx.run("debuild", *env_args, "-uc", "-us", env=env)
@@ -215,6 +220,11 @@ def rpm(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     spec_file = checkout / "pkg" / "rpm" / "salt.spec"
     ctx.run(
         "rpmbuild", "-bb", f"--define=_salt_src {checkout}", str(spec_file), env=env
@@ -682,6 +692,11 @@ def onedir_dependencies(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     ctx.run(
         str(python_bin),
         "-m",
@@ -944,6 +959,11 @@ def salt_onedir(
     env["PIP_CONSTRAINT"] = str(
         tools.utils.REPO_ROOT / "requirements" / "constraints.txt"
     )
+    # PIP_CONSTRAINT stopped affecting PEP-517 build-isolation envs in
+    # pip 26.x (deprecated in 26.1, enforced in 26.2); mirror the same
+    # constraints file via PIP_BUILD_CONSTRAINT so entries like
+    # ``Cython < 3.3`` reach pyzmq's source build.
+    env["PIP_BUILD_CONSTRAINT"] = env["PIP_CONSTRAINT"]
     # Download setuptools and wheel normally; pip is handled separately below
     # so that the pinned version is used instead of whatever PyPI resolves.
     ctx.run(


### PR DESCRIPTION
## What broke

Cython 3.3.0 was published to PyPI on 2026-08-22. Its tightened parser
rejects variable redeclarations in pyzmq 27.1.0's cython sources:

```
zmq/backend/cython/_zmq.py:357:8: 'hint' redeclared
zmq/backend/cython/_zmq.py:1112:12: 'c_addr' redeclared
ninja: build stopped: subcommand failed.
error: Failed to build installable wheels for some pyproject.toml based projects (pyzmq)
```

pyzmq is source-built under the relenv onedir toolchain
(`--no-binary=:all:` in `tools/pkg/build.py`), so pip's PEP-517
build-isolation env resolves Cython fresh from PyPI and picks up 3.3.0.
Every active branch's Build Onedir / Source Packages / Onedir Packages
jobs go red the same way.

## Fix

- Add `Cython < 3.3` to `requirements/constraints.txt`.
- Export the same file via `PIP_BUILD_CONSTRAINT` alongside
  `PIP_CONSTRAINT` in `noxfile.py` and `tools/pkg/build.py`. Necessary
  because `PIP_CONSTRAINT` stopped propagating into PEP-517
  build-isolation envs in pip 26.x (deprecated in 26.1, enforced in
  26.2 -- pip 26.1.2 already prints the deprecation on every install).

## Scope

Build-tooling only. No runtime dependency changes, no lock-file
regeneration, no Salt source touched.

## Cross-branch

Same fix opened in parallel on 3007.x / 3008.x / master. Sibling PR
links to be added once all four are open.