### PR TITLE
[3007.x] Fix Combine Code Coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,7 +592,7 @@ jobs:
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -569,7 +569,7 @@ jobs:
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -360,7 +360,7 @@
           # We can't yet use tokenless uploads with the codecov CLI
           # python3 -m pip install codecov-cli
           #
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+          curl -s https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --import
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/changelog/70136.fixed.md
+++ b/changelog/70136.fixed.md
@@ -1,0 +1,1 @@
+Fix the ``Combine Code Coverage`` job on 3007.x by fetching the Codecov uploader signing key from ``https://uploader.codecov.io/verification.gpg`` (the ``keybase.io/codecovsecurity`` URL returns HTTP 404 and gpg exits non-zero under ``bash -e``).


### PR DESCRIPTION
## Summary

The `Combine Code Coverage` job on 3007.x has been failing since commit `03014ce2976` (revert of PR #69622) restored the retired `keybase.io/codecovsecurity/pgp_keys.asc` URL. That URL returns HTTP 404 (32 bytes), `gpg --import` reports `no valid OpenPGP data found`, and `bash -e` in the `Install Codecov CLI` step exits 2 before the uploader is downloaded. The subsequent merge-forward from 3006.x (#70063) did not repair it because the conflict resolution kept the 3007.x side.

Point the signing-key fetch at `https://uploader.codecov.io/verification.gpg`, matching what 3006.x/master already use. Same fingerprint `27034E7FDB850E0BBC2C62FF806BB28AED779869` (3187-byte PGP key, verified 200 OK), same key that signs `codecov.SHA256SUM.sig`.

Updated three sites: `.github/workflows/templates/ci.yml.jinja`, the regenerated `.github/workflows/ci.yml`, and the hand-written `.github/workflows/depcheck.yml`.

Ref: https://github.com/saltstack/salt/actions/runs/32845992220/job/97888483036

## Test plan
- [ ] CI (`test:full` label applied)
- [x] Local verification: `curl -sI https://uploader.codecov.io/verification.gpg` returns 200, 3187 bytes valid PGP key; `curl -sI https://keybase.io/codecovsecurity/pgp_keys.asc` returns 404. Pre-commit `Generate GitHub Workflow Templates` passed with no follow-up regeneration needed.