### PR TITLE
[3008.x] Preserve EventPublisher setproctitle across MasterPubServerChannel respawns

### DIFF
--- a/changelog/70126.fixed.md
+++ b/changelog/70126.fixed.md
@@ -1,0 +1,1 @@
+Preserve `EventPublisher` process title across `MasterPubServerChannel._publish_daemon` respawns so operator monitoring keyed on the process title continues to work after ProcessManager restarts the daemon.

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -19,6 +19,13 @@ import zlib
 
 import tornado.ioloop
 
+try:
+    import setproctitle
+
+    HAS_SETPROCTITLE = True
+except ImportError:
+    HAS_SETPROCTITLE = False
+
 import salt.cache
 import salt.cluster.consensus.rpc
 import salt.crypt
@@ -2860,6 +2867,17 @@ class MasterPubServerChannel:
 
     def _publish_daemon(self, **kwargs):
         """Clean implementation: separate local IPC from cluster peer communication."""
+        # Ensure the process title is ``EventPublisher`` on both initial fork
+        # and respawn. ``ProcessManager.add_process`` is called with
+        # ``name="EventPublisher"`` from ``pre_fork``, but
+        # ``ProcessManager.restart_process`` drops the ``name`` kwarg, so on
+        # respawn the fallback ``__qualname__`` (``MasterPubServerChannel.
+        # _publish_daemon``) would otherwise be used instead. Setting the
+        # title explicitly here keeps the historical process label stable
+        # across restarts so operator tooling keyed on ``EventPublisher``
+        # continues to work.
+        if HAS_SETPROCTITLE:
+            setproctitle.setproctitle("EventPublisher")
         import salt.master  # pylint: disable=import-outside-toplevel
 
         if (

--- a/tests/pytests/unit/channel/test_server.py
+++ b/tests/pytests/unit/channel/test_server.py
@@ -1144,3 +1144,61 @@ async def test_publish_payload_cluster_peer_fanout_decodes_for_envelope(
     fake_pusher.publish.assert_called_once()
     # And the local transport still got the raw_payload fast path.
     channel.transport.publish_payload.assert_awaited_once_with(load, raw_payload=b"raw")
+
+
+def test_publish_daemon_sets_eventpublisher_process_title():
+    """
+    Regression: ``MasterPubServerChannel.pre_fork`` registers
+    ``_publish_daemon`` with ``ProcessManager.add_process`` using
+    ``name="EventPublisher"`` so the initial fork gets that setproctitle
+    string.  ``ProcessManager.restart_process``, however, drops the
+    ``name=`` kwarg when respawning, so a respawn otherwise falls back to
+    the class ``__qualname__`` (``MasterPubServerChannel._publish_daemon``)
+    and the process ends up with a different title after the very first
+    restart. Operator monitoring keyed on ``EventPublisher`` (grep/pgrep,
+    log correlation) silently breaks.
+
+    The fix sets the process title explicitly at the top of
+    ``_publish_daemon`` so both the initial fork and every respawn end up
+    with the same ``EventPublisher`` title. This test guards against a
+    regression to the earlier behaviour by patching
+    ``setproctitle.setproctitle`` and asserting the daemon calls it with
+    the historical label before doing any other work.
+
+    Sibling of PR #70111 (same bug pattern, ``FileserverUpdate``).
+    """
+    from tests.support.mock import MagicMock, patch
+
+    # ``setproctitle`` is an optional runtime dep; the fix imports it at
+    # module load and gates the call with ``HAS_SETPROCTITLE``. Skip
+    # cleanly if the host lacks the module -- there is nothing to
+    # observe in that case.
+    pytest.importorskip("setproctitle")
+
+    # The fix must expose the module as an attribute of the
+    # ``salt.channel.server`` namespace so we can patch it. Failing this
+    # assertion means the fix has been reverted or the import removed.
+    assert hasattr(server, "setproctitle"), (
+        "salt.channel.server must import ``setproctitle`` so "
+        "``MasterPubServerChannel._publish_daemon`` can override the "
+        "process title on both initial fork and respawn"
+    )
+
+    channel = server.MasterPubServerChannel.__new__(server.MasterPubServerChannel)
+    # ``event_publisher_niceness`` gates an ``os.nice`` call further down
+    # in ``_publish_daemon``; keep it falsy so the test does not need to
+    # patch ``os.nice`` or drive the tornado io_loop.
+    channel.opts = {"event_publisher_niceness": 0}
+    channel.transport = MagicMock()
+
+    # Short-circuit the rest of the daemon by making the very next line
+    # after the setproctitle call raise. If the fix is present the
+    # setproctitle call happens *first*, and the mock records the call
+    # before the ``StopIteration`` propagates.
+    with patch.object(server, "setproctitle", MagicMock()) as fake_setproctitle, patch(
+        "tornado.ioloop.IOLoop.current", side_effect=StopIteration
+    ):
+        with pytest.raises(StopIteration):
+            channel._publish_daemon()
+
+    fake_setproctitle.setproctitle.assert_called_once_with("EventPublisher")


### PR DESCRIPTION
## Summary

3008.x forward-port of #70124.

`ProcessManager.restart_process` drops the `name=` kwarg passed to `add_process(name="EventPublisher")`, so after any respawn the process title falls back to the `__qualname__` `MasterPubServerChannel._publish_daemon`. grep/pgrep/log correlation on `EventPublisher` silently breaks the first time the daemon is restarted.

Fix sets the process title explicitly at the top of `_publish_daemon` so initial fork and every respawn both show `EventPublisher`. The `name="EventPublisher"` kwarg on `add_process` is intentionally kept so the historical label still appears on initial fork.

Sibling of #70111 (same bug pattern, `FileserverUpdate`).

## Test plan

- [x] New regression test `tests/pytests/unit/channel/test_server.py::test_publish_daemon_sets_eventpublisher_process_title`.
- [x] Verified test fails against pre-fix `salt/channel/server.py` on 3008.x and passes with the fix applied.
- [x] `pre-commit` clean on all changed files.
- [ ] CI (`test:full` label applied).