### PR TITLE
nightly: sign DEB packages with debsigs, mirroring RPM signing path

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -24,6 +24,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages (via debsigs, using SIGNING_GPG_KEY)
       sign-macos-packages:
         type: boolean
         default: false
@@ -66,6 +70,7 @@ jobs:
 
   build-deb-packages:
     name: DEB
+    environment: ${{ inputs.environment }}
     if: ${{ toJSON(fromJSON(inputs.matrix)['linux']) != '[]' }}
     runs-on:
       - ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || inputs.linux_arm_runner }}
@@ -113,6 +118,10 @@ jobs:
           apt-get install -y devscripts
           # Installing patchelf for relenv ELF binary patching
           apt-get install -y patchelf
+          # Installing debsigs for DEB signing (invoked by tools pkg
+          # build deb --key-id=<id>). Cheap install even when signing is
+          # off so the toolchain is always ready.
+          apt-get install -y debsigs
 
       - name: Download Onedir Tarball as an Artifact
         if:  inputs.source == 'onedir'
@@ -155,6 +164,30 @@ jobs:
           salt-version: "${{ inputs.salt-version }}"
           cwd: pkgs/checkout/
 
+      - name: Setup GnuPG
+        if: ${{ inputs.sign-deb-packages }}
+        env:
+          SIGNING_GPG_KEY: ${{ secrets.SIGNING_GPG_KEY }}
+          SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
+        run: |
+          install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+          GNUPGHOME="$(mktemp -d -p /run/gpg)"
+          export GNUPGHOME
+          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+          cat <<EOF > "${GNUPGHOME}/gpg.conf"
+          batch
+          no-tty
+          pinentry-mode loopback
+          passphrase-file ${GNUPGHOME}/passphrase
+          EOF
+          echo "${SIGNING_PASSPHRASE}" > "${GNUPGHOME}/passphrase"
+          echo "${SIGNING_GPG_KEY}" | gpg --import -
+          # Discover the imported key's fingerprint so `tools pkg build
+          # deb --key-id=<id>` (and the debsigs call it makes) uses
+          # whatever key material was provided rather than a hardcoded id.
+          SIGN_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '$1=="fpr" {print $10; exit}')
+          echo "SIGN_KEY_ID=${SIGN_KEY_ID}" >> "$GITHUB_ENV"
+
       - name: Configure Git
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         working-directory: pkgs/checkout/
@@ -178,7 +211,7 @@ jobs:
               format('--onedir=salt-{0}-onedir-linux-{1}.tar.xz', inputs.salt-version, matrix.arch)
               ||
               format('--arch={0}', matrix.arch)
-          }}
+          }} ${{ inputs.sign-deb-packages && format('--key-id={0}', env.SIGN_KEY_ID) || '' }}
 
       - name: Cleanup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -484,6 +484,7 @@ jobs:
       environment: nightly
       sign-macos-packages: true
       sign-rpm-packages: true
+      sign-deb-packages: true
       sign-windows-packages: false
 
   build-pkgs-src:
@@ -506,6 +507,7 @@ jobs:
       environment: nightly
       sign-macos-packages: true
       sign-rpm-packages: true
+      sign-deb-packages: true
       sign-windows-packages: false
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,6 +22,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages
       skip-salt-test-suite:
         type: boolean
         default: false
@@ -512,6 +516,7 @@ jobs:
       environment: staging
       sign-macos-packages: true
       sign-rpm-packages: ${{ inputs.sign-rpm-packages }}
+      sign-deb-packages: ${{ inputs.sign-deb-packages }}
       sign-windows-packages: ${{ inputs.sign-windows-packages }}
 
   build-pkgs-src:
@@ -534,6 +539,7 @@ jobs:
       environment: staging
       sign-macos-packages: true
       sign-rpm-packages: ${{ inputs.sign-rpm-packages }}
+      sign-deb-packages: ${{ inputs.sign-deb-packages }}
       sign-windows-packages: ${{ inputs.sign-windows-packages }}
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -37,6 +37,7 @@
       environment: <{ gh_environment }>
       sign-macos-packages: true
       sign-rpm-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
+      sign-deb-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-deb-packages }} <%- endif %>
       sign-windows-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-windows-packages }} <%- endif %>
 
     <%- endif %>

--- a/.github/workflows/templates/staging.yml.jinja
+++ b/.github/workflows/templates/staging.yml.jinja
@@ -33,6 +33,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages
       skip-salt-test-suite:
         type: boolean
         default: false

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -226,6 +226,10 @@ build = command_group(
         "arch": {
             "help": "The arch to build for",
         },
+        "key_id": {
+            "help": "Signing key id (passed to debsigs on each built .deb)",
+            "required": False,
+        },
     },
 )
 def debian(
@@ -234,6 +238,7 @@ def debian(
     relenv_version: str = None,
     python_version: str = None,
     arch: str = None,
+    key_id: str = None,
 ):
     """
     Build the deb package.
@@ -295,6 +300,26 @@ def debian(
 
     ctx.run("ln", "-sf", "pkg/debian/", ".")
     ctx.run("debuild", *env_args, "-uc", "-us", env=env)
+
+    if key_id:
+        # debuild writes .deb (and .buildinfo, .changes, etc.) to the
+        # parent of the source directory. Sign every produced .deb with
+        # debsigs so downstream consumers can `debsigs --verify` against
+        # the matching public key.
+        checkout = pathlib.Path.cwd()
+        deb_files = sorted(checkout.parent.glob("*.deb"))
+        if not deb_files:
+            ctx.error("Signing requested but no .deb files were produced.")
+            ctx.exit(1)
+        for pkg in deb_files:
+            ctx.info(f"Running 'debsigs' on {pkg} ...")
+            ctx.run(
+                "debsigs",
+                "--sign=origin",
+                "--default-key",
+                key_id,
+                str(pkg),
+            )
 
     ctx.info("Done")
 


### PR DESCRIPTION
### What does this PR do?

Enables DEB signing for nightly builds, mirroring the RPM signing pathway that `#70141` added. Fixes a real gap discovered today when verifying nightly signing: RPMs signed, DEBs unsigned.

### What issues does this PR fix or reference?

Follow-up to #70141 and the subsequent secrets-inherit fix (#70159). Discovered when verifying nightly signing on saltstack/salt-nightlies run 33107756715 (post-#70155 + #70160 + #70162 backports on 3008.x):

- 16 RPMs (x86_64 + aarch64): all signed with `RSA/SHA256, Key ID 52f404520060a19b`, verified by `rpm --checksig`.
- 16 DEBs (amd64 + arm64): all unsigned. No `_gpgorigin` in the ar archive.

Root cause: `build-packages.yml` had `sign-rpm-packages`, `sign-macos-packages`, `sign-windows-packages` inputs but no `sign-deb-packages`. The `build-deb-packages` job lacked `environment:` (so it couldn't read caller secrets), lacked Setup GnuPG, and `tools/pkg/build.py`'s `deb` command took no `--key-id`. Every 3008.x nightly since RPM signing came online has shipped unsigned DEBs.

### New Behavior

Three coordinated changes:

**`tools/pkg/build.py`:** add `key_id` argument to the `deb` command. When set, after `debuild` completes, iterate the `.deb` files it produced in the parent directory and run `debsigs --sign=origin --default-key $KEY_ID <pkg>.deb` on each. Same style of post-build signing loop as the `rpm` command's `rpmsign` invocation.

**`.github/workflows/build-packages.yml`:**
- `sign-deb-packages` boolean input (default false).
- `environment: ${{ inputs.environment }}` on the `build-deb-packages` job so it can read caller-inherited secrets (previously only `build-rpm-packages` had this).
- `debsigs` added to Install build dependencies.
- Setup GnuPG step gated on `inputs.sign-deb-packages`, identical shape to the RPM job's version: imports `SIGNING_GPG_KEY` with `SIGNING_PASSPHRASE`, discovers the fingerprint via `gpg --list-secret-keys --with-colons | awk`, exports `SIGN_KEY_ID` to `$GITHUB_ENV`.
- Threads `--key-id=${env.SIGN_KEY_ID}` through to `tools pkg build deb` when signing is enabled.

**`templates/build-packages.yml.jinja`:** add `sign-deb-packages: true` for `gh_environment == 'nightly'`, matching the `sign-rpm-packages` pattern. Regenerates `nightly.yml` with the flag set on both `build-pkgs-onedir` and `build-pkgs-src` callers. `templates/staging.yml.jinja` also gains a matching `sign-deb-packages` input so stable releases can opt in explicitly.

### Impact

- The next scheduled nightly on saltstack/salt-nightlies (00:00 UTC daily) will produce signed DEBs alongside signed RPMs, using the same nightly signing key material already on the `nightly` environment.
- Consumers verify with:
  ```
  gpg --import <(curl -sSL https://packages.broadcom.com/artifactory/saltproject-generic/nightly/SALTPROJECT-NIGHTLY-GPG-PUBKEY-2026.pub)
  debsigs --verify <package.deb>
  # or, if not running debsigs: extract _gpgorigin from the ar archive and gpg --verify
  ```
- Stable release path: no behavior change unless `sign-deb-packages: true` is explicitly passed via `staging.yml` dispatch.
- CI path: no behavior change (`sign-deb-packages` remains false by default).

### DEB signing consumer caveat

`apt install` does not check debsigs-style file signatures by default (it verifies `Release`-file signatures from apt repos). Since salt-nightlies live in an Artifactory generic-typed repo without apt metadata by design, the signed DEBs are verifiable via `debsigs --verify` (or equivalent) after direct download. Same posture as signed nightly RPMs, which are also verified per-file rather than via yum repo metadata.

### Local verification

- pre-commit: `Generate GitHub Workflow Templates: Passed`, `Lint GitHub Actions Workflows: Passed`, `isort/black/mypy: Passed`.
- Standalone debsigs signing tested earlier against the exact same nightly key material in a debian:13 container against a real salt DEB &mdash; `_gpgorigin` written to the ar archive, `gpg --verify _gpgorigin <payload>` returns `Good signature from "SaltProject Nightly Signing (Automated) <noreply@saltproject.io>"`.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog &mdash; not applicable (CI workflow-only change)
- [ ] Tests written/updated &mdash; not applicable (workflow signing; verified via live nightly dispatch once merged and backported)

### Commits signed with GPG?

No.