### PR TITLE
Add win_wua reset/diagnostic-log functions for stuck Windows Updates

### DIFF
--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -161,6 +161,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - [ ] Input validation with `SaltInvocationError`
 - [ ] Error handling with `CommandExecutionError`
 - [ ] Context caching for expensive operations
+- [ ] `salt.utils.files.fopen()` for any file I/O, never bare `open()`
 - [ ] Unit tests
 
 ### State Module Checklist
@@ -189,6 +190,17 @@ log.debug(f"Processing file: {filename}")   # Bad
 ```
 
 **Never log sensitive data** (passwords, tokens, keys).
+
+### File Handling
+```python
+# Use salt.utils.files.fopen(), NOT the bare open() builtin
+import salt.utils.files
+with salt.utils.files.fopen(path, "r") as fp_:   # Good
+    content = fp_.read()
+with open(path, "r") as fp_:                     # Bad - fails lint (resource-leakage)
+    content = fp_.read()
+```
+This applies everywhere, including unit tests.
 
 ### Error Handling
 ```python

--- a/agents/COPILOT.md
+++ b/agents/COPILOT.md
@@ -134,6 +134,16 @@ log.debug(f"Processing: {filename}")   # Bad - f-strings evaluated early
 ```
 **Never log secrets.**
 
+### File Handling
+```python
+import salt.utils.files
+with salt.utils.files.fopen(path, "r") as fp_:   # Good
+    content = fp_.read()
+with open(path, "r") as fp_:                     # Bad - fails lint (resource-leakage)
+    content = fp_.read()
+```
+Applies to modules, states, utils, and tests alike.
+
 ### Docstrings
 Every function requires description, parameters, and CLI example:
 ```python

--- a/agents/CURSOR.md
+++ b/agents/CURSOR.md
@@ -116,6 +116,16 @@ log.debug(f"Processing {filename}")   # Bad - f-strings evaluated early
 ```
 **Never log secrets.**
 
+### File Handling
+```python
+import salt.utils.files
+with salt.utils.files.fopen(path, "r") as fp_:   # Good
+    content = fp_.read()
+with open(path, "r") as fp_:                     # Bad - fails lint (resource-leakage)
+    content = fp_.read()
+```
+Applies to modules, states, utils, and tests alike.
+
 ### Platform Detection
 ```python
 salt.utils.platform.is_windows()

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -117,6 +117,16 @@ log.debug(f"Processing: {filename}")   # Bad
 ```
 **Never log sensitive data.**
 
+### File Handling
+```python
+import salt.utils.files
+with salt.utils.files.fopen(path, "r") as fp_:   # Good
+    content = fp_.read()
+with open(path, "r") as fp_:                     # Bad - fails lint (resource-leakage)
+    content = fp_.read()
+```
+Applies to modules, states, utils, and tests alike.
+
 ### Error Handling
 ```python
 from salt.exceptions import (

--- a/agents/docs/module-templates.md
+++ b/agents/docs/module-templates.md
@@ -411,6 +411,38 @@ def my_function():
     return config_path
 ```
 
+### File Handling
+
+**Always use `salt.utils.files.fopen()` instead of the bare `open()` builtin**
+when reading or writing files in Salt code (modules, states, utils, and
+tests alike). `saltpylint`'s `resource-leakage` check (`W8470`) fails CI on
+any bare `open()` call.
+
+```python
+import salt.utils.files
+
+def my_function(path):
+    """Read/write files the Salt way"""
+    with salt.utils.files.fopen(path, "r") as fp_:
+        content = fp_.read()
+
+    with salt.utils.files.fopen(path, "w") as fp_:
+        fp_.write(content)
+
+    return content
+```
+
+```python
+# Bad - fails the resource-leakage lint check
+with open(path, "r") as fp_:
+    content = fp_.read()
+```
+
+`fopen()` is a thin wrapper around `open()` that additionally normalizes
+line endings/encoding across platforms and ensures file handles are tracked
+and closed consistently. Use it for every `open()` call, including binary
+mode (`"rb"`/`"wb"`) and in unit tests -- the lint check applies there too.
+
 ### Platform Detection
 
 ```python

--- a/changelog/70101.added.md
+++ b/changelog/70101.added.md
@@ -1,0 +1,1 @@
+Add `win_wua.reset_datastore`, `win_wua.reset_catroot`, `win_wua.reset`, `win_wua.get_cbs_log`, and `win_wua.get_windows_update_log` to help diagnose and recover from Windows Update issues, such as an update reporting success but not persisting through a reboot.

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -50,14 +50,48 @@ As of Windows 10 and Windows Server 2016, the ability to modify the Windows
 Update settings has been restricted. The settings can be modified in the Local
 Group Policy using the ``lgpo`` module.
 
+.. note::
+
+    **Troubleshooting an update that reports success but doesn't persist**
+
+    If :py:func:`win_wua.install <salt.modules.win_wua.install>` reports
+    success but the update does not appear installed after a reboot, start
+    with :py:func:`win_wua.get_needs_reboot
+    <salt.modules.win_wua.get_needs_reboot>` to make sure no reboot is
+    already pending (installing/resetting while a reboot is pending can
+    itself be the cause). Next use :py:func:`win_wua.get_cbs_log
+    <salt.modules.win_wua.get_cbs_log>` and :py:func:`win_wua.get_windows_update_log
+    <salt.modules.win_wua.get_windows_update_log>` to look for the
+    underlying servicing-stack (CBS) or Windows Update Agent error --
+    ``install()``'s return value only reflects the installer job's result
+    at call time, not whether the update actually persisted through a
+    required reboot. To confirm persistence, re-run
+    :py:func:`win_wua.installed <salt.modules.win_wua.installed>` or
+    :py:func:`win_wua.get <salt.modules.win_wua.get>` after the reboot
+    completes and compare against what was requested. Only after the logs
+    point at WUA datastore/catalog-cache corruption specifically should you
+    reach for :py:func:`win_wua.reset <salt.modules.win_wua.reset>` (or
+    :py:func:`win_wua.reset_datastore <salt.modules.win_wua.reset_datastore>`
+    / :py:func:`win_wua.reset_catroot <salt.modules.win_wua.reset_catroot>`)
+    as a troubleshooting last resort -- these do not fix component-store
+    (CBS)-level rejections, which require ``DISM /Cleanup-Image
+    /RestoreHealth`` instead.
+
 .. versionadded:: 2015.8.0
 
 :depends: salt.utils.win_update
 """
 
 import logging
+import os
+import shutil
+import tempfile
+import time
 
+import salt.utils.data
+import salt.utils.files
 import salt.utils.platform
+import salt.utils.win_pwsh
 import salt.utils.win_service
 import salt.utils.win_update
 import salt.utils.winapi
@@ -75,6 +109,11 @@ log = logging.getLogger(__name__)
 __func_alias__ = {
     "list_": "list",
 }
+
+# Services stopped/started (in this order) when resetting the WU datastore
+# or catalog cache. TrustedInstaller is intentionally excluded: it is
+# trigger-started by Windows and should not be manually stopped/started.
+_WU_SERVICES = ("wuauserv", "CryptSvc", "BITS", "msiserver")
 
 
 def __virtual__():
@@ -1232,3 +1271,598 @@ def get_needs_reboot():
         salt '*' win_wua.get_needs_reboot
     """
     return salt.utils.win_update.needs_reboot()
+
+
+def _windir():
+    """
+    Return the current ``%WinDir%``. Computed on every call (rather than
+    frozen as a module-level constant) so tests can sandbox it with
+    ``monkeypatch.setenv("WINDIR", ...)``.
+    """
+    return os.environ.get("WINDIR", r"C:\Windows")
+
+
+def _softwaredistribution_path():
+    return os.path.join(_windir(), "SoftwareDistribution")
+
+
+def _catroot2_path():
+    return os.path.join(_windir(), "System32", "catroot2")
+
+
+def _cbs_log_path():
+    return os.path.join(_windir(), "Logs", "CBS", "CBS.log")
+
+
+def _stop_wu_services():
+    """
+    Stop the Windows Update related services. Raises CommandExecutionError
+    (without touching any files) if any service fails to stop.
+    """
+    ret = {}
+    failed = []
+    for svc in _WU_SERVICES:
+        result = __salt__["service.stop"](svc)
+        ret[svc] = result
+        if not result:
+            failed.append(svc)
+
+    if failed:
+        raise CommandExecutionError(
+            "Failed to stop the following service(s), aborting reset: {}".format(
+                ", ".join(failed)
+            )
+        )
+
+    return ret
+
+
+def _start_wu_services():
+    """
+    Start the Windows Update related services. Raises
+    CommandExecutionError if any service fails to start.
+    """
+    ret = {}
+    failed = []
+    for svc in _WU_SERVICES:
+        result = __salt__["service.start"](svc)
+        ret[svc] = result
+        if not result:
+            failed.append(svc)
+
+    if failed:
+        raise CommandExecutionError(
+            "Failed to start the following service(s) after reset: {}".format(
+                ", ".join(failed)
+            )
+        )
+
+    return ret
+
+
+def _reset_dir(path, purge_old):
+    """
+    Rename ``path`` to ``path.old.<ms-timestamp>``, or delete it outright if
+    ``purge_old`` is true. No-op (but not an error) if ``path`` doesn't
+    exist.
+    """
+    ret = {"old_path": path, "new_path": None, "purged": False, "result": True}
+
+    if not os.path.isdir(path):
+        return ret
+
+    if salt.utils.data.is_true(purge_old):
+        try:
+            shutil.rmtree(path)
+        except OSError as exc:
+            raise CommandExecutionError(f"Failed to remove '{path}': {exc}")
+        ret["purged"] = True
+        return ret
+
+    new_path = f"{path}.old.{int(time.time() * 1000)}"
+    while os.path.exists(new_path):
+        new_path = f"{path}.old.{int(time.time() * 1000)}"
+
+    try:
+        os.rename(path, new_path)
+    except OSError as exc:
+        raise CommandExecutionError(f"Failed to rename '{path}' to '{new_path}': {exc}")
+
+    ret["new_path"] = new_path
+    return ret
+
+
+def reset_datastore(purge_old=False):
+    """
+    .. versionadded:: 3009.0
+
+    Resets the Windows Update datastore by stopping the Windows Update
+    related services, renaming the ``SoftwareDistribution`` directory, and
+    restarting the services. This is a common troubleshooting step for
+    Windows Update issues, such as an update that reports success but does
+    not persist (see the module-level note above for the full diagnostic
+    workflow).
+
+    .. warning::
+
+        This stops the Windows Update related services (interrupting any
+        in-progress download/install) and renames -- or, with
+        ``purge_old=True``, permanently **deletes** -- the
+        ``SoftwareDistribution`` directory, including all cached update
+        payloads and the local update history/metadata. This is a
+        destructive troubleshooting action and should not be run routinely
+        or included in a default highstate. ``purge_old=True`` is
+        irreversible: no ``.old.<timestamp>`` copy is left behind to
+        recover from.
+
+    Args:
+
+        purge_old (bool, optional):
+            If ``True``, deletes the existing ``SoftwareDistribution``
+            directory instead of renaming it. This is irreversible.
+
+            Default is ``False``
+
+    Returns:
+
+        dict: A dictionary containing the results of the reset
+
+        .. code-block:: cfg
+
+            {
+                "reboot_pending": False,
+                "SoftwareDistribution": {
+                    "old_path": "C:\\Windows\\SoftwareDistribution",
+                    "new_path": "C:\\Windows\\SoftwareDistribution.old.<ts>",
+                    "purged": False,
+                    "result": True,
+                }
+            }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wua.reset_datastore
+        salt '*' win_wua.reset_datastore purge_old=True
+    """
+    reboot_pending = salt.utils.win_update.needs_reboot()
+    _stop_wu_services()
+    try:
+        result = _reset_dir(_softwaredistribution_path(), purge_old)
+    finally:
+        _start_wu_services()
+
+    return {"reboot_pending": reboot_pending, "SoftwareDistribution": result}
+
+
+def reset_catroot(purge_old=False):
+    """
+    .. versionadded:: 3009.0
+
+    Resets the Windows Update catalog cache by stopping the Windows Update
+    related services, renaming the ``catroot2`` directory, and restarting
+    the services. This is a common troubleshooting step for Windows Update
+    issues (see the module-level note above for the full diagnostic
+    workflow).
+
+    .. warning::
+
+        This stops the Windows Update related services (interrupting any
+        in-progress download/install) and renames -- or, with
+        ``purge_old=True``, permanently **deletes** -- the ``catroot2``
+        directory. This is a destructive troubleshooting action and should
+        not be run routinely or included in a default highstate.
+        ``purge_old=True`` is irreversible: no ``.old.<timestamp>`` copy is
+        left behind to recover from.
+
+    Args:
+
+        purge_old (bool, optional):
+            If ``True``, deletes the existing ``catroot2`` directory
+            instead of renaming it. This is irreversible.
+
+            Default is ``False``
+
+    Returns:
+
+        dict: A dictionary containing the results of the reset
+
+        .. code-block:: cfg
+
+            {
+                "reboot_pending": False,
+                "catroot2": {
+                    "old_path": "C:\\Windows\\System32\\catroot2",
+                    "new_path": "C:\\Windows\\System32\\catroot2.old.<ts>",
+                    "purged": False,
+                    "result": True,
+                }
+            }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wua.reset_catroot
+        salt '*' win_wua.reset_catroot purge_old=True
+    """
+    reboot_pending = salt.utils.win_update.needs_reboot()
+    _stop_wu_services()
+    try:
+        result = _reset_dir(_catroot2_path(), purge_old)
+    finally:
+        _start_wu_services()
+
+    return {"reboot_pending": reboot_pending, "catroot2": result}
+
+
+def reset(purge_old=False):
+    """
+    .. versionadded:: 3009.0
+
+    Convenience function that resets both the Windows Update datastore
+    (``SoftwareDistribution``) and the Windows Update catalog cache
+    (``catroot2``) in a single pass. This stops the Windows Update related
+    services once, performs both resets, and restarts the services once,
+    which is more efficient than calling
+    :py:func:`win_wua.reset_datastore <salt.modules.win_wua.reset_datastore>`
+    and :py:func:`win_wua.reset_catroot <salt.modules.win_wua.reset_catroot>`
+    separately.
+
+    .. warning::
+
+        This stops the Windows Update related services (interrupting any
+        in-progress download/install) and renames -- or, with
+        ``purge_old=True``, permanently **deletes** -- both directories,
+        including all cached update payloads and the local update
+        history/metadata. This is a destructive troubleshooting action and
+        should not be run routinely or included in a default highstate.
+        ``purge_old=True`` is irreversible: no ``.old.<timestamp>`` copies
+        are left behind to recover from.
+
+    Args:
+
+        purge_old (bool, optional):
+            If ``True``, deletes the existing directories instead of
+            renaming them. This is irreversible.
+
+            Default is ``False``
+
+    Returns:
+
+        dict: A dictionary containing the results of both resets
+
+        .. code-block:: cfg
+
+            {
+                "reboot_pending": False,
+                "SoftwareDistribution": {
+                    "old_path": "C:\\Windows\\SoftwareDistribution",
+                    "new_path": "C:\\Windows\\SoftwareDistribution.old.<ts>",
+                    "purged": False,
+                    "result": True,
+                },
+                "catroot2": {
+                    "old_path": "C:\\Windows\\System32\\catroot2",
+                    "new_path": "C:\\Windows\\System32\\catroot2.old.<ts>",
+                    "purged": False,
+                    "result": True,
+                },
+            }
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wua.reset
+        salt '*' win_wua.reset purge_old=True
+    """
+    reboot_pending = salt.utils.win_update.needs_reboot()
+    _stop_wu_services()
+    try:
+        sd_result = _reset_dir(_softwaredistribution_path(), purge_old)
+        catroot_result = _reset_dir(_catroot2_path(), purge_old)
+    finally:
+        _start_wu_services()
+
+    return {
+        "reboot_pending": reboot_pending,
+        "SoftwareDistribution": sd_result,
+        "catroot2": catroot_result,
+    }
+
+
+def _tail_lines(path, count):
+    """
+    Return the last ``count`` lines of ``path`` without reading the whole
+    file into memory -- reads backward from EOF in chunks.
+    """
+    chunk_size = 65536
+    with salt.utils.files.fopen(path, "rb") as fp_:
+        fp_.seek(0, os.SEEK_END)
+        remaining = fp_.tell()
+        block = b""
+        while remaining > 0 and block.count(b"\n") <= count:
+            read_size = min(chunk_size, remaining)
+            remaining -= read_size
+            fp_.seek(remaining)
+            block = fp_.read(read_size) + block
+
+    text = block.decode("utf-8", errors="replace")
+    return "\n".join(text.splitlines()[-count:])
+
+
+def _grep_lines(path, patterns, max_matches=200, context=2):
+    """
+    Stream ``path`` line-by-line (no full in-memory read) and return only
+    the lines matching any of ``patterns`` (plain substring match,
+    case-insensitive), plus ``context`` lines before/after each match.
+    Stops once ``max_matches`` matches have been found.
+    """
+    patterns_lower = [p.lower() for p in patterns]
+
+    before_buffer = []
+    after_remaining = 0
+    last_emitted = -1
+    result = []
+    match_count = 0
+    truncated = False
+
+    with salt.utils.files.fopen(path, "r", encoding="utf-8", errors="replace") as fp_:
+        for idx, raw_line in enumerate(fp_):
+            line = raw_line.rstrip("\n")
+            is_match = any(pattern in line.lower() for pattern in patterns_lower)
+
+            if is_match:
+                if match_count >= max_matches:
+                    truncated = True
+                    break
+                match_count += 1
+
+                for b_idx, b_line in before_buffer:
+                    if b_idx > last_emitted:
+                        result.append(b_line)
+                        last_emitted = b_idx
+
+                if idx > last_emitted:
+                    result.append(line)
+                    last_emitted = idx
+
+                after_remaining = context
+            elif after_remaining > 0:
+                result.append(line)
+                last_emitted = idx
+                after_remaining -= 1
+
+            before_buffer.append((idx, line))
+            if len(before_buffer) > context:
+                before_buffer.pop(0)
+
+    text = "\n".join(result)
+    if truncated:
+        text += f"\n... (truncated: max_matches={max_matches} reached)"
+
+    return text
+
+
+def _tail_and_filter(path, tail=500, pattern=None, max_matches=200):
+    """
+    Shared implementation backing get_cbs_log/get_windows_update_log: read
+    ``path``, applying either a ``pattern`` filter (whole-file scan,
+    independent of ``tail``) or a ``tail`` limit (``None`` for the whole
+    file).
+    """
+    if tail is not None and tail < 1:
+        raise CommandExecutionError("'tail' must be a positive integer or None")
+
+    if not os.path.isfile(path):
+        raise CommandExecutionError(f"Log file not found: '{path}'")
+
+    if pattern:
+        # NOTE: this module defines its own module-level `list` function
+        # (the win_wua.list CLI function, see `list()` above), which shadows
+        # the builtin within this module's namespace -- use a comprehension
+        # instead of `list(pattern)` here.
+        patterns = [pattern] if isinstance(pattern, str) else [p for p in pattern]
+        return _grep_lines(path, patterns, max_matches=max_matches)
+
+    if tail is None:
+        with salt.utils.files.fopen(
+            path, "r", encoding="utf-8", errors="replace"
+        ) as fp_:
+            return fp_.read()
+
+    return _tail_lines(path, tail)
+
+
+def _write_out_file(out_file, content):
+    out_dir = os.path.dirname(out_file)
+    if out_dir and not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+
+    try:
+        with salt.utils.files.fopen(out_file, "w", encoding="utf-8") as fp_:
+            fp_.write(content)
+    except OSError as exc:
+        raise CommandExecutionError(f"Failed to write to '{out_file}': {exc}")
+
+
+def get_cbs_log(tail=500, pattern=None, out_file=None, max_matches=200):
+    """
+    .. versionadded:: 3009.0
+
+    Retrieves the contents of the Component-Based Servicing (CBS) log,
+    located at ``%WinDir%\\Logs\\CBS\\CBS.log``. This log often contains
+    detailed information about servicing/update failures not present in the
+    Windows Update log -- see :py:func:`win_wua.get_windows_update_log
+    <salt.modules.win_wua.get_windows_update_log>` for the complementary
+    agent-level log; a full diagnosis usually needs both.
+
+    .. note::
+
+        Things worth searching for in the output: ``Failed``,
+        ``Reject``/``rejected`` (a package the servicing stack refused to
+        (re)apply), ``resolved as superseded`` / ``Resolved(...)`` state
+        transitions, the specific package identifier
+        (``Package_for_KB<number>~...``), and HRESULT-style codes
+        (``0x800f...``, ``0x80073...``) which map to CBS/servicing-stack
+        error codes -- a distinct range from the ``0x8024...`` WUA-specific
+        codes seen in the Windows Update log. Searching for the KB number
+        (``pattern="KB1234567"``) is usually the fastest way to find the
+        relevant block in a huge log.
+
+    .. warning::
+
+        ``CBS.log`` can grow very large on long-lived systems. This
+        function defaults to the last 500 lines to stay safe for return
+        over the event bus. Passing ``tail=None`` reads the entire file
+        into memory and returns it, which can be slow/large -- prefer
+        ``pattern`` to search the whole file for specific terms instead.
+
+    Args:
+
+        tail (int, optional):
+            If provided, only the last ``tail`` lines of the log are
+            returned/written. Ignored when ``pattern`` is provided (which
+            always scans the whole file).
+
+            Default is ``500``. Pass ``None`` to return the entire log.
+
+        pattern (str, list, optional):
+            One or more plain substrings (case-insensitive) to search for.
+            When provided, returns only matching lines plus a couple of
+            context lines around each match, scanning the whole file
+            regardless of ``tail``.
+
+            Default is ``None``
+
+        out_file (str, optional):
+            If provided, the resulting (already tailed/filtered) content is
+            also written to this path.
+
+            Default is ``None``
+
+        max_matches (int, optional):
+            When ``pattern`` is used, the maximum number of matches to
+            return.
+
+            Default is ``200``
+
+    Returns:
+
+        str: The contents of the CBS log (or the last ``tail`` lines, or
+        the lines matching ``pattern``)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wua.get_cbs_log
+        salt '*' win_wua.get_cbs_log tail=2000
+        salt '*' win_wua.get_cbs_log pattern=KB5120233
+        salt '*' win_wua.get_cbs_log pattern=KB5120233 out_file='C:\\temp\\cbs_kb.log'
+    """
+    content = _tail_and_filter(
+        _cbs_log_path(), tail=tail, pattern=pattern, max_matches=max_matches
+    )
+
+    if out_file:
+        _write_out_file(out_file, content)
+
+    return content
+
+
+def get_windows_update_log(tail=500, pattern=None, out_file=None, max_matches=200):
+    """
+    .. versionadded:: 3009.0
+
+    Merges Windows Update ETW trace files into a single, readable
+    ``WindowsUpdate.log`` file using the PowerShell ``Get-WindowsUpdateLog``
+    cmdlet, then returns its contents -- see :py:func:`win_wua.get_cbs_log
+    <salt.modules.win_wua.get_cbs_log>` for the complementary
+    servicing-stack log; a full diagnosis usually needs both. The WU log
+    shows the agent-level request/response, while the CBS log shows what
+    the servicing stack actually did with it.
+
+    .. note::
+
+        Things worth searching for in the output: lines tagged
+        ``FATAL``/``WARNING`` (log severity markers), ``COMAPI`` entries
+        around the time of the install call (WUA-agent-level install/
+        download phase transitions), WU-specific HRESULT codes
+        (``0x8024...`` -- distinct from the ``0x800f...``/``0x80073...``
+        CBS-range codes seen in :py:func:`win_wua.get_cbs_log
+        <salt.modules.win_wua.get_cbs_log>`), and
+        ``reportEventBatch``/install-phase-completion lines around reboot
+        time.
+
+    .. warning::
+
+        This requires an elevated (Administrator) PowerShell session and is
+        only available on Windows 8 / Server 2012 and later. Depending on
+        the amount of Windows Update history on the system, this command
+        can take several minutes to complete -- there is no internal
+        timeout, so a caller needing one should apply it at the job level.
+        The merged output can also be large; this function defaults to the
+        last 500 lines for the same event-bus-size reasons as
+        :py:func:`win_wua.get_cbs_log <salt.modules.win_wua.get_cbs_log>`.
+
+    Args:
+
+        tail (int, optional):
+            If provided, only the last ``tail`` lines are returned. Ignored
+            when ``pattern`` is provided.
+
+            Default is ``500``. Pass ``None`` to return the entire log.
+
+        pattern (str, list, optional):
+            One or more plain substrings (case-insensitive) to search for,
+            returning only matching lines plus a couple of context lines,
+            scanning the whole file regardless of ``tail``.
+
+            Default is ``None``
+
+        out_file (str, optional):
+            The path where the full merged log file should be written (used
+            directly as the cmdlet's ``-LogPath``). The function's return
+            value is still the tailed/filtered content, not the full file.
+
+            Default is ``None``, which writes to a temporary location
+
+        max_matches (int, optional):
+            When ``pattern`` is used, the maximum number of matches to
+            return.
+
+            Default is ``200``
+
+    Returns:
+
+        str: The (tailed/filtered) contents of the merged Windows Update
+        log
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_wua.get_windows_update_log
+        salt '*' win_wua.get_windows_update_log pattern=0x8024
+        salt '*' win_wua.get_windows_update_log out_file='C:\\temp\\WindowsUpdate.log'
+    """
+    log_path = out_file or os.path.join(tempfile.gettempdir(), "WindowsUpdate.log")
+
+    cmd = f"Get-WindowsUpdateLog -LogPath '{log_path}'"
+    result = salt.utils.win_pwsh.run_dict(cmd)
+
+    result_path = log_path
+    if isinstance(result, dict) and result.get("Log"):
+        result_path = result["Log"]
+
+    if not os.path.isfile(result_path):
+        raise CommandExecutionError(
+            f"Get-WindowsUpdateLog did not produce a log file at '{result_path}'"
+        )
+
+    return _tail_and_filter(
+        result_path, tail=tail, pattern=pattern, max_matches=max_matches
+    )

--- a/tests/pytests/unit/modules/test_win_wua.py
+++ b/tests/pytests/unit/modules/test_win_wua.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 import salt.modules.win_wua as win_wua
+import salt.utils.files
 import salt.utils.platform
 import salt.utils.win_update
 from salt.exceptions import CommandExecutionError
@@ -663,7 +664,7 @@ def test_get_cbs_log_tail_less_than_one_raises(cbs_log):
 
 
 def test_get_cbs_log_non_utf8_bytes_do_not_crash(cbs_log):
-    with open(cbs_log, "wb") as fp_:
+    with salt.utils.files.fopen(cbs_log, "wb") as fp_:
         fp_.write(b"good line\n\xff\xfebad bytes\nmore good\n")
 
     result = win_wua.get_cbs_log()

--- a/tests/pytests/unit/modules/test_win_wua.py
+++ b/tests/pytests/unit/modules/test_win_wua.py
@@ -2,17 +2,40 @@
 Test the win_wua execution module
 """
 
+import os
+
 import pytest
 
 import salt.modules.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update
+from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, patch
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_unless_on_windows,
 ]
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {win_wua: {}}
+
+
+@pytest.fixture
+def wu_services(monkeypatch):
+    """
+    Patch service.stop/service.start/service.restart in win_wua.__salt__ to
+    succeed, and salt.utils.win_update.needs_reboot to return False, and
+    return the mocks for assertions.
+    """
+    mock_stop = MagicMock(return_value=True)
+    mock_start = MagicMock(return_value=True)
+    with patch.dict(
+        win_wua.__salt__, {"service.stop": mock_stop, "service.start": mock_start}
+    ), patch("salt.utils.win_update.needs_reboot", autospec=True, return_value=False):
+        yield {"stop": mock_stop, "start": mock_start}
 
 
 @pytest.fixture
@@ -279,3 +302,550 @@ def test_installed_kbs_only(updates_list):
     ):
         result = win_wua.installed(kbs_only=True)
         assert result == expected
+
+
+# ------------------------------------------------------------------------
+# reset_datastore / reset_catroot / reset
+# ------------------------------------------------------------------------
+
+
+def test_reset_datastore_happy_path(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_datastore renames an existing SoftwareDistribution directory
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+
+    with patch("time.time", return_value=1700000000.123):
+        result = win_wua.reset_datastore()
+
+    assert result["reboot_pending"] is False
+    assert result["SoftwareDistribution"]["old_path"] == str(sd_path)
+    assert (
+        result["SoftwareDistribution"]["new_path"]
+        == str(sd_path) + ".old.1700000000123"
+    )
+    assert result["SoftwareDistribution"]["purged"] is False
+    assert result["SoftwareDistribution"]["result"] is True
+    assert not sd_path.exists()
+    assert os.path.isdir(result["SoftwareDistribution"]["new_path"])
+    wu_services["stop"].assert_any_call("wuauserv")
+    wu_services["start"].assert_any_call("wuauserv")
+
+
+def test_reset_datastore_purge_old(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_datastore with purge_old=True deletes instead of renaming
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    (sd_path / "file.txt").write_text("data")
+
+    result = win_wua.reset_datastore(purge_old=True)
+
+    assert result["SoftwareDistribution"]["new_path"] is None
+    assert result["SoftwareDistribution"]["purged"] is True
+    assert not sd_path.exists()
+
+
+def test_reset_datastore_missing_dir(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_datastore when SoftwareDistribution doesn't exist: no-op
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+
+    result = win_wua.reset_datastore()
+
+    assert result["SoftwareDistribution"]["new_path"] is None
+    assert result["SoftwareDistribution"]["purged"] is False
+    assert result["SoftwareDistribution"]["result"] is True
+
+
+def test_reset_datastore_service_stop_fails(tmp_path, monkeypatch):
+    """
+    Test reset_datastore raises and does not touch the directory if a
+    service fails to stop
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+
+    mock_stop = MagicMock(side_effect=[True, False, True, True])
+    mock_start = MagicMock(return_value=True)
+    with patch.dict(
+        win_wua.__salt__, {"service.stop": mock_stop, "service.start": mock_start}
+    ), patch("salt.utils.win_update.needs_reboot", autospec=True, return_value=False):
+        with pytest.raises(CommandExecutionError):
+            win_wua.reset_datastore()
+
+    assert sd_path.exists()
+    mock_start.assert_not_called()
+
+
+def test_reset_datastore_rename_permission_error(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_datastore converts an OSError on rename to CommandExecutionError
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+
+    with patch("os.rename", side_effect=PermissionError("denied")):
+        with pytest.raises(CommandExecutionError):
+            win_wua.reset_datastore()
+
+    # services should still be restarted even though the rename failed
+    wu_services["start"].assert_any_call("wuauserv")
+
+
+def test_reset_datastore_rename_collision(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_datastore retries the timestamp suffix if the target already
+    exists
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    colliding = tmp_path / "SoftwareDistribution.old.1700000000123"
+    colliding.mkdir()
+
+    with patch("time.time", side_effect=[1700000000.123, 1700000000.124]):
+        result = win_wua.reset_datastore()
+
+    assert (
+        result["SoftwareDistribution"]["new_path"]
+        == str(sd_path) + ".old.1700000000124"
+    )
+
+
+def test_reset_catroot_happy_path(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_catroot renames an existing catroot2 directory
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    with patch("time.time", return_value=1700000000.5):
+        result = win_wua.reset_catroot()
+
+    assert result["catroot2"]["old_path"] == str(catroot_path)
+    assert result["catroot2"]["new_path"] == str(catroot_path) + ".old.1700000000500"
+    assert not catroot_path.exists()
+
+
+def test_reset_catroot_purge_old(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_catroot with purge_old=True deletes instead of renaming
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    result = win_wua.reset_catroot(purge_old=True)
+
+    assert result["catroot2"]["new_path"] is None
+    assert result["catroot2"]["purged"] is True
+    assert not catroot_path.exists()
+
+
+def test_reset_catroot_missing_dir(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset_catroot when catroot2 doesn't exist: no-op
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+
+    result = win_wua.reset_catroot()
+
+    assert result["catroot2"]["new_path"] is None
+    assert result["catroot2"]["result"] is True
+
+
+def test_reset_catroot_service_stop_fails(tmp_path, monkeypatch):
+    """
+    Test reset_catroot raises and does not touch the directory if a service
+    fails to stop
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    mock_stop = MagicMock(side_effect=[True, True, False, True])
+    mock_start = MagicMock(return_value=True)
+    with patch.dict(
+        win_wua.__salt__, {"service.stop": mock_stop, "service.start": mock_start}
+    ), patch("salt.utils.win_update.needs_reboot", autospec=True, return_value=False):
+        with pytest.raises(CommandExecutionError):
+            win_wua.reset_catroot()
+
+    assert catroot_path.exists()
+    mock_start.assert_not_called()
+
+
+def test_reset_services_stopped_and_started_once(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset() stops/starts each service exactly once (not once per
+    directory)
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    result = win_wua.reset()
+
+    assert wu_services["stop"].call_count == len(win_wua._WU_SERVICES)
+    assert wu_services["start"].call_count == len(win_wua._WU_SERVICES)
+    assert "SoftwareDistribution" in result
+    assert "catroot2" in result
+    assert not sd_path.exists()
+    assert not catroot_path.exists()
+
+
+def test_reset_purge_old_propagates(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset() propagates purge_old to both directories
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    result = win_wua.reset(purge_old=True)
+
+    assert result["SoftwareDistribution"]["purged"] is True
+    assert result["catroot2"]["purged"] is True
+
+
+def test_reset_one_dir_missing(tmp_path, monkeypatch, wu_services):
+    """
+    Test reset() succeeds when only one of the two directories exists
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    # catroot2 intentionally not created
+
+    result = win_wua.reset()
+
+    assert result["SoftwareDistribution"]["new_path"] is not None
+    assert result["catroot2"]["new_path"] is None
+
+
+def test_reset_stop_failure_aborts_before_any_rename(tmp_path, monkeypatch):
+    """
+    Test reset() raises before touching either directory if a service
+    fails to stop
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+    catroot_path = tmp_path / "System32" / "catroot2"
+    catroot_path.mkdir(parents=True)
+
+    mock_stop = MagicMock(return_value=False)
+    mock_start = MagicMock(return_value=True)
+    with patch.dict(
+        win_wua.__salt__, {"service.stop": mock_stop, "service.start": mock_start}
+    ), patch("salt.utils.win_update.needs_reboot", autospec=True, return_value=False):
+        with pytest.raises(CommandExecutionError):
+            win_wua.reset()
+
+    assert sd_path.exists()
+    assert catroot_path.exists()
+    mock_start.assert_not_called()
+
+
+def test_reset_datastore_reboot_pending_surfaced_not_blocking(tmp_path, monkeypatch):
+    """
+    Test reset_datastore surfaces reboot_pending=True without blocking the
+    reset
+    """
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    sd_path = tmp_path / "SoftwareDistribution"
+    sd_path.mkdir()
+
+    with patch.dict(
+        win_wua.__salt__,
+        {
+            "service.stop": MagicMock(return_value=True),
+            "service.start": MagicMock(return_value=True),
+        },
+    ), patch("salt.utils.win_update.needs_reboot", autospec=True, return_value=True):
+        result = win_wua.reset_datastore()
+
+    assert result["reboot_pending"] is True
+    assert not sd_path.exists()
+
+
+# ------------------------------------------------------------------------
+# get_cbs_log
+# ------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cbs_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+    log_dir = tmp_path / "Logs" / "CBS"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "CBS.log"
+    return log_path
+
+
+def test_get_cbs_log_default_tail(cbs_log):
+    """
+    Test get_cbs_log returns only the last 500 lines by default
+    """
+    lines = [f"line {i}" for i in range(600)]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log()
+
+    assert result.splitlines() == lines[-500:]
+
+
+def test_get_cbs_log_tail_n(cbs_log):
+    """
+    Test get_cbs_log tail=N matches content.splitlines()[-N:]
+    """
+    lines = [f"line {i}" for i in range(50)]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log(tail=10)
+
+    assert result.splitlines() == lines[-10:]
+
+
+def test_get_cbs_log_tail_none_returns_whole_file(cbs_log):
+    """
+    Test get_cbs_log tail=None returns the entire file
+    """
+    lines = [f"line {i}" for i in range(600)]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log(tail=None)
+
+    assert result.splitlines() == lines
+
+
+def test_get_cbs_log_missing_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("WINDIR", str(tmp_path))
+
+    with pytest.raises(CommandExecutionError):
+        win_wua.get_cbs_log()
+
+
+def test_get_cbs_log_out_file_writes_and_returns(cbs_log, tmp_path):
+    """
+    Test get_cbs_log writes to out_file and still returns the content
+    """
+    cbs_log.write_text("line 1\nline 2\n", encoding="utf-8")
+    out_file = tmp_path / "out" / "cbs_tail.log"
+
+    result = win_wua.get_cbs_log(out_file=str(out_file))
+
+    assert result.splitlines() == ["line 1", "line 2"]
+    assert out_file.read_text(encoding="utf-8") == result
+
+
+def test_get_cbs_log_tail_less_than_one_raises(cbs_log):
+    cbs_log.write_text("line 1\n", encoding="utf-8")
+
+    with pytest.raises(CommandExecutionError):
+        win_wua.get_cbs_log(tail=0)
+
+    with pytest.raises(CommandExecutionError):
+        win_wua.get_cbs_log(tail=-1)
+
+
+def test_get_cbs_log_non_utf8_bytes_do_not_crash(cbs_log):
+    with open(cbs_log, "wb") as fp_:
+        fp_.write(b"good line\n\xff\xfebad bytes\nmore good\n")
+
+    result = win_wua.get_cbs_log()
+
+    assert "good line" in result
+    assert "more good" in result
+
+
+def test_get_cbs_log_pattern_filters_matches(cbs_log):
+    """
+    Test get_cbs_log pattern returns only matching lines (plus context)
+    """
+    lines = [
+        "unrelated 1",
+        "unrelated 2",
+        "unrelated 3",
+        "starting up",
+        "doing stuff",
+        "Package rejected: KB1234567",
+        "cleanup",
+        "trailing",
+        "unrelated 4",
+        "unrelated 5",
+        "unrelated 6",
+    ]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log(pattern="rejected")
+
+    assert "Package rejected: KB1234567" in result
+    assert "unrelated" not in result
+
+
+def test_get_cbs_log_pattern_list_ors(cbs_log):
+    lines = [
+        "far away alpha",
+        "still far",
+        "also far",
+        "Failed to apply",
+        "beta",
+        "middle",
+        "gamma superseded",
+        "still going",
+        "also far 2",
+        "far away delta",
+    ]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log(pattern=["Failed", "superseded"])
+
+    assert "Failed to apply" in result
+    assert "gamma superseded" in result
+    assert "far away" not in result
+
+
+def test_get_cbs_log_pattern_max_matches_capped(cbs_log):
+    lines = [f"Failed line {i}" for i in range(10)]
+    cbs_log.write_text("\n".join(lines), encoding="utf-8")
+
+    result = win_wua.get_cbs_log(pattern="Failed", max_matches=3)
+
+    assert result.count("Failed line") == 3
+
+
+# ------------------------------------------------------------------------
+# get_windows_update_log
+# ------------------------------------------------------------------------
+
+
+def test_get_windows_update_log_happy_path(tmp_path):
+    log_path = tmp_path / "WindowsUpdate.log"
+    lines = [f"line {i}" for i in range(10)]
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict",
+        autospec=True,
+        return_value={"Log": str(log_path)},
+    ) as mock_run_dict:
+        result = win_wua.get_windows_update_log()
+
+    assert result.splitlines() == lines
+    assert mock_run_dict.call_count == 1
+
+
+def test_get_windows_update_log_out_file_controls_logpath(tmp_path):
+    out_file = tmp_path / "custom_wu.log"
+
+    def fake_run_dict(cmd):
+        assert str(out_file) in cmd
+        out_file.write_text("line 1\nline 2\n", encoding="utf-8")
+        return {"Log": str(out_file)}
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict", autospec=True, side_effect=fake_run_dict
+    ):
+        result = win_wua.get_windows_update_log(out_file=str(out_file))
+
+    assert result.splitlines() == ["line 1", "line 2"]
+
+
+def test_get_windows_update_log_generates_temp_path_when_out_file_none(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    expected_path = tmp_path / "WindowsUpdate.log"
+
+    def fake_run_dict(cmd):
+        assert str(expected_path) in cmd
+        expected_path.write_text("content\n", encoding="utf-8")
+        return {"Log": str(expected_path)}
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict", autospec=True, side_effect=fake_run_dict
+    ):
+        result = win_wua.get_windows_update_log()
+
+    assert result.splitlines() == ["content"]
+
+
+def test_get_windows_update_log_uses_log_key_from_run_dict(tmp_path, monkeypatch):
+    """
+    Test that when run_dict returns a "Log" path different from the one we
+    requested, we read from the path run_dict actually reports.
+    """
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    actual_path = tmp_path / "actual.log"
+    actual_path.write_text("actual content\n", encoding="utf-8")
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict",
+        autospec=True,
+        return_value={"Log": str(actual_path)},
+    ):
+        result = win_wua.get_windows_update_log()
+
+    assert result.splitlines() == ["actual content"]
+
+
+def test_get_windows_update_log_run_dict_error_propagates():
+    with patch(
+        "salt.utils.win_pwsh.run_dict",
+        autospec=True,
+        side_effect=CommandExecutionError("boom"),
+    ):
+        with pytest.raises(CommandExecutionError):
+            win_wua.get_windows_update_log()
+
+
+def test_get_windows_update_log_missing_output_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    missing_path = tmp_path / "never_written.log"
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict",
+        autospec=True,
+        return_value={"Log": str(missing_path)},
+    ):
+        with pytest.raises(CommandExecutionError):
+            win_wua.get_windows_update_log()
+
+
+def test_get_windows_update_log_tail_and_pattern_share_helper(tmp_path, monkeypatch):
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+    log_path = tmp_path / "WindowsUpdate.log"
+    lines = [
+        "far away alpha",
+        "still far",
+        "also far",
+        "Failed to sync",
+        "still far 2",
+        "also far 2",
+        "far away beta",
+    ]
+    log_path.write_text("\n".join(lines), encoding="utf-8")
+
+    with patch(
+        "salt.utils.win_pwsh.run_dict",
+        autospec=True,
+        return_value={"Log": str(log_path)},
+    ):
+        result = win_wua.get_windows_update_log(pattern="Failed")
+
+    assert "Failed to sync" in result
+    assert "far away" not in result


### PR DESCRIPTION
### What does this PR do?
Add reset_datastore, reset_catroot, and reset to run the standard Windows Update datastore/catalog-cache reset procedure (stop WU services, rename SoftwareDistribution/catroot2, restart services), and get_cbs_log / get_windows_update_log to retrieve CBS.log and the merged Windows Update log for diagnosis. Both log functions default to a bounded tail and support a substring pattern filter to stay event-bus-safe on large logs.

Motivated by #70101, where win_wua.install reports success for a previously-uninstalled KB but the update does not persist through a reboot. install()'s per-update ResultCode is already an honest result at call time; the failure happens later during the CBS commit phase, which these functions help diagnose (get_cbs_log/get_windows_update_log) and, as a last resort, recover from (reset*) without remoting into the box by hand.

Adds tests/pytests/unit/modules/test_win_wua.py coverage for all five functions and a changelog/70101.added.md fragment.

### What issues does this PR fix or reference?
Fixes #70101 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
