### PR TITLE
[3008.x] nightly: sign DEB packages with debsigs, mirroring RPM signing path

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -24,6 +24,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages (via debsigs, using SIGNING_GPG_KEY)
       sign-macos-packages:
         type: boolean
         default: false
@@ -66,6 +70,7 @@ jobs:
 
   build-deb-packages:
     name: DEB
+    environment: ${{ inputs.environment }}
     if: ${{ toJSON(fromJSON(inputs.matrix)['linux']) != '[]' }}
     runs-on:
       - ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || inputs.linux_arm_runner }}
@@ -113,6 +118,10 @@ jobs:
           apt-get install -y devscripts
           # Installing patchelf for relenv ELF binary patching
           apt-get install -y patchelf
+          # Installing debsigs for DEB signing (invoked by tools pkg
+          # build deb --key-id=<id>). Cheap install even when signing is
+          # off so the toolchain is always ready.
+          apt-get install -y debsigs
 
       - name: Download Onedir Tarball as an Artifact
         if:  inputs.source == 'onedir'
@@ -155,6 +164,30 @@ jobs:
           salt-version: "${{ inputs.salt-version }}"
           cwd: pkgs/checkout/
 
+      - name: Setup GnuPG
+        if: ${{ inputs.sign-deb-packages }}
+        env:
+          SIGNING_GPG_KEY: ${{ secrets.SIGNING_GPG_KEY }}
+          SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
+        run: |
+          install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+          GNUPGHOME="$(mktemp -d -p /run/gpg)"
+          export GNUPGHOME
+          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+          cat <<EOF > "${GNUPGHOME}/gpg.conf"
+          batch
+          no-tty
+          pinentry-mode loopback
+          passphrase-file ${GNUPGHOME}/passphrase
+          EOF
+          echo "${SIGNING_PASSPHRASE}" > "${GNUPGHOME}/passphrase"
+          echo "${SIGNING_GPG_KEY}" | gpg --import -
+          # Discover the imported key's fingerprint so `tools pkg build
+          # deb --key-id=<id>` (and the debsigs call it makes) uses
+          # whatever key material was provided rather than a hardcoded id.
+          SIGN_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '$1=="fpr" {print $10; exit}')
+          echo "SIGN_KEY_ID=${SIGN_KEY_ID}" >> "$GITHUB_ENV"
+
       - name: Configure Git
         if: ${{ startsWith(github.event.ref, 'refs/tags') == false }}
         working-directory: pkgs/checkout/
@@ -175,7 +208,7 @@ jobs:
               format('--onedir=salt-{0}-onedir-linux-{1}.tar.xz', inputs.salt-version, matrix.arch)
               ||
               format('--arch={0}', matrix.arch)
-          }}
+          }} ${{ inputs.sign-deb-packages && format('--key-id={0}', env.SIGN_KEY_ID) || '' }}
 
       - name: Cleanup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -484,6 +484,7 @@ jobs:
       environment: nightly
       sign-macos-packages: true
       sign-rpm-packages: true
+      sign-deb-packages: true
       sign-windows-packages: false
 
   build-pkgs-src:
@@ -506,6 +507,7 @@ jobs:
       environment: nightly
       sign-macos-packages: true
       sign-rpm-packages: true
+      sign-deb-packages: true
       sign-windows-packages: false
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages
       skip-salt-test-suite:
         type: boolean
         default: false
@@ -513,6 +517,7 @@ jobs:
       environment: staging
       sign-macos-packages: true
       sign-rpm-packages: ${{ inputs.sign-rpm-packages }}
+      sign-deb-packages: ${{ inputs.sign-deb-packages }}
       sign-windows-packages: ${{ inputs.sign-windows-packages }}
 
   build-pkgs-src:
@@ -535,6 +540,7 @@ jobs:
       environment: staging
       sign-macos-packages: true
       sign-rpm-packages: ${{ inputs.sign-rpm-packages }}
+      sign-deb-packages: ${{ inputs.sign-deb-packages }}
       sign-windows-packages: ${{ inputs.sign-windows-packages }}
   build-ci-deps:
     name: CI Deps

--- a/.github/workflows/templates/build-packages.yml.jinja
+++ b/.github/workflows/templates/build-packages.yml.jinja
@@ -37,6 +37,7 @@
       environment: <{ gh_environment }>
       sign-macos-packages: true
       sign-rpm-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-rpm-packages }} <%- endif %>
+      sign-deb-packages: <% if gh_environment == 'nightly' -%> true <%- else -%> ${{ inputs.sign-deb-packages }} <%- endif %>
       sign-windows-packages: <% if gh_environment == 'nightly' -%> false <%- else -%> ${{ inputs.sign-windows-packages }} <%- endif %>
 
     <%- endif %>

--- a/.github/workflows/templates/staging.yml.jinja
+++ b/.github/workflows/templates/staging.yml.jinja
@@ -34,6 +34,10 @@ on:
         type: boolean
         default: false
         description: Sign RPM Packages
+      sign-deb-packages:
+        type: boolean
+        default: false
+        description: Sign DEB Packages
       skip-salt-test-suite:
         type: boolean
         default: false

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -106,6 +106,10 @@ build = command_group(
         "arch": {
             "help": "The arch to build for",
         },
+        "key_id": {
+            "help": "Signing key id (passed to debsigs on each built .deb)",
+            "required": False,
+        },
     },
 )
 def debian(
@@ -114,6 +118,7 @@ def debian(
     relenv_version: str = None,
     python_version: str = None,
     arch: str = None,
+    key_id: str = None,
 ):
     """
     Build the deb package.
@@ -179,6 +184,26 @@ def debian(
     except Exception:
         pass
     ctx.run("debuild", *env_args, *debuild_flags, env=env)
+
+    if key_id:
+        # debuild writes .deb (and .buildinfo, .changes, etc.) to the
+        # parent of the source directory. Sign every produced .deb with
+        # debsigs so downstream consumers can `debsigs --verify` against
+        # the matching public key.
+        checkout = pathlib.Path.cwd()
+        deb_files = sorted(checkout.parent.glob("*.deb"))
+        if not deb_files:
+            ctx.error("Signing requested but no .deb files were produced.")
+            ctx.exit(1)
+        for pkg in deb_files:
+            ctx.info(f"Running 'debsigs' on {pkg} ...")
+            ctx.run(
+                "debsigs",
+                "--sign=origin",
+                "--default-key",
+                key_id,
+                str(pkg),
+            )
 
     ctx.info("Done")
 


### PR DESCRIPTION
### What does this PR do?

Backport of #70165 to 3008.x. Same clean cherry-pick of the DEB signing plumbing that mirrors RPM signing.

Fixes the DEB signing gap directly verified on saltstack/salt-nightlies run 33107756715 (post-#70155/#70160/#70162): 16 RPMs signed with the nightly key, all 16 DEBs unsigned (no `_gpgorigin` in the ar archive).

See #70165 for the full analysis, changes, and consumer verification path. This backport applies the identical diff to 3008.x so the next scheduled 3008.x nightly ships signed DEBs alongside signed RPMs.

### Fix

Cherry-picked #70165's single commit onto 3008.x. All hooks pass:
- `Generate GitHub Workflow Templates: Passed`
- `Lint GitHub Actions Workflows: Passed`
- `isort / black / mypy / bandit / Lint Salt: Passed`

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog — not applicable (CI workflow-only change)
- [ ] Tests written/updated — not applicable

### Commits signed with GPG?

No.