### PR TITLE
publish-nightly-release: skip publish when head_sha unchanged

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -105,11 +105,9 @@ jobs:
             exit 0
           fi
           body=$(gh release view "${last_tag}" --repo "${REPO}" --json body --jq .body 2>/dev/null || echo "")
-          # First 40-char hex string in the body is the head_sha. Release
-          # body template only contains one such string. Pattern is
-          # deliberately bare (no `commit `...`` anchors) to avoid a
-          # shellcheck SC2016 warning on literal backticks in a
-          # single-quoted grep pattern.
+          # Grab the first 40-char hex string from the body -- that is
+          # the head_sha. Release body template only contains one such
+          # string, so no additional context anchoring is required.
           prev_sha=$(printf '%s' "${body}" | grep -oE '[a-f0-9]{40}' | head -1 || true)
           if [ -z "${prev_sha}" ]; then
             echo "could not extract head_sha from ${last_tag}; failing open (proceeding with publish)"

--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -67,7 +67,61 @@ jobs:
             echo "already-exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: check for code changes since last publish
+
+        # Skip publishing when the triggering nightly built the same commit
+        # as the most recent nightly release for this branch. nightly.yml
+        # still fires daily (build + test signal stays fresh), but publish
+        # no-ops on unchanged branches. Rationale:
+        #   1. Republishing the same commit produces a redundant release
+        #      that carries no new bits for consumers.
+        #   2. Every publish re-rolls the actions/download-artifact drop
+        #      lottery -- fewer publishes = fewer chances to ship an
+        #      incomplete asset set (see 3006.x 8/22-8/25 incident).
+        #   3. Releases page and downstream mirrors stay tidy.
+        #
+        # Extracts head_sha from the previous release's body (format:
+        # "Nightly build from branch `X` at commit `SHA`."). Falls open
+        # on any parse failure -- if we can't determine the prior sha,
+        # we err on the side of publishing.
+        id: change-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BRANCH: ${{ steps.tag.outputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Sanitize branch same way the tag computation does.
+          branch_tag=$(printf '%s' "${BRANCH}" | tr '/' '-')
+          # Newest nightly release for this branch, excluding today's tag
+          # in case the idempotent-skip check above already created it.
+          today_tag="${{ steps.tag.outputs.tag }}"
+          last_tag=$(gh release list --repo "${REPO}" --limit 100 --json tagName --jq \
+            "[.[] | select(.tagName | test(\"^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}-${branch_tag}$\")) | select(.tagName != \"${today_tag}\")] | .[0].tagName // empty")
+          if [ -z "${last_tag}" ]; then
+            echo "no prior nightly release for branch ${BRANCH}; proceeding with publish"
+            echo "unchanged=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          body=$(gh release view "${last_tag}" --repo "${REPO}" --json body --jq .body 2>/dev/null || echo "")
+          prev_sha=$(printf '%s' "${body}" | grep -oE 'commit `[a-f0-9]{40}`' | head -1 | grep -oE '[a-f0-9]{40}' || true)
+          if [ -z "${prev_sha}" ]; then
+            echo "could not extract head_sha from ${last_tag}; failing open (proceeding with publish)"
+            echo "unchanged=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${prev_sha}" = "${HEAD_SHA}" ]; then
+            echo "head_sha ${HEAD_SHA} unchanged since ${last_tag}; skipping publish"
+            echo "::notice::Skipping publish -- no code changes on ${BRANCH} since ${last_tag} (${prev_sha:0:12})"
+            echo "unchanged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "head_sha changed since ${last_tag}: ${prev_sha:0:12} -> ${HEAD_SHA:0:12}; proceeding"
+            echo "unchanged=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: download all artifacts from the triggering nightly.yml run
+        if: steps.change-check.outputs.unchanged != 'true'
 
         uses: actions/download-artifact@v4
         with:
@@ -89,6 +143,7 @@ jobs:
           # find steps below still collect files recursively.
 
       - name: backfill build artifacts that download-artifact silently dropped
+        if: steps.change-check.outputs.unchanged != 'true'
 
         # `actions/download-artifact@v4` has been observed to silently drop
         # entries past some per-run size threshold on runs with hundreds
@@ -147,6 +202,7 @@ jobs:
           echo "backfilled: ${missing_count}   /zip-failed: ${fail_count}   final: ${final}/${total}"
 
       - name: drop source-build artifacts before publish
+        if: steps.change-check.outputs.unchanged != 'true'
         # `-rpm-from-src`, `-deb-from-src` etc. are internal source-build
         # verification outputs. They are never consumed downstream and
         # must not reach the release page -- their presence is what
@@ -166,6 +222,7 @@ jobs:
           echo "pruned ${removed} source-build artifact directories"
 
       - name: list assets to publish
+        if: steps.change-check.outputs.unchanged != 'true'
 
         run: |
           set -euo pipefail
@@ -191,7 +248,7 @@ jobs:
           cat /tmp/assets.txt
 
       - name: create release with all assets
-        if: steps.check.outputs.already-exists != 'true'
+        if: steps.check.outputs.already-exists != 'true' && steps.change-check.outputs.unchanged != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
@@ -233,6 +290,7 @@ jobs:
       # reflects the new release. See .github/scripts/generate_nightly_dashboard.py.
       # -----------------------------------------------------------------
       - name: download JUnit test-run artifacts from nightly.yml
+        if: steps.change-check.outputs.unchanged != 'true'
 
         continue-on-error: true
         uses: actions/download-artifact@v4
@@ -244,6 +302,7 @@ jobs:
           merge-multiple: false
 
       - name: backfill JUnit artifacts that download-artifact silently dropped
+        if: steps.change-check.outputs.unchanged != 'true'
 
         # actions/download-artifact@v4 has been observed to drop ~10% of
         # `testrun-junit-artifacts-*` items past some per-run size threshold
@@ -296,6 +355,7 @@ jobs:
           echo "backfilled: ${missing_count}   final: ${final}/${total}"
 
       - name: extract salt version from a built package name
+        if: steps.change-check.outputs.unchanged != 'true'
 
         id: salt-version
         env:
@@ -379,6 +439,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: checkout gh-pages branch into ./site (create if missing)
+        if: steps.change-check.outputs.unchanged != 'true'
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -397,6 +458,7 @@ jobs:
           fi
 
       - name: regenerate history.json + index.html
+        if: steps.change-check.outputs.unchanged != 'true'
 
         env:
           TAG: ${{ steps.tag.outputs.tag }}
@@ -424,6 +486,7 @@ jobs:
             --artifact-count "${asset_count}"
 
       - name: commit + push gh-pages
+        if: steps.change-check.outputs.unchanged != 'true'
 
         working-directory: site
         run: |

--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -105,7 +105,12 @@ jobs:
             exit 0
           fi
           body=$(gh release view "${last_tag}" --repo "${REPO}" --json body --jq .body 2>/dev/null || echo "")
-          prev_sha=$(printf '%s' "${body}" | grep -oE 'commit `[a-f0-9]{40}`' | head -1 | grep -oE '[a-f0-9]{40}' || true)
+          # First 40-char hex string in the body is the head_sha. Release
+          # body template only contains one such string. Pattern is
+          # deliberately bare (no `commit `...`` anchors) to avoid a
+          # shellcheck SC2016 warning on literal backticks in a
+          # single-quoted grep pattern.
+          prev_sha=$(printf '%s' "${body}" | grep -oE '[a-f0-9]{40}' | head -1 || true)
           if [ -z "${prev_sha}" ]; then
             echo "could not extract head_sha from ${last_tag}; failing open (proceeding with publish)"
             echo "unchanged=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What does this PR do?

Skips the publish flow when the triggering nightly built the same commit as the most recent nightly release for the branch. `nightly.yml` still fires daily (build + test signal stays fresh); only publish becomes commit-gated.

### What issues does this PR fix or reference?

Follow-up to #70128 and #70131. Same file; addresses a separate operational concern: quiet branches were producing a fresh release every day pointing at an unchanged commit, adding CI load and re-rolling the `actions/download-artifact@v4` drop lottery for no functional benefit.

### Previous Behavior

`run-nightly.yml` fires unconditionally at 00:00 UTC across `[3006.x, 3007.x, 3008.x, master]`. If a branch had zero commits since the last successful publish, the daily cron still:
1. Ran full CI (build + package tests + salt tests).
2. Fired `publish-nightly-release.yml`, which:
   - Downloaded ~700 artifacts.
   - Created a new `nightly-YYYY-MM-DD-<branch>` release object.
   - Attached whatever survived the download-artifact drop.
   - Updated the dashboard.

Two costs:
- **Redundant releases.** Same head_sha, same source, same-content build artifacts. The release attachment set would be byte-identical to yesterday's (modulo build timestamps).
- **Fresh dice roll on the download-artifact drop bug** (#70131). Even after the backfill lands, fewer publishes = strictly fewer chances to ship an incomplete asset set. 3006.x's 8/22 -> 8/24 -> 8/25 collapse (8 -> 8 -> 0 assets) happened while the branch head_sha didn't change; the 8/25 empty release would not have existed under this gate.

### New Behavior

Adds a new step immediately after `check if release already exists`:

```yaml
- name: check for code changes since last publish
  id: change-check
  ...
```

Queries `gh release list` for the most recent `nightly-*-<branch>` tag (excluding today's tag, so the check doesn't collide with the idempotent-skip check above), reads its body, and extracts the head_sha from the standard `commit \`SHA\`` phrase. If it matches `github.event.workflow_run.head_sha`, emits `unchanged=true` and a `::notice::` explaining the skip.

Every downstream step is gated with `if: steps.change-check.outputs.unchanged != 'true'` (11 steps: downloads, backfills, prune, list, release create, JUnit download/backfill, version probe, gh-pages checkout, dashboard regen, commit+push). The initial 4 steps (checkout, compute tag, exists check, change check) always run.

**Fails open** on any of: prior release missing, body format unexpected, network error. Any parse failure logs the reason and proceeds with the publish. Never gates in the wrong direction.

### Impact

- Quiet-branch nightlies stop republishing the same commit. Nightly build + test still runs daily for CI signal.
- Fewer publish runs on stable/maintenance branches; the 3006.x pattern of daily identical-commit republishes ends.
- Dashboard shows one row per _actual code change_ per branch instead of one row per day.
- Same-day retriggers of `nightly.yml` (`workflow_dispatch`) also skip when the head_sha matches. Idempotent.
- First run on a branch with no prior nightly release: proceeds (no prior to compare against).

### Not in this PR

- Path-based filtering (e.g. skip publish when only `docs/` changed). Could layer on later if useful.
- Any change to `run-nightly.yml` cron cadence.
- Any change to `nightly.yml` gating (build still runs daily as-is).

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (workflow gating; observable via publish behavior)

### Commits signed with GPG?

No.