### PR TITLE
Fix unit tests for pytest >=8

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -4,8 +4,8 @@ import time
 
 import pytest
 import tornado.escape
+import tornado.testing
 import tornado.web
-from tornado.testing import AsyncHTTPTestCase
 
 import salt.auth
 import salt.utils.json
@@ -22,9 +22,10 @@ def salt_api_account(salt_api_account_factory):
 
 
 class SaltnadoIntegrationTestsBase(
-    AsyncHTTPTestCase, AdaptedConfigurationTestCaseMixin
+    tornado.testing.AsyncHTTPTestCase, AdaptedConfigurationTestCaseMixin
 ):
-
+    # Force pytest>8 skip evaluating class with no tests
+    __test__ = False
     content_type_map = {
         "json": "application/json",
         "json-utf8": "application/json; charset=utf-8",
@@ -124,6 +125,11 @@ class SaltnadoIntegrationTestsBase(
 
 @pytest.mark.usefixtures("salt_sub_minion")
 class TestSaltAPIHandler(SaltnadoIntegrationTestsBase):
+    __test__ = True
+
+    def runTest(self):
+        pass
+
     def setUp(self):
         super().setUp()
         os.environ["ASYNC_TEST_TIMEOUT"] = "300"
@@ -208,6 +214,11 @@ class TestSaltAPIHandler(SaltnadoIntegrationTestsBase):
 
 
 class TestWebhookSaltAPIHandler(SaltnadoIntegrationTestsBase):
+    __test__ = True
+
+    def runTest(self):
+        pass
+
     def get_app(self):
 
         urls = [

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -9,8 +9,8 @@ import pytest
 import tornado.concurrent
 import tornado.gen
 import tornado.ioloop
+import tornado.testing
 from pytestshellutils.utils import ports
-from tornado.testing import AsyncTestCase
 
 import salt.channel.client
 import salt.channel.server
@@ -30,10 +30,15 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip(reason="Skip until we can devote time to fix this test")
-class AsyncPubServerTest(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
+class AsyncPubServerTest(
+    tornado.testing.AsyncTestCase, AdaptedConfigurationTestCaseMixin
+):
     """
     Tests around the publish system
     """
+
+    def runTest(self):
+        pass
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### What does this PR do?

Pytest >= 8 expects the `runTest` function to be defined. Without this dummy definition, tests will fail to load, e.g.:

```
04:28:49  ERROR tests/unit/transport/test_tcp.py::AsyncTestCase - AttributeError: 'AsyncTestCase' object has no attribute 'runTest'
04:28:49  ERROR tests/unit/transport/test_tcp.py::AsyncPubServerTest - AttributeError: 'AsyncPubServerTest' object has no attribute 'runTest'
```

I believe Salt is in the process of migrating these tests to pytest. In the meantime, this change enables the tests to be executed with the new pytest.

### What issues does this PR fix or reference?

### Previous Behavior
Tests fail to load.

### New Behavior
Test can execute with both the old and new pytest.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
