### PR TITLE
publish-nightly-release: don't publish source-build artifacts

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -74,7 +74,38 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           path: nightly-artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          merge-multiple: true
+          # Do NOT set merge-multiple: true. Several build jobs upload
+          # artifacts that contain files with the same basename (notably
+          # `-rpm` vs `-rpm-from-src`, both containing
+          # salt-<ver>-0.x86_64.rpm at different sizes/content). With
+          # merge-multiple: true, the second extraction can partially
+          # overlay the first without truncating, producing a same-size
+          # Frankenstein RPM whose header index is corrupt. That is
+          # exactly the failure that shipped as
+          # nightly-2026-08-19-3008.x on the release page (build 210,
+          # tag[49] BAD tag 1118 header index broken).
+          # Keeping merge-multiple: false puts each artifact in its own
+          # subdirectory under nightly-artifacts/<artifact-name>/; the
+          # find steps below still collect files recursively.
+
+      - name: drop source-build artifacts before publish
+        # `-rpm-from-src`, `-deb-from-src` etc. are internal source-build
+        # verification outputs. They are never consumed downstream and
+        # must not reach the release page -- their presence is what
+        # created the same-basename collision that produced the
+        # Frankenstein RPM in the 2026-08-19 incident.
+        # Removing their subdirs entirely before the asset-find step is
+        # simpler and less error-prone than filtering find output.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          removed=0
+          for d in nightly-artifacts/*-from-src; do
+            echo "pruning source-build artifact: ${d}"
+            rm -rf "${d}"
+            removed=$((removed + 1))
+          done
+          echo "pruned ${removed} source-build artifact directories"
 
       - name: list assets to publish
 


### PR DESCRIPTION
### What does this PR do?

Stops `publish-nightly-release.yml` from attaching source-build artifacts (`salt-*-rpm-from-src`, `salt-*-deb-from-src`, etc.) to the nightly GitHub Release, and prevents the same-basename collision that produced a corrupt RPM on `nightly-2026-08-19-3008.x`.

### What issues does this PR fix or reference?

Follow-up to #70078, which noted:

> The first `download all artifacts` step (which feeds the release-upload) has the same underlying issue &mdash; also drops entries silently &mdash; but is scoped differently (release-completeness rather than dashboard-correctness) and worth its own follow-up.

This is that follow-up, plus a concrete failure mode discovered while investigating a downstream bug report.

### Previous Behavior

The `download all artifacts` step used `merge-multiple: true`, which flattens every artifact into `nightly-artifacts/`. Two build jobs upload artifacts that contain files with the same basename but different content/size:

| Artifact | Contains | Size (build 210, x86_64) |
| --- | --- | --- |
| `salt-3008.2+210.g9a41326f33-x86_64-rpm` | `salt-3008.2+210.g9a41326f33-0.x86_64.rpm` | 41,073,011 B |
| `salt-3008.2+210.g9a41326f33-x86_64-rpm-from-src` | `salt-3008.2+210.g9a41326f33-0.x86_64.rpm` | 40,765,804 B |

With `merge-multiple: true`, the second extraction of a same-named file can partially overlay the first without truncating &mdash; producing a **same-size, byte-mangled** file. The result on `nightly-2026-08-19-3008.x`:

```
$ rpm --nosignature -qpi salt-3008.2+210.g9a41326f33-0.x86_64.rpm
error: tag[49]: BAD, tag 1118 type 8 offset 971522 count 803 len 90450
error: not an rpm package (or package manifest)
```

Same-size (41,073,011 B) as the valid onedir-built RPM &mdash; but with a Frankenstein content: first 344,321 B match `-from-src`, last 307,207 B match `-rpm`, hundreds of interleaved regions in between (verified via byte-diff of the release attachment against both source artifacts). Consumers on Photon, Rocky Linux 9, and a Python RPM parser reproduced the failure across 3 independent systems.

Nightly package tests never caught this because they run against the pre-publish `-rpm` GHA artifact directly (which is valid). The corruption is introduced by `publish-nightly-release.yml` afterward, and nothing between then and consumer download re-checks the file.

Non-determinism: `merge-multiple`'s extraction order depends on filesystem timing, which is why builds 205/206/214 shipped valid RPMs and 210 didn't.

### New Behavior

Two changes in one hunk:

1. **Drop `merge-multiple: true`** on the primary `download-artifact@v4` step. Each artifact now lives in its own `nightly-artifacts/<artifact-name>/` subdir. No same-basename collisions possible &mdash; the Frankenstein failure mode is eliminated regardless of what artifacts a build produces. The subsequent `find nightly-artifacts -type f ...` steps already recurse, so no other changes needed.

2. **Prune `*-from-src` artifact dirs** before the asset-find step. These are internal source-build verification outputs; they are never consumed downstream and should not be release attachments. Removing whole subdirs is simpler and less error-prone than filtering `find` output. Logs `pruned N source-build artifact directories` for visibility.

Either change alone would prevent the specific 8/19 incident (the collision, or the presence of the colliding file). Doing both closes the failure mode _and_ removes the artifacts that shouldn't have been publishable in the first place.

### Impact

- Nightly releases no longer publish `-from-src` build outputs. If any downstream consumer was actually depending on those release attachments (unlikely &mdash; they're internal SRPM/source-build verification), they'd need to consume the GHA artifact directly instead.
- Common-case log output on a healthy build: `pruned 0 source-build artifact directories`. Only builds with a `-from-src` artifact see any removal.
- The `find nightly-artifacts -type f` steps in later jobs (asset list, salt-version probe) continue to work unchanged &mdash; recursive find handles the new subdir layout.
- Fixes affect all nightly branches (workflow_run triggers use the workflow file from the default branch), including 3008.x.

### Not in this PR

- No changes to the second `download-artifact@v4` step (for JUnit artifacts). That already has its own backfill fix from #70078.
- No new tests. The failure mode is a `download-artifact@v4` runtime characteristic and can't be exercised in unit tests. The natural regression check is that future nightly releases don't ship byte-corrupt RPMs; validation on the downstream uploader is being added separately as belt-and-braces.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (see above)

### Commits signed with GPG?

No.