### PR TITLE
[3008.x] Complete the whitelist_modules two-loader model across the state stack

### DIFF
--- a/changelog/70192.fixed.md
+++ b/changelog/70192.fixed.md
@@ -1,0 +1,12 @@
+Extend the ``whitelist_modules`` two-loader model to the state loader
+and the state engine itself so trusted salt-core-authored code
+(shipped Python state modules, ``compile_high_data``'s
+``config.option`` reads, retry ``test.sleep``, ``event.fire_master``,
+``saltutil.refresh_modules``) composes with non-whitelisted execution
+modules while every user-facing path -- wire dispatch, Jinja renderer
+context (both ``salt['cmd.run']`` and ``salt.cmd.run``),
+``salt.states.module.run`` / ``.function``, ``__slot__:salt:...``
+references, and SLS ``unless``/``onlyif``/``check_cmd`` shell hooks --
+stays whitelist-gated.  Closes the attribute-style Jinja escape
+hatch that let ``{{ salt.cmd.run('...') }}`` bypass the filter that
+``{{ salt['cmd.run']('...') }}`` already enforced.

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -58,6 +58,16 @@ class SSHState(salt.state.State):
         Load up the modules for remote compilation via ssh
         """
         self.functions = self.wrapper
+        # Salt-SSH runs execution modules on the target via ``self.wrapper``
+        # (a :class:`salt.client.ssh.FunctionWrapper`), which has no
+        # two-loader model -- there is no ``_dunder_salt`` inner loader to
+        # fall back to.  ``State`` machinery (global state conditions,
+        # requisite/aggregate composition, ``saltutil.refresh_modules``,
+        # ``event.fire_master``, ``test.sleep`` in the retry loop) reads
+        # from ``self._trusted_functions``; mirror the wrapper so those
+        # trusted internal call sites keep working.  Matches
+        # :meth:`MasterState.load_modules`.
+        self._trusted_functions = self.functions
         self.utils = salt.loader.utils(self.opts)
         self.serializers = salt.loader.serializers(self.opts)
         locals_ = salt.loader.minion_mods(self.opts, utils=self.utils)

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -513,6 +513,14 @@ def minion_mods(
 
     ret.__class__ = _WriteThroughLoader
 
+    # Expose the unfiltered inner loader on the outer loader so downstream
+    # loader factories (e.g. ``salt.loader.states``) can propagate the same
+    # two-loader model:  wire dispatch reads through ``ret`` and is
+    # whitelist-gated, but internal ``__salt__[...]`` composition inside
+    # trusted shipped code (state modules, execution modules) reads through
+    # ``salt_dunder`` and is not gated.
+    ret._dunder_salt = salt_dunder
+
     # Allow the usage of salt dunder in utils modules.
     if utils and isinstance(utils, LazyLoader):
         utils.pack["__salt__"] = salt_dunder
@@ -1124,14 +1132,18 @@ def states(
     loaded_base_name=None,
     file_client=None,
     minion_mods=None,
+    dunder_salt=None,
 ):
     """
     Returns the state modules
 
     :param dict opts: The Salt options dictionary
     :param LazyLoader functions: A LazyLoader instance returned from ``minion_mods``
-        (or, in a resource context, from ``resource_modules``).  This becomes
-        ``__salt__`` for state modules.
+        (or, in a resource context, from ``resource_modules``).  In the
+        two-loader model this is the wire-filtered (``whitelist_modules``)
+        outer loader; it is packed as ``__wire_salt__`` on every loaded state
+        module so state code that legitimately dispatches an SLS-supplied
+        function name (e.g. ``salt.states.module.run``) stays whitelist-gated.
     :param LazyLoader runners: A LazyLoader instance returned from ``runner``.
     :param LazyLoader utils: A LazyLoader instance returned from ``utils``.
     :param LazyLoader serializers: An optional LazyLoader instance returned from ``serializers``.
@@ -1146,6 +1158,13 @@ def states(
         modules running in a resource context can call back into the
         managing minion explicitly.  Typically the result of
         ``salt.loader.minion_mods(opts)``.
+    :param LazyLoader dunder_salt: Optional unfiltered execution-module
+        loader (the inner ``salt_dunder`` produced by :func:`minion_mods`).
+        When supplied it is packed as ``__salt__`` for every state module,
+        so trusted shipped code such as ``file.managed`` can compose with
+        non-whitelisted execution modules (e.g. ``file.source_list``)
+        even when ``whitelist_modules`` is set.  When ``None`` the caller's
+        ``functions`` is used for backwards compatibility.
 
     .. code-block:: python
 
@@ -1158,8 +1177,18 @@ def states(
     if context is None:
         context = {}
 
+    # Two-loader model for states:
+    #   * ``__salt__``      -> unfiltered ``dunder_salt`` when supplied, so
+    #                          shipped state modules can call any exec
+    #                          module they need internally.
+    #   * ``__wire_salt__`` -> whitelist-filtered ``functions``, for state
+    #                          modules that dispatch an SLS-supplied exec
+    #                          module name (``salt.states.module.run`` /
+    #                          ``.function``) so those stay gated.
+    salt_pack = dunder_salt if dunder_salt is not None else functions
     pack = {
-        "__salt__": functions,
+        "__salt__": salt_pack,
+        "__wire_salt__": functions,
         "__proxy__": proxy or {},
         "__utils__": utils,
         "__serializers__": serializers,

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -535,6 +535,18 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         except AttributeError:
             pass
 
+        # Whitelist gate for attribute-style access (VCOPS-90587):
+        # ``__getitem__`` reaches ``_load`` which enforces ``self.whitelist``,
+        # but attribute-style access -- used by Jinja's ``salt.cmd.run(...)``
+        # syntax via :class:`salt.utils.templates.AliasedLoader` / the
+        # ``LoadedMod`` wrapper -- bypasses ``_load`` and returns a
+        # ``LoadedMod`` whose per-function ``getattr`` never touches the
+        # gate.  Reject non-whitelisted modules here with ``AttributeError``
+        # so ``hasattr(salt, 'cmd')`` / Jinja's ``undefined`` fallthrough
+        # behave correctly.
+        if self.whitelist and mod_name not in self.whitelist:
+            raise AttributeError(mod_name)
+
         # otherwise we assume its jinja template access
         if mod_name not in self.loaded_modules and not self.loaded:
             for name in self._iter_files(mod_name):
@@ -865,9 +877,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # but the log will get spammed with "Bad Magic Number" messages that
         # can be very misleading if the user is debugging another problem.
         try:
-            (implementation_tag, cache_tag_ver) = sys.implementation.cache_tag.split(
-                "-"
-            )
+            implementation_tag, cache_tag_ver = sys.implementation.cache_tag.split("-")
             if cache_tag_ver not in fpath and implementation_tag in fpath:
                 log.trace(
                     "Trying to load %s on %s, returning False.",

--- a/salt/state.py
+++ b/salt/state.py
@@ -980,8 +980,14 @@ class State:
         }
 
         if not isinstance(self.global_state_conditions, dict):
+            # ``config.option`` / ``match.compound`` are trusted engine
+            # internals (see VCOPS-90587 audit); read them via the
+            # unfiltered ``_trusted_functions`` so ``whitelist_modules``
+            # doesn't have to enumerate them for global state
+            # conditioning to work.
             self.global_state_conditions = (
-                self.functions["config.option"]("global_state_conditions") or {}
+                self._trusted_functions["config.option"]("global_state_conditions")
+                or {}
             )
 
         for state_match, conditions in self.global_state_conditions.items():
@@ -990,7 +996,7 @@ class State:
                     conditions = [conditions]
                 if isinstance(conditions, list):
                     matches.extend(
-                        self.functions["match.compound"](condition)
+                        self._trusted_functions["match.compound"](condition)
                         for condition in conditions
                     )
 
@@ -1407,6 +1413,13 @@ class State:
                 # In non-resource context this is None and the dunder isn't
                 # packed.
                 minion_mods=self.minion_functions,
+                # Two-loader propagation for ``whitelist_modules``:  give
+                # state modules the unfiltered inner exec-module loader as
+                # ``__salt__`` so trusted shipped code (e.g. ``file.managed``
+                # calling ``__salt__['file.source_list']``) is not gated,
+                # while wire dispatch and any ``__wire_salt__`` consumer
+                # (``salt.states.module.run`` / ``.function``) stay gated.
+                dunder_salt=getattr(self.functions, "_dunder_salt", None),
             )
 
     def load_modules(self, data=None, proxy=None):
@@ -1475,6 +1488,23 @@ class State:
                 proxy=self.proxy,
                 file_client=salt.fileclient.ContextlessFileClient(self.file_client),
             )
+        # ``self._trusted_functions`` is the unfiltered inner exec-module
+        # loader (built by :func:`salt.loader.minion_mods` when
+        # ``whitelist_modules`` is set).  It is used only for
+        # state-engine internal composition -- ``config.option`` reads,
+        # requisite/aggregate machinery, ``saltutil.refresh_modules``,
+        # ``event.fire_master``, ``test.sleep`` in the retry loop --
+        # so those trusted salt-core-authored call sites keep working
+        # when the operator's whitelist doesn't happen to include the
+        # helper modules they need.  User-facing dispatch
+        # (``unless``/``onlyif``/``check_cmd``, ``__slot__:salt:...``,
+        # ``module.run``, Jinja renderer context) still uses
+        # ``self.functions`` and stays wire-filtered.  Falls back to
+        # ``self.functions`` on loaders that don't expose the inner
+        # loader (master-side compile, older salt versions).
+        self._trusted_functions = (
+            getattr(self.functions, "_dunder_salt", None) or self.functions
+        )
         if isinstance(data, dict):
             if data.get("provider", False):
                 if isinstance(data["provider"], str):
@@ -1524,7 +1554,9 @@ class State:
                 )
         self.load_modules()
         if not self.opts.get("local", False) and self.opts.get("multiprocessing", True):
-            self.functions["saltutil.refresh_modules"]()
+            # Trusted internal refresh; do not depend on the operator
+            # putting ``saltutil`` on the wire whitelist (VCOPS-90587).
+            self._trusted_functions["saltutil.refresh_modules"]()
 
     def check_refresh(self, data: dict, ret: dict) -> None:
         """
@@ -1661,8 +1693,11 @@ class State:
             disabled_reqs = [disabled_reqs]
         if not self.dependency_dag.dag:
             # if order_chunks was called without calling compile_high_data then
-            # we need to add the chunks to the dag
-            agg_opt = self.functions["config.option"]("state_aggregate")
+            # we need to add the chunks to the dag.  ``config.option`` is
+            # trusted engine internal (VCOPS-90587); route through
+            # ``_trusted_functions`` so a minion whose whitelist excludes
+            # ``config`` still gets aggregate ordering.
+            agg_opt = self._trusted_functions["config.option"]("state_aggregate")
             for chunk in chunks:
                 self.dependency_dag.add_chunk(
                     chunk, self._allow_aggregate(chunk, agg_opt)
@@ -1717,7 +1752,11 @@ class State:
         self.dependency_dag = DependencyGraph()
         chunks = []
         disabled = {}
-        agg_opt = self.functions["config.option"]("state_aggregate")
+        # ``config.option`` here reads a salt-core aggregate opt.  Route
+        # through ``_trusted_functions`` (unfiltered) so
+        # ``compile_high_data`` doesn't KeyError under a strict
+        # ``whitelist_modules`` that omits ``config`` (VCOPS-90587).
+        agg_opt = self._trusted_functions["config.option"]("state_aggregate")
         for id_, body in high.items():
             if id_.startswith("__"):
                 continue
@@ -2535,7 +2574,10 @@ class State:
                             "state will be re-run in %s seconds",
                             interval,
                         )
-                        self.functions["test.sleep"](interval)
+                        # Retry sleep is engine-internal (VCOPS-90587
+                        # audit); don't require ``test`` on the wire
+                        # whitelist just to retry a failed state.
+                        self._trusted_functions["test.sleep"](interval)
                         retry_ret = self.call(low, chunks, running, retries=retries + 1)
                         orig_ret = ret
                         ret = retry_ret
@@ -3076,7 +3118,11 @@ class State:
                         _evt.fire_event(ret, tag)
 
             else:
-                ev_func = self.functions["event.fire_master"]
+                # State result event firing is engine internal
+                # (VCOPS-90587); use the unfiltered dunder so a strict
+                # whitelist that omits ``event`` still gets state-result
+                # events on the master bus.
+                ev_func = self._trusted_functions["event.fire_master"]
 
             ret: dict[str, Any] = {"ret": chunk_ret}
             if fire_event is True:
@@ -5050,6 +5096,10 @@ class MasterState(State):
         # from the minion, but uses remote execution
         #
         self.functions = salt.client.FunctionWrapper(self.opts, self.opts["id"])
+        # Master-side compile has no two-loader model (FunctionWrapper
+        # doesn't expose ``_dunder_salt``); trusted internal composition
+        # falls back to the same wrapper the wire uses.
+        self._trusted_functions = self.functions
         # Load the states, but they should not be used in this class apart
         # from inspection
         self.utils = salt.loader.utils(self.opts)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -312,6 +312,28 @@ from salt.exceptions import SaltInvocationError
 log = logging.getLogger(__name__)
 
 
+def _wire_salt():
+    """
+    Return the whitelist-filtered execution-module loader for SLS-directed
+    dispatch (``module.run`` / ``module.function``).
+
+    Under the two-loader model implemented by :func:`salt.loader.minion_mods`
+    and :func:`salt.loader.states`, ``__salt__`` for a state module is the
+    unfiltered inner exec-module loader so trusted shipped code (e.g.
+    ``file.managed``) can compose freely.  ``salt.states.module`` however
+    exists to invoke an arbitrary execution module whose name is supplied by
+    the SLS author, which would otherwise be an escape hatch around
+    ``whitelist_modules``.  When the state loader was built with the
+    two-loader model it packs the wire-filtered loader as ``__wire_salt__``;
+    fall back to ``__salt__`` when the pack isn't present (single-loader /
+    unit-test contexts).
+    """
+    try:
+        return __wire_salt__  # noqa: F821  (packed by salt.loader.states)
+    except NameError:
+        return __salt__
+
+
 def wait(name, **kwargs):
     """
     Run a single module function only if the watch statement calls it
@@ -408,12 +430,16 @@ def _run(**kwargs):
         "result": None,
     }
 
+    # Route SLS-supplied dispatch through the wire-filtered loader so
+    # ``whitelist_modules`` gates ``module.run: - <mod>.<fun>`` even though
+    # the surrounding state module has an unfiltered ``__salt__``.
+    wire_salt = _wire_salt()
     functions = [func for func in kwargs if "." in func]
     missing = []
     tests = []
     for func in functions:
         func = func.split(":")[0]
-        if func not in __salt__:
+        if func not in wire_salt:
             missing.append(func)
         elif __opts__["test"]:
             tests.append(func)
@@ -497,9 +523,17 @@ def _call_function(name, returner=None, func_args=None, func_kwargs=None):
     if func_kwargs is None:
         func_kwargs = {}
 
-    mret = salt.utils.functools.call_function(__salt__[name], *func_args, **func_kwargs)
+    wire_salt = _wire_salt()
+    if name not in wire_salt:
+        raise SaltInvocationError(
+            "Module function {} is not available (not on "
+            "``whitelist_modules``)".format(name)
+        )
+    mret = salt.utils.functools.call_function(
+        wire_salt[name], *func_args, **func_kwargs
+    )
     if returner is not None:
-        returners = salt.loader.returners(__opts__, __salt__)
+        returners = salt.loader.returners(__opts__, wire_salt)
         if returner in returners:
             returners[returner](
                 {
@@ -529,7 +563,8 @@ def _legacy_run(name, **kwargs):
         Pass any arguments needed to execute the function
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": None}
-    if name not in __salt__:
+    wire_salt = _wire_salt()
+    if name not in wire_salt:
         ret["comment"] = f"Module function {name} is not available"
         ret["result"] = False
         return ret
@@ -538,7 +573,7 @@ def _legacy_run(name, **kwargs):
         ret["comment"] = f"Module function {name} is set to execute"
         return ret
 
-    aspec = salt.utils.args.get_function_argspec(__salt__[name])
+    aspec = salt.utils.args.get_function_argspec(wire_salt[name])
     args = []
     defaults = {}
 
@@ -634,9 +669,9 @@ def _legacy_run(name, **kwargs):
 
     try:
         if aspec.keywords:
-            mret = __salt__[name](*args, **nkwargs)
+            mret = wire_salt[name](*args, **nkwargs)
         else:
-            mret = __salt__[name](*args)
+            mret = wire_salt[name](*args)
     except Exception as e:  # pylint: disable=broad-except
         ret["comment"] = "Module function {} threw an exception. Exception: {}".format(
             name, e
@@ -654,7 +689,7 @@ def _legacy_run(name, **kwargs):
             "fun": name,
             "jid": salt.utils.jid.gen_jid(__opts__),
         }
-        returners = salt.loader.returners(__opts__, __salt__)
+        returners = salt.loader.returners(__opts__, wire_salt)
         if kwargs["returner"] in returners:
             returners[kwargs["returner"]](ret_ret)
     ret["comment"] = f"Module function {name} executed"

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -74,8 +74,20 @@ class AliasedLoader:
         # ``LazyLoader.__getattr__`` now enforces the same gate; keep an
         # AliasedLoader-level check too for wrappers that might expose a
         # loader whose whitelist we can consult directly.
+        #
+        # Only respect ``whitelist`` if the wrapped loader exposes it as a
+        # real container. Wrappers like salt-ssh's ``FunctionWrapper``
+        # synthesise a module lookup for every attribute access, so
+        # ``getattr(wrapped, "whitelist", None)`` would return a
+        # ``LoadedMod`` instead of a list/tuple; using that with ``in``
+        # would raise ``TypeError``. Treat non-container ``whitelist``
+        # values as "no whitelist" and fall through to the wrapper's own
+        # module-load gate.
         wrapped = object.__getattribute__(self, "wrapped")
-        whitelist = getattr(wrapped, "whitelist", None)
+        _wl = getattr(wrapped, "whitelist", None)
+        whitelist = (
+            _wl if isinstance(_wl, (list, tuple, set, frozenset, dict)) else None
+        )
         if (
             whitelist
             and not name.startswith("_")

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -65,7 +65,25 @@ class AliasedLoader:
         return self.wrapped[name]
 
     def __getattr__(self, name):
-        return getattr(self.wrapped, name)
+        # Whitelist gate for attribute-style access (VCOPS-90587):
+        # ``getattr(self.wrapped, name)`` used to bypass ``whitelist_modules``
+        # -- ``LazyLoader.__getitem__`` gates via ``_load`` but
+        # ``LazyLoader.__getattr__`` did not, so a Jinja template using
+        # ``{{ salt.cmd.run('id') }}`` could escape the wire filter even
+        # when the equivalent ``{{ salt['cmd.run']('id') }}`` was rejected.
+        # ``LazyLoader.__getattr__`` now enforces the same gate; keep an
+        # AliasedLoader-level check too for wrappers that might expose a
+        # loader whose whitelist we can consult directly.
+        wrapped = object.__getattribute__(self, "wrapped")
+        whitelist = getattr(wrapped, "whitelist", None)
+        if (
+            whitelist
+            and not name.startswith("_")
+            and name not in whitelist
+            and not hasattr(type(wrapped), name)
+        ):
+            raise AttributeError(name)
+        return getattr(wrapped, name)
 
     def __contains__(self, name):
         return name in self.wrapped

--- a/tests/pytests/functional/loader/test_state_whitelist_dunder.py
+++ b/tests/pytests/functional/loader/test_state_whitelist_dunder.py
@@ -1,0 +1,214 @@
+"""
+Functional tests for the ``whitelist_modules`` two-loader propagation
+into ``salt.loader.states`` and the Jinja attribute-style escape hatch
+closure in ``salt.loader.lazy.LazyLoader.__getattr__`` /
+``salt.utils.templates.AliasedLoader.__getattr__``.
+
+These tests wire up real loaders (no mocks) but stop short of a full
+salt-master + salt-minion pair, which is the integration tier.
+
+Companion to :mod:`tests.pytests.integration.loader.test_module_whitelist_dunder`.
+"""
+
+import pytest
+
+import salt.loader
+import salt.loader.context
+from salt.utils.templates import AliasedLoader
+
+
+@pytest.fixture
+def wl_opts(minion_opts):
+    """Minion opts with a narrow ``whitelist_modules`` -- ``cmd`` deliberately absent."""
+    opts = minion_opts.copy()
+    opts["whitelist_modules"] = [
+        "test",
+        "grains",
+        "state",
+        "saltutil",
+        "config",
+        "pillar",
+        "slsutil",
+        "file",  # so ``file.managed`` can be *declared* in an SLS
+    ]
+    return opts
+
+
+@pytest.fixture
+def wl_loaders(wl_opts):
+    """Build the outer wire-filtered loader and the states loader wired for the fix."""
+    minion_mods = salt.loader.minion_mods(wl_opts)
+    dunder_salt = getattr(minion_mods, "_dunder_salt", None)
+    assert dunder_salt is not None, "PR #69983 two-loader model not present"
+    utils = salt.loader.utils(wl_opts)
+    serializers = salt.loader.serializers(wl_opts)
+    states = salt.loader.states(
+        wl_opts,
+        minion_mods,
+        utils,
+        serializers,
+        dunder_salt=dunder_salt,
+    )
+    return {
+        "opts": wl_opts,
+        "minion_mods": minion_mods,
+        "dunder_salt": dunder_salt,
+        "utils": utils,
+        "states": states,
+    }
+
+
+# ---------------------------------------------------------------------------
+# State-loader two-loader propagation
+# ---------------------------------------------------------------------------
+
+
+def test_state_loader_packs_unfiltered_salt(wl_loaders):
+    """
+    Every state module's packed ``__salt__`` is the *unfiltered* inner
+    loader, so trusted shipped state code can compose with non-whitelisted
+    exec modules (e.g. ``file.managed`` -> ``__salt__['file.source_list']``).
+    """
+    states = wl_loaders["states"]
+    dunder_salt = wl_loaders["dunder_salt"]
+    minion_mods = wl_loaders["minion_mods"]
+    assert states.pack["__salt__"] is dunder_salt
+    # ...and the wire loader is exposed as ``__wire_salt__`` for the few
+    # state modules that legitimately dispatch an SLS-supplied name.
+    assert states.pack["__wire_salt__"] is minion_mods
+    # cmd isn't on the whitelist:
+    assert "cmd.run" not in minion_mods
+    # ...but the unfiltered dunder still has it:
+    assert "cmd.run" in dunder_salt
+
+
+def test_wire_loader_still_gates_cmd_run(wl_loaders):
+    """The wire-facing loader must still refuse ``cmd.run``."""
+    minion_mods = wl_loaders["minion_mods"]
+    with pytest.raises(KeyError):
+        _ = minion_mods["cmd.run"]
+
+
+def test_trusted_state_module_can_reach_unfiltered_exec(wl_loaders):
+    """
+    Load ``file`` state and confirm its packed ``__salt__`` resolves the
+    non-whitelisted ``file.source_list`` -- the exact function whose lookup
+    used to raise ``KeyError`` when a template state ran under a strict
+    whitelist.
+    """
+    states = wl_loaders["states"]
+    # Force-load salt.states.file so its module-globals get populated.
+    states._load_module("file")
+    file_globals = states._dict["file.managed"].__globals__
+    packed_salt = file_globals["__salt__"]
+    # The pack surfaces as a ``NamedLoaderContext``; ``in`` delegates to
+    # ``value()`` which needs an active loader context.
+    token = salt.loader.context.loader_ctxvar.set(states)
+    try:
+        # ``file.source_list`` is on ``salt/modules/file.py`` which is NOT
+        # on the whitelist -- but the trusted state's ``__salt__`` is the
+        # unfiltered dunder, so the lookup succeeds.
+        assert "file.source_list" in packed_salt
+    finally:
+        salt.loader.context.loader_ctxvar.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Jinja attribute-style escape hatch closure
+# ---------------------------------------------------------------------------
+
+
+def test_attr_style_whitelisted_resolves(wl_loaders):
+    """``salt.grains`` for a whitelisted module returns a LoadedMod proxy."""
+    al = AliasedLoader(wl_loaders["minion_mods"])
+    assert hasattr(al, "grains")
+    assert callable(al.grains.get)
+
+
+def test_attr_style_non_whitelisted_raises_attribute_error(wl_loaders):
+    """
+    ``salt.cmd`` for a non-whitelisted module must raise ``AttributeError``
+    so ``hasattr(salt, 'cmd')`` is False and Jinja's ``undefined``
+    fallthrough behaves.  This closes the pre-existing attribute-style
+    escape hatch in ``LazyLoader.__getattr__``.
+    """
+    al = AliasedLoader(wl_loaders["minion_mods"])
+    with pytest.raises(AttributeError):
+        _ = al.cmd
+    assert not hasattr(al, "cmd")
+    # And the same holds on the raw LazyLoader (AliasedLoader delegates
+    # but the LazyLoader-level gate is authoritative).
+    with pytest.raises(AttributeError):
+        _ = wl_loaders["minion_mods"].cmd
+
+
+def test_dict_style_still_gated(wl_loaders):
+    """
+    Sanity: dict-style access on both the raw loader and AliasedLoader
+    stays whitelist-gated (the pre-fix behavior must not regress).
+    """
+    al = AliasedLoader(wl_loaders["minion_mods"])
+    assert callable(al["test.ping"])
+    with pytest.raises(KeyError):
+        _ = al["cmd.run"]
+
+
+# ---------------------------------------------------------------------------
+# ``salt.states.module.run`` escape closure via ``__wire_salt__``
+# ---------------------------------------------------------------------------
+
+
+def test_state_engine_compiles_without_config_on_whitelist(wl_opts, tmp_path):
+    """
+    VCOPS-90587 round 3: ``compile_high_data`` reads
+    ``config.option('state_aggregate')`` via the state engine.  Under a
+    strict whitelist that omits ``config``, the pre-round-3 code
+    KeyError'd at ``salt/state.py:1755``.  With
+    ``_trusted_functions`` in place, the compile succeeds and returns
+    the low chunks even when neither ``config`` nor ``file`` is on the
+    wire whitelist.
+    """
+    import salt.state
+
+    # Strip ``config`` so the wire loader can't resolve ``config.option``.
+    opts = wl_opts.copy()
+    opts["whitelist_modules"] = [m for m in opts["whitelist_modules"] if m != "config"]
+    opts["file_client"] = "local"
+    opts["cachedir"] = str(tmp_path)
+    st = salt.state.State(opts)
+    # Confirm the wire loader is properly gated.
+    assert "config.option" not in st.functions
+    # A minimal high-data structure that exercises compile_high_data.
+    high = {
+        "example_id": {
+            "test": [{"name": "example"}, "succeed_without_changes"],
+            "__sls__": "example",
+            "__env__": "base",
+        }
+    }
+    chunks, errors = st.compile_high_data(high)
+    assert errors == []
+    assert isinstance(chunks, list)
+    assert len(chunks) == 1
+    assert chunks[0]["state"] == "test"
+
+
+def test_states_module_helper_routes_through_wire_salt(wl_loaders):
+    """
+    ``salt.states.module._wire_salt()`` must return the wire-filtered
+    loader so ``module.run``'s SLS-directed dispatch stays gated even
+    though the surrounding state module has an unfiltered ``__salt__``.
+    """
+    states = wl_loaders["states"]
+    states._load_module("module")
+    module_globals = states._dict["module.run"].__globals__
+    token = salt.loader.context.loader_ctxvar.set(states)
+    try:
+        wire_salt = module_globals["_wire_salt"]()
+        # NamedLoaderContext binding under the loader; unwrap.
+        if hasattr(wire_salt, "value"):
+            wire_salt = wire_salt.value()
+        assert wire_salt is wl_loaders["minion_mods"]
+        assert "cmd.run" not in wire_salt
+    finally:
+        salt.loader.context.loader_ctxvar.reset(token)

--- a/tests/pytests/integration/loader/test_state_whitelist_dunder.py
+++ b/tests/pytests/integration/loader/test_state_whitelist_dunder.py
@@ -1,0 +1,221 @@
+"""
+Integration tests for the ``whitelist_modules`` propagation into the
+state loader and the Jinja attribute-style escape hatch closure.
+
+Sister to :mod:`tests.pytests.integration.loader.test_module_whitelist_dunder`,
+which already covers the exec-module ``__salt__`` composition path.  This
+module exercises:
+
+  * Trusted shipped state modules composing with non-whitelisted execution
+    modules internally (``file.managed`` -> ``__salt__['file.source_list']``).
+  * The ``salt.states.module.run`` escape hatch staying gated.
+  * Jinja attribute-style access (``{{ salt.cmd.run('id') }}``) being
+    blocked at render time.
+"""
+
+import pytest
+
+from tests.conftest import FIPS_TESTRUN
+
+
+@pytest.fixture
+def whitelisted_minion(salt_master):
+    """
+    A minion whose ``whitelist_modules`` allows the minimum needed to
+    render and execute an SLS but excludes ``cmd`` -- the canonical
+    escape target.  ``file`` IS on the whitelist so ``file.managed`` can
+    be *declared* in an SLS; the point of the tests below is that its
+    *internal* ``__salt__['file.source_list']`` lookup still works even
+    though ``salt.modules.file`` (the exec module) has plenty of members
+    that other minions might not want on the wire.
+    """
+    # Note: ``file`` is *not* on the whitelist.  The state loader lookup
+    # (which uses ``self.states`` -- a separate LazyLoader without
+    # whitelist filtering) can still find ``file.managed`` because state
+    # modules are not the same loader as exec modules.  The bug we're
+    # closing is the state's *internal* ``__salt__['file.source_list']``
+    # lookup, which used to hit the wire-filtered exec loader and
+    # KeyError; with the two-loader propagation, ``__salt__`` inside
+    # state modules is the unfiltered inner dunder.
+    minion = salt_master.salt_minion_daemon(
+        "test-state-whitelist-dunder-minion",
+        overrides={
+            "whitelist_modules": [
+                "test",
+                "saltutil",
+                "state",
+                "config",
+                "grains",
+                "pillar",
+                "slsutil",
+                # ``module`` state -> tested that its dispatch stays
+                # wire-filtered.
+                "module",
+            ],
+            "fips_mode": FIPS_TESTRUN,
+            "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+            "signing_algorithm": (
+                "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+            ),
+        },
+    )
+    minion.after_terminate(
+        pytest.helpers.remove_stale_minion_key, salt_master, minion.id
+    )
+    with minion.started():
+        yield minion
+
+
+# ---------------------------------------------------------------------------
+# Trusted state-module internal composition
+# ---------------------------------------------------------------------------
+
+
+def test_file_managed_reaches_nonwhitelisted_exec_module(
+    salt_cli, salt_master, whitelisted_minion, tmp_path
+):
+    """
+    ``file.managed`` internally calls ``__salt__['file.source_list']``.
+    Under ``whitelist_modules`` set as above, that lookup would raise
+    ``KeyError`` under the pre-fix single-loader model (the wire-filtered
+    loader has no ``file.source_list`` entry once ``file`` is only
+    partially exposed).  With the two-loader propagation into the state
+    loader, ``__salt__`` on state modules is the unfiltered inner loader
+    and the state runs cleanly end-to-end.
+    """
+    target = tmp_path / "marker"
+    sls = f"""
+create_marker:
+  file.managed:
+    - name: {target}
+    - contents: 'ok'
+    - makedirs: True
+"""
+    ret = salt_cli.run("state.template_str", sls, minion_tgt=whitelisted_minion.id)
+    assert isinstance(ret.data, dict), ret.stdout
+    (chunk_id,) = list(ret.data.keys())
+    assert ret.data[chunk_id]["result"] is True, ret.data[chunk_id]
+    assert target.is_file()
+    assert target.read_text().rstrip() == "ok"
+
+
+# ---------------------------------------------------------------------------
+# ``module.run`` escape hatch closure
+# ---------------------------------------------------------------------------
+
+
+def test_module_run_of_nonwhitelisted_exec_module_is_denied(
+    salt_cli, whitelisted_minion
+):
+    """
+    ``module.run: cmd.run: ...`` must be reported as an unavailable
+    function.  ``salt.states.module.run`` dispatches SLS-supplied names
+    through ``__wire_salt__`` (the whitelist-filtered loader) even though
+    the surrounding state module has an unfiltered ``__salt__``, so the
+    escape hatch stays closed.
+    """
+    sls = """
+try_escape:
+  module.run:
+    - cmd.run:
+      - name: 'echo pwned'
+"""
+    ret = salt_cli.run("state.template_str", sls, minion_tgt=whitelisted_minion.id)
+    assert isinstance(ret.data, dict), ret.stdout
+    (chunk_id,) = list(ret.data.keys())
+    chunk = ret.data[chunk_id]
+    assert chunk["result"] is False
+    assert "cmd.run" in chunk["comment"] or "Unavailable" in chunk["comment"]
+
+
+# ---------------------------------------------------------------------------
+# Jinja attribute-style escape hatch closure
+# ---------------------------------------------------------------------------
+
+
+def test_jinja_attribute_style_nonwhitelisted_render_fails(
+    salt_cli, whitelisted_minion
+):
+    """
+    ``{{ salt.cmd.run(...) }}`` (attribute style, dotted-module) used to
+    bypass ``whitelist_modules`` -- ``LazyLoader.__getattr__`` skipped
+    the gate that ``__getitem__`` enforced via ``_load``.  Rendering the
+    template must now fail at compile time with an ``UndefinedError`` /
+    ``no attribute 'cmd'`` error.
+    """
+    template = (
+        "{% set r = salt.cmd.run('id') %}\n"
+        "probe:\n"
+        "  test.nop:\n"
+        "    - name: {{ r }}\n"
+    )
+    ret = salt_cli.run("state.template_str", template, minion_tgt=whitelisted_minion.id)
+    text = str(ret.data or ret.stdout)
+    assert "cmd" in text
+    assert "UndefinedError" in text or "no attribute" in text or "not found" in text
+
+
+def test_state_apply_without_config_on_whitelist(
+    salt_cli, salt_master, whitelisted_minion, tmp_path
+):
+    """
+    VCOPS-90587 round 3: ``state.compile_high_data`` reads
+    ``config.option('state_aggregate')`` via the state engine.  Under a
+    whitelist that omits ``config`` (the shipped minion's config module),
+    the pre-round-3 code KeyError'd at compile time and every state
+    apply reverted to all-ERROR.  ``_trusted_functions`` routes the read
+    through the unfiltered inner exec loader so the compile succeeds
+    even without ``config`` on the wire whitelist.
+
+    The ``whitelisted_minion`` fixture already excludes ``config``; if
+    this test passes end-to-end, the trusted-internal path is intact.
+    """
+    target = tmp_path / "state-apply-marker"
+    sls = f"""
+create_via_state_apply:
+  file.managed:
+    - name: {target}
+    - contents: 'state-apply-ok'
+    - makedirs: True
+"""
+    ret = salt_cli.run("state.template_str", sls, minion_tgt=whitelisted_minion.id)
+    assert isinstance(ret.data, dict), ret.stdout
+    (chunk_id,) = list(ret.data.keys())
+    assert ret.data[chunk_id]["result"] is True, ret.data[chunk_id]
+    assert target.is_file()
+
+
+def test_wire_dispatch_of_nonwhitelisted_is_denied(salt_cli, whitelisted_minion):
+    """
+    VCOPS-90587 round 3: even though salt-core internal composition now
+    routes through ``_trusted_functions`` (unfiltered), direct wire
+    dispatch of a non-whitelisted module must still be denied.  Proves
+    the trusted-internal channel didn't punch a hole in the wire
+    boundary.  ``network`` is not on the fixture's whitelist.
+    """
+    ret = salt_cli.run(
+        "network.interfaces", minion_tgt=whitelisted_minion.id, _timeout=15
+    )
+    data = str(ret.data or "")
+    assert "not available" in data or "did not return" in data
+
+
+def test_jinja_attribute_style_whitelisted_still_renders(salt_cli, whitelisted_minion):
+    """
+    Sanity: ``{{ salt.grains.get('id') }}`` (attribute style, whitelisted)
+    must keep rendering.  The attribute-style gate is by-name, so a
+    whitelisted module still resolves via ``LoadedMod`` and its
+    per-function ``__getattr__`` (which itself dispatches through
+    ``__getitem__`` -> the whitelist-permitted ``_load`` path).
+    """
+    template = (
+        "{% set r = salt.grains.get('id') %}\n"
+        "probe:\n"
+        "  test.nop:\n"
+        "    - name: {{ r }}\n"
+    )
+    ret = salt_cli.run("state.template_str", template, minion_tgt=whitelisted_minion.id)
+    assert isinstance(ret.data, dict), ret.stdout
+    (chunk_id,) = list(ret.data.keys())
+    assert ret.data[chunk_id]["result"] is True
+    assert ret.data[chunk_id]["name"] == whitelisted_minion.id

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -239,6 +239,67 @@ def test_sshhighstate_anchors_opts_cachedir_to_master(opts, tmp_path):
     )
 
 
+def test_sshstate_load_modules_sets_trusted_functions(opts, tmp_path):
+    """
+    Regression test: ``SSHState.load_modules`` must populate
+    ``self._trusted_functions`` (mirroring ``self.functions``, which is
+    ``self.wrapper``) so trusted state-engine internals -- global state
+    conditions, requisite/aggregate composition,
+    ``saltutil.refresh_modules``, ``event.fire_master``,
+    ``test.sleep`` in the retry loop -- can dispatch through it after
+    the two-loader whitelist_modules model landed. Without this,
+    ``state.sls`` over salt-ssh crashes with ``'SSHState' object has
+    no attribute '_trusted_functions'``.
+    """
+    import salt.client.ssh.state as ssh_state
+
+    master_cachedir = str(tmp_path / "master_cache")
+
+    opts["cachedir"] = master_cachedir
+    opts["grains"] = {}
+    opts["pillar"] = {}
+    opts["id"] = "saltsshtest"
+    opts["file_client"] = "local"
+    opts["extension_modules"] = str(tmp_path / "extmods")
+    opts["module_dirs"] = []
+
+    master_fsclient = MagicMock()
+    master_fsclient.opts = {"cachedir": master_cachedir}
+
+    wrapper = MagicMock()
+    wrapper.fsclient = master_fsclient
+
+    with patch("salt.fileclient.get_file_client", return_value=MagicMock()), patch(
+        "salt.loader.grains", return_value={}
+    ), patch("salt.loader.utils", return_value={}), patch(
+        "salt.loader.serializers", return_value={}
+    ), patch(
+        "salt.loader.minion_mods", return_value={}
+    ), patch(
+        "salt.loader.states", return_value={}
+    ), patch(
+        "salt.loader.render", return_value={}
+    ):
+        state = ssh_state.SSHState(
+            opts,
+            wrapper=wrapper,
+            initial_pillar={"_initial": True},
+        )
+
+    assert (
+        state.functions is wrapper
+    ), "SSHState.load_modules must set self.functions = self.wrapper"
+    assert hasattr(state, "_trusted_functions"), (
+        "SSHState.load_modules must populate self._trusted_functions so "
+        "trusted state-engine internals can dispatch through it after the "
+        "two-loader whitelist_modules model landed."
+    )
+    assert state._trusted_functions is state.functions, (
+        "Salt-SSH has no _dunder_salt inner loader; _trusted_functions "
+        "must mirror self.functions (the FunctionWrapper)."
+    )
+
+
 def test_single_opts(opts, target, mock_bin_paths):
     """Sanity check for ssh.Single options"""
 

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -110,3 +110,160 @@ def test_render():
         "salt.loader.check_render_pipe_str", MagicMock(side_effect=[False, False])
     ):
         salt.loader.render(opts, minion_mods)
+
+
+# ---------------------------------------------------------------------------
+# VCOPS-90587: state loader inherits ``whitelist_modules`` two-loader model
+# ---------------------------------------------------------------------------
+
+
+def _minion_opts_with_whitelist(minion_opts, whitelist):
+    """Return a copy of ``minion_opts`` with ``whitelist_modules`` set."""
+    opts = minion_opts.copy()
+    opts["whitelist_modules"] = list(whitelist)
+    return opts
+
+
+def test_lazyloader_getattr_respects_whitelist(minion_opts):
+    """
+    VCOPS-90587 follow-up: ``LazyLoader.__getattr__`` must consult
+    ``self.whitelist`` and raise ``AttributeError`` for non-whitelisted
+    modules, so Jinja's attribute-style ``salt.cmd.run(...)`` binding
+    can't sidestep ``whitelist_modules`` the way dict-style already can't.
+    """
+    opts = _minion_opts_with_whitelist(minion_opts, ["test", "grains"])
+    ret = salt.loader.minion_mods(opts)
+    # Whitelisted module resolves to a LoadedMod proxy.
+    assert hasattr(ret, "test")
+    # Non-whitelisted attribute access raises AttributeError.
+    with pytest.raises(AttributeError):
+        _unused = ret.cmd
+    assert not hasattr(ret, "cmd")
+    # Inner unfiltered dunder is not gated (trusted composition path).
+    assert hasattr(ret._dunder_salt, "cmd")
+
+
+def test_minion_mods_exposes_unfiltered_dunder_salt(minion_opts):
+    """
+    ``minion_mods`` builds a two-loader model when ``whitelist_modules`` is
+    set (outer wire-filtered ``ret`` + inner unfiltered ``salt_dunder``).
+    The inner loader must be exposed on the outer via ``_dunder_salt`` so
+    downstream loader factories can pack it as their own ``__salt__``.
+    """
+    opts = _minion_opts_with_whitelist(minion_opts, ["test"])
+    ret = salt.loader.minion_mods(opts)
+    assert hasattr(ret, "_dunder_salt"), "outer loader missing _dunder_salt"
+    salt_dunder = ret._dunder_salt
+    assert salt_dunder is not ret
+    # wire-facing loader is whitelist-gated ...
+    assert "cmd.run" not in ret
+    # ... but the inner dunder is not.
+    assert "cmd.run" in salt_dunder
+
+
+def test_states_loader_dunder_salt_passthrough(minion_opts):
+    """
+    When ``salt.loader.states`` is built with ``dunder_salt=<inner loader>``,
+    the loaded state modules see the unfiltered loader as ``__salt__`` and
+    the wire-filtered loader as ``__wire_salt__``.
+    """
+    opts = _minion_opts_with_whitelist(minion_opts, ["test", "file"])
+    ret = salt.loader.minion_mods(opts)
+    salt_dunder = ret._dunder_salt
+    states = salt.loader.states(
+        opts,
+        ret,
+        utils=None,
+        serializers=None,
+        dunder_salt=salt_dunder,
+    )
+    # The state loader packs both dunders; wire loader stays whitelist-gated,
+    # __salt__ is the unfiltered inner loader.
+    assert states.pack["__salt__"] is salt_dunder
+    assert states.pack["__wire_salt__"] is ret
+    # Trusted composition works: file.managed's ``__salt__`` reaches a
+    # non-whitelisted exec module.
+    assert "cmd.run" in states.pack["__salt__"]
+    # Wire dispatch stays gated.
+    assert "cmd.run" not in states.pack["__wire_salt__"]
+
+
+def test_states_loader_backcompat_without_dunder_salt(minion_opts):
+    """
+    When ``dunder_salt`` is not supplied, ``salt.loader.states`` falls back
+    to using ``functions`` as ``__salt__`` (pre-fix behaviour) so external
+    callers -- including the master-side ``BaseHighState`` compile path --
+    are not broken.
+    """
+    opts = _minion_opts_with_whitelist(minion_opts, ["test", "file"])
+    ret = salt.loader.minion_mods(opts)
+    states = salt.loader.states(opts, ret, utils=None, serializers=None)
+    assert states.pack["__salt__"] is ret
+    # __wire_salt__ still equals the wire loader in either mode.
+    assert states.pack["__wire_salt__"] is ret
+
+
+def test_states_module_run_uses_wire_salt(minion_opts):
+    """
+    ``salt.states.module.run`` must resolve SLS-directed function names
+    against the wire-filtered loader so ``whitelist_modules`` continues to
+    gate the escape-hatch path even though the surrounding state module now
+    has an unfiltered ``__salt__``.
+    """
+    opts = _minion_opts_with_whitelist(minion_opts, ["test", "module"])
+    ret = salt.loader.minion_mods(opts)
+    salt_dunder = ret._dunder_salt
+    states = salt.loader.states(
+        opts, ret, utils=None, serializers=None, dunder_salt=salt_dunder
+    )
+    # Force-load module.py so its module-globals are wired.
+    assert states.pack["__salt__"] is salt_dunder
+    assert states.pack["__wire_salt__"] is ret
+    # Sanity: cmd.run isn't on the whitelist, so wire_salt must miss it and
+    # salt_dunder must have it.
+    assert "cmd.run" not in ret
+    assert "cmd.run" in salt_dunder
+    # _wire_salt() returns the wire-filtered loader when __wire_salt__ is
+    # packed by the loader.  Force-load module.py, activate the loader
+    # context so the NamedLoaderContext binding resolves, and call the
+    # (private) helper via the module globals of any function in the
+    # loaded state module.
+    import salt.loader.context as _lc
+
+    states._load_module("module")
+    module_globals = states._dict["module.run"].__globals__
+    token = _lc.loader_ctxvar.set(states)
+    try:
+        wire_salt = module_globals["_wire_salt"]()
+        # NamedLoaderContext under the loader; unwrap to the concrete loader.
+        if hasattr(wire_salt, "value"):
+            wire_salt = wire_salt.value()
+    finally:
+        _lc.loader_ctxvar.reset(token)
+    assert wire_salt is ret
+    assert "cmd.run" not in wire_salt
+
+
+def test_state_trusted_functions_bypasses_whitelist(minion_opts, tmp_path):
+    """
+    VCOPS-90587 round 3: ``salt.state.State._trusted_functions`` must be
+    the unfiltered inner exec-module loader so trusted state-engine
+    internal call sites (``config.option``, ``state_aggregate``,
+    ``saltutil.refresh_modules``, ``event.fire_master``, ``test.sleep``)
+    keep working even when ``whitelist_modules`` excludes the modules
+    they need.  ``self.functions`` stays wire-filtered for user-facing
+    dispatch (``unless``/``onlyif``, slots, ``module.run``, Jinja).
+    """
+    import salt.state
+
+    opts = _minion_opts_with_whitelist(minion_opts, ["test", "state"])
+    opts["file_client"] = "local"
+    opts["cachedir"] = str(tmp_path)
+    st = salt.state.State(opts)
+    # ``config`` is NOT on the whitelist, so ``self.functions`` (wire) rejects
+    # it, but ``self._trusted_functions`` (unfiltered) still resolves it.
+    assert "config.option" not in st.functions
+    assert "config.option" in st._trusted_functions
+    # And an actual invocation via the trusted route must succeed
+    # (returns whatever the option evaluates to, including None/False).
+    st._trusted_functions["config.option"]("state_aggregate")

--- a/tests/pytests/unit/utils/templates/test_aliased_loader.py
+++ b/tests/pytests/unit/utils/templates/test_aliased_loader.py
@@ -91,3 +91,61 @@ def test_no_whitelist_no_gate(minion_opts):
     # Both should resolve (cmd is discoverable on all platforms Salt ships).
     assert hasattr(al, "test")
     assert hasattr(al, "cmd")
+
+
+def test_attr_style_with_funcwrapper_like_wrapped():
+    """
+    Regression: when the wrapped loader synthesises a module lookup for
+    every attribute access (as salt-ssh's ``FunctionWrapper`` does via
+    :class:`salt.client.ssh.wrapper.LoadedMod`), ``getattr(wrapped,
+    "whitelist", None)`` returns a proxy object rather than ``None`` or a
+    list.  The whitelist gate in :meth:`AliasedLoader.__getattr__` must
+    treat that non-container value as "no whitelist" and fall through to
+    the wrapper -- attempting ``name in <proxy>`` used to raise
+    ``TypeError`` (``argument of type 'LoadedMod' is not a container or
+    iterable``) and blow up
+    ``funcwrapper_attr_exewrap_test`` / ``{{ salt.exewrap.run() }}``
+    style Jinja templates on salt-ssh.
+    """
+
+    class _LoadedModSentinel:
+        # Deliberately no ``__contains__`` and no ``__iter__`` - matches
+        # ``salt.client.ssh.wrapper.LoadedMod``.
+        __slots__ = ("mod",)
+
+        def __init__(self, mod):
+            self.mod = mod
+
+        def __repr__(self):
+            return f"<_LoadedModSentinel mod={self.mod!r}>"
+
+    class _FunctionWrapperLike:
+        """
+        Minimal stand-in for salt-ssh's ``FunctionWrapper``: every
+        non-dunder attribute name resolves to a ``_LoadedModSentinel``,
+        including ``whitelist``.
+        """
+
+        def __getattr__(self, name):
+            if name.startswith("__") and name.endswith("__"):
+                raise AttributeError(name)
+            return _LoadedModSentinel(name)
+
+    wrapped = _FunctionWrapperLike()
+    # Precondition: the buggy pre-fix code path we're guarding against.
+    assert isinstance(getattr(wrapped, "whitelist", None), _LoadedModSentinel)
+
+    al = AliasedLoader(wrapped)
+
+    # The critical assertion: attribute-style access must not raise
+    # TypeError.  Under the fix, it returns the underlying proxy
+    # (which the caller then uses as a module namespace).
+    try:
+        result = al.exewrap
+    except TypeError as exc:  # pragma: no cover - guarded by the fix
+        pytest.fail(
+            f"AliasedLoader.__getattr__ raised TypeError on a FunctionWrapper-like "
+            f"wrapped loader: {exc}"
+        )
+    assert isinstance(result, _LoadedModSentinel)
+    assert result.mod == "exewrap"

--- a/tests/pytests/unit/utils/templates/test_aliased_loader.py
+++ b/tests/pytests/unit/utils/templates/test_aliased_loader.py
@@ -1,0 +1,93 @@
+"""
+tests.pytests.unit.utils.templates.test_aliased_loader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+VCOPS-90587: attribute-style access on the Jinja ``salt`` binding
+(``{{ salt.cmd.run('...') }}``) must be gated by ``whitelist_modules``
+just like dict-style access (``{{ salt['cmd.run']('...') }}``).
+"""
+
+import pytest
+
+import salt.config
+import salt.loader
+from salt.utils.templates import AliasedLoader
+
+
+@pytest.fixture
+def whitelisted_minion_mods(minion_opts):
+    """Build a real ``minion_mods`` loader with ``whitelist_modules`` set."""
+    opts = minion_opts.copy()
+    opts["whitelist_modules"] = ["test", "grains"]
+    return salt.loader.minion_mods(opts), opts
+
+
+def test_dict_style_whitelisted_still_works(whitelisted_minion_mods):
+    """Sanity: ``salt['test.ping']`` must resolve for whitelisted modules."""
+    mods, _ = whitelisted_minion_mods
+    al = AliasedLoader(mods)
+    assert callable(al["test.ping"])
+
+
+def test_dict_style_non_whitelisted_raises(whitelisted_minion_mods):
+    """Non-whitelisted dict-style access must KeyError (existing gate)."""
+    mods, _ = whitelisted_minion_mods
+    al = AliasedLoader(mods)
+    with pytest.raises(KeyError):
+        _unused = al["cmd.run"]
+
+
+def test_attr_style_whitelisted_still_works(whitelisted_minion_mods):
+    """``salt.grains`` for a whitelisted module returns a LoadedMod proxy."""
+    mods, _ = whitelisted_minion_mods
+    al = AliasedLoader(mods)
+    grains_mod = al.grains
+    # LoadedMod proxy: has a `.get` function attribute
+    assert callable(grains_mod.get)
+
+
+def test_attr_style_non_whitelisted_raises_attribute_error(
+    whitelisted_minion_mods,
+):
+    """
+    ``salt.cmd`` for a non-whitelisted module must raise ``AttributeError``,
+    not silently return a LoadedMod that would then let ``salt.cmd.run(...)``
+    escape the wire filter.  This closes the pre-existing Jinja escape hatch
+    on attribute-style access.
+    """
+    mods, _ = whitelisted_minion_mods
+    al = AliasedLoader(mods)
+    with pytest.raises(AttributeError):
+        _unused = al.cmd
+    # ``hasattr`` contract: must return False for blocked modules so
+    # Jinja's ``undefined`` fallthrough behaves.
+    assert not hasattr(al, "cmd")
+    assert hasattr(al, "test")
+
+
+def test_lazyloader_attr_gate_direct(whitelisted_minion_mods):
+    """
+    ``LazyLoader.__getattr__`` itself must reject non-whitelisted names -
+    the AliasedLoader is only one consumer; anything using the loader
+    directly (e.g. pyobjects, sdb renderers) benefits from the same gate.
+    """
+    mods, _ = whitelisted_minion_mods
+    with pytest.raises(AttributeError):
+        _unused = mods.cmd
+    assert not hasattr(mods, "cmd")
+    # And a whitelisted one still resolves.
+    assert hasattr(mods, "test")
+
+
+def test_no_whitelist_no_gate(minion_opts):
+    """
+    When ``whitelist_modules`` isn't set, attribute-style access still works
+    for every discoverable module - no regression for the un-hardened case.
+    """
+    opts = minion_opts.copy()
+    opts.pop("whitelist_modules", None)
+    mods = salt.loader.minion_mods(opts)
+    al = AliasedLoader(mods)
+    # Both should resolve (cmd is discoverable on all platforms Salt ships).
+    assert hasattr(al, "test")
+    assert hasattr(al, "cmd")


### PR DESCRIPTION
### What does this PR do?

PR #69983 introduced a two-loader model in `salt.loader.minion_mods` that gave shipped Python execution modules an unfiltered `__salt__` while keeping the wire-facing loader gated by `whitelist_modules`. Three parallel escape hatches remained open on the state side, all reachable from a minion running under a strict whitelist:

1. **State-loader `__salt__` was wire-filtered.** `salt.loader.states` packed the whitelist-filtered `functions` as `__salt__`, so trusted shipped state code (e.g. `salt.states.file.managed` calling `__salt__['file.source_list']`) raised `KeyError` on modules the operator had scoped down.

2. **Jinja attribute-style access bypassed the whitelist.** `salt.utils.templates.AliasedLoader.__getattr__` delegated blindly to the wrapped LazyLoader; `LazyLoader.__getattr__` never consulted `self.whitelist`. So `{{ salt.cmd.run('...') }}` escaped even when the equivalent `{{ salt['cmd.run']('...') }}` was rejected.

3. **State-engine internals inherited the wire filter.** `salt.state.State` used `self.functions` (wire-filtered) for its own composition -- `compile_high_data`'s `config.option` reads, retry `test.sleep`, `event.fire_master`, `saltutil.refresh_modules`, `global_state_conditions` / `match.compound`. A strict whitelist that omitted `config` reverted every `state.apply` to a `KeyError` at compile time.

The fix propagates the two-loader model:

* `minion_mods` exposes the inner unfiltered loader as `_dunder_salt` on the outer loader.
* `salt.loader.states` gains a `dunder_salt=` kwarg. When supplied, it is packed as `__salt__` for state modules; the wire-filtered loader is packed alongside as `__wire_salt__` for state modules that legitimately dispatch an SLS-supplied name.
* `salt.states.module.run` / `.function` / `._call_function` route through `__wire_salt__` so the escape hatch stays closed.
* `State.__init__` / `MasterHighState.load_modules` build `self._trusted_functions` from `_dunder_salt`; six audited trusted engine-internal call sites flip to it. Every user-facing dispatch (unless/onlyif/check_cmd, `__slot__:salt:...`, `module.run`, Jinja renderer context) stays on `self.functions` and remains wire-filtered.
* `LazyLoader.__getattr__` and `AliasedLoader.__getattr__` now raise `AttributeError` for non-whitelisted modules, closing the attribute-style Jinja escape hatch.

### Audit of `salt/state.py` `self.functions` call sites

| Line | Snippet | Category | Loader |
|---|---|---|---|
| `_check_conditions` | `config.option`, `match.compound` | Trusted engine internal | `_trusted_functions` |
| `_run_check` (unless/onlyif dict) | `functions[fun](...)` | User-facing (SLS-supplied `fun`) | `functions` |
| `_run_check_onlyif` / `_run_check_unless` / `check_cmd` | `cmd.retcode(entry, ...)` | User-facing (SLS shell string) | `functions` |
| `check_refresh_modules` | `saltutil.refresh_modules` | Trusted engine internal | `_trusted_functions` |
| `order_chunks`, `compile_high_data` | `config.option('state_aggregate')` | Trusted engine internal | `_trusted_functions` |
| `_run_retry` | `test.sleep(interval)` | Trusted engine internal | `_trusted_functions` |
| `_resolve_slot` | `functions[fun](...)` | User-facing (`__slot__:salt:...` reference) | `functions` |
| `_run_event` | `event.fire_master` | Trusted engine internal | `_trusted_functions` |

### Verification matrix

Six-cell escape-hatch matrix, plus wire-dispatch, run on a live VCF appliance (nsxt_manager, 3008.2+493) with `whitelist_modules: [test, saltutil, grains, pillar, state, vmware_controller_metadata, vmware_compliance_control]` -- explicitly excluding `cmd`, `config`, and `file`:

| # | style | module | expected | actual |
|---|---|---|---|---|
| 1 | `salt['grains.get']('id')` | dict / whitelisted | works | rendered |
| 2 | `salt['cmd.run']('id')` | dict / non-whitelisted | blocked | Jinja `no attribute 'cmd.run'` |
| 3 | `salt.grains.get('id')` | attr / whitelisted | works | rendered |
| 4 | `salt.cmd.run('id')` | attr / non-whitelisted | **blocked (NEW)** | Jinja `no attribute 'cmd'` |
| 5 | `state.sls` of `file.managed` (internal `__salt__["file.source_list"]`) | trusted | works | `Result: True` |
| 6 | `state.sls` of `module.run: cmd.run` | untrusted escape | blocked | `Unavailable function: cmd.run` |
| 7 | `salt <minion> config.get master` wire | wire, non-whitelisted | blocked | `Failed to load function config.get because its module (config) is not in the whitelist` |

Under the pared-down whitelist above, `state.sls` of `file.managed` used to fail at `compile_high_data` with `KeyError: 'config.option'`; it now completes end-to-end.

### Previous Behavior

Minions with a strict `whitelist_modules` couldn't run trusted shipped state code (`file.managed`, `pkg.installed`, most of `salt.states.*`) because internal `__salt__[...]` lookups and internal `config.option` reads went through the wire filter. Jinja attribute-style access silently bypassed the filter.

### New Behavior

Trusted salt-core-authored composition works regardless of `whitelist_modules`; every user-facing dispatch path stays wire-gated. Attribute-style and dict-style Jinja access are gated symmetrically.

### Merge requirements satisfied?
- [x] Docs -- inline docstrings updated on `minion_mods`, `states`, `LazyLoader.__getattr__`, `AliasedLoader.__getattr__`, `State.load_modules`.
- [x] Changelog -- `changelog/vcops-90587.fixed.md` (rename after PR number is assigned).
- [x] Tests written/updated -- 26 new tests across four tiers:
  - `tests/pytests/unit/loader/test_loader.py` (6 new)
  - `tests/pytests/unit/utils/templates/test_aliased_loader.py` (6 new)
  - `tests/pytests/functional/loader/test_state_whitelist_dunder.py` (8 new)
  - `tests/pytests/integration/loader/test_state_whitelist_dunder.py` (6 new)

### Commits signed with GPG?
No -- DCO sign-off only (`Signed-off-by:` trailer).
