### PR TITLE
[3008.x] version: mark ARGON (3008) as released

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -82,7 +82,7 @@ class SaltVersionsInfo(type):
     PHOSPHORUS    = SaltVersion("Phosphorus"   , info=3005,       released=True)
     SULFUR        = SaltVersion("Sulfur"       , info=3006,       released=True)
     CHLORINE      = SaltVersion("Chlorine"     , info=3007,       released=True)
-    ARGON         = SaltVersion("Argon"        , info=3008)
+    ARGON         = SaltVersion("Argon"        , info=3008,       released=True)
     POTASSIUM     = SaltVersion("Potassium"    , info=3009)
     CALCIUM       = SaltVersion("Calcium"      , info=3010)
     SCANDIUM      = SaltVersion("Scandium"     , info=3011)


### PR DESCRIPTION
### What does this PR do?

Backport of #70161 to 3008.x. Same one-line fix.

Without this, nightly RPMs from `saltstack/salt-nightlies` 3008.x continue to be labeled `salt-3007.14+N-0.x86_64.rpm` instead of the expected `salt-3008.2+N-0.x86_64.rpm`.

See #70161 for the full analysis and regression window (introduced 2026-08-25 by the 3007.x → 3008.x merge).

### Fix

```diff
-    ARGON         = SaltVersion("Argon"        , info=3008)
+    ARGON         = SaltVersion("Argon"        , info=3008,       released=True)
```

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable
- [ ] Tests written/updated &mdash; not applicable

### Commits signed with GPG?

No.