### PR TITLE
[3006.x] Bump relenv to 0.22.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -461,7 +461,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -478,7 +478,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -508,7 +508,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -525,7 +525,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -546,7 +546,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -493,7 +493,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -510,7 +510,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -527,7 +527,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -467,7 +467,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -507,7 +507,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.23"
+      relenv-version: "0.22.25"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/changelog/70142.fixed.md
+++ b/changelog/70142.fixed.md
@@ -1,0 +1,3 @@
+* Relenv 0.22.25
+  - Fix 2^n slowdown in wrap_sysconfig by making it idempotent (fixes Salt highstate hangs on long-lived Python 3.13+ onedir minions) - #321 / #325
+  - Update openssl to 3.5.8 (0.22.24)

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.11.16"
-relenv_version: "0.22.23"
+relenv_version: "0.22.25"
 release_branches:
   - "3006.x"
   - "3007.x"


### PR DESCRIPTION
## Summary

Bumps pinned relenv from 0.22.23 to 0.22.25 on 3006.x, regenerating ci/nightly/scheduled/staging workflow YAMLs via the shared context.

## Relenv 0.22.25 highlights (vs 0.22.23)

- Fix 2^n slowdown in \`wrap_sysconfig\` by making it idempotent — saltstack/relenv#321 / saltstack/relenv#325.
  Stops the wrapper stacking that made \`state.module_refresh()\` hang long-lived Python 3.13+ onedir minions on highstates.
- Update openssl to 3.5.8 (0.22.24).

Tracker: #70142

## Test plan

- [ ] CI green on 3006.x targets (Linux, macOS, Windows).
- [ ] Onedir builds pick up relenv 0.22.25 (Python point versions unchanged from 0.22.23: 3.10.21, 3.11.16, 3.12.14, 3.13.15).
- [ ] Package tests (install / upgrade / downgrade) still pass on supported OSes.