### PR TITLE
Add APT multiarch preflight regression test

### DIFF
--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1069,6 +1069,51 @@ def test_installed_preserves_apt_multiarch_pkg_names_for_update_holds():
     }
 
 
+def test_installed_recognizes_unversioned_native_multiarch_package():
+    """
+    An installed native-arch package must not be targeted again when APT
+    reports its normalized name without the explicit architecture suffix.
+    """
+    pkg_names = ["libnvidia-container-tools", "libnvidia-container1:amd64"]
+    installed = {
+        "libnvidia-container-tools": ["1.20.0-1"],
+        "libnvidia-container1": ["1.20.0-1"],
+    }
+    install_mock = MagicMock()
+    salt_dict = {
+        "pkg.install": install_mock,
+        "pkg.list_pkgs": MagicMock(
+            side_effect=lambda purge_desired=False, **_kwargs: (
+                {} if purge_desired else installed
+            )
+        ),
+        "pkg.normalize_name": lambda pkg: (
+            pkg.rsplit(":", 1)[0] if pkg.endswith(":amd64") else pkg
+        ),
+        "pkg_resource.check_extra_requirements": MagicMock(return_value=True),
+        "pkg_resource.version_clean": pkg_resource.version_clean,
+    }
+
+    with patch.dict(pkg.__salt__, salt_dict), patch.dict(
+        pkg_resource.__salt__, salt_dict
+    ), patch.dict(
+        pkg.__grains__, {"os": "Ubuntu", "os_family": "Debian", "osarch": "amd64"}
+    ), patch.dict(
+        pkg_resource.__grains__, {"os": "Ubuntu", "os_family": "Debian"}
+    ):
+        ret = pkg.installed(
+            "test_install",
+            pkgs=pkg_names,
+            skip_suggestions=True,
+            update_holds=True,
+        )
+
+    install_mock.assert_not_called()
+    assert ret["result"] is True, ret
+    assert ret["changes"] == {}
+    assert "already installed" in ret["comment"]
+
+
 def test_verify_install_normalizes_debian_multiarch_names():
     """
     Test _verify_install matches Debian native-arch package names correctly.


### PR DESCRIPTION
### What does this PR do?

Adds regression coverage for `pkg.installed` handling of an already
installed native-architecture APT package whose explicit package name
contains an architecture suffix.

The test reproduces the NVIDIA container package scenario with:

- `libnvidia-container-tools`
- `libnvidia-container1:amd64`

APT reports the latter from `pkg.list_pkgs()` as the normalized
`libnvidia-container1` name. The test verifies that `pkg.installed`
recognizes both packages as already installed and does not call
`pkg.install`.

The test passes on the current `3006.x` branch and fails on v3006.26,
where `libnvidia-container1:amd64` is incorrectly passed to
`pkg.install` as an installation target.

### What issues does this PR fix or reference?

References #68932 and #69604.
Closes #70209

### Previous Behavior

The v3006.26 preflight incorrectly considered an installed native
multiarch package missing when the desired name contained `:amd64` but
`pkg.list_pkgs()` returned its normalized name.

### New Behavior

The existing normalized-name fallback is covered by a regression test
using the original two-package reproduction.

### Merge requirements satisfied?

- [x] Docs — not applicable; test-only change
- [x] Changelog — not applicable; test-only change
- [x] Tests written/updated

### Commits signed with GPG?

No