### PR TITLE
fix: do not open listen events socket in webhook

### DIFF
--- a/changelog/70164.fixed.md
+++ b/changelog/70164.fixed.md
@@ -1,0 +1,1 @@
+Stop open pull-socket in engine `webhook` for fixing a memory leak in `EventPublisher`.

--- a/salt/engines/webhook.py
+++ b/salt/engines/webhook.py
@@ -50,7 +50,7 @@ def start(address=None, port=5000, ssl_crt=None, ssl_key=None):
     """
     if __opts__.get("__role") == "master":
         fire_master = salt.utils.event.get_master_event(
-            __opts__, __opts__["sock_dir"]
+            __opts__, __opts__["sock_dir"], listen=False
         ).fire_event
     else:
         fire_master = None

--- a/tests/pytests/unit/engines/test_webhook.py
+++ b/tests/pytests/unit/engines/test_webhook.py
@@ -1,0 +1,27 @@
+"""
+unit tests for the webhook engine
+"""
+
+from pytest import fixture
+
+import salt.engines.webhook as webhook
+from tests.support.mock import MagicMock, patch
+
+
+@fixture
+def configure_loader_modules(master_opts):
+    return {webhook: {"__opts__": master_opts}}
+
+
+def test_start_uses_listen_false_for_master(configure_loader_modules):
+    with patch("salt.utils.event.get_master_event") as get_master_event, patch(
+        "tornado.httpserver.HTTPServer"
+    ) as fake_http_server, patch("tornado.ioloop.IOLoop") as fake_io_loop:
+        get_master_event.return_value.fire_event = MagicMock()
+
+        webhook.start()
+
+        get_master_event.assert_called_once_with(
+            webhook.__opts__, webhook.__opts__["sock_dir"], listen=False
+        )
+        fake_io_loop.return_value.start.assert_called_once()


### PR DESCRIPTION
### What does this PR do?
Fixes a memory leak caused by using `webhook` engine by incorrect `get_master_event` parameters.

### What issues does this PR fix or reference?
Memory leak in EventPublisher

### Previous Behavior
`get_master_event` returns an object with opened `pull`-socket, which was not required for the publication of events, what causes memory leak in `EventPublisher`: `EventPublisher` sends a message for another process, but `webhook` doesn't even plan to read them.

### New Behavior
`get_master_event` don't opens a `pull`-socket.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No
