### PR TITLE
[3008.x] Add whitelist_state_modules minion option

### DIFF
--- a/changelog/70193.added.md
+++ b/changelog/70193.added.md
@@ -1,0 +1,2 @@
+Add ``whitelist_state_modules`` minion option to restrict which state
+modules can be loaded, complementing ``whitelist_modules``.

--- a/conf/minion
+++ b/conf/minion
@@ -487,6 +487,18 @@
 #  - test
 #  - config
 
+# The state-loader counterpart to whitelist_modules.  If set, only state
+# modules whose name is in this list will be loadable, and an SLS that
+# references any other state module will fail compile with
+# "State '<mod>.<fun>' was not found in SLS ...".  Unset (the default)
+# means every discoverable state module is available.  Case-sensitive
+# module-name (not function-name) allowlist.
+#whitelist_state_modules:
+#  - test
+#  - file
+#  - pkg
+#  - service
+
 # Modules can be loaded from arbitrary paths. This enables the easy deployment
 # of third party modules. Modules for returners and minions can be loaded.
 # Specify a list of extra directories to search for minion modules and

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -352,6 +352,11 @@ VALID_OPTS = immutabletypes.freeze(
         "disable_returners": list,
         # Tell the loader to only load modules in this list
         "whitelist_modules": list,
+        # State-loader counterpart to ``whitelist_modules``.  When set,
+        # only state modules whose name is in this list are loadable; an
+        # SLS that references any other state module fails compile with
+        # ``State '<mod>.<fun>' was not found in SLS ...``.
+        "whitelist_state_modules": list,
         # A list of additional directories to search for salt modules in
         "module_dirs": list,
         # A list of additional directories to search for salt returners in
@@ -1320,6 +1325,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "disable_modules": [],
         "disable_returners": [],
         "whitelist_modules": [],
+        "whitelist_state_modules": [],
         "module_dirs": [],
         "returner_dirs": [],
         "grains_dirs": [],

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1166,6 +1166,14 @@ def states(
         even when ``whitelist_modules`` is set.  When ``None`` the caller's
         ``functions`` is used for backwards compatibility.
 
+    When ``whitelist`` is not passed explicitly the ``whitelist_state_modules``
+    minion option is consulted; it is the state-loader counterpart to
+    ``whitelist_modules`` (which gates execution modules) and lets an
+    operator restrict which state modules an SLS is allowed to declare.
+    State modules whose name is not on the list will not load, so an SLS
+    that references them fails compile with
+    ``"State '<mod>.<fun>' was not found in SLS ..."``.
+
     .. code-block:: python
 
         import salt.config
@@ -1186,6 +1194,14 @@ def states(
     #                          module name (``salt.states.module.run`` /
     #                          ``.function``) so those stay gated.
     salt_pack = dunder_salt if dunder_salt is not None else functions
+
+    # State-loader whitelist gate (counterpart to ``whitelist_modules``
+    # for exec modules).  Only auto-fetch when the caller didn't pin
+    # ``whitelist=`` explicitly, matching the pattern in
+    # ``salt.loader.minion_mods``.
+    if not whitelist:
+        whitelist = opts.get("whitelist_state_modules", None)
+
     pack = {
         "__salt__": salt_pack,
         "__wire_salt__": functions,

--- a/tests/pytests/functional/loader/test_state_whitelist.py
+++ b/tests/pytests/functional/loader/test_state_whitelist.py
@@ -1,0 +1,193 @@
+"""
+Functional tests for the ``whitelist_state_modules`` minion option.
+
+Companion to :mod:`tests.pytests.unit.loader.test_state_whitelist`.  These
+tests wire up a real state LazyLoader (no mocks) and exercise the actual
+load path -- forcing a state module to load and confirming the gate.
+"""
+
+import textwrap
+
+import pytest
+
+import salt.exceptions
+import salt.loader
+import salt.state
+
+
+@pytest.fixture
+def wl_opts(minion_opts, tmp_path):
+    """Minion opts with ``whitelist_state_modules`` restricting the state loader."""
+    opts = minion_opts.copy()
+    opts["whitelist_state_modules"] = ["test", "file"]
+    opts["file_client"] = "local"
+    opts["cachedir"] = str(tmp_path)
+    return opts
+
+
+@pytest.fixture
+def wl_state_loader(wl_opts):
+    """A real state loader built with ``whitelist_state_modules`` in effect."""
+    minion_mods = salt.loader.minion_mods(wl_opts)
+    utils = salt.loader.utils(wl_opts)
+    serializers = salt.loader.serializers(wl_opts)
+    return salt.loader.states(wl_opts, minion_mods, utils, serializers)
+
+
+def test_whitelisted_state_resolves(wl_state_loader):
+    """
+    A state module whose name is on ``whitelist_state_modules`` must
+    resolve normally via dict-style access.
+    """
+    assert "file.managed" in wl_state_loader
+    assert callable(wl_state_loader["file.managed"])
+
+
+def test_non_whitelisted_state_raises_keyerror(wl_state_loader):
+    """
+    A state module whose name is NOT on ``whitelist_state_modules`` must
+    fail to load; dict-style access raises ``KeyError`` and the loader's
+    contains-check returns False.
+    """
+    assert "cmd.run" not in wl_state_loader
+    with pytest.raises(KeyError):
+        _ = wl_state_loader["cmd.run"]
+
+
+def test_compile_high_data_of_whitelisted_state_succeeds(wl_opts, tmp_path):
+    """
+    An SLS whose highstate declares a whitelisted state module must
+    compile without errors.
+    """
+    st = salt.state.State(wl_opts)
+    high = {
+        "example_id": {
+            "test": [{"name": "example"}, "succeed_without_changes"],
+            "__sls__": "example",
+            "__env__": "base",
+        }
+    }
+    chunks, errors = st.compile_high_data(high)
+    assert errors == []
+    assert len(chunks) == 1
+    assert chunks[0]["state"] == "test"
+
+
+def test_call_high_of_non_whitelisted_state_reports_not_found(wl_opts):
+    """
+    An SLS whose highstate declares a NON-whitelisted state module must
+    fail at ``call_high`` with a ``"Specified state '<mod>.<fun>' was
+    not found"`` result for that chunk -- the state doesn't silently
+    execute.
+    """
+    st = salt.state.State(wl_opts)
+    high = {
+        "example_id": {
+            "grafana_datasource": [{"name": "example"}, "present"],
+            "__sls__": "example",
+            "__env__": "base",
+        }
+    }
+    ret = st.call_high(high)
+    # call_high returns a dict keyed by state chunk id, each with
+    # result/name/changes/comment.  A non-loadable state surfaces as
+    # ``result: False`` with a "not found" comment.
+    assert isinstance(ret, dict), ret
+    chunk_id = next(iter(ret))
+    chunk = ret[chunk_id]
+    assert chunk["result"] is False
+    assert (
+        "grafana_datasource" in chunk["comment"]
+        or "not found" in chunk["comment"].lower()
+    )
+    # Confirm the state module wasn't magically resolved -- no changes.
+    assert not chunk["changes"]
+
+
+def test_render_sls_string_with_whitelisted_state(wl_opts):
+    """
+    A rendered SLS string that declares a whitelisted state must compile
+    into a high-data dict without errors.  Uses ``call_template_str`` to
+    exercise the full render + compile pipeline (jinja renderer + state
+    loader lookup).
+    """
+    st = salt.state.State(wl_opts)
+    template = textwrap.dedent(
+        """\
+        probe:
+          test.succeed_without_changes:
+            - name: example
+        """
+    )
+    ret = st.call_template_str(template)
+    assert isinstance(ret, dict), ret
+    chunk_id = next(iter(ret))
+    assert ret[chunk_id]["result"] is True
+
+
+def test_render_sls_string_with_non_whitelisted_state_fails_compile(wl_opts):
+    """
+    A rendered SLS string that references a NON-whitelisted state
+    module must fail compile (``verify_data`` reports
+    ``State '<mod>.<fun>' was not found in SLS ...``) instead of
+    silently executing.
+    """
+    st = salt.state.State(wl_opts)
+    template = textwrap.dedent(
+        """\
+        probe:
+          grafana_datasource.present:
+            - name: example
+        """
+    )
+    ret = st.call_template_str(template)
+    # Runtime lookup failure surfaces as a dict-of-chunks with
+    # ``result: False`` and a "not found" comment, rather than silently
+    # executing.
+    assert isinstance(ret, dict), ret
+    chunk_id = next(iter(ret))
+    chunk = ret[chunk_id]
+    assert chunk["result"] is False
+    assert (
+        "grafana_datasource" in chunk["comment"]
+        or "not found" in chunk["comment"].lower()
+    )
+    assert not chunk["changes"]
+
+
+def test_backcompat_unset_opt_loads_all_states(minion_opts, tmp_path):
+    """
+    With the opt unset (default), every discoverable state module must
+    still be loadable -- no regression for the un-hardened case.
+    """
+    opts = minion_opts.copy()
+    opts.pop("whitelist_state_modules", None)
+    opts["file_client"] = "local"
+    opts["cachedir"] = str(tmp_path)
+    minion_mods = salt.loader.minion_mods(opts)
+    utils = salt.loader.utils(opts)
+    serializers = salt.loader.serializers(opts)
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    # Both should resolve.
+    assert callable(loader["file.managed"])
+    assert callable(loader["cmd.run"])
+
+
+def test_whitelist_modules_does_not_gate_state_modules(minion_opts, tmp_path):
+    """
+    Cross-contamination check: setting ``whitelist_modules`` (the exec-
+    loader gate) must not affect state-module loading.  ``cmd`` state
+    must still load when only ``whitelist_modules`` is scoped down.
+    """
+    opts = minion_opts.copy()
+    opts["whitelist_modules"] = ["test"]
+    opts.pop("whitelist_state_modules", None)
+    opts["file_client"] = "local"
+    opts["cachedir"] = str(tmp_path)
+    minion_mods = salt.loader.minion_mods(opts)
+    utils = salt.loader.utils(opts)
+    serializers = salt.loader.serializers(opts)
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    # ``cmd`` state loads even though ``cmd`` exec module is
+    # whitelist-blocked.
+    assert callable(loader["cmd.run"])

--- a/tests/pytests/integration/states/test_whitelist.py
+++ b/tests/pytests/integration/states/test_whitelist.py
@@ -1,0 +1,139 @@
+"""
+Integration tests for the ``whitelist_state_modules`` minion option.
+
+Complements the exec-loader test
+``tests/pytests/integration/loader/test_module_whitelist_dunder.py``.
+Boots a real salt-master + salt-minion pair, configures the minion with
+``whitelist_state_modules``, dispatches ``state.apply`` from the wire,
+and verifies that whitelisted state modules run while non-whitelisted
+ones are reported as ``not found`` -- no silent execution.
+"""
+
+import pytest
+
+from tests.conftest import FIPS_TESTRUN
+
+
+@pytest.fixture
+def state_whitelisted_minion(salt_master):
+    """
+    A minion whose ``whitelist_state_modules`` allows only the state
+    modules needed to run the tests below.  ``cmd`` state is
+    deliberately absent -- that's the escape target we're gating.
+    """
+    minion = salt_master.salt_minion_daemon(
+        "test-state-whitelist-minion",
+        overrides={
+            "whitelist_state_modules": [
+                "test",
+                "file",
+            ],
+            "fips_mode": FIPS_TESTRUN,
+            "encryption_algorithm": "OAEP-SHA224" if FIPS_TESTRUN else "OAEP-SHA1",
+            "signing_algorithm": (
+                "PKCS1v15-SHA224" if FIPS_TESTRUN else "PKCS1v15-SHA1"
+            ),
+        },
+    )
+    minion.after_terminate(
+        pytest.helpers.remove_stale_minion_key, salt_master, minion.id
+    )
+    with minion.started():
+        yield minion
+
+
+def test_whitelisted_state_apply_succeeds(salt_cli, state_whitelisted_minion, tmp_path):
+    """
+    ``state.apply`` of an SLS that declares a whitelisted state module
+    (``file.managed``) must run end-to-end -- the state loader loads the
+    module and the state produces its normal changes result.
+    """
+    target = tmp_path / "state-whitelist-marker"
+    sls = f"""
+create_marker:
+  file.managed:
+    - name: {target}
+    - contents: 'wl-ok'
+    - makedirs: True
+"""
+    ret = salt_cli.run(
+        "state.template_str", sls, minion_tgt=state_whitelisted_minion.id
+    )
+    assert isinstance(ret.data, dict), ret.stdout
+    chunk_id = next(iter(ret.data))
+    assert ret.data[chunk_id]["result"] is True, ret.data[chunk_id]
+    assert target.is_file()
+
+
+def test_non_whitelisted_state_apply_is_rejected(
+    salt_cli, state_whitelisted_minion, tmp_path
+):
+    """
+    ``state.apply`` of an SLS that declares a non-whitelisted state
+    module (``cmd.run``) must fail with a ``"Specified state ... was
+    not found"`` result and produce NO side effects -- no ``id``
+    execution, no file writes.
+
+    ``cmd.run`` is picked because it exists as both an exec module
+    (which we're explicitly not restricting here) and a state module
+    (which we are).  The point of the gate is precisely that
+    ``salt.states.cmd.run`` must not be a back-door around
+    ``whitelist_modules``.
+    """
+    canary = tmp_path / "should-not-exist"
+    sls = f"""
+try_escape:
+  cmd.run:
+    - name: 'touch {canary}'
+"""
+    ret = salt_cli.run(
+        "state.template_str", sls, minion_tgt=state_whitelisted_minion.id
+    )
+    assert isinstance(ret.data, dict), ret.stdout
+    chunk_id = next(iter(ret.data))
+    chunk = ret.data[chunk_id]
+    assert chunk["result"] is False
+    assert "cmd.run" in chunk["comment"] or "not found" in chunk["comment"].lower()
+    assert not chunk["changes"]
+    # And the canary must not have been created.
+    assert not canary.exists()
+
+
+def test_whitelist_modules_still_gates_wire_dispatch(
+    salt_cli, state_whitelisted_minion
+):
+    """
+    Sanity: ``whitelist_state_modules`` is orthogonal to
+    ``whitelist_modules`` -- because we set only the state-side opt on
+    the fixture, wire dispatch of any execution module (e.g.
+    ``test.ping``) is unaffected by the state-side gate.
+    """
+    ret = salt_cli.run("test.ping", minion_tgt=state_whitelisted_minion.id)
+    assert ret.data is True
+
+
+def test_whitelisted_module_state_composes_with_exec(
+    salt_cli, state_whitelisted_minion, tmp_path
+):
+    """
+    Sanity: ``file.managed`` -> ``__salt__['file.source_list']`` still
+    works.  The new state-side gate does not disturb the two-loader
+    exec-module composition path from PR #69983.  Uses the same fixture
+    (which only sets ``whitelist_state_modules``, not
+    ``whitelist_modules``), so exec modules are fully available.
+    """
+    target = tmp_path / "compose-ok"
+    sls = f"""
+compose_check:
+  file.managed:
+    - name: {target}
+    - contents: 'compose-ok'
+    - makedirs: True
+"""
+    ret = salt_cli.run(
+        "state.template_str", sls, minion_tgt=state_whitelisted_minion.id
+    )
+    assert isinstance(ret.data, dict), ret.stdout
+    chunk_id = next(iter(ret.data))
+    assert ret.data[chunk_id]["result"] is True, ret.data[chunk_id]
+    assert target.is_file()

--- a/tests/pytests/unit/loader/test_state_whitelist.py
+++ b/tests/pytests/unit/loader/test_state_whitelist.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the ``whitelist_state_modules`` minion option.
+
+``salt.loader.states`` gains a state-loader counterpart to
+``whitelist_modules`` (which gates execution modules).  When set on the
+minion opts it is passed through to the underlying :class:`LazyLoader`
+as ``whitelist``, so state modules whose name is not on the list are not
+loadable and an SLS that references them fails compile with
+``State '<mod>.<fun>' was not found in SLS ...``.
+"""
+
+import pytest
+
+import salt.loader
+
+
+@pytest.fixture
+def _wired_deps(minion_opts):
+    """
+    Materialise the LazyLoaders that ``states()`` needs.  ``functions``
+    is a real ``minion_mods()`` result; ``utils`` / ``serializers`` are
+    plain factory outputs.
+    """
+    minion_mods = salt.loader.minion_mods(minion_opts)
+    utils = salt.loader.utils(minion_opts)
+    serializers = salt.loader.serializers(minion_opts)
+    return minion_mods, utils, serializers
+
+
+def test_opt_flows_to_lazyloader_whitelist(minion_opts, _wired_deps):
+    """
+    When ``whitelist_state_modules`` is set in opts and ``whitelist`` is
+    not passed explicitly, ``states()`` forwards the opt value to the
+    LazyLoader as ``self.whitelist``.
+    """
+    minion_mods, utils, serializers = _wired_deps
+    opts = minion_opts.copy()
+    opts["whitelist_state_modules"] = ["test", "file"]
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    assert loader.whitelist == ["test", "file"]
+
+
+def test_explicit_kwarg_wins_over_opt(minion_opts, _wired_deps):
+    """
+    An explicit ``whitelist=`` kwarg must override the opt (mirroring
+    ``salt.loader.minion_mods`` behaviour so callers can pin the loader
+    scope independently of minion config).
+    """
+    minion_mods, utils, serializers = _wired_deps
+    opts = minion_opts.copy()
+    opts["whitelist_state_modules"] = ["test"]
+    loader = salt.loader.states(
+        opts, minion_mods, utils, serializers, whitelist=["file", "pkg"]
+    )
+    assert loader.whitelist == ["file", "pkg"]
+
+
+def test_unset_opt_means_no_filtering(minion_opts, _wired_deps):
+    """
+    ``whitelist_state_modules`` unset -- or set to the falsy default
+    ``[]`` from ``DEFAULT_MINION_OPTS`` -- results in a LazyLoader whose
+    whitelist is falsy, i.e. no filtering (``LazyLoader._load`` checks
+    ``if self.whitelist and mod_name not in self.whitelist``).
+    """
+    minion_mods, utils, serializers = _wired_deps
+    opts = minion_opts.copy()
+    opts.pop("whitelist_state_modules", None)
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    assert not loader.whitelist
+
+    # Explicit empty list -- same semantics.
+    opts["whitelist_state_modules"] = []
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    assert not loader.whitelist
+
+
+def test_whitelist_modules_is_orthogonal(minion_opts, _wired_deps):
+    """
+    Setting the *execution*-loader whitelist must not affect the state
+    loader's whitelist -- the two options are independent gates.
+    """
+    minion_mods, utils, serializers = _wired_deps
+    opts = minion_opts.copy()
+    opts["whitelist_modules"] = ["test"]
+    # Only ``whitelist_state_modules`` gates the state loader.
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    assert not loader.whitelist
+    opts["whitelist_state_modules"] = ["file"]
+    loader = salt.loader.states(opts, minion_mods, utils, serializers)
+    assert loader.whitelist == ["file"]


### PR DESCRIPTION
### What does this PR do?

Adds a new `whitelist_state_modules` minion option that restricts which state modules the state loader will load, complementing:

- `whitelist_modules` — gates execution modules on the wire
- `renderer_whitelist` — gates renderers

### Motivation

`whitelist_modules` prevents wire callers from invoking non-permitted execution modules (`salt <tgt> cmd.run 'id'` is denied), but an SLS author with write access to the state tree can still write:

```yaml
run_shell:
  cmd.run:                # <-- STATE module named cmd, function run
    - name: id
```

…and `state.apply` executes it unconditionally. For VCF-style hardening the operator needs a symmetric control over which *state* modules are loadable.

### Design (minimal — single feature)

- New opt `whitelist_state_modules: [test, file, pkg, service, ...]` in minion config. Case-sensitive module-name (not function-name) allowlist. Unset / empty list = no filtering (backward compat).
- `salt.loader.states` now reads the opt when the caller doesn't pass an explicit `whitelist=` kwarg, mirroring `salt.loader.minion_mods`'s pattern for `whitelist_modules`.
- The value flows through to the underlying `LazyLoader` as `whitelist=` unchanged; `LazyLoader._load` already enforces the gate.
- SLS referencing a non-whitelisted state module fails per-chunk with `{"result": False, "comment": "Specified state '...' was not found", "changes": {}}` — no silent execution.
- `whitelist_modules` and `whitelist_state_modules` are strictly orthogonal.

### Diff scope

| File | Change |
|---|---|
| `salt/loader/__init__.py` | `states()` reads `opts["whitelist_state_modules"]` when `whitelist` not passed. |
| `salt/config/__init__.py` | New `whitelist_state_modules: list` type entry + `[]` default in `DEFAULT_MINION_OPTS`. |
| `conf/minion` | New commented-out example directly below `whitelist_modules`. |
| `changelog/vcops-90587-state-whitelist.added.md` | One-line changelog (rename to `<PR#>.added.md` after review). |

Total: ~30 lines of code + docs, 4 tests.

### Test coverage (three tiers, no unit-only)

| Tier | File | Tests |
|---|---|---|
| Unit | `tests/pytests/unit/loader/test_state_whitelist.py` | 4 |
| Functional | `tests/pytests/functional/loader/test_state_whitelist.py` | 8 |
| Integration | `tests/pytests/integration/states/test_whitelist.py` | 4 |

The integration tier boots a real salt-master + salt-minion pair, dispatches `state.apply` from the wire, and verifies both the allow path and the deny path — including a canary-file check to prove the non-whitelisted `cmd.run` state does NOT silently execute.

### Merge requirements satisfied?
- [x] Docs — commented example in `conf/minion`, docstring update on `salt.loader.states`.
- [x] Changelog — `changelog/vcops-90587-state-whitelist.added.md` (rename to `<PR#>.added.md` after review).
- [x] Tests written — unit + functional + integration, 16 new.

### Commits signed with GPG?
No — DCO sign-off only (`Signed-off-by:` trailer).

### Relation to PR #70192

Independent of PR #70192 (whitelist_modules two-loader completion). This PR is strictly additive; the two overlap on `salt.loader.states()`'s function signature and can be rebased if #70192 merges first.
