### PR TITLE
publish-nightly-release: skip publish for test-nightly-* branches

### DIFF
--- a/.github/workflows/publish-nightly-release.yml
+++ b/.github/workflows/publish-nightly-release.yml
@@ -67,6 +67,32 @@ jobs:
             echo "already-exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: check for test-nightly branch (skip publish)
+
+        # Branches named `test-nightly-*` are for exercising the full
+        # nightly.yml pipeline (build, signing, tests) without producing
+        # a release. When head_branch matches, mark this run as skip-only
+        # and every downstream step no-ops.
+        #
+        # Usage: `gh workflow run nightly.yml --repo saltstack/salt-nightlies
+        #         --ref test-nightly-verify-signing` (branch must exist
+        # in the salt-nightlies mirror).
+        id: test-branch-check
+        env:
+          BRANCH: ${{ steps.tag.outputs.branch }}
+        run: |
+          set -euo pipefail
+          case "${BRANCH}" in
+            test-nightly-*)
+              echo "test-nightly branch ${BRANCH}; publish will be skipped"
+              echo "::notice::Skipping publish -- test-nightly branch (${BRANCH})"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
       - name: check for code changes since last publish
 
         # Skip publishing when the triggering nightly built the same commit
@@ -124,7 +150,7 @@ jobs:
           fi
 
       - name: download all artifacts from the triggering nightly.yml run
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         uses: actions/download-artifact@v4
         with:
@@ -146,7 +172,7 @@ jobs:
           # find steps below still collect files recursively.
 
       - name: backfill build artifacts that download-artifact silently dropped
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         # `actions/download-artifact@v4` has been observed to silently drop
         # entries past some per-run size threshold on runs with hundreds
@@ -205,7 +231,7 @@ jobs:
           echo "backfilled: ${missing_count}   /zip-failed: ${fail_count}   final: ${final}/${total}"
 
       - name: drop source-build artifacts before publish
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
         # `-rpm-from-src`, `-deb-from-src` etc. are internal source-build
         # verification outputs. They are never consumed downstream and
         # must not reach the release page -- their presence is what
@@ -225,7 +251,7 @@ jobs:
           echo "pruned ${removed} source-build artifact directories"
 
       - name: list assets to publish
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         run: |
           set -euo pipefail
@@ -251,7 +277,7 @@ jobs:
           cat /tmp/assets.txt
 
       - name: create release with all assets
-        if: steps.check.outputs.already-exists != 'true' && steps.change-check.outputs.unchanged != 'true'
+        if: steps.check.outputs.already-exists != 'true' && steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
@@ -293,7 +319,7 @@ jobs:
       # reflects the new release. See .github/scripts/generate_nightly_dashboard.py.
       # -----------------------------------------------------------------
       - name: download JUnit test-run artifacts from nightly.yml
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         continue-on-error: true
         uses: actions/download-artifact@v4
@@ -305,7 +331,7 @@ jobs:
           merge-multiple: false
 
       - name: backfill JUnit artifacts that download-artifact silently dropped
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         # actions/download-artifact@v4 has been observed to drop ~10% of
         # `testrun-junit-artifacts-*` items past some per-run size threshold
@@ -358,7 +384,7 @@ jobs:
           echo "backfilled: ${missing_count}   final: ${final}/${total}"
 
       - name: extract salt version from a built package name
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         id: salt-version
         env:
@@ -442,7 +468,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: checkout gh-pages branch into ./site (create if missing)
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -461,7 +487,7 @@ jobs:
           fi
 
       - name: regenerate history.json + index.html
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         env:
           TAG: ${{ steps.tag.outputs.tag }}
@@ -489,7 +515,7 @@ jobs:
             --artifact-count "${asset_count}"
 
       - name: commit + push gh-pages
-        if: steps.change-check.outputs.unchanged != 'true'
+        if: steps.change-check.outputs.unchanged != 'true' && steps.test-branch-check.outputs.skip != 'true'
 
         working-directory: site
         run: |


### PR DESCRIPTION
### What does this PR do?

Adds an escape hatch for exercising the full `nightly.yml` pipeline (build, signing, tests) end-to-end without producing a release. When the triggering nightly's `head_branch` matches `test-nightly-*`, publish-nightly-release marks the run skip-only and every downstream step no-ops.

### What issues does this PR fix or reference?

Follow-up to #70137 (which added the head_sha-unchanged skip). Same pattern applied to a different skip condition. Enables workflows like:
- Verifying newly-configured signing secrets on a branch of your choice.
- Testing a workflow_dispatch code path without polluting the releases page.
- Any dry-run scenario where the build + test signal matters but attaching the artifacts to a release does not.

### Previous Behavior

Every successful `nightly.yml` run whose head_branch didn't match a prior release's head_sha produced a release. No way to trigger a nightly for testing purposes without either accepting the release or racing to delete it afterward. Complicates verification of things like signing, artifact backfill, or downstream mirror plumbing.

### New Behavior

New step immediately after the idempotent-skip check:

```yaml
- name: check for test-nightly branch (skip publish)
  id: test-branch-check
  env:
    BRANCH: ${{ steps.tag.outputs.branch }}
  run: |
    set -euo pipefail
    case "${BRANCH}" in
      test-nightly-*)
        echo "test-nightly branch ${BRANCH}; publish will be skipped"
        echo "::notice::Skipping publish -- test-nightly branch (${BRANCH})"
        echo "skip=true" >> "$GITHUB_OUTPUT"
        ;;
      *)
        echo "skip=false" >> "$GITHUB_OUTPUT"
        ;;
    esac
```

Every downstream step (download, backfill, prune, list, create-release, JUnit download/backfill, version probe, gh-pages checkout, dashboard regen, commit+push &mdash; 11 steps total) gets `... && steps.test-branch-check.outputs.skip != 'true'` appended to its existing `if:` guard.

### Usage

```bash
# Create the test branch on the salt-nightlies mirror (any base commit)
gh api repos/saltstack/salt-nightlies/git/refs -f ref=refs/heads/test-nightly-verify-signing -f sha=<any-sha-from-3008.x-or-master>

# Dispatch nightly on it
gh workflow run nightly.yml \
  --repo saltstack/salt-nightlies \
  --ref test-nightly-verify-signing
```

The build runs, tests run, RPM/DEB artifacts are produced (and signed if the branch inherits the secrets), but publish-nightly-release fires only to emit the `::notice::` and immediately skip. No release object, no dashboard entry, no mirror-side effects.

### Impact

- No behavior change on any branch not matching `test-nightly-*`. All existing gates (already-exists, unchanged head_sha) continue to apply.
- Test-nightly runs never write to the releases page or gh-pages.
- Any user with dispatch permissions on the mirror can now run a full end-to-end nightly for testing without needing to clean up after.

### Not in this PR

- No changes to `nightly.yml` (build workflow). Test-nightly-* branches are still valid inputs to any workflow that reads `github.ref_name`; nightly.yml doesn't need to know about the naming convention.
- No CI-side branch enforcement. Anyone can push a test-nightly-* branch; that's intentional (low-cost escape hatch, not a security boundary).

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (workflow gating; verified via a dispatch on a test branch after merge)

### Commits signed with GPG?

No.