### PR TITLE
[3008.x] ci: skip CI on saltstack/salt-nightlies (duplicate of upstream)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
+    if: vars.SKIP_CI != 'true'
     outputs:
       changed-files: ${{ steps.process-changed-files.outputs.changed-files }}
       salt-version: ${{ steps.setup-salt-version.outputs.salt-version }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -90,7 +90,7 @@ jobs:
     name: Prepare Workflow Run
     runs-on: ubuntu-22.04
     environment: ci
-    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}
+    if: ${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_SCHEDULED != 'true' }}
     needs:
       - workflow-requirements
     outputs:

--- a/.github/workflows/templates/ci.yml.jinja
+++ b/.github/workflows/templates/ci.yml.jinja
@@ -2,6 +2,13 @@
 
 <%- extends 'layout.yml.jinja' %>
 <%- set pre_commit_version = "4.3.0" %>
+{# Repo-level opt-out. Set `SKIP_CI=true` on repos where ci.yml would
+   otherwise re-run tests already run upstream (e.g. saltstack/salt-nightlies,
+   whose mirror workflow force-pushes branches from saltstack/salt).
+   Gates prepare-workflow; downstream jobs cascade-skip via `needs: prepare-workflow`.
+   Uses `|default(...)` so child templates that extend ci.yml.jinja (nightly,
+   scheduled, staging) can override with their own gate or disable it. #}
+<%- set prepare_workflow_if_check = prepare_workflow_if_check|default("vars.SKIP_CI != 'true'") %>
 
 
 <%- block jobs %>

--- a/.github/workflows/templates/nightly.yml.jinja
+++ b/.github/workflows/templates/nightly.yml.jinja
@@ -2,6 +2,12 @@
 <%- set skip_test_coverage_check = skip_test_coverage_check|default("true") %>
 <%- set prepare_workflow_skip_test_suite = "${{ inputs.skip-salt-test-suite && ' --skip-tests' || '' }}" %>
 <%- set prepare_workflow_skip_pkg_test_suite = "${{ inputs.skip-salt-pkg-test-suite && ' --skip-pkg-tests' || '' }}" %>
+{#- Disable ci.yml.jinja's SKIP_CI gate on nightly.yml. Nightlies are
+    intentionally run on saltstack/salt-nightlies, which sets SKIP_CI=true
+    to silence duplicate ci.yml runs -- that same variable must not also
+    silence the nightlies themselves. -#}
+
+<%- set prepare_workflow_if_check = prepare_workflow_if_check|default(False) %>
 <%- extends 'ci.yml.jinja' %>
 
 <%- block name %>

--- a/.github/workflows/templates/scheduled.yml.jinja
+++ b/.github/workflows/templates/scheduled.yml.jinja
@@ -1,5 +1,11 @@
 <%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) }}" %>
 <%- set skip_test_coverage_check = "true" %>
+{#- On saltstack/salt-nightlies the mirror workflow force-pushes branches
+    from saltstack/salt. This scheduled workflow already has its own gate
+    via `RUN_SCHEDULED_BUILDS`; ci.yml.jinja's SKIP_CI-based gate would
+    stack on top of that and cause double-skipping. Set our own gate
+    explicitly here. -#}
+<%- set prepare_workflow_if_check = "${{ fromJSON(needs.workflow-requirements.outputs.requirements-met) && vars.SKIP_SCHEDULED != 'true' }}" %>
 <%- extends 'ci.yml.jinja' %>
 
 


### PR DESCRIPTION
### What does this PR do?

Backport of #70043 to 3008.x, updated to use master's current (cleaner) template syntax. Prevents `ci.yml` from running on `saltstack/salt-nightlies` when the mirror workflow force-pushes branches from `saltstack/salt` &mdash; those pushes currently fire `ci.yml` on salt-nightlies to re-run the exact tests already run upstream.

Observed today after mirror-from-saltstack-salt.yaml pushed the #70162 fix onto salt-nightlies 3008.x: a full CI run kicked off (run 33107736750) alongside the deliberate Nightly dispatch we cared about. Pure duplicate of upstream tests.

`vars.SKIP_CI = true` is already set on saltstack/salt-nightlies (along with SKIP_BACKPORT, SKIP_DEPENDABOT_SYNC, SKIP_DOC_LINKCHECK, SKIP_RELEASE, SKIP_SCHEDULED). Only the workflow-side gate was missing on this branch.

### Changes

- `templates/ci.yml.jinja`: `prepare_workflow_if_check = "vars.SKIP_CI != 'true'"` gate variable (with `|default(...)` so child templates can override).
- `templates/nightly.yml.jinja`: override to `False` &mdash; nightlies are intentionally run on salt-nightlies and must NOT skip when SKIP_CI=true.
- `templates/scheduled.yml.jinja`: override to combine `workflow-requirements` result AND `vars.SKIP_SCHEDULED != 'true'` &mdash; keeps existing scheduled-run gating.
- `templates/staging.yml.jinja`: already sets `False` at top of file on this branch; no change needed.
- Regenerated `ci.yml`, `nightly.yml`, `scheduled.yml`.

### Effect

| Workflow | On saltstack/salt (SKIP_CI unset) | On saltstack/salt-nightlies (SKIP_CI=true) |
| --- | --- | --- |
| CI | runs as before | prepare-workflow skipped &rarr; whole workflow no-ops |
| Nightly | runs as before | runs as before (override to False) |
| Scheduled | runs when RUN_SCHEDULED_BUILDS + SKIP_SCHEDULED gates allow | same |
| Staging | runs as before | runs as before (own gate = False) |

### Regeneration syntax note

Original #70043 landed on master with `<%- # ... %>` comment syntax which the Jinja parser rejects (breaks template regen). Master has since switched to `{# ... #}` and the `|default(...)` override pattern. This backport uses master's current form.

### Local verification

- pre-commit: `Generate GitHub Workflow Templates: Passed`, `Lint GitHub Actions Workflows: Passed`.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable

### Commits signed with GPG?

No.