### PR TITLE
[3006.x] Bump relenv to 0.22.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -462,7 +462,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -479,7 +479,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -494,10 +494,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -514,7 +514,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -532,7 +532,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.config)['skip_code_coverage'] }}
       workflow-slug: ci
       default-timeout: 180

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -461,7 +461,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -478,7 +478,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -509,7 +509,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -526,7 +526,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -547,7 +547,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -566,10 +566,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -586,7 +586,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -604,7 +604,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       workflow-slug: nightly
       default-timeout: 360

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -508,7 +508,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -525,7 +525,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -546,7 +546,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -493,7 +493,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -510,7 +510,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -527,7 +527,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -494,7 +494,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -511,7 +511,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -528,7 +528,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -543,10 +543,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -563,7 +563,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -581,7 +581,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       workflow-slug: scheduled
       default-timeout: 360

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -468,7 +468,7 @@ jobs:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -486,7 +486,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -508,7 +508,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
       relenv-version: "0.22.23"
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
@@ -527,10 +527,10 @@ jobs:
     with:
       nox-session: ci-test-onedir
       nox-version: 2022.8.7
-      python-version: "3.11.15"
+      python-version: "3.11.16"
       ci-python-version: "3.14"
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       nox-archive-hash: "${{ needs.prepare-workflow.outputs.nox-archive-hash }}"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['build-matrix']) }}
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
@@ -547,7 +547,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       nox-version: 2022.8.7
       ci-python-version: "3.14"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['pkg-test-matrix']) }}
@@ -565,7 +565,7 @@ jobs:
       ci-python-version: "3.14"
       testrun: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['testrun']) }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.15
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.11.16
       skip-code-coverage: true
       workflow-slug: staging
       default-timeout: 180

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -467,7 +467,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "onedir"
@@ -507,7 +507,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.18"
+      relenv-version: "0.22.23"
       python-version: "3.11.15"
       ci-python-version: "3.14"
       source: "src"

--- a/changelog/70133.fixed.md
+++ b/changelog/70133.fixed.md
@@ -1,0 +1,3 @@
+* Relenv 0.22.23
+  - Fix Verify Builds on Python 3.14 (cffi 2.0.0 for 3.14, swig PyPI shim collision) - #316
+  - Various native-build platform hardening across releases 0.22.19 - 0.22.23

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.11.15"
-relenv_version: "0.22.18"
+relenv_version: "0.22.23"
 release_branches:
   - "3006.x"
   - "3007.x"

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,5 +1,5 @@
 nox_version: "2022.8.7"
-python_version: "3.11.15"
+python_version: "3.11.16"
 relenv_version: "0.22.23"
 release_branches:
   - "3006.x"

--- a/cicd/windows-ssl-104135-patch.py
+++ b/cicd/windows-ssl-104135-patch.py
@@ -10,7 +10,7 @@ Background
 
 The build-deps-ci Windows job extracts the salt onedir, then runs
 ``nox --install-only -e ci-test-onedir`` and ``nox -e pre-archive-cleanup``.
-Both sessions target the onedir's relenv-bundled Python (3.10.20 on 3006.x)
+Both sessions target the onedir's relenv-bundled Python (3.10.21 on 3006.x)
 and create virtualenvs from it. The ``ci-test-onedir`` session uses
 ``--system-site-packages``; ``pre-archive-cleanup`` does not. Either way,
 both venvs share the onedir's ``Lib/ssl.py`` because virtualenv leaves the

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -173,10 +173,10 @@ def _onedir_build_matrix(os_kind, linux_arm_runner, python_versions=None):
     """
     if python_versions is None:
         python_versions = [
-            "3.10.20",
-            "3.11.15",
-            "3.12.13",
-            "3.13.14",
+            "3.10.21",
+            "3.11.16",
+            "3.12.14",
+            "3.13.15",
         ]
     _matrix = []
     if os_kind == "windows":


### PR DESCRIPTION
## Summary

Bumps the pinned relenv version from 0.22.18 to 0.22.23 on 3006.x, regenerating the CI/nightly/scheduled/staging workflow YAMLs from the shared context.

## Relenv 0.22.23 highlights (vs 0.22.18)

- Fix Verify Builds on Python 3.14 (cffi 2.0.0 for 3.14, swig PyPI shim collision) — saltstack/relenv#316
- Various native-build platform hardening across releases 0.22.19 through 0.22.23.

Tracker: #70133

## Test plan

- [ ] CI green on 3006.x targets (Linux, macOS, Windows).
- [ ] Verify onedir builds pick up relenv 0.22.23 and Python 3.10.20 as before.
- [ ] Package tests (install / upgrade / downgrade) still pass on all supported OSes.