### PR TITLE
Drop nightly-stress-test.yml's own schedule and branch input on 3006.x

### DIFF
--- a/.github/workflows/nightly-stress-test.yml
+++ b/.github/workflows/nightly-stress-test.yml
@@ -1,13 +1,15 @@
 name: Nightly Stress Test
+run-name: "Nightly Stress Test (branch: ${{ github.ref_name }})"
 
+# No `schedule:` here -- run-nightly-stress.yml is the sole cron owner
+# and the sole source of the branch list (matching nightly.yml /
+# run-nightly.yml's split). `--ref X` from run-nightly-stress.yml's
+# matrix is what selects the branch this runs against; github.ref_name
+# below picks that same branch back up for cache keys, artifact names,
+# and the stress-snapshots run path -- no `branch` input needed.
 on:
-  schedule:
-    - cron: '0 2 * * *' # 2 AM UTC
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to check out and test'
-        required: true
       duration:
         description: Stress test duration (GitHub-hosted runner caps at 6h)
         required: true
@@ -47,8 +49,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,9 +57,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ inputs.branch }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ inputs.branch }}-
+            ${{ runner.os }}-buildx-${{ github.ref_name }}-
 
       - name: Build and Start Environment
         run: |
@@ -110,8 +110,10 @@ jobs:
 
           # Empty WORKER_THREADS (the default) means "leave this branch's
           # own master.conf value alone" -- only touch it when the caller
-          # explicitly asked for a specific value, so a default-parameter
-          # run isn't nudged into an unrequested config change + restart.
+          # explicitly asked for a specific value, so master/3006.x runs
+          # (which never had this knob before) aren't nudged into an
+          # unrequested config change + restart just because this input
+          # merged in from 3008.x's own copy of this workflow.
           current_workers=$(awk '/^worker_threads:/ {print $2}' master.conf)
           if [ -n "$WORKER_THREADS" ] && [ -n "$current_workers" ] && [ "$current_workers" != "$WORKER_THREADS" ]; then
             echo "Setting worker_threads: $current_workers -> $WORKER_THREADS"
@@ -234,7 +236,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: stress-test-results-${{ inputs.branch }}
+          # Branch-qualified for readability when browsing runs/artifacts
+          # across dispatches, not for collision-avoidance -- each
+          # dispatch (nightly or manual) is its own workflow run with its
+          # own github.run_id, so names can't collide across branches.
+          name: stress-test-results-${{ github.ref_name }}
           path: |
             artifacts/
             prometheus-data.tar.gz
@@ -255,7 +261,7 @@ jobs:
           set -e
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           BRANCH=stress-snapshots
-          RUN_DIR="runs/${{ github.run_id }}/${{ inputs.branch }}"
+          RUN_DIR="runs/${{ github.run_id }}/${{ github.ref_name }}"
 
           if git ls-remote --exit-code --heads "$REPO_URL" "$BRANCH" >/dev/null 2>&1; then
             git clone --depth=1 --branch="$BRANCH" "$REPO_URL" snaps
@@ -310,6 +316,6 @@ jobs:
           cd tests/monitoring
           PANELS_DIR="${GITHUB_WORKSPACE}/artifacts/panels" \
             python3 render_panels.py --summary --from-existing \
-              --artifact-name stress-test-results-${{ inputs.branch }} \
+              --artifact-name stress-test-results-${{ github.ref_name }} \
               --artifact-url "${{ steps.upload-artifacts.outputs.artifact-url }}" \
               --image-url-prefix "${{ steps.publish-snapshots.outputs.url-prefix }}"


### PR DESCRIPTION
## Summary
- Removes `nightly-stress-test.yml`'s own `schedule:` trigger on 3006.x -- `run-nightly-stress.yml` (master) becomes the sole cron owner and sole branch list, matching the existing `nightly.yml`/`run-nightly.yml` split elsewhere in this repo
- Removes the `branch` workflow_dispatch input (previously `required: true`, no default); every place that read `inputs.branch` (checkout ref, Docker layer cache key, artifact name, stress-snapshots run path) now reads `github.ref_name` instead
- No other behavior changes -- this stays a single file that does the actual Docker/stress-test work itself, same as before

## Why
3006.x's `schedule:` never actually fires (GitHub only honors `schedule:` from the repository's default branch), so it was dead weight. Meanwhile the file already relied on the caller to pass `-f branch=3006.x` explicitly, which is redundant with `--ref 3006.x` -- both were always set to the same value by any real caller, so `github.ref_name` reads the same information without a second parameter that could drift out of sync.

## Test plan
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Manually dispatch `nightly-stress-test.yml --ref 3006.x` (no `-f` flags) and confirm the job runs end-to-end against 3006.x
https://github.com/charzl/salt/actions/runs/33450150511