### PR TITLE
Fix ZMQ REQ identity collisions causing 60s salt-call hangs (backport #69920 to 3006.x)

### DIFF
--- a/changelog/69920.fixed.md
+++ b/changelog/69920.fixed.md
@@ -1,0 +1,1 @@
+Give each daemon ``AsyncReqMessageClient`` a per-instance UUID as its ZMQ ``IDENTITY``, so the master ROUTER's routing-id entry maps 1:1 to a client whose lifecycle Salt itself owns.  Replaces the earlier process-wide ``_REQ_IDENTITY_SLOT`` counter whose state was inherited across ``fork()`` and produced colliding identities in forked minion children (root cause of #69753).

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -5,7 +5,6 @@ Zeromq transport classes
 import datetime
 import errno
 import hashlib
-import itertools
 import logging
 import os
 import secrets
@@ -13,6 +12,7 @@ import signal
 import socket
 import sys
 import threading
+import uuid
 from random import randint
 
 import zmq.error
@@ -49,17 +49,6 @@ REQUEST_TIMEOUT = 60
 
 # Payload marker for AsyncReqMessageClient queue: stop _send_recv gracefully.
 _REQ_QUEUE_SHUTDOWN = object()
-
-# Per-process counter used to give each AsyncReqMessageClient instance a
-# stable, unique routing-id slot.  Long-lived daemons (minions, syndics)
-# multiplex multiple concurrent REQ sockets over one process, so each
-# socket must claim a distinct identity -- otherwise the master's
-# ROUTER_HANDOVER=1 would drop in-flight replies when a sibling socket
-# reconnected with the same identity.  Within a single socket instance the
-# identity is reused across ZMQ-level reconnects, which is what lets the
-# master's ROUTER replace the previous peer table entry instead of
-# leaking one per reconnect.
-_REQ_IDENTITY_SLOT = itertools.count()
 
 # Per-process 24-bit random slot used to disambiguate concurrent salt CLI
 # processes claiming the same host/uid/role IDENTITY on the master's ROUTER.
@@ -713,30 +702,16 @@ class AsyncReqMessageClient:
             )
             self.socket.setsockopt(zmq.IDENTITY, identity.encode("utf-8"))
         elif _role in ("minion", "syndic") and _minion_id:
-            # Long-lived minion / syndic daemon.  Each AsyncReqMessageClient
-            # instance gets its own slot from a process-lifetime counter so
-            # concurrent siblings differ (avoiding the ROUTER_HANDOVER drop
-            # that caused the earlier syndic regression), while the slot is
-            # reused across ZMQ-level reconnects so the master's ROUTER
-            # replaces the prior peer entry instead of leaking one per
-            # reconnect.  Without this, ``MWorkerQueue`` was observed
-            # leaking ~23 GB / 2 days under sustained stress as libzmq
-            # never reclaims routing-id table entries.  On daemon restart
-            # slots replay in construction order and overwrite the prior
-            # master-side entries cleanly.
-            #
-            # Include ``os.getpid()`` so forked minion children (scheduled
-            # jobs, published-command handlers) each have a distinct
-            # IDENTITY.  Without the pid, two concurrent children inherit
-            # the parent's ``_REQ_IDENTITY_SLOT`` state and both draw the
-            # same slot value after fork -- with ``ROUTER_HANDOVER=1`` on
-            # the master, in-flight replies queued for one child get re-
-            # routed to the sibling and fail nonce verification (#69753).
-            identity = "salt-req/{role}/{minion_id}/{pid}/{slot}".format(
+            # Per-RequestClient UUID: one IDENTITY per instance lifetime, so the
+            # master ROUTER's routing-id entry maps 1:1 to a client we open and
+            # close ourselves.  Naturally distinct across fork boundaries (each
+            # child draws a fresh UUID) so the identity-collision retry class
+            # that motivated #69753 is impossible by construction.
+            identity = "salt-req/{role}/{minion_id}/{pid}/{uuid}".format(
                 role=_role,
                 minion_id=_minion_id,
                 pid=os.getpid(),
-                slot=next(_REQ_IDENTITY_SLOT),
+                uuid=uuid.uuid4().hex,
             )
             self.socket.setsockopt(zmq.IDENTITY, identity.encode("utf-8"))
 

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -2370,19 +2370,14 @@ def test_minion_daemon_identity_includes_pid_to_disambiguate_forks(minion_opts):
     """
     Regression test for #69753.
 
-    The minion / syndic daemon branch of ``_init_socket`` uses a
-    process-lifetime ``itertools.count`` counter to hand each
-    ``AsyncReqMessageClient`` a distinct slot for its ZMQ IDENTITY.  When
-    the minion daemon forks a child (scheduled job, published-command
-    handler) the child inherits the counter's current state -- so two
-    concurrent forked children calling ``next(_REQ_IDENTITY_SLOT)`` for the
-    first time BOTH get the same slot value.  Combined with
-    ``ROUTER_HANDOVER=1`` on the master's ROUTER, in-flight replies for
-    one child are re-routed to the sibling and fail nonce verification.
-
-    Fix: the daemon-branch IDENTITY must include ``os.getpid()`` so forked
-    children are disambiguated by pid even when they draw the same slot
-    number.
+    The minion / syndic daemon branch of ``_init_socket`` assigns each
+    ``AsyncReqMessageClient`` a fresh ``uuid.uuid4().hex`` as its ZMQ
+    IDENTITY slot.  A per-instance UUID matches the client's own
+    open/close lifetime, and each forked child draws its own UUID, so
+    the identity-collision retry class that motivated #69753 is
+    impossible by construction.  ``os.getpid()`` is also included as a
+    second disambiguator so the identity is human-parseable back to a
+    process.
     """
     opts = dict(minion_opts)
     opts["__role"] = "minion"
@@ -2391,12 +2386,13 @@ def test_minion_daemon_identity_includes_pid_to_disambiguate_forks(minion_opts):
     try:
         client.connect()
         ident = client.socket.getsockopt(zmq.IDENTITY).decode("utf-8")
-        # Format: salt-req/minion/<minion_id>/<pid>/<slot>
+        # Format: salt-req/minion/<minion_id>/<pid>/<uuid-hex>
         parts = ident.split("/")
         assert parts[0] == "salt-req"
         assert parts[1] == "minion"
         assert parts[2] == "test-minion"
         assert parts[3] == str(os.getpid())
-        assert parts[4].isdigit()
+        assert len(parts[4]) == 32
+        assert all(c in "0123456789abcdef" for c in parts[4])
     finally:
         client.close()

--- a/tests/pytests/unit/transport/test_zeromq_identity_uuid.py
+++ b/tests/pytests/unit/transport/test_zeromq_identity_uuid.py
@@ -1,0 +1,131 @@
+"""
+Unit tests for the per-instance UUID ZMQ IDENTITY assigned to daemon
+``AsyncReqMessageClient`` sockets.
+
+The daemon (minion / syndic) branch of ``_init_socket`` gives each
+``AsyncReqMessageClient`` a fresh ``uuid.uuid4().hex`` slot as its ZMQ
+IDENTITY so the master ROUTER's routing-id entry maps 1:1 to a client
+whose lifecycle Salt itself owns.  Fork inheritance of the earlier
+process-wide counter (root cause of #69753) is impossible by
+construction -- each child draws a fresh UUID.
+"""
+
+import os
+import re
+
+import pytest
+
+import salt.transport.zeromq
+from tests.support.mock import MagicMock
+
+DAEMON_IDENTITY_RE = re.compile(r"^salt-req/(?:minion|syndic)/[^/]+/\d+/[0-9a-f]{32}$")
+
+
+@pytest.fixture
+def _mock_socket_setsockopt_capture():
+    """Yield a list that captures every setsockopt(IDENTITY, ...) call."""
+    captured = []
+
+    def _fake_setsockopt(opt, value):
+        # Only capture the IDENTITY call; other options (LINGER, IPV6...) are
+        # noise for these tests.
+        import zmq
+
+        if opt == zmq.IDENTITY:
+            captured.append(value)
+
+    fake_socket = MagicMock()
+    fake_socket.setsockopt.side_effect = _fake_setsockopt
+
+    yield captured, fake_socket
+
+
+def _make_client_and_capture_identity(minion_opts, role="minion"):
+    """Instantiate one AsyncReqMessageClient with the socket mocked out.
+
+    Returns the identity string (utf-8 decoded) that was passed to
+    ``setsockopt(zmq.IDENTITY, ...)``.
+    """
+    import zmq
+
+    opts = dict(minion_opts)
+    opts["__role"] = role
+    opts["id"] = "test-daemon"
+
+    captured = []
+
+    def _fake_setsockopt(opt, value):
+        if opt == zmq.IDENTITY:
+            captured.append(value)
+
+    fake_socket = MagicMock()
+    fake_socket.setsockopt.side_effect = _fake_setsockopt
+    fake_context = MagicMock()
+    fake_context.socket.return_value = fake_socket
+
+    client = salt.transport.zeromq.AsyncReqMessageClient(opts, "tcp://127.0.0.1:4506")
+    # Bypass the real ZMQ context that ``connect`` would open.
+    client.context = fake_context
+    client._init_socket()
+
+    assert captured, "expected setsockopt(zmq.IDENTITY, ...) to be called"
+    return captured[-1].decode("utf-8")
+
+
+def test_daemon_identity_is_uuid_per_instance(minion_opts):
+    """
+    Two consecutive AsyncReqMessageClient instances (same role, same
+    minion id, same pid) must produce IDENTITY strings whose final path
+    component (the uuid slot) differs.
+    """
+    ident_a = _make_client_and_capture_identity(minion_opts)
+    ident_b = _make_client_and_capture_identity(minion_opts)
+
+    slot_a = ident_a.rsplit("/", 1)[-1]
+    slot_b = ident_b.rsplit("/", 1)[-1]
+
+    assert slot_a != slot_b, (ident_a, ident_b)
+    # Both slots must be 32-char lowercase hex (uuid4().hex).
+    assert re.fullmatch(r"[0-9a-f]{32}", slot_a), slot_a
+    assert re.fullmatch(r"[0-9a-f]{32}", slot_b), slot_b
+
+
+@pytest.mark.parametrize("role", ["minion", "syndic"])
+def test_daemon_identity_format(minion_opts, role):
+    """
+    The IDENTITY must match ``salt-req/<role>/<minion_id>/<pid>/<uuid>``
+    with a 32-char lowercase-hex uuid tail.
+    """
+    ident = _make_client_and_capture_identity(minion_opts, role=role)
+
+    assert DAEMON_IDENTITY_RE.match(ident), ident
+
+    parts = ident.split("/")
+    assert parts[0] == "salt-req"
+    assert parts[1] == role
+    assert parts[2] == "test-daemon"
+    assert parts[3] == str(os.getpid())
+
+
+def test_cli_identity_slot_unchanged():
+    """
+    The CLI-mode process-lifetime slot (``_CLI_IDENTITY_SLOT``) is
+    orthogonal to the daemon UUID change and must still be present as a
+    module-level 24-bit integer, cached at import time.  Guards against
+    accidental deletion while removing the (now-gone) daemon-side slot
+    counter.
+    """
+    slot = salt.transport.zeromq._CLI_IDENTITY_SLOT
+    assert isinstance(slot, int)
+    assert 0 <= slot < 2**24
+    # Cached at import time: two accesses return the same value.
+    assert slot == salt.transport.zeromq._CLI_IDENTITY_SLOT
+
+
+def test_slot_counter_infrastructure_removed():
+    """
+    The old process-wide ``_REQ_IDENTITY_SLOT`` counter and its
+    associated environment-variable cap must be gone -- the per-instance
+    UUID design replaces both.
+    """
+    assert not hasattr(salt.transport.zeromq, "_REQ_IDENTITY_SLOT")


### PR DESCRIPTION
## Summary

Backports upstream commit 098e4bee00a240b8c4cbb0fbf41358c39139a026
("zeromq: per-instance UUID IDENTITY for daemon AsyncReqMessageClient
(#69920)") from `master` to `3006.x`.

## Problem

3006.27 introduced a stable ZMQ IDENTITY for the AsyncReqMessageClient
REQ socket used by long-lived minion/syndic daemons. A running
`salt-minion` daemon and a one-off `salt-call` invocation both set
`opts["__role"] = "minion"` and share the same `minion_id`, so they end
up requesting the *same* IDENTITY. This causes the master's ROUTER
socket to drop replies for one of the two clients, resulting in
requests stalling for the full ~60s REQUEST_TIMEOUT before retrying.

See #70127 for the full report and root-cause analysis.

## Fix

Each `AsyncReqMessageClient` now generates a per-instance
`uuid.uuid4().hex` as its ZMQ IDENTITY instead of relying on a
process-wide counter (`_REQ_IDENTITY_SLOT` / `SALT_REQ_IDENTITY_SLOT_MAX`).
Since every RequestClient is opened and closed by Salt itself, a
per-instance UUID matches the object's lifetime 1:1, so concurrent
`salt-call` and `salt-minion` processes (or any other short-lived
clients) can no longer collide on the same identity, regardless of
role or minion ID.

## Testing

- Cherry-picked cleanly onto `3006.x` with one trivial import-order
  conflict in `salt/transport/zeromq.py` (unrelated `zlib` import from
  master history was dropped; not present on 3006.x).
- Includes the upstream unit tests
  (`tests/pytests/unit/transport/test_zeromq_identity_uuid.py`) and
  updated existing tests in `test_zeromq.py`.

Fixes #70127