### PR TITLE
Plug tag_map leak in job_not_running that flaked test_mem_leak_in_event_listener

### DIFF
--- a/changelog/70152.fixed.md
+++ b/changelog/70152.fixed.md
@@ -1,0 +1,1 @@
+Plug the ``event_listener.tag_map`` / ``timeout_map`` leak in ``saltnado.job_not_running`` when the outer job finishes with an in-flight ``saltutil.find_job`` ping.

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1172,6 +1172,25 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 if f is is_finished:
                     if not event.done():
                         event.set_result(None)
+                    # ``set_result(None)`` resolves the Future but leaves
+                    # it in ``event_listener.tag_map`` / ``timeout_map``.
+                    # ``job_not_running`` runs as a ``spawn_callback``
+                    # coroutine independent of the handler; if it has
+                    # already registered a ping wait when the handler's
+                    # ``on_finish`` -> ``clean_by_request`` runs, that
+                    # entry escapes cleanup and lingers up to
+                    # ``gather_job_timeout`` seconds until the timeout
+                    # callback fires. Reap it inline so the maps drain
+                    # promptly (see ``test_mem_leak_in_event_listener``).
+                    listener = self.application.event_listener
+                    timeout_handle = listener.timeout_map.pop(event, None)
+                    if timeout_handle is not None:
+                        tornado.ioloop.IOLoop.current().remove_timeout(timeout_handle)
+                    listener._timeout_future(
+                        ping_tag,
+                        EventListener.prefix_matcher,
+                        event,
+                    )
                     raise tornado.gen.Return(True)
                 event = f.result()
             except TimeoutException:


### PR DESCRIPTION
## Summary
- `saltnado._disbatch_local` spawns `job_not_running` as an `IOLoop.spawn_callback` coroutine.  When the outer job's `is_finished` future completes first, `job_not_running` resolves the in-flight ping future via `event.set_result(None)` and returns — but never removes the future from `event_listener.tag_map` / `timeout_map`.
- Because `spawn_callback` runs independently of the handler, the ping may be registered *after* the handler's `on_finish -> clean_by_request` has already emptied `request_map`, so the leaked entry only clears when the `gather_job_timeout` callback fires (10 s default, 30 s under the netapi test fixture).
- `test_mem_leak_in_event_listener` allows only a 1 s poll window before asserting the maps are empty, so any leaked ping trips `AssertionError: assert 2 == 0` — the exact flake caught on the 3008.x nightly `Amazon Linux 2 integration zeromq 4` (run 32913591224 job 98023096704, first attempt failed / retry passed) and reproduced on merge-forward PR #70132.
- Fix: after `set_result(None)`, cancel the tornado timeout callback and call `_timeout_future(...)` to drop the entry from `tag_map`, matching the cleanup that `clean_by_request` would have performed had the request still been tracked.

Fixes #70152

## Test plan
- [ ] `tests/pytests/integration/netapi/rest_tornado/test_minions_api_handler.py::test_mem_leak_in_event_listener` passes on Amazon Linux 2 integration zeromq 4 without needing pytest-salt-factories retry
- [ ] Netapi `rest_tornado` integration split otherwise unchanged