### PR TITLE
Tear down deltaproxy sub-proxies on shutdown (#70221)

### DIFF
--- a/changelog/70221.fixed.md
+++ b/changelog/70221.fixed.md
@@ -1,0 +1,1 @@
+Made a deltaproxy tear down its sub-proxies when it stops. Sub-proxies live in ``deltaproxy_objs`` and each owns its own ``req_channel``, schedule, beacons and periodic callbacks, but nothing in the shutdown path ever touched them, so every stop or restart abandoned them.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -6333,6 +6333,27 @@ class ProxyMinion(Minion):
         mp_call = _metaproxy_call(self.opts, "tune_in")
         return mp_call(self, start)
 
+    def destroy(self):
+        """
+        Tear down the proxy minion.
+
+        A deltaproxy holds its sub-proxies in ``deltaproxy_objs``, and each of
+        them owns its own ``req_channel``, schedule, beacons and periodic
+        callbacks.  Nothing used to tear those down, so every stop or restart
+        abandoned them.  Destroy the sub-proxies first, then this minion.
+        """
+        subproxies = getattr(self, "deltaproxy_objs", None) or {}
+        for minion_id, _minion in list(subproxies.items()):
+            try:
+                _minion.destroy()
+            except Exception:  # pylint: disable=broad-except
+                log.warning(
+                    "Unable to tear down sub proxy %s", minion_id, exc_info=True
+                )
+        if subproxies:
+            subproxies.clear()
+        super().destroy()
+
     def _target_load(self, load):
         """
         Verify that the publication is valid and applies to this minion

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -2441,3 +2441,61 @@ async def test_stop_async_calls_notify_stopping_and_terminates_subprocess_list(
         # code path; the .destroy() call would try to tear down channels
         # we never created. A best-effort close is enough.
         pass
+
+
+def test_proxy_minion_destroy_tears_down_subproxies(minion_opts):
+    """
+    A deltaproxy holds its sub-proxies in ``deltaproxy_objs`` and each of them
+    owns its own ``req_channel``, schedule, beacons and periodic callbacks.
+    Nothing tore those down, so every stop or restart abandoned them.
+    """
+    minion_opts["metaproxy"] = "deltaproxy"
+    proxy = salt.minion.ProxyMinion.__new__(salt.minion.ProxyMinion)
+    proxy.opts = minion_opts
+
+    sub1 = MagicMock()
+    sub2 = MagicMock()
+    proxy.deltaproxy_objs = {"minion1": sub1, "minion2": sub2}
+
+    with patch.object(salt.minion.Minion, "destroy") as parent_destroy:
+        proxy.destroy()
+
+    assert sub1.destroy.called
+    assert sub2.destroy.called
+    # The control proxy itself is still torn down afterwards.
+    assert parent_destroy.called
+
+
+def test_proxy_minion_destroy_survives_a_bad_subproxy(minion_opts):
+    """
+    One sub-proxy failing to tear down must not stop the others, nor the
+    control proxy's own teardown.
+    """
+    minion_opts["metaproxy"] = "deltaproxy"
+    proxy = salt.minion.ProxyMinion.__new__(salt.minion.ProxyMinion)
+    proxy.opts = minion_opts
+
+    bad = MagicMock()
+    bad.destroy.side_effect = RuntimeError("device gone")
+    good = MagicMock()
+    proxy.deltaproxy_objs = {"minion1": bad, "minion2": good}
+
+    with patch.object(salt.minion.Minion, "destroy") as parent_destroy:
+        proxy.destroy()
+
+    assert good.destroy.called
+    assert parent_destroy.called
+
+
+def test_proxy_minion_destroy_without_subproxies(minion_opts):
+    """
+    Inverse: a single (non-delta) proxy has no ``deltaproxy_objs`` at all and
+    must still tear itself down normally.
+    """
+    proxy = salt.minion.ProxyMinion.__new__(salt.minion.ProxyMinion)
+    proxy.opts = minion_opts
+
+    with patch.object(salt.minion.Minion, "destroy") as parent_destroy:
+        proxy.destroy()
+
+    assert parent_destroy.called


### PR DESCRIPTION
### What does this PR do?

Makes a deltaproxy tear down its sub-proxies when it stops.

### What issues does this PR fix?

Fixes #70221

### Root cause

`post_master_init` builds the sub-proxies into `self.deltaproxy_objs`, and nothing in the shutdown path ever touches that dict again. `salt.minion.ProxyMinion` had no `destroy()` of its own, so it inherited `Minion.destroy()`, which tears down only the instance it is called on. Each sub-proxy is a full `ProxyMinion` with its own `req_channel`, schedule, beacons and periodic callbacks, so all of those were abandoned on every stop or restart.

### Previous Behavior

A `SIGTERM` to a deltaproxy hosting three sub-proxies produced exactly one teardown:

```
destroy dpcontrol
```

### New Behavior

```
destroy minion1
destroy minion2
destroy minion3
destroy dpcontrol
```

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Tests written?

Yes, three in `tests/pytests/unit/test_minion.py`: sub-proxies are torn down and the control proxy still tears itself down afterwards; one sub-proxy raising does not stop the others or the control proxy; and a single proxy with no `deltaproxy_objs` is unaffected. The first two fail against unmodified 3008.x.

Verified against a live deltaproxy on 3008.2 with three sub-proxies, where `destroy()` calls went from 1 to 4 in the order above.

One note on reproducing: this is only observable once the proxy actually reaches its teardown. On an unpatched 3008.2 the daemon exits before the scheduled graceful shutdown runs at all, which is #70217 / #70218, so that fix needs to be in place first or nothing is torn down regardless. The two are independent changes.

### A related question, deliberately not addressed here

While tracing this I noticed the proxymodule's own `shutdown()` is never invoked on daemon stop for **any** proxy, not just sub-proxies -- the only callers anywhere in `salt/` are `salt/modules/junos.py` and `salt/modules/status.py`. So a proxymodule that opens a device session has no teardown hook salt itself calls when the daemon stops.

That may be deliberate, and changing it would alter behaviour for every proxy deployment rather than just deltaproxy, so this PR does not touch it. Raised in #70221 in case it is not intentional, and happy to follow up separately if you want it changed.

### Commits signed with GPG?

No
