### PR TITLE
Fix Ctrl+C on salt-run reported as a runner exception

### DIFF
--- a/changelog/70176.fixed.md
+++ b/changelog/70176.fixed.md
@@ -1,0 +1,1 @@
+Fixed Ctrl+C printing a spurious "Exception occurred in runner" traceback (and exiting with the wrong code) when interrupting a blocking runner command such as ``salt-run state.event``.

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -401,7 +401,7 @@ class SyncClientMixin(ClientStateMixin):
                     data["success"] = salt.utils.state.check_result(
                         data["return"]["data"]
                     )
-            except (Exception, SystemExit) as ex:  # pylint: disable=broad-except
+            except Exception as ex:  # pylint: disable=broad-except
                 if isinstance(ex, salt.exceptions.NotImplemented):
                     data["return"] = str(ex)
                 else:

--- a/tests/pytests/functional/cli/test_salt_run_.py
+++ b/tests/pytests/functional/cli/test_salt_run_.py
@@ -19,6 +19,20 @@ def test_salt_run_exception_exit(salt_run_cli):
     assert ret.returncode == 1
 
 
+def test_salt_run_system_exit(salt_run_cli):
+    """
+    A SystemExit raised inside a runner (e.g. from Ctrl-C's SIGINT handler,
+    or a runner module calling sys.exit() directly) should propagate and
+    exit the process normally, not be reported as a runner "Exception
+    occurred" error.
+    """
+    ret = salt_run_cli.run("error.error", "name='SystemExit'", "message='Bye'")
+    assert ret.returncode == 1
+    assert "Bye" in ret.stderr
+    assert "Exception occurred in runner" not in ret.stdout
+    assert "Exception occurred in runner" not in ret.stderr
+
+
 def test_salt_run_non_exception_exit(salt_run_cli):
     """
     Test standard exitcode and output when runner works.


### PR DESCRIPTION
### What does this PR do?
``SyncClientMixin.low()`` caught ``SystemExit`` alongside ``Exception`` to turn a runner module accidentally calling ``sys.exit()`` into a nicer error message. This also swallowed the ``SystemExit`` raised by ``scripts.py``'s ``SIGINT`` / ``SIGTERM`` handler when ``Ctrl+C`` interrupts a blocking runner call (e.g. ``salt-run state.event``), turning a clean, intentional shutdown into a spurious "Exception occurred in runner ..." traceback with the wrong exit code.

Stop catching ``SystemExit`` here so it propagates normally and the CLI exits the way ``_handle_signals`` intended.

### What issues does this PR fix or reference?
Fixes #70176

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
