### PR TITLE
build-packages: parameterize --key-id for RPM signing

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -24,6 +24,16 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-rpm-key-id:
+        type: string
+        default: "64CBBC8173D76B3F"
+        description: >
+          GPG key id passed to `tools pkg build rpm --key-id=<id>` when
+          sign-rpm-packages is true. Defaults to the SaltProjectKey
+          currently used for stable releases. Nightly (or any other
+          isolated build path) should override with its own key id and
+          provide the matching SIGNING_GPG_KEY / SIGNING_PASSPHRASE
+          secrets on the calling repo.
       sign-macos-packages:
         type: boolean
         default: false
@@ -302,7 +312,7 @@ jobs:
               format('--onedir=salt-{0}-onedir-linux-{1}.tar.xz', inputs.salt-version, matrix.arch)
               ||
               format('--arch={0}', matrix.arch)
-          }} ${{ inputs.sign-rpm-packages && '--key-id=64CBBC8173D76B3F' || '' }}
+          }} ${{ inputs.sign-rpm-packages && format('--key-id={0}', inputs.sign-rpm-key-id) || '' }}
 
       - name: Set Artifact Name
         id: set-artifact-name


### PR DESCRIPTION
### What does this PR do?

Adds a `sign-rpm-key-id` input to the `build-packages.yml` reusable workflow, defaulting to the current prod key `64CBBC8173D76B3F`. Preparation for signing nightly RPMs with a dedicated key without touching the stable release path.

### What issues does this PR fix or reference?

Groundwork for a follow-up that flips nightly.yml to sign RPMs with a dedicated `SaltProjectNightlyKey`. Blast-radius isolation: nightly key compromise should not affect stable consumers.

### Previous Behavior

`build-packages.yml` hardcoded the key id in the Build RPM step:
```yaml
${{ inputs.sign-rpm-packages && '--key-id=64CBBC8173D76B3F' || '' }}
```

Every caller that opts into RPM signing (currently just `staging.yml` for stable releases) gets the same production key. There was no way to sign a subset of builds with a different key.

### New Behavior

Adds a string input:
```yaml
sign-rpm-key-id:
  type: string
  default: "64CBBC8173D76B3F"
  description: >
    GPG key id passed to `tools pkg build rpm --key-id=<id>` when
    sign-rpm-packages is true. Defaults to the SaltProjectKey
    currently used for stable releases. Nightly (or any other
    isolated build path) should override with its own key id and
    provide the matching SIGNING_GPG_KEY / SIGNING_PASSPHRASE
    secrets on the calling repo.
```

Build RPM step now composes the flag from the input:
```yaml
${{ inputs.sign-rpm-packages && format('--key-id={0}', inputs.sign-rpm-key-id) || '' }}
```

### Impact

- **No behavior change on this PR.** None of the current callers (`ci.yml`, `staging.yml`, `nightly.yml`, `scheduled.yml`, `depcheck.yml`) pass `sign-rpm-key-id`, so the default `64CBBC8173D76B3F` applies. Stable release path continues to sign with the SaltProjectKey exactly as before.
- Unlocks a follow-up PR that will:
  1. Add `NIGHTLY_SIGNING_GPG_KEY` + `NIGHTLY_SIGNING_PASSPHRASE` secrets on `saltstack/salt-nightlies` (secret coordination step outside code &mdash; delegated to the salt project team).
  2. Modify `nightly.yml` to set `sign-rpm-packages: true` and pass the nightly key id.
  3. Publish the nightly public key at a discoverable URL on packages.broadcom.com so consumers can verify.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change, no user-visible behavior change)
- [ ] Tests written/updated &mdash; not applicable (workflow input plumbing; existing signing tests still exercise the default)

### Commits signed with GPG?

No.