### PR TITLE
[3008.x] Update packaging git-config email to broadcom.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -358,7 +358,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -363,7 +363,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           git config --global --add safe.directory "$(pwd)"
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
           git config --global user.signingkey 64CBBC8173D76B3F
           git config --global commit.gpgsign true
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -417,7 +417,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -392,7 +392,7 @@ jobs:
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -159,7 +159,7 @@
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         run: |
           git config --global user.name "Salt Project Packaging"
-          git config --global user.email saltproject-packaging@vmware.com
+          git config --global user.email saltproject-packaging@broadcom.com
 
       - name: Setup Pre-Commit
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}

--- a/changelog/70150.changed.md
+++ b/changelog/70150.changed.md
@@ -1,0 +1,1 @@
+Update CI git commit author email from `saltproject-packaging@vmware.com` to `saltproject-packaging@broadcom.com` in seven workflow files to reflect Salt's Broadcom stewardship.


### PR DESCRIPTION
## Summary

Replace `saltproject-packaging@vmware.com` with `saltproject-packaging@broadcom.com` in the seven workflow files that configure the git author identity for CI-generated commits.

Matches the `broadcom.com` email domain already used elsewhere in the repository:
- `saltproject.pdl@broadcom.com` in `README.rst` and `CODE_OF_CONDUCT.md`
- `saltproject-security.pdl@broadcom.com` in `SECURITY.md`

Files:
- `.github/workflows/ci.yml`
- `.github/workflows/depcheck.yml`
- `.github/workflows/nightly.yml`
- `.github/workflows/release.yml`
- `.github/workflows/scheduled.yml`
- `.github/workflows/staging.yml`
- `.github/workflows/templates/ci.yml.jinja`

Plus a `changelog/70150.changed.md` entry.

## Follow-ups (not in this PR)

Other ``vmware.com`` references on 3008.x that were **not** touched here — target URLs need confirmation before rewriting:

- `README.rst` + `SUPPORT.rst`: ``https://www.vmware.com/products/app-platform/tanzu-salt`` — Tanzu Salt product URL. Correct Broadcom equivalent unknown; leaving for a follow-up.
- ``doc/_themes/saltstack2/layout.html``: privacy-policy link + ``© VMware, Inc.`` footer attribution. Policy call about theme attribution rather than a mechanical URL swap.

Historical VMware references intentionally left in place:
- ``salt/utils/vmware.py``, ``salt/modules/vsphere.py``, ``doc/topics/cloud/vmware.rst`` and similar — these are the VMware product modules/docs; ``vmware.com`` remains the product's home even post-acquisition.
- ``pkg/debian/changelog``, ``pkg/rpm/salt.spec`` — append-only historical changelog entries.

## Test plan

- [x] ``pre-commit run`` on all 8 changed files — clean (``Generate GitHub Workflow Templates`` + ``Lint GitHub Actions Workflows`` both Passed).
- [ ] CI (``test:full`` label applied).