### PR TITLE
[3008.x] nightly: sign RPM packages with whichever key is in the signing secret

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -278,6 +278,13 @@ jobs:
           EOF
           echo "${SIGNING_PASSPHRASE}" > "${GNUPGHOME}/passphrase"
           echo "${SIGNING_GPG_KEY}" | gpg --import -
+          # Discover the fingerprint of the just-imported signing key so
+          # Build RPM can pass it to rpmsign without hardcoding a specific
+          # key id. Lets each repo (saltstack/salt, saltstack/salt-nightlies)
+          # provide its own key material via SIGNING_GPG_KEY and have the
+          # workflow use whatever's in the resulting keyring.
+          SIGN_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '$1=="fpr" {print $10; exit}')
+          echo "SIGN_KEY_ID=${SIGN_KEY_ID}" >> "$GITHUB_ENV"
 
       - name: Configure Git
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
@@ -296,7 +303,7 @@ jobs:
               format('--onedir=salt-{0}-onedir-linux-{1}.tar.xz', inputs.salt-version, matrix.arch)
               ||
               format('--arch={0}', matrix.arch)
-          }} ${{ inputs.sign-rpm-packages && '--key-id=64CBBC8173D76B3F' || '' }}
+          }} ${{ inputs.sign-rpm-packages && format('--key-id={0}', env.SIGN_KEY_ID) || '' }}
 
       - name: Set Artifact Name
         id: set-artifact-name

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -482,7 +482,7 @@ jobs:
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
       environment: nightly
       sign-macos-packages: true
-      sign-rpm-packages: false
+      sign-rpm-packages: true
       sign-windows-packages: false
 
   build-pkgs-src:
@@ -503,7 +503,7 @@ jobs:
       linux_arm_runner: ${{ fromJSON(needs.prepare-workflow.outputs.config)['linux_arm_runner'] }}
       environment: nightly
       sign-macos-packages: true
-      sign-rpm-packages: false
+      sign-rpm-packages: true
       sign-windows-packages: false
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -36,7 +36,7 @@
     <%- if gh_environment != "ci" %>
       environment: <{ gh_environment }>
       sign-macos-packages: true
-      sign-rpm-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
+      sign-rpm-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
       sign-windows-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-windows-packages }} <%- endif %>
 
     <%- endif %>


### PR DESCRIPTION
### What does this PR do?

Backport of #70141 to the 3008.x branch. Same change: enables RPM signing for nightly builds on 3008.x, using whichever key material the running repo's `SIGNING_GPG_KEY` secret contains.

### What issues does this PR fix or reference?

Backport of #70141 (merged to master 2026-08-26).

Without this backport, nightly builds on 3008.x continue to ship unsigned RPMs even though the signing key material and workflow logic are ready. Verified today: `nightly-2026-08-27` builds for 3006.x and 3008.x succeeded but all RPMs show `Signature: (none)` because those release branches still have `sign-rpm-packages: false` in their pinned copy of nightly.yml.

### Previous Behavior

`nightly.yml` on 3008.x had `sign-rpm-packages: false`; Setup GnuPG step was skipped; RPMs shipped unsigned.

### New Behavior

Cherry-picked #70141's single commit onto 3008.x:

- `templates/build-packages.yml.jinja`: flip nightly-environment override from `false` to `true`.
- `nightly.yml` (regenerated from template): `sign-rpm-packages: true` in both `build-pkgs-onedir` and `build-pkgs-src` callers.
- `build-packages.yml`: Setup GnuPG discovers the imported key's fingerprint via `gpg --list-secret-keys --with-colons | awk` and exports `SIGN_KEY_ID` to `$GITHUB_ENV`; Build RPM uses `env.SIGN_KEY_ID` instead of hardcoded `64CBBC8173D76B3F`. Lets salt-nightlies sign with its dedicated `SaltProjectNightlyKey` (fingerprint `6A4868F7...52F404520060A19B`) while stable release path on saltstack/salt continues to sign with `SaltProjectKey`.

Diff is 11+/4- across 3 files — pure cherry-pick, no additional changes.

### Impact

- The next scheduled 3008.x nightly on `saltstack/salt-nightlies` (00:00 UTC daily) will produce signed RPMs.
- Consumers verify with:
  ```
  rpm --import https://packages.broadcom.com/artifactory/saltproject-generic/nightly/SALTPROJECT-NIGHTLY-GPG-PUBKEY-2026.pub
  rpm --checksig <package.rpm>
  ```
  Pubkey is already live at that URL.
- No behavior change for stable 3008.x releases (staging.yml unaffected).

### Local verification

- `pre-commit run --files ...`: `Lint GitHub Actions Workflows: Passed`, `Generate GitHub Workflow Templates: Passed`.
- Same code path locally exercised end-to-end with rpmsign + rpm --checksig in a fedora container against a real salt RPM — signature verifies clean against the nightly pubkey.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change, master change already had no changelog)
- [ ] Tests written/updated &mdash; not applicable

### Commits signed with GPG?

No.