### PR TITLE
nightly: sign RPM packages with whichever key is in the signing secret

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -281,6 +281,13 @@ jobs:
           EOF
           echo "${SIGNING_PASSPHRASE}" > "${GNUPGHOME}/passphrase"
           echo "${SIGNING_GPG_KEY}" | gpg --import -
+          # Discover the fingerprint of the just-imported signing key so
+          # Build RPM can pass it to rpmsign without hardcoding a specific
+          # key id. Lets each repo (saltstack/salt, saltstack/salt-nightlies)
+          # provide its own key material via SIGNING_GPG_KEY and have the
+          # workflow use whatever's in the resulting keyring.
+          SIGN_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '$1=="fpr" {print $10; exit}')
+          echo "SIGN_KEY_ID=${SIGN_KEY_ID}" >> "$GITHUB_ENV"
 
       - name: Configure Git
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
@@ -302,7 +309,7 @@ jobs:
               format('--onedir=salt-{0}-onedir-linux-{1}.tar.xz', inputs.salt-version, matrix.arch)
               ||
               format('--arch={0}', matrix.arch)
-          }} ${{ inputs.sign-rpm-packages && '--key-id=64CBBC8173D76B3F' || '' }}
+          }} ${{ inputs.sign-rpm-packages && format('--key-id={0}', env.SIGN_KEY_ID) || '' }}
 
       - name: Set Artifact Name
         id: set-artifact-name

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -482,7 +482,7 @@ jobs:
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
       environment: nightly
       sign-macos-packages: true
-      sign-rpm-packages: false
+      sign-rpm-packages: true
       sign-windows-packages: false
 
   build-pkgs-src:
@@ -503,7 +503,7 @@ jobs:
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
       environment: nightly
       sign-macos-packages: true
-      sign-rpm-packages: false
+      sign-rpm-packages: true
       sign-windows-packages: false
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -36,7 +36,7 @@
     <%- if gh_environment != "ci" %>
       environment: <{ gh_environment }>
       sign-macos-packages: true
-      sign-rpm-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
+      sign-rpm-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
       sign-windows-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-windows-packages }} <%- endif %>
 
     <%- endif %>


### PR DESCRIPTION
### What does this PR do?

Enables RPM signing for nightly builds, using whatever key material the running repo's `SIGNING_GPG_KEY` secret contains &mdash; without hardcoding a fingerprint. Prep for using a dedicated nightly signing key on `saltstack/salt-nightlies` distinct from the stable `SaltProjectKey` held on `saltstack/salt`.

### Previous Behavior

Two barriers to nightly signing:

1. `templates/build-packages.yml.jinja` explicitly set `sign-rpm-packages: false` when `gh_environment == 'nightly'`, so the generated `nightly.yml` always passed `false` regardless of secrets.
2. `build-packages.yml` hardcoded `--key-id=64CBBC8173D76B3F` (the `SaltProjectKey` fingerprint) into the Build RPM step. Even if #1 were flipped, `rpmsign` would fail on any repo whose imported keyring didn't contain that specific fingerprint &mdash; which is exactly the case if `salt-nightlies` uses its own key.

### New Behavior

**`templates/build-packages.yml.jinja`** (and regenerated `nightly.yml`):

```diff
-      sign-rpm-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
+      sign-rpm-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
```

**`build-packages.yml`** &mdash; Setup GnuPG step now discovers the fingerprint of whatever key was imported and exports it to `$GITHUB_ENV`:

```yaml
echo "${SIGNING_GPG_KEY}" | gpg --import -
SIGN_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '$1=="fpr" {print $10; exit}')
echo "SIGN_KEY_ID=${SIGN_KEY_ID}" >> "$GITHUB_ENV"
```

Build RPM step now uses that env var instead of a hardcoded fingerprint:

```diff
-          }} ${{ inputs.sign-rpm-packages && '--key-id=64CBBC8173D76B3F' || '' }}
+          }} ${{ inputs.sign-rpm-packages && format('--key-id={0}', env.SIGN_KEY_ID) || '' }}
```

### Impact

| Repo | `SIGNING_GPG_KEY` secret | Result |
| --- | --- | --- |
| `saltstack/salt-nightlies` with nightly key set | Yes (nightly key) | Setup GnuPG imports nightly key, discovers its fingerprint, Build RPM signs with it &mdash; blast-radius isolated from stable |
| `saltstack/salt` stable release (`staging.yml`) | Yes (`SaltProjectKey`) | Imports `SaltProjectKey`, discovers `64CBBC8173D76B3F`, signs identically to before &mdash; behavior unchanged |
| Any repo without the secret set | No | Setup GnuPG step's `if: ${{ inputs.sign-rpm-packages }}` short-circuits before running, `SIGN_KEY_ID` never set, `env.SIGN_KEY_ID` evaluates empty, `--key-id=` not appended, no signing attempted, no failure |

Zero caller plumbing. Zero per-repo GitHub UI configuration (no vars). Zero hardcoded fingerprint. Adding a new signing key on a new repo is just: upload `SIGNING_GPG_KEY` + `SIGNING_PASSPHRASE` secrets, done.

### Prerequisites for effective nightly signing

This PR is the workflow-side piece. To actually get signed nightly RPMs published, `saltstack/salt-nightlies` still needs the salt project team to:

1. Generate the `SaltProjectNightlyKey` keypair (offline).
2. Upload the ASCII-armored private key as `SIGNING_GPG_KEY` and the passphrase as `SIGNING_PASSPHRASE` on the `nightly` environment (or repo-level secrets) of `saltstack/salt-nightlies`.
3. Publish the matching public key at a discoverable URL under `packages.broadcom.com` so consumers can verify.

Until #2 lands, nightly builds run identically to today (Setup GnuPG's `if` short-circuits when the secret isn't set).

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (workflow signing; observable via a nightly run on `salt-nightlies` once key material is uploaded)

### Commits signed with GPG?

No.