### PR TITLE
templates/build-packages: pass secrets: inherit for nightly too

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -471,6 +471,7 @@ jobs:
       - build-source-tarball
       - build-salt-onedir
     uses: ./.github/workflows/build-packages.yml
+    secrets: inherit
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
@@ -492,6 +493,7 @@ jobs:
       - prepare-workflow
       - build-source-tarball
     uses: ./.github/workflows/build-packages.yml
+    secrets: inherit
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -21,7 +21,7 @@
       - build-salt-onedir
       <%- endif %>
     uses: ./.github/workflows/build-packages.yml
-    <% if gh_environment == 'staging' -%>
+    <% if gh_environment != 'ci' -%>
     secrets: inherit
     <% endif -%>
     with:


### PR DESCRIPTION
### What does this PR do?

Fixes nightly RPM signing being broken because the reusable `build-packages.yml` workflow doesn't receive secrets from the nightly caller. `#70141` (enabling nightly signing) landed the workflow-side logic but couldn't work until the caller also inherits secrets.

### What issues does this PR fix or reference?

Follow-up to #70141. Discovered when saltstack/salt-nightlies run 33098010828 (first 3008.x nightly with signing enabled via #70155) failed at Setup GnuPG:

```
env:
  SIGNING_GPG_KEY:
  SIGNING_PASSPHRASE:
...
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
Process completed with exit code 2.
```

Blank env values (not `***` redaction) confirm the secrets weren't resolved &mdash; they existed on `saltstack/salt-nightlies` `nightly` environment but the reusable workflow couldn't see them.

### Previous Behavior

`templates/build-packages.yml.jinja`:

```yaml
uses: ./.github/workflows/build-packages.yml
<% if gh_environment == 'staging' -%>
secrets: inherit
<% endif -%>
```

Only staging path inherited caller secrets. Nightly path never did, so `build-packages.yml`'s `Setup GnuPG` step got empty `secrets.SIGNING_GPG_KEY` / `secrets.SIGNING_PASSPHRASE` even when they were properly configured on the nightly environment.

### New Behavior

```yaml
uses: ./.github/workflows/build-packages.yml
<% if gh_environment != 'ci' -%>
secrets: inherit
<% endif -%>
```

Matches the pattern of the `environment:` / `sign-macos-packages:` / `sign-rpm-packages:` block directly below, which is also gated on `gh_environment != 'ci'`. Regenerates `nightly.yml` with `secrets: inherit` on both `build-pkgs-onedir` and `build-pkgs-src` callers.

### Impact

- Nightly builds now actually import the `SIGNING_GPG_KEY` and produce signed RPMs when the caller repo (`saltstack/salt-nightlies`) has that secret configured.
- Staging: no behavior change (already had `secrets: inherit`).
- CI: no behavior change (still no `secrets: inherit`, no signing).
- `scheduled` environment (if used): now also gets `secrets: inherit`. Safe &mdash; if scheduled builds don't set the relevant secrets, `sign-rpm-packages` remains false and signing is skipped anyway.

Needs to be backported to 3008.x (and any other supported release branch where signing is enabled) to actually fix nightlies on those branches.

### Local verification

- `pre-commit run --files ...`: `Generate GitHub Workflow Templates: Passed`, `Lint GitHub Actions Workflows: Passed`.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (workflow plumbing; verified via a live nightly dispatch once merged and backported)

### Commits signed with GPG?

No.