### PR TITLE
[3008.x] version: constrain git-describe --match to v3008.* on 3008.x

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -645,12 +645,13 @@ def __discover_version(saltstack_version):
                 "describe",
                 "--tags",
                 "--long",
-                # Constrain to the 3007.x series so that 3008.x tags left
-                # reachable in the git graph (e.g. from a reverted mis-merge
-                # of 3008.x content into 3007.x) do not hijack the detected
-                # version and break docs / packaging jobs that key off it.
+                # Constrain to the branch's own major (3008.x) so tags
+                # from other majors reachable in the git graph do not hijack
+                # the detected version. Merged forward from 3007.x's
+                # v3007.* constraint (see git log for f3ffc8f9c9ea) and
+                # rebased to this branch's major.
                 "--match",
-                "v3007.*",
+                "v3008.*",
                 "--always",
                 "--candidates=150",
             ],


### PR DESCRIPTION
### What does this PR do?

Fixes salt-3008.x nightly packages coming out as `salt-3008.0+N-...` instead of the expected `salt-3008.2+N-...`. Root cause is a leftover `--match v3007.*` constraint that got merged forward from 3007.x on 2026-08-25 and never rebased to 3008's own major.

### What issues does this PR fix or reference?

Discovered when verifying nightly signing on saltstack/salt-nightlies run [33122447777](https://github.com/saltstack/salt-nightlies/actions/runs/33122447777): all 32 packages signed correctly, but named `salt-3008.0+2651.gfd8241adb4` instead of `salt-3008.2+2651.gfd8241adb4`.

Same regression fingerprint I noted earlier in this cycle but didn't chase — worth chasing now that everything else works.

### Root cause chain

1. **f3ffc8f9c9ea** (2026-08-18, targeting 3007.x): "Constrain git-describe tag match to v3007.* on 3007.x". Legitimate fix — 3007.x had unwanted `v3008.1` tags reachable in the graph from a reverted mis-merge, so `git describe` was picking `v3008.1-N-gSHA` on 3007.x and breaking docs. Constraint to `v3007.*` fixed 3007.x.

2. **17c1f44bb3fa** (2026-08-25): Routine merge-forward `3007.x → 3008.x` brought the constraint over without updating it to `v3008.*`.

3. **Result on 3008.x since Aug 25**: `git describe --match v3007.*` skips every `v3008.*` tag (v3008.0, v3008.1, v3008.2, and their rc/patch variants) and reports the branch as `v3007.14-<ahead>-gSHA`.

4. In `__discover_version()`, `parsed.major = 3007 < saltstack_version.major = 3008` triggers the "lift baseline" code path that replaces the parsed base with `SaltVersionsInfo.current_release()` (ARGON, `info=(3008,)` — no minor). Minor defaults to 0.

5. Every 3008.x nightly RPM/DEB since the merge has been labeled `salt-3008.0+N-...`.

### Fix

One-line change (plus comment update):

```diff
-                # Constrain to the 3007.x series so that 3008.x tags left
-                # reachable in the git graph (e.g. from a reverted mis-merge
-                # of 3008.x content into 3007.x) do not hijack the detected
-                # version and break docs / packaging jobs that key off it.
+                # Constrain to the branch's own major (3008.x) so tags
+                # from other majors reachable in the git graph do not hijack
+                # the detected version. Merged forward from 3007.x's
+                # v3007.* constraint (see git log for f3ffc8f9c9ea) and
+                # rebased to this branch's major.
                 "--match",
-                "v3007.*",
+                "v3008.*",
```

Same intent as the original 3007.x commit: pin `git describe` to only consider tags from the branch's own calver line so unrelated tags don't hijack the detected version. Just adapted to 3008.x's own major.

### Impact

- `git describe` returns `v3008.2-<ahead>-gSHA` on 3008.x.
- `__discover_version()` parses it directly (parsed.major == saltstack_version.major, no lift-baseline branch taken).
- Next nightly build: RPMs and DEBs labeled `salt-3008.2+N-...` correctly.
- No effect on master (uses `--match v[0-9]*` — no branch-major constraint since master doesn't need one).

### Local verification

pre-commit: isort/black/Lint Salt/bandit all pass.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog — not applicable (metadata/tooling fix affecting nightly package naming; no user-facing runtime change)
- [ ] Tests written/updated — not applicable

### Commits signed with GPG?

No.