### PR TITLE
publish-nightly-release: backfill dropped build artifacts + dedupe by basename

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -88,6 +88,64 @@ jobs:
           # subdirectory under nightly-artifacts/<artifact-name>/; the
           # find steps below still collect files recursively.
 
+      - name: backfill build artifacts that download-artifact silently dropped
+
+        # `actions/download-artifact@v4` has been observed to silently drop
+        # entries past some per-run size threshold on runs with hundreds
+        # of artifacts. The JUnit-download step below has a matching
+        # backfill for the same reason (see 8/18 3008.x publish 32089946413
+        # dropping 36/336 testrun-junit dirs). Without a backfill on THIS
+        # step, an unlucky drop of every `salt-*-<arch>-rpm`,
+        # `salt-*-<arch>-deb`, `salt-*-onedir-*` etc. produces a release
+        # with zero (or almost zero) attachments -- observed on 3006.x
+        # for nightly-2026-08-24-3006.x (only 8 aarch64 rpm files
+        # survived) and nightly-2026-08-25-3006.x (0 assets, "count: 0").
+        #
+        # Cross-check what actually landed against the API's authoritative
+        # artifact list for the triggering run, and pull anything missing
+        # via `gh api ... /zip`. Excludes `*-from-src` here as an
+        # optimisation -- the prune step below would remove them anyway.
+        # Per-artifact backfill failure is non-fatal; the subsequent
+        # find/create-release steps operate on whatever landed.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p nightly-artifacts
+          gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            --paginate \
+            --jq '.artifacts[] | select(.name | endswith("-from-src") | not) | "\(.id)\t\(.name)"' \
+            > /tmp/expected-build-artifacts.tsv
+          total=$(wc -l < /tmp/expected-build-artifacts.tsv | tr -d ' ')
+          existing=$(find nightly-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+          echo "expected: ${total}   already-downloaded: ${existing}"
+
+          missing_count=0
+          fail_count=0
+          while IFS=$'\t' read -r id name; do
+            if [ -d "nightly-artifacts/${name}" ]; then
+              continue
+            fi
+            missing_count=$((missing_count + 1))
+            echo "  backfilling ${name} (id=${id})"
+            mkdir -p "nightly-artifacts/${name}"
+            if gh api -H 'Accept: application/vnd.github+json' \
+                 "repos/${REPO}/actions/artifacts/${id}/zip" \
+                 > "/tmp/backfill-${id}.zip" 2>/dev/null
+            then
+              unzip -q -o "/tmp/backfill-${id}.zip" -d "nightly-artifacts/${name}" || true
+            else
+              echo "    WARN: /zip fetch failed for ${name}"
+              fail_count=$((fail_count + 1))
+            fi
+            rm -f "/tmp/backfill-${id}.zip"
+          done < /tmp/expected-build-artifacts.tsv
+
+          final=$(find nightly-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+          echo "backfilled: ${missing_count}   /zip-failed: ${fail_count}   final: ${final}/${total}"
+
       - name: drop source-build artifacts before publish
         # `-rpm-from-src`, `-deb-from-src` etc. are internal source-build
         # verification outputs. They are never consumed downstream and
@@ -114,10 +172,21 @@ jobs:
           echo "=== files under nightly-artifacts/ ==="
           find nightly-artifacts -type f | sort
           echo "=== filtered assets (release-ready formats only) ==="
+          # De-duplicate by basename via awk. Some build artifacts contain
+          # the same-named file (notably the debian source tarball
+          # `salt_<ver>.tar.xz` is inside BOTH `salt-*-x86_64-deb` and
+          # `salt-*-arm64-deb` artifacts). With merge-multiple: false those
+          # both survive extraction under separate subdirs; passing both
+          # paths to `gh release create` produces HTTP 422
+          # "ReleaseAsset.name already exists" mid-upload -- observed on
+          # nightly-2026-08-25-3008.x. First-sorted path wins. Safe as
+          # long as duplicates are semantically equivalent (they are for
+          # the debian source tarball: same source, both arches).
           find nightly-artifacts -type f \
             \( -name '*.rpm' -o -name '*.deb' -o -name '*.msi' -o -name '*.exe' \
                -o -name '*.pkg' -o -name '*.tar.xz' -o -name '*.tar.gz' \
-               -o -name '*onedir*.zip' -o -name '*onedir*.xz' \) | sort > /tmp/assets.txt
+               -o -name '*onedir*.zip' -o -name '*onedir*.xz' \) | sort \
+            | awk -F/ '!seen[$NF]++' > /tmp/assets.txt
           echo "count: $(wc -l < /tmp/assets.txt)"
           cat /tmp/assets.txt
 


### PR DESCRIPTION
### What does this PR do?

Two follow-ups to #70128, both observed in publishes on 8/25.

### What issues does this PR fix or reference?

Follow-up to #70128 (merged 8/24). Also follows the same backfill pattern from #70078.

### Previous Behavior

Two distinct failure modes surfaced on today's publishes:

**A. 3006.x: empty release page.** `actions/download-artifact@v4` silently drops entries past some per-run size threshold on runs with hundreds of artifacts &mdash; the same known bug the JUnit download below already backfills for. On the primary `download all artifacts` step the drop-rate has trended catastrophic for 3006.x:

| Release | Assets |
| --- | --- |
| nightly-2026-08-18-3006.x | 25 |
| nightly-2026-08-22-3006.x | 8 (arm64 rpm only) |
| nightly-2026-08-24-3006.x | 8 (arm64 rpm only) |
| nightly-2026-08-25-3006.x | **0** |

Publish log for 8/25 3006.x:
```
Total of 700 artifact(s) downloaded
=== filtered assets (release-ready formats only) ===
count: 0
##[warning]no release-format assets found in nightly-artifacts/. Creating an empty release for record-keeping.
```
Source run had 773 artifacts including 16 release-target build outputs (salt-*-x86_64-rpm, salt-*-arm64-deb, salt-*-onedir-linux-*, etc.). Download dropped 73/773, and by unlucky ordering ALL 16 build-target ones were among the drops. Dashboard shows "unknown" version as a downstream symptom.

The `publish-nightly-release.yml` author already flagged this exact failure mode in #70078's body:

> The first `download all artifacts` step (which feeds the release-upload) has the same underlying issue &mdash; also drops entries silently &mdash; but is scoped differently (release-completeness rather than dashboard-correctness) and worth its own follow-up.

This is that follow-up.

**B. 3008.x: publish workflow fails with HTTP 422 duplicate asset name.** Side-effect of #70128 introducing `merge-multiple: false`. Some artifacts contain the same-named file. In today's 8/25 3008.x publish (run 32812765698):

```
count: 40
...
HTTP 422: ReleaseAsset.name already exists
  (salt_3008.2+251.gc3fc30d217.tar.xz)
##[error]Process completed with exit code 123.
```

The duplicate:
```
nightly-artifacts/salt-3008.2+251.gc3fc30d217-arm64-deb/salt_3008.2+251.gc3fc30d217.tar.xz
nightly-artifacts/salt-3008.2+251.gc3fc30d217-x86_64-deb/salt_3008.2+251.gc3fc30d217.tar.xz
```
The debian source tarball is packaged inside *both* the arm64-deb and x86_64-deb build artifacts (natural: same source drives both arch builds). Old `merge-multiple: true` silently overlaid them (harmless when identical, Frankenstein when not &mdash; the RPM failure that motivated #70128). New `merge-multiple: false` keeps both; `gh release create` chokes on the collision.

### New Behavior

Two changes in one hunk, both surgical:

**1. Backfill step for the primary download-artifact step.** Mirrors the JUnit backfill pattern already in this file below the primary download. Cross-checks what actually landed under `nightly-artifacts/` against the API's authoritative artifact list for the triggering nightly.yml run and pulls anything missing via `gh api .../artifacts/<id>/zip`. Excludes `*-from-src` as an optimisation since the prune step below removes those. Per-artifact backfill failure is non-fatal; the subsequent find/create-release steps operate on whatever landed. Runs immediately after the primary download and before the `-from-src` prune.

**2. Awk de-dupe by basename in the `list assets to publish` step.**
```
find nightly-artifacts -type f \( ... \) | sort \
  | awk -F/ '!seen[$NF]++' > /tmp/assets.txt
```
First-sorted path wins per basename. Safe as long as duplicates are semantically equivalent (they are for the debian source tarball &mdash; same source input to both arch builds).

### Impact

- 3006.x nightlies: complete asset attachments restored. When the download-artifact drop happens (regardless of scale), missing entries are backfilled by ID before the publish list is computed.
- 3008.x nightlies: publish workflow no longer fails on the debian source tarball duplicate. Any future same-basename dupe from other artifact combos is handled generically.
- Common-case impact: on a healthy run where nothing was dropped, backfill logs `backfilled: 0` and adds ~2s. On a run with a same-basename dupe, de-dupe silently keeps one; otherwise no-op.
- Fixes affect all nightly branches (`workflow_run` uses the workflow file from the default branch).

### Not in this PR

- The 8/23-24 3008.x nightly *build* failures (pyzmq wheel build) &mdash; those are salt requirements/toolchain issues unrelated to this workflow, and appear to have resolved themselves on 8/25.
- No changes to the JUnit backfill step (already correct via #70078).

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (`actions/download-artifact@v4` runtime behavior; observed via nightly runs)

### Commits signed with GPG?

No.