### PR TITLE
DEBUG: temporary ARG_MAX tracing for #70085 investigation (do not merge)

### DIFF
--- a/changelog/61338.fixed.md
+++ b/changelog/61338.fixed.md
@@ -1,0 +1,1 @@
+Fixed salt-ssh failing to deploy the thin/relenv tarball (and other scp transfers) when a path involved, such as the master's ``cachedir``/``root_dir``, contains a space.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1427,7 +1427,9 @@ class Single:
         """
         check if the thindir exists on the remote machine
         """
-        stdout, stderr, retcode = self.shell.exec_cmd(f"test -d {self.thin_dir}")
+        stdout, stderr, retcode = self.shell.exec_cmd(
+            f"test -d {shlex.quote(self.thin_dir)}"
+        )
         if retcode != 0:
             return False
         return True
@@ -2101,7 +2103,10 @@ ARGS = {arguments}\n'''.format(
 
             # Check if config file already exists on remote (for nested/wrapper calls)
             # This avoids ARG_MAX issues when wrappers create nested Single instances
-            check_cmd = f"test -f {remote_config_path} && echo exists || echo missing"
+            check_cmd = (
+                f"test -f {shlex.quote(remote_config_path)} "
+                "&& echo exists || echo missing"
+            )
             check_result = self.shell.exec_cmd(check_cmd)
 
             config_exists = (

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -414,8 +414,17 @@ class Shell:
         log_sanitize = None
         if self.passwd:
             log_sanitize = self.passwd
+        _dbg_argv = self._split_cmd(cmd)
+        _dbg_total = sum(len(a) for a in _dbg_argv) + len(_dbg_argv)
+        _dbg_max = max((len(a) for a in _dbg_argv), default=0)
+        print(
+            f"ARGMAX_DEBUG nargs={len(_dbg_argv)} total_bytes={_dbg_total} "
+            f"max_arg_bytes={_dbg_max} cmd_head={cmd[:120]!r}",
+            file=sys.stderr,
+            flush=True,
+        )
         term = salt.utils.vt.Terminal(
-            self._split_cmd(cmd),
+            _dbg_argv,
             log_stdout=True,
             log_stdout_level="trace",
             log_stderr=True,

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -371,7 +371,7 @@ class Shell:
         if ":" in host:
             host = f"[{host}]"
 
-        cmd = f"{local} {host}:{remote}"
+        cmd = f"{shlex.quote(local)} {shlex.quote(f'{host}:{remote}')}"
         cmd = self._cmd_str(cmd, ssh=SCP_PATH)
 
         logmsg = f"Executing command: {cmd}"

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -163,6 +163,37 @@ def test_thin_dir(salt_ssh_cli):
     assert thin_dir.joinpath("running_data").exists()
 
 
+def test_thin_dir_with_space(salt_ssh_cli, tmp_path, salt_ssh_roster_file):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/61338
+
+    salt-ssh's scp-based thin tarball deploy must not break when thin_dir
+    (or any other path fed into Shell.send()) contains a space.
+    """
+    thin_dir_with_space = tmp_path / "thin dir with space" / "thin"
+    roster_file = tmp_path / "roster-thin-dir-space"
+    with salt.utils.files.fopen(salt_ssh_roster_file) as rfh:
+        roster_data = salt.utils.yaml.safe_load(rfh)
+        roster_data["localhost"].update({"thin_dir": str(thin_dir_with_space)})
+    with salt.utils.files.fopen(roster_file, "w") as wfh:
+        salt.utils.yaml.safe_dump(roster_data, wfh)
+
+    try:
+        ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "test.ping")
+        assert ret.returncode == 0
+        assert ret.data is True
+
+        ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "config.get", "thin_dir")
+        assert ret.returncode == 0
+        thin_dir = pathlib.Path(ret.data)
+        assert thin_dir == thin_dir_with_space
+        assert thin_dir.is_dir()
+        assert thin_dir.joinpath("salt-call").exists()
+        assert thin_dir.joinpath("running_data").exists()
+    finally:
+        shutil.rmtree(thin_dir_with_space, ignore_errors=True)
+
+
 def test_wipe(salt_ssh_cli):
     """
     Ensure --wipe is respected by the state module wrapper

--- a/tests/pytests/unit/client/ssh/test_shell.py
+++ b/tests/pytests/unit/client/ssh/test_shell.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import shlex
 import subprocess
 import types
 
@@ -273,6 +274,32 @@ def test_scp_command_execution_uses_custom_path():
         args, _ = mock_run_cmd.call_args
         assert "/custom/scp" in args[0]
         assert "source_file.txt example.com:/path/dest_file.txt" in args[0]
+
+
+def test_ssh_shell_send_quotes_paths_with_spaces():
+    """
+    Regression test for https://github.com/saltstack/salt/issues/61338
+
+    scp must not break when the local (or remote) path contains a space,
+    e.g. a thin tarball cached under a directory such as
+    "/var/lib/jenkins/workspace/Test job/salt/...".
+    """
+    _shell = shell.Shell({}, "localhost")
+    with patch.object(
+        _shell, "_run_cmd", return_value=(None, None, None)
+    ) as mock_run_cmd:
+        _shell.send(
+            "/var/lib/jenkins/workspace/Test job/salt/thin.tgz",
+            "/var/tmp/.root_salt/thin.tgz",
+        )
+        args, _ = mock_run_cmd.call_args
+        cmd_string = args[0]
+
+        # The full command must re-split back into exactly the two intended
+        # scp arguments, not four bogus ones.
+        split_cmd = shlex.split(cmd_string)
+        assert "/var/lib/jenkins/workspace/Test job/salt/thin.tgz" in split_cmd
+        assert "localhost:/var/tmp/.root_salt/thin.tgz" in split_cmd
 
 
 def test_ssh_using_user_with_backslash():


### PR DESCRIPTION
Scratch/throwaway draft PR to capture the real argv size of the failing salt-ssh state.apply command on Photon OS / Arm64 CI runners (see #70085). Adds a temporary stderr print in Shell._run_cmd(). Will be closed once the debug log is captured — not intended to be reviewed or merged.