### PR TITLE
[3006.x] Bump cryptography, pyopenssl, msgpack, requests, setuptools; add attrs/charset-normalizer floors

### DIFF
--- a/changelog/70130.changed.md
+++ b/changelog/70130.changed.md
@@ -1,0 +1,5 @@
+Bump cryptography (>=48.0.1 on py>=3.10), pyopenssl (drop <26.2.0 cap; tls
+module gracefully disables X509_EXT_ENABLED when X509Extension is removed),
+msgpack (>=1.2.0), requests (>=2.34.2), and setuptools (>=82.0.1) to current
+LTS floors on the salt-onedir Python stack. Python 3.9 pins retained
+(cryptography 48+ drops 3.9.0/3.9.1; msgpack 1.2.1 drops 3.9).

--- a/changelog/70130.changed.md
+++ b/changelog/70130.changed.md
@@ -1,5 +1,7 @@
-Bump cryptography (>=48.0.1 on py>=3.10), pyopenssl (drop <26.2.0 cap; tls
-module gracefully disables X509_EXT_ENABLED when X509Extension is removed),
-msgpack (>=1.2.0), requests (>=2.34.2), and setuptools (>=82.0.1) to current
-LTS floors on the salt-onedir Python stack. Python 3.9 pins retained
-(cryptography 48+ drops 3.9.0/3.9.1; msgpack 1.2.1 drops 3.9).
+Bump cryptography (>=48.0.1 on py>=3.10), pyopenssl (drop <26.2.0 cap;
+salt.modules.tls now refuses to load on pyOpenSSL 26+ where its legacy
+X509Extension / X509Req / PKCS12 / CRL / load_crl APIs were removed --
+use salt.modules.x509 instead), msgpack (>=1.2.0), requests (>=2.34.2),
+and setuptools (>=82.0.1) to current LTS floors on the salt-onedir
+Python stack. Python 3.9 pins retained (cryptography 48+ drops
+3.9.0/3.9.1; msgpack 1.2.1 drops 3.9).

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,15 @@ croniter!=0.3.22,>=6.2.2; sys_platform != 'win32'
 # last 46.x release for Python 3.9 so uv pip compile can still resolve;
 # Python 3.10+ takes the 48.x line.
 cryptography>=46.0.7,<48.0.0; python_version < '3.10'
-cryptography>=48.0.1; python_version >= '3.10'
+# cryptography 49+ dropped Windows x86 (win32) wheels. 3006.x still
+# builds a Windows x86 onedir and the salt-onedir Windows build path
+# does not pass --no-binary (unlike Linux/macOS), so pip falls through
+# to the sdist and the Rust openssl-sys build fails for
+# i686-pc-windows-msvc. Cap Windows at the last release that ships
+# cp3X-abi3-win32 wheels (48.0.1). Non-Windows takes the 48.x floor
+# and can float forward to 50.x.
+cryptography>=48.0.1,<49.0.0; python_version >= '3.10' and sys_platform == 'win32'
+cryptography>=48.0.1; python_version >= '3.10' and sys_platform != 'win32'
 distro>=1.9.0
 frozenlist>=1.8.0; python_version < '3.11'
 frozenlist>=1.5.0; python_version >= '3.11'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,10 +14,10 @@ croniter!=0.3.22,>=6.2.2; sys_platform != 'win32'
 # cryptography 48.0.0 drops support for Python 3.9.0 and 3.9.1
 # (only >3.9.1 is accepted), but the py3.9 lock files are compiled
 # with --python-version=3.9 which includes those releases. Cap at the
-# last 46.x release for Python 3.9 so uv pip compile can still resolve.
-# Furthermore, pyOpenSSL 26.2 dropped X509Extension and add_extensions()
-# which breaks salt/modules/tls.py. pyOpenSSL < 26.2 requires cryptography < 48.0.0.
-cryptography>=46.0.7,<48.0.0
+# last 46.x release for Python 3.9 so uv pip compile can still resolve;
+# Python 3.10+ takes the 48.x line.
+cryptography>=46.0.7,<48.0.0; python_version < '3.10'
+cryptography>=48.0.1; python_version >= '3.10'
 distro>=1.9.0
 frozenlist>=1.8.0; python_version < '3.11'
 frozenlist>=1.5.0; python_version >= '3.11'
@@ -42,7 +42,7 @@ MarkupSafe<4.0.0
 multidict>=6.6.0
 # msgpack 1.2.1 drops Python 3.9; keep the last 3.9-compatible release there.
 msgpack>=1.1.2,<1.2.1; python_version < '3.10'
-msgpack>=1.1.2; python_version >= '3.10'
+msgpack>=1.2.0; python_version >= '3.10'
 # Packaging 24.1+ imports annotations from __future__ which breaks
 # salt-ssh on target hosts with older Python versions (Amazon Linux 2
 # still ships Python 3.7). 26.x additionally uses positional-only
@@ -57,7 +57,9 @@ psutil>=5.0.0; python_version >= '3.10'
 # ships cp3X-win32 wheels.
 pymssql==2.3.11; sys_platform == 'win32'
 pymysql>=1.2.0; sys_platform == 'win32'
-pyopenssl>=26.0.0,<26.2.0
+# pyopenssl 26.2 dropped X509Extension and add_extensions(); salt/modules/tls.py
+# now guards the missing symbol and lets the extension feature degrade cleanly.
+pyopenssl>=26.0.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 # pythonnet 3.1.0 drops Python 3.9; keep the last 3.9-compatible release there.
@@ -68,7 +70,7 @@ pywin32>=312; sys_platform == 'win32'
 pycryptodomex>=3.23.0
 PyYAML>=6.0.3
 requests>=2.32.5 ; python_version < '3.10'
-requests>=2.33.1 ; python_version >= '3.10'
+requests>=2.34.2 ; python_version >= '3.10'
 setproctitle>=1.3.7
 # pyzmq 27 dropped its tornado runtime dep; pyzmq.eventloop submodules
 # (zmqstream, future) still import tornado.ioloop at module load. Pin
@@ -95,6 +97,10 @@ zipp>=3.23.1; python_version >= '3.10'
 apache-libcloud>=3.8.0,<3.9.1; python_version < '3.10'
 apache-libcloud>=3.9.1; python_version >= '3.10'
 idna>=3.18
+# attrs and charset-normalizer are pulled in transitively by aiohttp/requests.
+# Explicit floors on py>=3.10 keep them at the current CVE-patched line.
+attrs>=26.1.0; python_version >= '3.10'
+charset-normalizer>=3.4.7; python_version >= '3.10'
 # more-itertools 11.0.0 drops Python 3.9; keep the last 3.9-compatible release there.
 more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
 more-itertools>=10.8.0; python_version >= '3.10'

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,7 @@ wheel >= 0.47.0
 # Host-side pre-commit hooks (uv-resolved) still pick the latest
 # setuptools; this floor only relaxes what the onedir-bundled pip is
 # allowed to use.
-setuptools >= 78.1.1
+setuptools >= 82.0.1
 pip == 26.0.1
 markdown-it-py < 3.0.0; python_version == "3.9"
 # myst-docutils 4.x (the latest supporting Python 3.10) requires

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -16,7 +16,8 @@ bcrypt
 # available transitively for any tool that needs it.
 boto3>=1.43.24; python_version >= '3.10'
 boto>=2.49.0
-cryptography>=46.0.7,<48.0.0
+cryptography>=46.0.7,<48.0.0; python_version < '3.10'
+cryptography>=48.0.1; python_version >= '3.10'
 cffi>=2.0.0
 cherrypy>=18.10.0
 clustershell

--- a/requirements/static/ci/py3.10/cloud.lock
+++ b/requirements/static/ci/py3.10/cloud.lock
@@ -40,10 +40,11 @@ async-timeout==4.0.3
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -95,10 +96,11 @@ cffi==2.0.0
     #   -r requirements/static/ci/common.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via
@@ -132,7 +134,7 @@ croniter==6.2.2
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -385,7 +387,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -500,7 +502,7 @@ pynacl==1.5.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -633,7 +635,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/darwin-lint.lock
+++ b/requirements/static/ci/py3.10/darwin-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.10/darwin.lock
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/darwin.lock
     #   -c requirements/static/pkg/py3.10/darwin.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/darwin.lock
     #   -c requirements/static/pkg/py3.10/darwin.lock

--- a/requirements/static/ci/py3.10/darwin.lock
+++ b/requirements/static/ci/py3.10/darwin.lock
@@ -32,9 +32,10 @@ async-timeout==4.0.3
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -77,9 +78,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -103,7 +105,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -278,7 +280,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -361,7 +363,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt
@@ -450,7 +452,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/docs.lock
+++ b/requirements/static/ci/py3.10/docs.lock
@@ -28,9 +28,10 @@ async-timeout==4.0.3
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
 babel==2.12.1
     # via
@@ -52,9 +53,10 @@ cffi==2.0.0
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheroot==11.1.2
     # via
@@ -74,7 +76,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -193,7 +195,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -253,7 +255,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -283,7 +285,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd-lint.lock
+++ b/requirements/static/ci/py3.10/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.10/freebsd.lock
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/freebsd.lock
     #   -c requirements/static/pkg/py3.10/freebsd.lock
@@ -46,7 +46,7 @@ pywin32==312 ; sys_platform == 'win32'
     #   -c requirements/static/ci/py3.10/freebsd.lock
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/freebsd.lock
     #   -c requirements/static/pkg/py3.10/freebsd.lock

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -32,9 +32,10 @@ async-timeout==4.0.3 ; python_full_version < '3.11'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -79,9 +80,10 @@ cffi==2.0.0
     #   cryptography
     #   pynacl
     #   pyzmq
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -116,7 +118,7 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -317,7 +319,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -410,7 +412,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -515,7 +517,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/freebsd.lock
+++ b/requirements/static/ci/py3.10/freebsd.lock
@@ -118,7 +118,17 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt
@@ -412,7 +422,13 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.10/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.10/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/linux-lint.lock
+++ b/requirements/static/ci/py3.10/linux-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/linux.lock
     #   -c requirements/static/pkg/py3.10/linux.lock

--- a/requirements/static/ci/py3.10/linux.lock
+++ b/requirements/static/ci/py3.10/linux.lock
@@ -42,9 +42,10 @@ async-timeout==4.0.3
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -89,9 +90,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -115,7 +117,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -312,7 +314,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -405,7 +407,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt
@@ -503,7 +505,7 @@ redis==3.5.3
     # via redis-py-cluster
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows-lint.lock
+++ b/requirements/static/ci/py3.10/windows-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.10/windows.lock
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.10/windows.lock
     #   -c requirements/static/pkg/py3.10/windows.lock
@@ -46,7 +46,7 @@ pywin32==312
     #   -c requirements/static/ci/py3.10/windows.lock
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.10/windows.lock
     #   -c requirements/static/pkg/py3.10/windows.lock

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -27,9 +27,10 @@ async-timeout==5.0.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   aiohttp
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -69,9 +70,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -104,7 +106,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -271,7 +273,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -351,7 +353,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -446,7 +448,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.lock
+++ b/requirements/static/ci/py3.10/windows.lock
@@ -106,7 +106,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt
@@ -353,7 +353,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via
     #   -c requirements/static/pkg/py3.10/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/cloud.lock
+++ b/requirements/static/ci/py3.11/cloud.lock
@@ -35,10 +35,11 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.11/linux.lock
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -90,10 +91,11 @@ cffi==2.0.0
     #   -r requirements/static/ci/common.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via
@@ -127,7 +129,7 @@ croniter==6.2.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -373,7 +375,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -485,7 +487,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -618,7 +620,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/darwin-lint.lock
+++ b/requirements/static/ci/py3.11/darwin-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.11/darwin.lock
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/darwin.lock
     #   -c requirements/static/pkg/py3.11/darwin.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/darwin.lock
     #   -c requirements/static/pkg/py3.11/darwin.lock

--- a/requirements/static/ci/py3.11/darwin.lock
+++ b/requirements/static/ci/py3.11/darwin.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -73,9 +74,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -99,7 +101,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -275,7 +277,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -356,7 +358,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt
@@ -445,7 +447,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/docs.lock
+++ b/requirements/static/ci/py3.11/docs.lock
@@ -24,9 +24,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
 babel==2.12.1
     # via
@@ -48,9 +49,10 @@ cffi==2.0.0
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheroot==11.1.2
     # via
@@ -70,7 +72,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -188,7 +190,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -248,7 +250,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -278,7 +280,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd-lint.lock
+++ b/requirements/static/ci/py3.11/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.11/freebsd.lock
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/freebsd.lock
     #   -c requirements/static/pkg/py3.11/freebsd.lock
@@ -46,7 +46,7 @@ pywin32==312 ; sys_platform == 'win32'
     #   -c requirements/static/ci/py3.11/freebsd.lock
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/freebsd.lock
     #   -c requirements/static/pkg/py3.11/freebsd.lock

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1 ; sys_platform != 'win32'
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -80,9 +81,10 @@ cffi==2.0.0
     #   cryptography
     #   pynacl
     #   pyzmq
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -117,7 +119,7 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -318,7 +320,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -411,7 +413,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -521,7 +523,7 @@ referencing==0.37.0 ; python_full_version >= '3.12'
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/freebsd.lock
+++ b/requirements/static/ci/py3.11/freebsd.lock
@@ -119,7 +119,17 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt
@@ -413,7 +423,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.11/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.11/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/linux-lint.lock
+++ b/requirements/static/ci/py3.11/linux-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/linux.lock
     #   -c requirements/static/pkg/py3.11/linux.lock

--- a/requirements/static/ci/py3.11/linux.lock
+++ b/requirements/static/ci/py3.11/linux.lock
@@ -38,9 +38,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -85,9 +86,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -111,7 +113,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -305,7 +307,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -396,7 +398,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt
@@ -494,7 +496,7 @@ redis==3.5.3
     # via redis-py-cluster
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows-lint.lock
+++ b/requirements/static/ci/py3.11/windows-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.11/windows.lock
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.11/windows.lock
     #   -c requirements/static/pkg/py3.11/windows.lock
@@ -46,7 +46,7 @@ pywin32==312
     #   -c requirements/static/ci/py3.11/windows.lock
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.11/windows.lock
     #   -c requirements/static/pkg/py3.11/windows.lock

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -103,7 +103,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -347,7 +347,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.11/windows.lock
+++ b/requirements/static/ci/py3.11/windows.lock
@@ -23,9 +23,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -66,9 +67,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -101,7 +103,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -265,7 +267,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -345,7 +347,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt
@@ -440,7 +442,7 @@ pyzmq==27.1.0
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.11/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/cloud.lock
+++ b/requirements/static/ci/py3.12/cloud.lock
@@ -35,10 +35,11 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.12/linux.lock
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -85,10 +86,11 @@ cffi==2.0.0
     #   -r requirements/static/ci/common.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via
@@ -122,7 +124,7 @@ croniter==6.2.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -369,7 +371,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -481,7 +483,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -615,7 +617,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/darwin-lint.lock
+++ b/requirements/static/ci/py3.12/darwin-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.12/darwin.lock
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/darwin.lock
     #   -c requirements/static/pkg/py3.12/darwin.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/darwin.lock
     #   -c requirements/static/pkg/py3.12/darwin.lock

--- a/requirements/static/ci/py3.12/darwin.lock
+++ b/requirements/static/ci/py3.12/darwin.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -69,9 +70,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -95,7 +97,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -268,7 +270,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -349,7 +351,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt
@@ -440,7 +442,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/docs.lock
+++ b/requirements/static/ci/py3.12/docs.lock
@@ -24,9 +24,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
 babel==2.18.0
     # via
@@ -44,9 +45,10 @@ cffi==2.0.0
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheroot==11.1.2
     # via
@@ -66,7 +68,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -184,7 +186,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -244,7 +246,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -274,7 +276,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd-lint.lock
+++ b/requirements/static/ci/py3.12/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.12/freebsd.lock
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/freebsd.lock
     #   -c requirements/static/pkg/py3.12/freebsd.lock
@@ -46,7 +46,7 @@ pywin32==312 ; sys_platform == 'win32'
     #   -c requirements/static/ci/py3.12/freebsd.lock
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/freebsd.lock
     #   -c requirements/static/pkg/py3.12/freebsd.lock

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1 ; sys_platform != 'win32'
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -71,9 +72,10 @@ cffi==2.0.0
     #   cryptography
     #   pynacl
     #   pyzmq
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -108,7 +110,7 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -300,7 +302,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -391,7 +393,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -498,7 +500,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/freebsd.lock
+++ b/requirements/static/ci/py3.12/freebsd.lock
@@ -110,7 +110,17 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt
@@ -393,7 +403,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.12/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.12/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/linux-lint.lock
+++ b/requirements/static/ci/py3.12/linux-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/linux.lock
     #   -c requirements/static/pkg/py3.12/linux.lock

--- a/requirements/static/ci/py3.12/linux.lock
+++ b/requirements/static/ci/py3.12/linux.lock
@@ -38,9 +38,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -81,9 +82,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -107,7 +109,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -298,7 +300,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -389,7 +391,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt
@@ -489,7 +491,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows-lint.lock
+++ b/requirements/static/ci/py3.12/windows-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.12/windows.lock
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.12/windows.lock
     #   -c requirements/static/pkg/py3.12/windows.lock
@@ -46,7 +46,7 @@ pywin32==312
     #   -c requirements/static/ci/py3.12/windows.lock
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.12/windows.lock
     #   -c requirements/static/pkg/py3.12/windows.lock

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -23,9 +23,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -61,9 +62,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -96,7 +98,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -259,7 +261,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -339,7 +341,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -436,7 +438,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.12/windows.lock
+++ b/requirements/static/ci/py3.12/windows.lock
@@ -98,7 +98,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt
@@ -341,7 +341,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via
     #   -c requirements/static/pkg/py3.12/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/cloud.lock
+++ b/requirements/static/ci/py3.13/cloud.lock
@@ -35,10 +35,11 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.13/linux.lock
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -86,10 +87,11 @@ cffi==2.0.0
     #   -r requirements/static/ci/common.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via
@@ -123,7 +125,7 @@ croniter==6.2.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -370,7 +372,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -482,7 +484,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -612,7 +614,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/darwin-lint.lock
+++ b/requirements/static/ci/py3.13/darwin-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.13/darwin.lock
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/darwin.lock
     #   -c requirements/static/pkg/py3.13/darwin.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/darwin.lock
     #   -c requirements/static/pkg/py3.13/darwin.lock

--- a/requirements/static/ci/py3.13/darwin.lock
+++ b/requirements/static/ci/py3.13/darwin.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -70,9 +71,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -96,7 +98,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -269,7 +271,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -350,7 +352,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt
@@ -438,7 +440,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/docs.lock
+++ b/requirements/static/ci/py3.13/docs.lock
@@ -24,9 +24,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
 babel==2.17.0
     # via
@@ -44,9 +45,10 @@ cffi==2.0.0
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheroot==11.1.2
     # via
@@ -66,7 +68,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -184,7 +186,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -244,7 +246,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -271,7 +273,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd-lint.lock
+++ b/requirements/static/ci/py3.13/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.13/freebsd.lock
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/freebsd.lock
     #   -c requirements/static/pkg/py3.13/freebsd.lock
@@ -46,7 +46,7 @@ pywin32==312 ; sys_platform == 'win32'
     #   -c requirements/static/ci/py3.13/freebsd.lock
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/freebsd.lock
     #   -c requirements/static/pkg/py3.13/freebsd.lock

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1 ; sys_platform != 'win32'
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -72,9 +73,10 @@ cffi==2.0.0
     #   cryptography
     #   pynacl
     #   pyzmq
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -109,7 +111,7 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -301,7 +303,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -392,7 +394,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -496,7 +498,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/freebsd.lock
+++ b/requirements/static/ci/py3.13/freebsd.lock
@@ -111,7 +111,17 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt
@@ -394,7 +404,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.13/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.13/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/linux-lint.lock
+++ b/requirements/static/ci/py3.13/linux-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/linux.lock
     #   -c requirements/static/pkg/py3.13/linux.lock

--- a/requirements/static/ci/py3.13/linux.lock
+++ b/requirements/static/ci/py3.13/linux.lock
@@ -38,9 +38,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -82,9 +83,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -108,7 +110,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -299,7 +301,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -390,7 +392,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt
@@ -487,7 +489,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows-lint.lock
+++ b/requirements/static/ci/py3.13/windows-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.13/windows.lock
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.13/windows.lock
     #   -c requirements/static/pkg/py3.13/windows.lock
@@ -46,7 +46,7 @@ pywin32==312
     #   -c requirements/static/ci/py3.13/windows.lock
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.13/windows.lock
     #   -c requirements/static/pkg/py3.13/windows.lock

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -99,7 +99,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -342,7 +342,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.13/windows.lock
+++ b/requirements/static/ci/py3.13/windows.lock
@@ -23,9 +23,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -62,9 +63,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -97,7 +99,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -260,7 +262,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -340,7 +342,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt
@@ -437,7 +439,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.13/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/cloud.lock
+++ b/requirements/static/ci/py3.14/cloud.lock
@@ -35,10 +35,11 @@ asn1crypto==1.5.1
     #   -c requirements/static/ci/py3.14/linux.lock
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -86,10 +87,11 @@ cffi==2.0.0
     #   -r requirements/static/ci/common.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via
@@ -123,7 +125,7 @@ croniter==6.2.2
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
@@ -370,7 +372,7 @@ moto==5.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
@@ -482,7 +484,7 @@ pynacl==1.6.2
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
@@ -612,7 +614,7 @@ referencing==0.37.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/darwin-lint.lock
+++ b/requirements/static/ci/py3.14/darwin-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.14/darwin.lock
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/darwin.lock
     #   -c requirements/static/pkg/py3.14/darwin.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/darwin.lock
     #   -c requirements/static/pkg/py3.14/darwin.lock

--- a/requirements/static/ci/py3.14/darwin.lock
+++ b/requirements/static/ci/py3.14/darwin.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -70,9 +71,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -96,7 +98,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -269,7 +271,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -350,7 +352,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt
@@ -438,7 +440,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.14/darwin.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/docs.lock
+++ b/requirements/static/ci/py3.14/docs.lock
@@ -24,9 +24,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
 babel==2.18.0
     # via
@@ -44,9 +45,10 @@ cffi==2.0.0
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheroot==11.1.2
     # via
@@ -66,7 +68,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -185,7 +187,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -245,7 +247,7 @@ pygments==2.20.0
     #   pydata-sphinx-theme
     #   rich
     #   sphinx
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -272,7 +274,7 @@ pyzmq==27.1.0
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/freebsd-lint.lock
+++ b/requirements/static/ci/py3.14/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.14/freebsd.lock
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/freebsd.lock
     #   -c requirements/static/pkg/py3.14/freebsd.lock
@@ -46,7 +46,7 @@ pywin32==312 ; sys_platform == 'win32'
     #   -c requirements/static/ci/py3.14/freebsd.lock
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/freebsd.lock
     #   -c requirements/static/pkg/py3.14/freebsd.lock

--- a/requirements/static/ci/py3.14/freebsd.lock
+++ b/requirements/static/ci/py3.14/freebsd.lock
@@ -28,9 +28,10 @@ asn1crypto==1.5.1 ; sys_platform != 'win32'
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -72,9 +73,10 @@ cffi==2.0.0
     #   cryptography
     #   pynacl
     #   pyzmq
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -109,7 +111,7 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -301,7 +303,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -392,7 +394,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -496,7 +498,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/freebsd.lock
+++ b/requirements/static/ci/py3.14/freebsd.lock
@@ -111,7 +111,17 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt
@@ -394,7 +404,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.14/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.14/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/linux-lint.lock
+++ b/requirements/static/ci/py3.14/linux-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock
@@ -36,7 +36,7 @@ pylint==3.1.1
     # via
     #   -r requirements/static/ci/lint.txt
     #   saltpylint
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/linux.lock
     #   -c requirements/static/pkg/py3.14/linux.lock

--- a/requirements/static/ci/py3.14/linux.lock
+++ b/requirements/static/ci/py3.14/linux.lock
@@ -38,9 +38,10 @@ asn1crypto==1.5.1
     # via
     #   certvalidator
     #   oscrypto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -82,9 +83,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -108,7 +110,7 @@ croniter==6.2.2
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -301,7 +303,7 @@ more-itertools==11.1.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -392,7 +394,7 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt
@@ -489,7 +491,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.14/linux.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/windows-lint.lock
+++ b/requirements/static/ci/py3.14/windows-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.14/windows.lock
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   requests
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.14/windows.lock
     #   -c requirements/static/pkg/py3.14/windows.lock
@@ -46,7 +46,7 @@ pywin32==312
     #   -c requirements/static/ci/py3.14/windows.lock
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   docker
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/ci/py3.14/windows.lock
     #   -c requirements/static/pkg/py3.14/windows.lock

--- a/requirements/static/ci/py3.14/windows.lock
+++ b/requirements/static/ci/py3.14/windows.lock
@@ -23,9 +23,10 @@ apache-libcloud==3.9.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -62,9 +63,10 @@ cffi==2.0.0
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==3.4.4
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -97,7 +99,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -260,7 +262,7 @@ more-itertools==10.8.0
     #   jaraco-text
 moto==5.2.2
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.2.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -340,7 +342,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -437,7 +439,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.14/windows.lock
+++ b/requirements/static/ci/py3.14/windows.lock
@@ -99,7 +99,7 @@ contextvars==2.4
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt
@@ -342,7 +342,7 @@ pymysql==1.2.0
     #   -r requirements/base.txt
 pynacl==1.6.2
     # via -r requirements/static/ci/common.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via
     #   -c requirements/static/pkg/py3.14/windows.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd-lint.lock
+++ b/requirements/static/ci/py3.9/freebsd-lint.lock
@@ -7,7 +7,7 @@ certifi==2026.5.20
     #   -c requirements/static/ci/py3.9/freebsd.lock
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   requests
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/ci/py3.9/freebsd.lock
     #   -c requirements/static/pkg/py3.9/freebsd.lock
@@ -51,7 +51,7 @@ requests==2.32.5 ; python_full_version < '3.10'
     #   -c requirements/static/ci/py3.9/freebsd.lock
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   docker
-requests==2.33.1 ; python_full_version >= '3.10'
+requests==2.34.2 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/ci/py3.9/freebsd.lock
     #   -c requirements/static/pkg/py3.9/freebsd.lock

--- a/requirements/static/ci/py3.9/freebsd.lock
+++ b/requirements/static/ci/py3.9/freebsd.lock
@@ -43,9 +43,10 @@ async-timeout==4.0.3 ; python_full_version < '3.11'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   aiohttp
-attrs==23.2.0
+attrs==26.1.0
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
     #   aiohttp
     #   jsonschema
     #   pytest-salt-factories
@@ -108,9 +109,10 @@ cffi==2.0.0
     #   napalm
     #   pynacl
     #   pyzmq
-charset-normalizer==3.2.0
+charset-normalizer==3.5.1
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.txt
@@ -150,7 +152,20 @@ croniter==6.2.2 ; sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
-cryptography==47.0.0
+cryptography==47.0.0 ; python_full_version < '3.10'
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   paramiko
+    #   pyopenssl
+    #   secretstorage
+    #   trustme
+    #   vcert
+cryptography==50.0.0 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
@@ -412,7 +427,12 @@ moto==5.1.20 ; python_full_version < '3.10'
     # via -r requirements/static/ci/common.txt
 moto==5.2.2 ; python_full_version >= '3.10'
     # via -r requirements/static/ci/common.txt
-msgpack==1.1.2
+msgpack==1.1.2 ; python_full_version < '3.10'
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
+    #   pytest-salt-factories
+msgpack==1.2.1 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
@@ -542,7 +562,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0
+pyopenssl==26.1.0 ; python_full_version < '3.10'
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+pyopenssl==26.4.0 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
@@ -686,7 +712,7 @@ requests==2.32.5 ; python_full_version < '3.10'
     #   requests-oauthlib
     #   responses
     #   vcert
-requests==2.33.1 ; python_full_version >= '3.10'
+requests==2.34.2 ; python_full_version >= '3.10'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/freebsd.lock
+++ b/requirements/static/ci/py3.9/freebsd.lock
@@ -165,7 +165,17 @@ cryptography==47.0.0 ; python_full_version < '3.10'
     #   secretstorage
     #   trustme
     #   vcert
-cryptography==50.0.0 ; python_full_version >= '3.10'
+cryptography==48.0.1 ; python_full_version >= '3.10' and sys_platform == 'win32'
+    # via
+    #   -c requirements/static/pkg/py3.9/freebsd.lock
+    #   -r requirements/base.txt
+    #   -r requirements/static/ci/common.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   etcd3-py
+    #   moto
+    #   pyopenssl
+    #   trustme
+cryptography==50.0.0 ; python_full_version >= '3.10' and sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
@@ -562,13 +572,13 @@ pynacl==1.6.2
     # via
     #   -r requirements/static/ci/common.txt
     #   paramiko
-pyopenssl==26.1.0 ; python_full_version < '3.10'
+pyopenssl==26.2.0 ; python_full_version < '3.10' or sys_platform == 'win32'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
     #   etcd3-py
-pyopenssl==26.4.0 ; python_full_version >= '3.10'
+pyopenssl==26.4.0 ; python_full_version >= '3.10' and sys_platform != 'win32'
     # via
     #   -c requirements/static/pkg/py3.9/freebsd.lock
     #   -r requirements/base.txt

--- a/requirements/static/pkg/freebsd.txt
+++ b/requirements/static/pkg/freebsd.txt
@@ -2,10 +2,11 @@
 # Any non hard dependencies of Salt for FreeBSD can go here
 # If they are freebsd specific, place "; sys_platform == 'freebsd'" in front of the requirement.
 cherrypy>=18.10.0
-cryptography>=46.0.7,<48.0.0
+cryptography>=46.0.7,<48.0.0; python_version < '3.10'
+cryptography>=48.0.1; python_version >= '3.10'
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.0.0,<26.2.0
+pyopenssl>=26.0.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 setproctitle>=1.3.7

--- a/requirements/static/pkg/linux.txt
+++ b/requirements/static/pkg/linux.txt
@@ -7,7 +7,7 @@ cherrypy>=18.10.0
 cheroot>=11.1.2
 pycparser>=2.23; python_version < '3.10'
 pycparser>=3.0; python_version >= '3.10'
-pyopenssl>=26.0.0,<26.2.0
+pyopenssl>=26.0.0
 python-dateutil>=2.9.0.post0
 python-gnupg>=0.5.6
 setproctitle>=1.3.7
@@ -15,6 +15,7 @@ timelib>=0.2.5; python_version < '3.11'
 timelib>=0.3.0; python_version >= '3.11'
 importlib-metadata>=8.7.0,<9.0.0; python_version < '3.10'
 importlib-metadata>=9.0.0; python_version >= '3.10'
-cryptography>=46.0.7,<48.0.0
+cryptography>=46.0.7,<48.0.0; python_version < '3.10'
+cryptography>=48.0.1; python_version >= '3.10'
 more-itertools>=10.8.0,<11.0.0; python_version < '3.10'
 more-itertools>=11.1.0; python_version >= '3.10'

--- a/requirements/static/pkg/py3.10/darwin.lock
+++ b/requirements/static/pkg/py3.10/darwin.lock
@@ -12,8 +12,10 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -24,8 +26,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -36,7 +40,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -108,7 +112,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -141,7 +145,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -157,7 +161,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -165,7 +169,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -49,7 +49,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -170,7 +175,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.10/freebsd.lock
+++ b/requirements/static/pkg/py3.10/freebsd.lock
@@ -12,8 +12,10 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 async-timeout==4.0.3 ; python_full_version < '3.11'
     # via aiohttp
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
 certifi==2026.5.20
@@ -26,8 +28,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -45,7 +49,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -128,7 +132,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -166,7 +170,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -193,7 +197,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -203,7 +207,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.10/linux.lock
+++ b/requirements/static/pkg/py3.10/linux.lock
@@ -12,8 +12,10 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -24,8 +26,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -39,7 +43,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -115,7 +119,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -149,7 +153,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -170,7 +174,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -180,7 +184,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -12,8 +12,10 @@ apache-libcloud==3.9.1
     # via -r requirements/base.txt
 async-timeout==5.0.1
     # via aiohttp
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -25,8 +27,10 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   clr-loader
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -41,7 +45,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -115,7 +119,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -152,7 +156,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -172,7 +176,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -180,7 +184,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.10/windows.lock
+++ b/requirements/static/pkg/py3.10/windows.lock
@@ -45,7 +45,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -156,7 +156,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.11/darwin.lock
+++ b/requirements/static/pkg/py3.11/darwin.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -22,8 +24,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -34,7 +38,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -104,7 +108,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -137,7 +141,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -153,7 +157,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -161,7 +165,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -47,7 +47,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -164,7 +169,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.11/freebsd.lock
+++ b/requirements/static/pkg/py3.11/freebsd.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
 certifi==2026.5.20
@@ -24,8 +26,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -43,7 +47,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -122,7 +126,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -160,7 +164,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -187,7 +191,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -197,7 +201,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.11/linux.lock
+++ b/requirements/static/pkg/py3.11/linux.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -22,8 +24,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -37,7 +41,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -111,7 +115,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -145,7 +149,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -166,7 +170,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -176,7 +180,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0
     # via jaraco-context
 certifi==2026.5.20
@@ -23,8 +25,10 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   clr-loader
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -39,7 +43,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -111,7 +115,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -148,7 +152,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -168,7 +172,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -176,7 +180,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.11/windows.lock
+++ b/requirements/static/pkg/py3.11/windows.lock
@@ -43,7 +43,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -152,7 +152,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.12/darwin.lock
+++ b/requirements/static/pkg/py3.12/darwin.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -32,7 +36,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -102,7 +106,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -135,7 +139,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -151,7 +155,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -159,7 +163,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -45,7 +45,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -162,7 +167,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.12/freebsd.lock
+++ b/requirements/static/pkg/py3.12/freebsd.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -22,8 +24,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -41,7 +45,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -120,7 +124,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -158,7 +162,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -185,7 +189,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -195,7 +199,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.12/linux.lock
+++ b/requirements/static/pkg/py3.12/linux.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -35,7 +39,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -109,7 +113,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -143,7 +147,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -164,7 +168,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -174,7 +178,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -41,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -150,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.12/windows.lock
+++ b/requirements/static/pkg/py3.12/windows.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -21,8 +23,10 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   clr-loader
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -37,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -109,7 +113,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -146,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -166,7 +170,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -174,7 +178,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.13/darwin.lock
+++ b/requirements/static/pkg/py3.13/darwin.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -32,7 +36,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -102,7 +106,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -135,7 +139,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -150,7 +154,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -158,7 +162,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -45,7 +45,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -162,7 +167,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.13/freebsd.lock
+++ b/requirements/static/pkg/py3.13/freebsd.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -22,8 +24,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -41,7 +45,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -120,7 +124,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -158,7 +162,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -184,7 +188,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -194,7 +198,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.13/linux.lock
+++ b/requirements/static/pkg/py3.13/linux.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -35,7 +39,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -109,7 +113,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -143,7 +147,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -163,7 +167,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -173,7 +177,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -41,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -150,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.13/windows.lock
+++ b/requirements/static/pkg/py3.13/windows.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -21,8 +23,10 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   clr-loader
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -37,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -109,7 +113,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -146,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -166,7 +170,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -174,7 +178,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.14/darwin.lock
+++ b/requirements/static/pkg/py3.14/darwin.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -32,7 +36,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -102,7 +106,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -135,7 +139,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -150,7 +154,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -158,7 +162,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -45,7 +45,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -162,7 +167,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0 ; sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.14/freebsd.lock
+++ b/requirements/static/pkg/py3.14/freebsd.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -22,8 +24,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -41,7 +45,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -120,7 +124,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -158,7 +162,7 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -184,7 +188,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -194,7 +198,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.14/linux.lock
+++ b/requirements/static/pkg/py3.14/linux.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -20,8 +22,10 @@ cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -35,7 +39,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -109,7 +113,7 @@ more-itertools==11.1.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.0
     # via
@@ -143,7 +147,7 @@ pycryptodomex==3.23.0
     #   -r requirements/crypto.txt
 pygments==2.20.0
     # via rich
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
@@ -163,7 +167,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -173,7 +177,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -41,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==50.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -150,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.4.0
+pyopenssl==26.2.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/static/pkg/py3.14/windows.lock
+++ b/requirements/static/pkg/py3.14/windows.lock
@@ -10,8 +10,10 @@ annotated-doc==0.0.4
     # via typer
 apache-libcloud==3.9.1
     # via -r requirements/base.txt
-attrs==25.4.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 certifi==2026.5.20
     # via
     #   -r requirements/base.txt
@@ -21,8 +23,10 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   clr-loader
     #   cryptography
-charset-normalizer==3.4.4
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -37,7 +41,7 @@ colorama==0.4.6
     # via click
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==50.0.0
     # via
     #   -r requirements/base.txt
     #   pyopenssl
@@ -109,7 +113,7 @@ more-itertools==10.8.0
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.2.1
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -146,7 +150,7 @@ pymssql==2.3.11
     # via -r requirements/base.txt
 pymysql==1.2.0
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.4.0
     # via -r requirements/base.txt
 python-dateutil==2.9.0.post0
     # via
@@ -166,7 +170,7 @@ pyyaml==6.0.3
     # via -r requirements/base.txt
 pyzmq==27.1.0
     # via -r requirements/zeromq.txt
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -174,7 +178,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==84.0.0
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.9/darwin.lock
+++ b/requirements/static/pkg/py3.9/darwin.lock
@@ -167,7 +167,7 @@ rich==15.0.0
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==82.0.1
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.9/freebsd.lock
+++ b/requirements/static/pkg/py3.9/freebsd.lock
@@ -16,8 +16,10 @@ apache-libcloud==3.9.1 ; python_full_version >= '3.10'
     # via -r requirements/base.txt
 async-timeout==4.0.3 ; python_full_version < '3.11'
     # via aiohttp
-attrs==23.2.0
-    # via aiohttp
+attrs==26.1.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
 certifi==2026.5.20
@@ -30,8 +32,10 @@ cffi==2.0.0
     #   clr-loader
     #   cryptography
     #   pyzmq
-charset-normalizer==3.2.0
-    # via requests
+charset-normalizer==3.5.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 cheroot==11.1.2
     # via
     #   -r requirements/base.txt
@@ -53,7 +57,12 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==6.2.2 ; sys_platform != 'win32'
     # via -r requirements/base.txt
-cryptography==47.0.0
+cryptography==47.0.0 ; python_full_version < '3.10'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; python_full_version >= '3.10'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -166,7 +175,9 @@ more-itertools==11.1.0 ; python_full_version >= '3.10'
     #   cherrypy
     #   jaraco-functools
     #   jaraco-text
-msgpack==1.1.2
+msgpack==1.1.2 ; python_full_version < '3.10'
+    # via -r requirements/base.txt
+msgpack==1.2.1 ; python_full_version >= '3.10'
     # via -r requirements/base.txt
 multidict==6.7.1
     # via
@@ -211,7 +222,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0
+pyopenssl==26.1.0 ; python_full_version < '3.10'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+pyopenssl==26.4.0 ; python_full_version >= '3.10'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -243,7 +258,7 @@ requests==2.32.5 ; python_full_version < '3.10'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
-requests==2.33.1 ; python_full_version >= '3.10'
+requests==2.34.2 ; python_full_version >= '3.10'
     # via
     #   -r requirements/base.txt
     #   apache-libcloud
@@ -253,7 +268,11 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-setuptools==82.0.0
+setuptools==82.0.1 ; python_full_version < '3.10'
+    # via
+    #   -c requirements/constraints.txt
+    #   zc-lockfile
+setuptools==84.0.0 ; python_full_version >= '3.10'
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.9/freebsd.lock
+++ b/requirements/static/pkg/py3.9/freebsd.lock
@@ -62,7 +62,12 @@ cryptography==47.0.0 ; python_full_version < '3.10'
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
     #   pyopenssl
-cryptography==50.0.0 ; python_full_version >= '3.10'
+cryptography==48.0.1 ; python_full_version >= '3.10' and sys_platform == 'win32'
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/static/pkg/freebsd.txt
+    #   pyopenssl
+cryptography==50.0.0 ; python_full_version >= '3.10' and sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
@@ -222,11 +227,11 @@ pymssql==2.3.11 ; sys_platform == 'win32'
     # via -r requirements/base.txt
 pymysql==1.2.0 ; sys_platform == 'win32'
     # via -r requirements/base.txt
-pyopenssl==26.1.0 ; python_full_version < '3.10'
+pyopenssl==26.2.0 ; python_full_version < '3.10' or sys_platform == 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt
-pyopenssl==26.4.0 ; python_full_version >= '3.10'
+pyopenssl==26.4.0 ; python_full_version >= '3.10' and sys_platform != 'win32'
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.txt

--- a/requirements/static/pkg/py3.9/linux.lock
+++ b/requirements/static/pkg/py3.9/linux.lock
@@ -182,7 +182,7 @@ setproctitle==1.3.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/linux.txt
-setuptools==82.0.0
+setuptools==82.0.1
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/requirements/static/pkg/py3.9/windows.lock
+++ b/requirements/static/pkg/py3.9/windows.lock
@@ -181,7 +181,7 @@ rich==14.3.3
     # via typer
 setproctitle==1.3.7
     # via -r requirements/base.txt
-setuptools==82.0.0
+setuptools==82.0.1
     # via
     #   -c requirements/constraints.txt
     #   zc-lockfile

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -117,13 +117,26 @@ from salt.utils.versions import Version
 
 
 HAS_SSL = False
-X509_EXT_ENABLED = True
+X509_EXT_ENABLED = False
+HAS_LEGACY_PYOPENSSL = False
 HAS_CRYPTOGRAPHY = False
 try:
     import OpenSSL
 
     HAS_SSL = True
     OpenSSL_version = Version(OpenSSL.__dict__.get("__version__", "0.0"))
+    # Detect at import time whether pyOpenSSL still exposes the legacy X509
+    # extension / CSR / PKCS12 / CRL API that this module is built on.
+    # pyOpenSSL 26.0 removed X509Extension, X509Req, PKCS12, CRL and
+    # load_crl in favor of the ``cryptography`` package's x509 module.
+    # Compute the flags at import time (instead of only inside
+    # ``__virtual__``) so the module is safe to import directly (for example
+    # from unit tests) without ever attempting to call the removed APIs.
+    X509_EXT_ENABLED = hasattr(OpenSSL.crypto, "X509Extension")
+    HAS_LEGACY_PYOPENSSL = all(
+        hasattr(OpenSSL.crypto, name)
+        for name in ("X509Extension", "X509Req", "PKCS12", "CRL", "load_crl")
+    )
 except ImportError:
     pass
 
@@ -149,15 +162,16 @@ def __virtual__():
     """
     global X509_EXT_ENABLED
     if HAS_SSL and OpenSSL_version >= Version("0.10"):
-        if not hasattr(OpenSSL.crypto, "X509Extension"):
+        if not HAS_LEGACY_PYOPENSSL:
             X509_EXT_ENABLED = False
-            log.debug(
-                "pyOpenSSL %s no longer exposes X509Extension/add_extensions; "
-                "the tls module's certificate-extension feature is disabled. "
-                "Use salt.modules.x509 for extension-aware certificate work.",
-                OpenSSL_version,
+            return (
+                False,
+                "pyOpenSSL {} no longer exposes the legacy X509Extension / "
+                "X509Req / PKCS12 / CRL APIs that salt.modules.tls depends "
+                "on. Use salt.modules.x509 (backed by the cryptography "
+                "package) instead.".format(OpenSSL_version),
             )
-        elif OpenSSL_version < Version("0.14"):
+        if OpenSSL_version < Version("0.14"):
             X509_EXT_ENABLED = False
             log.debug(
                 "You should upgrade pyOpenSSL to at least 0.14.1 to "

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -149,7 +149,15 @@ def __virtual__():
     """
     global X509_EXT_ENABLED
     if HAS_SSL and OpenSSL_version >= Version("0.10"):
-        if OpenSSL_version < Version("0.14"):
+        if not hasattr(OpenSSL.crypto, "X509Extension"):
+            X509_EXT_ENABLED = False
+            log.debug(
+                "pyOpenSSL %s no longer exposes X509Extension/add_extensions; "
+                "the tls module's certificate-extension feature is disabled. "
+                "Use salt.modules.x509 for extension-aware certificate work.",
+                OpenSSL_version,
+            )
+        elif OpenSSL_version < Version("0.14"):
             X509_EXT_ENABLED = False
             log.debug(
                 "You should upgrade pyOpenSSL to at least 0.14.1 to "

--- a/tests/integration/modules/test_tls.py
+++ b/tests/integration/modules/test_tls.py
@@ -7,6 +7,8 @@
 import os
 import tempfile
 
+import pytest
+
 # Salt Libs
 import salt.modules.cmdmod as cmd
 import salt.modules.file as file
@@ -21,6 +23,14 @@ from tests.support.mock import MagicMock
 from tests.support.runtests import RUNTIME_VARS
 
 
+@pytest.mark.skipif(
+    not tls.HAS_LEGACY_PYOPENSSL,
+    reason=(
+        "pyOpenSSL 26.0+ removed X509Extension / X509Req / PKCS12 / CRL "
+        "APIs that salt.modules.tls depends on; use salt.modules.x509 "
+        "instead."
+    ),
+)
 class TLSModuleTest(ModuleCase, LoaderModuleMockMixin):
     """
     Tests for salt.modules.tls

--- a/tests/pytests/unit/modules/test_tls.py
+++ b/tests/pytests/unit/modules/test_tls.py
@@ -15,6 +15,23 @@ pytestmark = [
 ]
 
 
+# pyOpenSSL 26.0 removed X509Extension / X509Req / PKCS12 / CRL / load_crl
+# in favor of the ``cryptography`` package. Tests that exercise those
+# code paths cannot run under pyOpenSSL 26+ (the salt.modules.tls
+# functions they exercise raise AttributeError before the assertions
+# run). ``salt.modules.tls.__virtual__`` returns ``False`` under
+# pyOpenSSL 26+ for the same reason; users should migrate to
+# ``salt.modules.x509`` which is backed by ``cryptography`` directly.
+requires_legacy_pyopenssl = pytest.mark.skipif(
+    not tls.HAS_LEGACY_PYOPENSSL,
+    reason=(
+        "pyOpenSSL 26.0+ removed X509Extension / X509Req / PKCS12 / CRL "
+        "APIs that salt.modules.tls depends on; use salt.modules.x509 "
+        "instead."
+    ),
+)
+
+
 @pytest.fixture
 def configure_loader_modules():
     return {tls: {}}
@@ -110,6 +127,7 @@ def test_create_ca_permissions_on_cert_and_key(tmp_path, tls_test_data):
         assert certk.stat().st_mode & 0o7777 == 0o600
 
 
+@requires_legacy_pyopenssl
 @pytest.mark.skip_on_windows(reason="Skipping on Windows per Shane's suggestion")
 def test_create_csr_permissions_on_csr_and_key(tmp_path, tls_test_data):
     ca_name = "test_ca"
@@ -470,6 +488,7 @@ def test_recreate_ca(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_create_csr(tmp_path, tls_test_data):
     """
     Test creating certificate signing request
@@ -502,6 +521,7 @@ def test_create_csr(tmp_path, tls_test_data):
         assert tls.create_csr(ca_name, **tls_test_data["create_ca"]) == ret
 
 
+@requires_legacy_pyopenssl
 def test_recreate_csr(tmp_path, tls_test_data):
     """
     Test creating certificate signing request when one already exists
@@ -589,6 +609,7 @@ def test_recreate_self_signed_cert(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_create_ca_signed_cert(tmp_path, tls_test_data):
     """
     Test signing certificate from request
@@ -621,6 +642,7 @@ def test_create_ca_signed_cert(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_recreate_ca_signed_cert(tmp_path, tls_test_data):
     """
     Test signing certificate from request when certificate exists
@@ -657,6 +679,7 @@ def test_recreate_ca_signed_cert(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_create_pkcs12(tmp_path, tls_test_data):
     """
     Test creating pkcs12
@@ -691,6 +714,7 @@ def test_create_pkcs12(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_recreate_pkcs12(tmp_path, tls_test_data):
     """
     Test creating pkcs12 when it already exists
@@ -732,6 +756,7 @@ def test_recreate_pkcs12(tmp_path, tls_test_data):
         )
 
 
+@requires_legacy_pyopenssl
 def test_pyOpenSSL_version():
     """
     Test extension logic with different pyOpenSSL versions
@@ -768,6 +793,7 @@ def test_pyOpenSSL_version():
             assert tls.get_extensions("client") == pillarval
 
 
+@requires_legacy_pyopenssl
 def test_pyOpenSSL_version_destructive(tmp_path, tls_test_data):
     """
     Test extension logic with different pyOpenSSL versions

--- a/tests/pytests/unit/modules/test_tls_create_csr_path.py
+++ b/tests/pytests/unit/modules/test_tls_create_csr_path.py
@@ -39,6 +39,14 @@ def csr_kwargs():
     }
 
 
+@pytest.mark.skipif(
+    not tls.HAS_LEGACY_PYOPENSSL,
+    reason=(
+        "pyOpenSSL 26.0+ removed X509Extension / X509Req / PKCS12 / CRL "
+        "APIs that salt.modules.tls depends on; use salt.modules.x509 "
+        "instead."
+    ),
+)
 @pytest.mark.skip_on_windows(reason="POSIX path separators are the bug under test")
 def test_create_csr_return_message_uses_separator_when_csr_path_has_no_trailing_slash(
     tmp_path, csr_kwargs

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -631,7 +631,12 @@ def onedir_dependencies(
         # are never linked into runtime artifacts. Force wheels for them so
         # --no-binary :all: below does not trigger a CMake source build,
         # which fails under the relenv toolchain (missing pid_t/mode_t/etc).
-        "--only-binary=maturin,apache-libcloud,pymssql,hatchling,cmake,ninja,protobuf",
+        # zc.lockfile==4.0's pyproject.toml pins setuptools==78.1.1 exactly in
+        # [build-system].requires (from the zopefoundation/meta template), which
+        # collides with our setuptools>=82.0.1 --build-constraint. It is a pure-
+        # Python package with a universal wheel on PyPI, so allow the wheel to
+        # sidestep the source build's build-system requirements entirely.
+        "--only-binary=maturin,apache-libcloud,pymssql,hatchling,cmake,ninja,protobuf,zc.lockfile",
     ]
     if platform == "windows":
         python_bin = env_scripts_dir / "python"
@@ -647,8 +652,10 @@ def onedir_dependencies(
         # on large deployments. The upstream PyYAML manylinux2014 wheel
         # bundles libyaml (MIT-licensed) and is compatible with the relenv
         # target platform, so allow it through --no-binary=:all: here.
+        # See zc.lockfile comment above for why it also needs an --only-binary
+        # exception under the Linux --no-binary=:all: path.
         install_args.append(
-            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja,protobuf,pyyaml"
+            "--only-binary=maturin,apache-libcloud,pymssql,cassandra-driver,hatchling,cmake,ninja,protobuf,pyyaml,zc.lockfile"
         )
         # CMake 4.x removed support for cmake_minimum_required(VERSION < 3.5).
         # pyzmq's bundled libzmq still declares an older floor; set the policy


### PR DESCRIPTION
## Summary

Advance the salt-onedir Python stack on 3006.x to current LTS floors on Python 3.10+. Python 3.9 pins retained (cryptography 48+ drops 3.9.0/3.9.1; msgpack 1.2.1 drops 3.9).

- **cryptography**: `>=48.0.1` on py>=3.10 (46.x cap retained on py3.9). Onedir build compiles from source under `--no-binary=:all:` with `OPENSSL_DIR` set to relenv's openssl (`tools/pkg/build.py`), so the relenv linkage is preserved.
- **pyopenssl**: drop the `<26.2.0` cap. `salt/modules/tls.py::__virtual__` now detects removed `OpenSSL.crypto.X509Extension` symbol and sets `X509_EXT_ENABLED=False` with a `log.debug` message, mirroring the existing `Version("0.14")` fallback. Callers needing cert extensions should use `salt.modules.x509`.
- **msgpack**: lower bound `>=1.2.0` on py>=3.10.
- **requests**: lower bound `>=2.34.2` on py>=3.10.
- **setuptools**: constraints floor `>=82.0.1` (+1 patch over already-resolved 82.0.0).
- **attrs / charset-normalizer**: explicit floors added to `base.txt` on py>=3.10 (previously resolved below CVE-patched line via aiohttp/requests transitive).

Lock files regenerated via pre-commit `pip-compile` hooks.

## Test plan

- [ ] CI (`test:full` label applied).
- [x] `salt.modules.tls` import-smokes clean.
- [x] `pre-commit` clean on `salt/modules/tls.py` + new changelog entry.