### PR TITLE
[3008.x] templates/build-packages: pass secrets: inherit for nightly too

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -471,6 +471,7 @@ jobs:
       - build-source-tarball
       - build-salt-onedir
     uses: ./.github/workflows/build-packages.yml
+    secrets: inherit
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
@@ -492,6 +493,7 @@ jobs:
       - prepare-workflow
       - build-source-tarball
     uses: ./.github/workflows/build-packages.yml
+    secrets: inherit
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -21,7 +21,7 @@
       - build-salt-onedir
       <%- endif %>
     uses: ./.github/workflows/build-packages.yml
-    <% if gh_environment == 'staging' -%>
+    <% if gh_environment != 'ci' -%>
     secrets: inherit
     <% endif -%>
     with:


### PR DESCRIPTION
### What does this PR do?

Backport of #70159 to 3008.x. Same one-commit cherry-pick.

Without this, saltstack/salt-nightlies 3008.x nightlies (enabled by #70155) build unsigned RPMs because the reusable `build-packages.yml` workflow receives empty `secrets.SIGNING_GPG_KEY` / `secrets.SIGNING_PASSPHRASE`. `Setup GnuPG` step fails:

```
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
Process completed with exit code 2.
```

Observed in salt-nightlies run 33098010828 (the first post-#70155 3008.x dispatch). Env log showed both secret variables literally blank, not `***` redacted — the reusable workflow simply never saw them.

### Fix

`templates/build-packages.yml.jinja`:

```diff
     uses: ./.github/workflows/build-packages.yml
-    <% if gh_environment == 'staging' -%>
+    <% if gh_environment != 'ci' -%>
     secrets: inherit
     <% endif -%>
```

Matches the `!= 'ci'` pattern used just below for the `environment:` / `sign-*-packages:` block. Regenerates `nightly.yml` with `secrets: inherit` on both `build-pkgs-onedir` and `build-pkgs-src` callers.

### Impact

Once merged and mirrored to salt-nightlies, 3008.x nightlies will actually produce signed RPMs. Consumers verify with:

```
rpm --import https://packages.broadcom.com/artifactory/saltproject-generic/nightly/SALTPROJECT-NIGHTLY-GPG-PUBKEY-2026.pub
rpm --checksig <package.rpm>
```

Pubkey served since earlier today. Fingerprint `6A4868F7 CCB4 FDB4 C0EC 2710 52F4 0452 0060 A19B`.

### Local verification

- Cherry-pick of #70159 (master); no conflicts.
- pre-commit: `Generate GitHub Workflow Templates: Passed`, `Lint GitHub Actions Workflows: Passed`.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog — not applicable (CI workflow-only change)
- [ ] Tests written/updated — not applicable (workflow plumbing)

### Commits signed with GPG?

No.