### PR TITLE
Destroy Runner/MasterMinion resources in salt-run and fix MasterMinion.__del__

### DIFF
--- a/changelog/70174.fixed.md
+++ b/changelog/70174.fixed.md
@@ -1,0 +1,1 @@
+Fixed ``salt-run`` logging "unclosed Runner ..." and "unclosed MasterMinion ..." WARNING messages on every invocation. The Runner (and the MasterMinion it lazily creates) is now destroyed deterministically instead of relying on ``__del__``'s GC-time safety net, and ``MasterMinion.__del__`` no longer misreports a properly ``destroy()``'d instance as unclosed.

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -20,8 +20,7 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
 
         profiling_enabled = self.options.profiling_enabled
 
-        runner = salt.runner.Runner(self.config)
-        try:
+        with salt.runner.Runner(self.config) as runner:
             if self.options.doc:
                 runner.print_docs()
                 self.exit(salt.defaults.exitcodes.EX_OK)
@@ -56,5 +55,3 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
 
             except SaltClientError as exc:
                 raise SystemExit(str(exc))
-        finally:
-            runner.destroy()

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -21,37 +21,40 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
         profiling_enabled = self.options.profiling_enabled
 
         runner = salt.runner.Runner(self.config)
-        if self.options.doc:
-            runner.print_docs()
-            self.exit(salt.defaults.exitcodes.EX_OK)
-
-        # Run this here so SystemExit isn't raised anywhere else when
-        # someone tries to use the runners via the python API
         try:
-            if check_user(self.config["user"]):
-                pr = salt.utils.profile.activate_profile(profiling_enabled)
-                try:
-                    ret = runner.run(full_return=True)
-                    # In older versions ret['data']['retcode'] was used
-                    # for signaling the return code. This has been
-                    # changed for the orchestrate runner, but external
-                    # runners might still use it. For this reason, we
-                    # also check ret['data']['retcode'] if
-                    # ret['retcode'] is not available.
-                    if (
-                        isinstance(ret, dict)
-                        and "return" in ret
-                        and "retcode" not in ret
-                    ):
-                        ret = ret["return"]
-                    if isinstance(ret, dict) and "retcode" in ret:
-                        self.exit(ret["retcode"])
-                    elif isinstance(ret, dict) and "retcode" in ret.get("data", {}):
-                        self.exit(ret["data"]["retcode"])
-                finally:
-                    salt.utils.profile.output_profile(
-                        pr, stats_path=self.options.profiling_path, stop=True
-                    )
+            if self.options.doc:
+                runner.print_docs()
+                self.exit(salt.defaults.exitcodes.EX_OK)
 
-        except SaltClientError as exc:
-            raise SystemExit(str(exc))
+            # Run this here so SystemExit isn't raised anywhere else when
+            # someone tries to use the runners via the python API
+            try:
+                if check_user(self.config["user"]):
+                    pr = salt.utils.profile.activate_profile(profiling_enabled)
+                    try:
+                        ret = runner.run(full_return=True)
+                        # In older versions ret['data']['retcode'] was used
+                        # for signaling the return code. This has been
+                        # changed for the orchestrate runner, but external
+                        # runners might still use it. For this reason, we
+                        # also check ret['data']['retcode'] if
+                        # ret['retcode'] is not available.
+                        if (
+                            isinstance(ret, dict)
+                            and "return" in ret
+                            and "retcode" not in ret
+                        ):
+                            ret = ret["return"]
+                        if isinstance(ret, dict) and "retcode" in ret:
+                            self.exit(ret["retcode"])
+                        elif isinstance(ret, dict) and "retcode" in ret.get("data", {}):
+                            self.exit(ret["data"]["retcode"])
+                    finally:
+                        salt.utils.profile.output_profile(
+                            pr, stats_path=self.options.profiling_path, stop=True
+                        )
+
+            except SaltClientError as exc:
+                raise SystemExit(str(exc))
+        finally:
+            runner.destroy()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1370,6 +1370,16 @@ class MasterMinion:
     def destroy(self):
         """
         Destroy the MasterMinion object
+
+        Each component's teardown is isolated in its own try/except and its
+        attribute is *unconditionally* reset to ``{}`` afterward, so that one
+        component raising during teardown can never (a) leave a later
+        component un-torn-down, or (b) leave an already-destroyed component's
+        attribute in a state ``__del__``'s "already torn down" check can't
+        recognize. This also guarantees ``destroy()`` itself never raises,
+        since callers (``RunnerClient``/``WheelClient``) now call it
+        unconditionally from their own ``destroy()``, which in turn may run
+        from a ``finally:`` block (see ``salt/cli/run.py``).
         """
         if self.returners is not None:
             # Some returners have a destroy method
@@ -1380,42 +1390,72 @@ class MasterMinion:
                         func.destroy()
                 except Exception:  # pylint: disable=broad-except
                     pass
-            if hasattr(self.returners, "destroy"):
-                self.returners.destroy()
-            self.returners = {}
-        if self.functions is not None and hasattr(self.functions, "destroy"):
-            self.functions.destroy()
+            try:
+                if hasattr(self.returners, "destroy"):
+                    self.returners.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion returners: %s", exc)
+        self.returners = {}
+        try:
+            if self.functions is not None and hasattr(self.functions, "destroy"):
+                self.functions.destroy()
+        except Exception as exc:  # pylint: disable=broad-except
+            log.error("Error destroying MasterMinion functions: %s", exc)
         self.functions = {}
-        if self.utils is not None and hasattr(self.utils, "destroy"):
-            self.utils.destroy()
+        try:
+            if self.utils is not None and hasattr(self.utils, "destroy"):
+                self.utils.destroy()
+        except Exception as exc:  # pylint: disable=broad-except
+            log.error("Error destroying MasterMinion utils: %s", exc)
         self.utils = {}
         if hasattr(self, "states") and self.states is not None:
-            if hasattr(self.states, "destroy"):
-                self.states.destroy()
+            try:
+                if hasattr(self.states, "destroy"):
+                    self.states.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion states: %s", exc)
             self.states = {}
         if hasattr(self, "rend") and self.rend is not None:
-            if hasattr(self.rend, "destroy"):
-                self.rend.destroy()
+            try:
+                if hasattr(self.rend, "destroy"):
+                    self.rend.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion rend: %s", exc)
             self.rend = {}
         if hasattr(self, "matchers") and self.matchers is not None:
-            if hasattr(self.matchers, "destroy"):
-                self.matchers.destroy()
+            try:
+                if hasattr(self.matchers, "destroy"):
+                    self.matchers.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion matchers: %s", exc)
             self.matchers = {}
         if hasattr(self, "executors") and self.executors is not None:
-            if hasattr(self.executors, "destroy"):
-                self.executors.destroy()
+            try:
+                if hasattr(self.executors, "destroy"):
+                    self.executors.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion executors: %s", exc)
             self.executors = {}
         if hasattr(self, "proxy") and self.proxy is not None:
-            if hasattr(self.proxy, "destroy"):
-                self.proxy.destroy()
+            try:
+                if hasattr(self.proxy, "destroy"):
+                    self.proxy.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion proxy: %s", exc)
             self.proxy = {}
         if hasattr(self, "serializers") and self.serializers is not None:
-            if hasattr(self.serializers, "destroy"):
-                self.serializers.destroy()
+            try:
+                if hasattr(self.serializers, "destroy"):
+                    self.serializers.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion serializers: %s", exc)
             self.serializers = {}
         if self.opts and "grains" in self.opts:
-            if hasattr(self.opts["grains"], "destroy"):
-                self.opts["grains"].destroy()
+            try:
+                if hasattr(self.opts["grains"], "destroy"):
+                    self.opts["grains"].destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying MasterMinion grains: %s", exc)
             self.opts["grains"] = {}
 
     def __enter__(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1434,10 +1434,14 @@ class MasterMinion:
         # fallback and requires callers to use a context manager or
         # explicit ``destroy()``.
         try:
+            # ``destroy()`` leaves these as ``{}``, not ``None`` (see
+            # above), so the "already torn down" check must treat an
+            # empty mapping the same as unset, or a properly-destroyed
+            # MasterMinion still trips this warning at GC time.
             already_torn_down = (
-                getattr(self, "returners", None) is None
-                and getattr(self, "functions", None) is None
-                and getattr(self, "utils", None) is None
+                not getattr(self, "returners", None)
+                and not getattr(self, "functions", None)
+                and not getattr(self, "utils", None)
             )
         except Exception:  # pylint: disable=broad-except
             return

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -62,6 +62,9 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin):
             if hasattr(self.utils, "destroy"):
                 self.utils.destroy()
             self.utils = {}
+        if hasattr(self, "_mminion") and self._mminion is not None:
+            self._mminion.destroy()
+            self._mminion = None
 
     def __enter__(self):
         return self

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -51,19 +51,35 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin):
         )
 
     def destroy(self):
+        # Each resource's teardown is isolated in its own try/except and its
+        # attribute is unconditionally reset afterward, so one resource
+        # raising during teardown can never prevent the others (in
+        # particular _mminion) from being destroyed too.
         if self.event is not None:
-            self.event.destroy()
+            try:
+                self.event.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying RunnerClient event: %s", exc)
             self.event = None
         if hasattr(self, "_functions") and self._functions is not None:
-            if hasattr(self._functions, "destroy"):
-                self._functions.destroy()
+            try:
+                if hasattr(self._functions, "destroy"):
+                    self._functions.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying RunnerClient functions: %s", exc)
             self._functions = {}
         if hasattr(self, "utils") and self.utils is not None:
-            if hasattr(self.utils, "destroy"):
-                self.utils.destroy()
+            try:
+                if hasattr(self.utils, "destroy"):
+                    self.utils.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying RunnerClient utils: %s", exc)
             self.utils = {}
         if hasattr(self, "_mminion") and self._mminion is not None:
-            self._mminion.destroy()
+            try:
+                self._mminion.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying RunnerClient mminion: %s", exc)
             self._mminion = None
 
     def __enter__(self):

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -56,15 +56,28 @@ class WheelClient(
         self.functions = salt.loader.wheels(opts, context=self.context)
 
     def destroy(self):
+        # Each resource's teardown is isolated in its own try/except and its
+        # attribute is unconditionally reset afterward, so one resource
+        # raising during teardown can never prevent the others (in
+        # particular _mminion) from being destroyed too.
         if self.event is not None:
-            self.event.destroy()
+            try:
+                self.event.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying WheelClient event: %s", exc)
             self.event = None
         if hasattr(self, "functions") and self.functions is not None:
-            if hasattr(self.functions, "destroy"):
-                self.functions.destroy()
+            try:
+                if hasattr(self.functions, "destroy"):
+                    self.functions.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying WheelClient functions: %s", exc)
             self.functions = {}
         if hasattr(self, "_mminion") and self._mminion is not None:
-            self._mminion.destroy()
+            try:
+                self._mminion.destroy()
+            except Exception as exc:  # pylint: disable=broad-except
+                log.error("Error destroying WheelClient mminion: %s", exc)
             self._mminion = None
 
     def __enter__(self):

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -63,6 +63,9 @@ class WheelClient(
             if hasattr(self.functions, "destroy"):
                 self.functions.destroy()
             self.functions = {}
+        if hasattr(self, "_mminion") and self._mminion is not None:
+            self._mminion.destroy()
+            self._mminion = None
 
     def __enter__(self):
         return self

--- a/tests/pytests/unit/cli/test_run.py
+++ b/tests/pytests/unit/cli/test_run.py
@@ -24,6 +24,31 @@ def _fake_saltrun():
     return fake
 
 
+def _fake_runner():
+    """
+    A stand-in for the ``salt.runner.Runner`` instance ``run()`` uses as a
+    context manager (``with salt.runner.Runner(self.config) as runner:``).
+
+    A bare ``MagicMock()`` doesn't wire its auto-generated ``__enter__``/
+    ``__exit__`` to any real behavior, so left unconfigured ``__enter__()``
+    would return a *different* mock than ``fake_runner`` (making ``runner``
+    inside the ``with`` block not the object the test asserts against), and
+    ``__exit__()`` would be a no-op instead of calling ``destroy()``. Wire
+    both to mirror ``RunnerClient.__enter__``/``__exit__`` for real -- note
+    ``__exit__`` must return ``None`` (falsy), not ``destroy()``'s mock
+    return value, or the ``with`` statement treats it as "exception handled"
+    and swallows the ``SystemExit`` the tests are asserting on.
+    """
+    fake_runner = MagicMock()
+    fake_runner.__enter__.return_value = fake_runner
+
+    def _exit(*args):
+        fake_runner.destroy()
+
+    fake_runner.__exit__.side_effect = _exit
+    return fake_runner
+
+
 def test_run_destroys_runner_on_normal_exit():
     """
     Regression test for GH #70174: salt-run leaked its Runner (and the
@@ -33,7 +58,7 @@ def test_run_destroys_runner_on_normal_exit():
     run on the normal, successful exit path too.
     """
     fake = _fake_saltrun()
-    fake_runner = MagicMock()
+    fake_runner = _fake_runner()
     fake_runner.run.return_value = {"retcode": 0}
     with (
         patch("salt.runner.Runner", return_value=fake_runner),
@@ -51,7 +76,7 @@ def test_run_destroys_runner_on_doc_exit():
     """
     fake = _fake_saltrun()
     fake.options.doc = True
-    fake_runner = MagicMock()
+    fake_runner = _fake_runner()
     with patch("salt.runner.Runner", return_value=fake_runner):
         with pytest.raises(SystemExit):
             SaltRun.run(fake)
@@ -64,7 +89,7 @@ def test_run_destroys_runner_on_saltclienterror():
     destroy() must still run when runner.run() raises SaltClientError.
     """
     fake = _fake_saltrun()
-    fake_runner = MagicMock()
+    fake_runner = _fake_runner()
     fake_runner.run.side_effect = SaltClientError("boom")
     with (
         patch("salt.runner.Runner", return_value=fake_runner),

--- a/tests/pytests/unit/cli/test_run.py
+++ b/tests/pytests/unit/cli/test_run.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for the salt-run CLI (salt.cli.run.SaltRun).
+"""
+
+import pytest
+
+from salt.cli.run import SaltRun
+from salt.exceptions import SaltClientError
+from tests.support.mock import MagicMock, patch
+
+
+def _fake_saltrun():
+    """
+    A stand-in SaltRun self with just the attributes run() touches, so the
+    method can be exercised without full CLI parsing.
+    """
+    fake = MagicMock()
+    fake.options.profiling_enabled = False
+    fake.options.doc = False
+    fake.config = {"user": "root"}
+    # Mirrors optparse.OptionParser.exit(): raises SystemExit for real
+    # instead of being swallowed as a no-op mock call.
+    fake.exit.side_effect = SystemExit(0)
+    return fake
+
+
+def test_run_destroys_runner_on_normal_exit():
+    """
+    Regression test for GH #70174: salt-run leaked its Runner (and the
+    MasterMinion it lazily creates) because it was never destroy()'d,
+    relying instead on __del__'s GC-time safety net -- which now logs a
+    loud "unclosed Runner"/"unclosed MasterMinion" WARNING. destroy() must
+    run on the normal, successful exit path too.
+    """
+    fake = _fake_saltrun()
+    fake_runner = MagicMock()
+    fake_runner.run.return_value = {"retcode": 0}
+    with (
+        patch("salt.runner.Runner", return_value=fake_runner),
+        patch("salt.cli.run.check_user", return_value=True),
+    ):
+        with pytest.raises(SystemExit):
+            SaltRun.run(fake)
+    fake_runner.destroy.assert_called_once()
+
+
+def test_run_destroys_runner_on_doc_exit():
+    """
+    ``--doc`` exits early, before the runner is ever executed; destroy()
+    must still run.
+    """
+    fake = _fake_saltrun()
+    fake.options.doc = True
+    fake_runner = MagicMock()
+    with patch("salt.runner.Runner", return_value=fake_runner):
+        with pytest.raises(SystemExit):
+            SaltRun.run(fake)
+    fake_runner.print_docs.assert_called_once()
+    fake_runner.destroy.assert_called_once()
+
+
+def test_run_destroys_runner_on_saltclienterror():
+    """
+    destroy() must still run when runner.run() raises SaltClientError.
+    """
+    fake = _fake_saltrun()
+    fake_runner = MagicMock()
+    fake_runner.run.side_effect = SaltClientError("boom")
+    with (
+        patch("salt.runner.Runner", return_value=fake_runner),
+        patch("salt.cli.run.check_user", return_value=True),
+    ):
+        with pytest.raises(SystemExit):
+            SaltRun.run(fake)
+    fake_runner.destroy.assert_called_once()

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -2441,3 +2441,73 @@ async def test_stop_async_calls_notify_stopping_and_terminates_subprocess_list(
         # code path; the .destroy() call would try to tear down channels
         # we never created. A best-effort close is enough.
         pass
+
+
+def test_masterminion_del_silent_after_destroy():
+    """
+    Regression test for GH #70174.
+
+    ``MasterMinion.destroy()`` leaves ``returners``/``functions``/``utils``
+    as ``{}``, not ``None``, but ``__del__``'s "already torn down" check
+    looked for ``None`` specifically. So a ``MasterMinion`` that was
+    properly torn down via ``destroy()`` (e.g. by
+    ``RunnerClient.destroy()``) still fired the loud "unclosed
+    MasterMinion" WARNING at GC time.
+    """
+    import gc
+    import warnings
+
+    mm = salt.minion.MasterMinion.__new__(salt.minion.MasterMinion)
+    # Mirrors the post-destroy() state: emptied, not None.
+    mm.returners = {}
+    mm.functions = {}
+    mm.utils = {}
+    # ``gc.collect()`` can also finalize unrelated garbage left behind by
+    # other tests in the same process; scope the assertion to warnings
+    # naming *this* object so that pollution doesn't produce a false
+    # failure (or, worse, mask a real one).
+    mm_repr = repr(mm)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del mm
+        gc.collect()
+    resource_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, ResourceWarning) and mm_repr in str(w.message)
+    ]
+    assert not resource_warnings, (
+        "A destroy()'d MasterMinion must not warn at GC; got: "
+        f"{[str(w.message) for w in resource_warnings]}"
+    )
+
+
+def test_masterminion_del_warns_when_unclosed():
+    """
+    Inverse of the above: a MasterMinion that was never destroy()'d must
+    still warn, so the "already torn down" fix doesn't silence real leaks.
+    """
+    import gc
+    import warnings
+
+    mm = salt.minion.MasterMinion.__new__(salt.minion.MasterMinion)
+    mm.returners = {"some_returner": object()}
+    mm.functions = {}
+    mm.utils = {}
+    mm_repr = repr(mm)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del mm
+        gc.collect()
+    resource_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, ResourceWarning) and mm_repr in str(w.message)
+    ]
+    assert resource_warnings, (
+        "An un-destroyed MasterMinion must still warn at GC; got: "
+        f"{[(w.category.__name__, str(w.message)) for w in caught]}"
+    )
+    msg = str(resource_warnings[0].message)
+    assert "MasterMinion" in msg
+    assert "destroy" in msg or "context manager" in msg

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -2511,3 +2511,28 @@ def test_masterminion_del_warns_when_unclosed():
     msg = str(resource_warnings[0].message)
     assert "MasterMinion" in msg
     assert "destroy" in msg or "context manager" in msg
+
+
+def test_masterminion_destroy_isolates_component_failures():
+    """
+    Regression test for GH #70174 review follow-up.
+
+    ``MasterMinion.destroy()`` runs several components' teardown
+    back-to-back. If an earlier component's ``.destroy()`` raises, later
+    components must still be torn down and reset to ``{}`` -- both so no
+    resource is silently leaked, and so ``destroy()`` itself never raises
+    (it's now called unconditionally from ``RunnerClient``/``WheelClient``
+    ``destroy()``, which in turn may run from a ``finally:`` block).
+    """
+    mm = salt.minion.MasterMinion.__new__(salt.minion.MasterMinion)
+    mm.returners = None
+    mm.functions = MagicMock()
+    mm.functions.destroy.side_effect = RuntimeError("boom")
+    utils = mm.utils = MagicMock()
+    mm.opts = {}
+
+    mm.destroy()  # must not raise
+
+    assert mm.functions == {}
+    utils.destroy.assert_called_once()
+    assert mm.utils == {}

--- a/tests/pytests/unit/test_runner.py
+++ b/tests/pytests/unit/test_runner.py
@@ -1,0 +1,40 @@
+"""
+Unit tests for salt.runner
+"""
+
+from unittest.mock import MagicMock
+
+import salt.runner
+
+
+def test_runnerclient_destroy_cleans_up_mminion():
+    """
+    RunnerClient.destroy() must tear down a lazily-created MasterMinion
+    (``self._mminion``) too. Without this, the MasterMinion created by
+    ``mixins.SyncClientMixin.mminion`` during ``low()`` is only ever torn
+    down by ``__del__``'s GC-time safety net, which now logs a loud
+    "unclosed MasterMinion" WARNING (see GH #70174).
+    """
+    client = salt.runner.RunnerClient.__new__(salt.runner.RunnerClient)
+    client.event = None
+    client._functions = None
+    client.utils = None
+    mminion = client._mminion = MagicMock()
+
+    client.destroy()
+
+    mminion.destroy.assert_called_once()
+    assert client._mminion is None
+
+
+def test_runnerclient_destroy_without_mminion_is_a_noop():
+    """
+    RunnerClient.destroy() must not raise when ``mminion`` was never
+    accessed (``_mminion`` was never set on the instance).
+    """
+    client = salt.runner.RunnerClient.__new__(salt.runner.RunnerClient)
+    client.event = None
+    client._functions = None
+    client.utils = None
+
+    client.destroy()  # should not raise

--- a/tests/pytests/unit/test_runner.py
+++ b/tests/pytests/unit/test_runner.py
@@ -2,9 +2,8 @@
 Unit tests for salt.runner
 """
 
-from unittest.mock import MagicMock
-
 import salt.runner
+from tests.support.mock import MagicMock
 
 
 def test_runnerclient_destroy_cleans_up_mminion():

--- a/tests/pytests/unit/test_runner.py
+++ b/tests/pytests/unit/test_runner.py
@@ -37,3 +37,25 @@ def test_runnerclient_destroy_without_mminion_is_a_noop():
     client.utils = None
 
     client.destroy()  # should not raise
+
+
+def test_runnerclient_destroy_still_destroys_mminion_if_event_destroy_fails():
+    """
+    Regression test for GH #70174 review follow-up.
+
+    If ``self.event.destroy()`` raises, ``destroy()`` must still go on to
+    tear down ``self._mminion`` -- otherwise the very resource this fix was
+    meant to clean up would be skipped whenever event teardown fails.
+    """
+    client = salt.runner.RunnerClient.__new__(salt.runner.RunnerClient)
+    client.event = MagicMock()
+    client.event.destroy.side_effect = RuntimeError("boom")
+    client._functions = None
+    client.utils = None
+    mminion = client._mminion = MagicMock()
+
+    client.destroy()  # must not raise
+
+    assert client.event is None
+    mminion.destroy.assert_called_once()
+    assert client._mminion is None

--- a/tests/pytests/unit/wheel/test_init.py
+++ b/tests/pytests/unit/wheel/test_init.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for salt.wheel.WheelClient
+"""
+
+from unittest.mock import MagicMock
+
+import salt.wheel
+
+
+def test_wheelclient_destroy_cleans_up_mminion():
+    """
+    WheelClient.destroy() must tear down a lazily-created MasterMinion
+    (``self._mminion``), mirroring the same fix applied to
+    salt.runner.RunnerClient (GH #70174).
+    """
+    client = salt.wheel.WheelClient.__new__(salt.wheel.WheelClient)
+    client.event = None
+    client.functions = None
+    mminion = client._mminion = MagicMock()
+
+    client.destroy()
+
+    mminion.destroy.assert_called_once()
+    assert client._mminion is None
+
+
+def test_wheelclient_destroy_without_mminion_is_a_noop():
+    """
+    WheelClient.destroy() must not raise when ``mminion`` was never
+    accessed (``_mminion`` was never set on the instance).
+    """
+    client = salt.wheel.WheelClient.__new__(salt.wheel.WheelClient)
+    client.event = None
+    client.functions = None
+
+    client.destroy()  # should not raise

--- a/tests/pytests/unit/wheel/test_init.py
+++ b/tests/pytests/unit/wheel/test_init.py
@@ -33,3 +33,24 @@ def test_wheelclient_destroy_without_mminion_is_a_noop():
     client.functions = None
 
     client.destroy()  # should not raise
+
+
+def test_wheelclient_destroy_still_destroys_mminion_if_event_destroy_fails():
+    """
+    Regression test for GH #70174 review follow-up.
+
+    If ``self.event.destroy()`` raises, ``destroy()`` must still go on to
+    tear down ``self._mminion`` -- otherwise the very resource this fix was
+    meant to clean up would be skipped whenever event teardown fails.
+    """
+    client = salt.wheel.WheelClient.__new__(salt.wheel.WheelClient)
+    client.event = MagicMock()
+    client.event.destroy.side_effect = RuntimeError("boom")
+    client.functions = None
+    mminion = client._mminion = MagicMock()
+
+    client.destroy()  # must not raise
+
+    assert client.event is None
+    mminion.destroy.assert_called_once()
+    assert client._mminion is None

--- a/tests/pytests/unit/wheel/test_init.py
+++ b/tests/pytests/unit/wheel/test_init.py
@@ -2,9 +2,8 @@
 Unit tests for salt.wheel.WheelClient
 """
 
-from unittest.mock import MagicMock
-
 import salt.wheel
+from tests.support.mock import MagicMock
 
 
 def test_wheelclient_destroy_cleans_up_mminion():


### PR DESCRIPTION
### What does this PR do?
``salt-run`` left its Runner ``un-destroy()``'d, and ``RunnerClient`` / ``WheelClient`` never cleaned up the ``MasterMinion`` they lazily create via ``SyncClientMixin.mminion``. Both were only reclaimed by ``__del__``'s GC-time safety net, which now logs a loud "unclosed Runner"/ "unclosed MasterMinion" WARNING on every ``salt-run`` invocation instead of being silently filtered.

- ``salt/cli/run.py``: wrap ``SaltRun.run()`` in ``try`` / ``finally`` so ``runner.destroy()`` always runs, covering both the ``--doc`` early-exit and the normal path.
- ``salt/runner.py``, ``salt/wheel/__init__.py``: ``destroy()`` now also tears down ``self._mminion``.
- ``salt/minion.py``: ``MasterMinion.destroy()`` leaves returners/functions/utils as ``{}``, not ``None``, but ``__del__``'s "already torn down" check tested for ``None`` specifically, so even a properly ``destroy()``'d MasterMinion kept tripping the warning. Check falsiness instead.

### What issues does this PR fix or reference?
Fixes #70174

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
