### PR TITLE
version: mark ARGON (3008) as released

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -82,7 +82,7 @@ class SaltVersionsInfo(type):
     PHOSPHORUS    = SaltVersion("Phosphorus"   , info=3005,       released=True)
     SULFUR        = SaltVersion("Sulfur"       , info=3006,       released=True)
     CHLORINE      = SaltVersion("Chlorine"     , info=3007,       released=True)
-    ARGON         = SaltVersion("Argon"        , info=3008)
+    ARGON         = SaltVersion("Argon"        , info=3008,       released=True)
     POTASSIUM     = SaltVersion("Potassium"    , info=3009)
     CALCIUM       = SaltVersion("Calcium"      , info=3010)
     SCANDIUM      = SaltVersion("Scandium"     , info=3011)


### PR DESCRIPTION
### What does this PR do?

Flips `released=True` on the ARGON (3008) `SaltVersion` entry in `salt/version.py` so `SaltVersionsInfo.current_release()` returns ARGON instead of CHLORINE (3007) on the 3008.x line. Fixes a version-string regression that was making nightly RPMs come out as `salt-3007.14+N-0.x86_64.rpm` instead of `salt-3008.2+N-0.x86_64.rpm`.

### What issues does this PR fix or reference?

Discovered while verifying nightly RPM signing on saltstack/salt-nightlies run 33103981309 (a 3008.x dispatch). The "Prepare Release" step printed `Prepare Release: 3007.14+2643.gca4940b8f0` &mdash; but the branch is 3008.x and the head_sha lives well past v3008.2.

### Root cause

`salt/version.py`:

```python
CHLORINE = SaltVersion("Chlorine", info=3007, released=True)
ARGON    = SaltVersion("Argon",    info=3008)           # ← missing released=True
POTASSIUM = SaltVersion("Potassium", info=3009)
```

`SaltVersionsInfo.current_release()` iterates and returns "the last codename with `released=True`". With ARGON unflagged, it returns CHLORINE (3007). The code path in `__discover_version()` then lifts `git describe`'s output to `current_release()` when the parsed major is older than the hardcoded major &mdash; so `git describe` output like `v3007.9-2643-gca4940b8f0` gets normalized to `3007.14+2643.gca4940b8f0` instead of a proper `3008.2+2643.gca4940b8f0`.

### Regression window on 3008.x

- **Aug 19 (build 210)**: `salt-3008.2+210.g9a41326f33-0.x86_64.rpm` &mdash; correct.
- **Aug 25**: `Merge remote-tracking branch 'origin/3007.x' into merge/3007.x/3008.x-08-25-26` (commit `17c1f44bb3fa`) merged 3007.x's version.py (where ARGON is correctly not released) into 3008.x, un-flipping the flag.
- **Aug 26 onward**: every 3008.x nightly labeled `3007.14+N`.

Master has the same bug and would have the same symptom on its nightlies once those start succeeding again.

### Fix

```diff
-    ARGON         = SaltVersion("Argon"        , info=3008)
+    ARGON         = SaltVersion("Argon"        , info=3008,       released=True)
```

Needs to be backported to 3008.x separately; opening that PR alongside.

### Local verification

`pre-commit run --files salt/version.py`: all applicable hooks pass.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (metadata flip fixing a version-string CI regression; nothing user-facing beyond nightly package naming which is a moving target anyway)
- [ ] Tests written/updated &mdash; not applicable (single-value metadata, verified by running the CI itself post-merge)

### Commits signed with GPG?

No.