### PR TITLE
[master] Fix timing-fragile unit + stress tests exposed by container-image drift

### DIFF
--- a/tests/pytests/stress/master_subprocess/mworker/test_mworker_stress.py
+++ b/tests/pytests/stress/master_subprocess/mworker/test_mworker_stress.py
@@ -268,17 +268,29 @@ def test_requester_disconnect_midflight_leaves_worker_alive(
 
         # MWorker had already dispatched and queued the reply for the
         # "drop-me" request before we closed the DEALER; on reconnect
-        # libzmq redelivers that queued reply to our fresh DEALER
-        # first.  Drain it, then send + receive a fresh request.
-        try:
-            stale = handle.recv(timeout=2.0)
-            log.info("drained stale reply after reconnect: %r", stale)
-        except TimeoutError:
-            # Some libzmq versions do not redeliver buffered replies
-            # after a peer identity change; that is fine too.
-            log.info("no stale reply queued")
-
-        good = handle.send_recv(_ping("after-reconnect"), timeout=10.0)
+        # libzmq may redeliver that queued reply to our fresh DEALER
+        # first.  Send the new request and then loop-drain until we
+        # see its reply -- widening the drain window (was a single
+        # 2 s recv) so slower container runtimes that don't flush the
+        # stale reply within 2 s don't confuse it with the fresh one.
+        # On the 2026-08-31 salt-ci-containers image rebuild the
+        # queued drop-me reply consistently arrived >2 s later, past
+        # the old bounded drain, causing send_recv to return the stale
+        # reply instead of `after-reconnect`.
+        handle.send(_ping("after-reconnect"))
+        good = None
+        drain_deadline = time.monotonic() + 15.0
+        while time.monotonic() < drain_deadline:
+            try:
+                reply = handle.recv(timeout=2.0)
+            except TimeoutError:
+                continue
+            if reply == {"cmd": "ping", "id": "after-reconnect"}:
+                good = reply
+                break
+            # Stale reply (e.g. the queued drop-me reply); log and keep
+            # draining until the fresh one arrives.
+            log.info("drained stale reply after reconnect: %r", reply)
         assert good == {"cmd": "ping", "id": "after-reconnect"}
     finally:
         handle.stop()

--- a/tests/pytests/stress/master_subprocess/mworkerqueue/test_mworkerqueue_stress.py
+++ b/tests/pytests/stress/master_subprocess/mworkerqueue/test_mworkerqueue_stress.py
@@ -329,6 +329,30 @@ def test_requester_churn_fd_bounded(mworkerqueue, proc_stats):
     pid = mworkerqueue.process.pid
     worker = mworkerqueue.worker()
 
+    # Warm-up round-trip: attach the worker to the queue's DEALER by
+    # driving one full REQ→ROUTER→DEALER→REP→REP→DEALER→ROUTER→REQ cycle
+    # before we start the churn budget. Without this, the very first
+    # churn iteration races the worker's initial zmq handshake to the
+    # queue subprocess and can time out (`queue stalled at warm0`) on
+    # slower container runtimes -- observed after the 2026-08-31
+    # salt-ci-containers image rebuild widened the connect/handshake
+    # window past this test's 2 s per-cycle poll budget. The warm-up
+    # itself gets a wider poll deadline for exactly this reason.
+    warmup = mworkerqueue.ctx.socket(zmq.REQ)
+    try:
+        warmup.setsockopt(zmq.LINGER, 0)
+        warmup.setsockopt(zmq.IDENTITY, b"churn-warmup")
+        warmup.setsockopt(zmq.RCVTIMEO, 10000)
+        warmup.setsockopt(zmq.SNDTIMEO, 10000)
+        warmup.connect(mworkerqueue.router_uri)
+        warmup.send(b"warmup")
+        req = _poll_recv(worker, 10000)
+        assert req is not None, "worker never attached to MWorkerQueue DEALER"
+        worker.send(b"ok")
+        warmup.recv()
+    finally:
+        warmup.close(linger=0)
+
     def _churn(n_cycles: int, id_prefix: str) -> None:
         for i in range(n_cycles):
             m = mworkerqueue.ctx.socket(zmq.REQ)
@@ -338,7 +362,7 @@ def test_requester_churn_fd_bounded(mworkerqueue, proc_stats):
             m.setsockopt(zmq.SNDTIMEO, 2000)
             m.connect(mworkerqueue.router_uri)
             m.send(b"churn")
-            req = _poll_recv(worker, 2000)
+            req = _poll_recv(worker, 5000)
             assert req is not None, f"queue stalled at {id_prefix}{i}"
             worker.send(b"ok")
             m.recv()

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -175,6 +175,13 @@ def test_send_req_fires_completion_event(event, minion_opts):
                 minion.destroy()
 
 
+@pytest.mark.no_blocking(
+    reason="Minion.__init__() → start_engines() runs the engine-bootstrap "
+    "Handle synchronously (see salt/engines/__init__.py). The 50-115 ms "
+    "cost is inherent to the sync bootstrap path being exercised, not a "
+    "handler regression. Container-image drift on salt-ci-containers "
+    "(2026-08-31 rebuild) tipped the runtime just past the 50 ms budget."
+)
 async def test_send_req_async_regression_62453(minion_opts):
 
     class MockEvent:


### PR DESCRIPTION
## Summary

Fixes two test-failure clusters on master exposed by the 2026-08-31 salt-ci-containers image rebuild (see `agents/reports/rootcause-pr-vs-push-divergence` for the digest evidence -- pre/post-rebuild image digests differ, same salt tree hash, same runner).

- `tests/pytests/unit/test_minion.py::test_send_req_async_regression_62453` -- teardown ERROR from the `_asyncio_blocking_detection` autouse fixture: `start_engines()` runs sync at bootstrap and its 50-115 ms cost tips past the 50 ms budget on the new container. Added `@pytest.mark.no_blocking(reason=...)` -- mirrors the round-2 exemption pattern (PR #70129). Systemic follow-up (refactor `start_engines()` to yield, or narrow the fixture's scope) noted but out of scope.

- `tests/pytests/stress/master_subprocess/mworker/test_mworker_stress.py::test_requester_disconnect_midflight_leaves_worker_alive` -- round-2's single-shot 2 s stale-reply drain misses the queued drop-me reply on the new container (arrives >2 s later); replaced with a loop-until-matching-reply within a 15 s deadline.

- `tests/pytests/stress/master_subprocess/mworkerqueue/test_mworkerqueue_stress.py::test_requester_churn_fd_bounded` -- the first churn cycle races the worker's initial DEALER<->REP handshake to the queue subprocess; added an explicit warmup round-trip with a 10 s poll budget before churn starts, and widened per-cycle poll from 2 s to 5 s. `MWorkerQueueHandle` is a proxy-shape handle, not a subprocess-DEALER-bind like `MWorkerHandle`, so the round-2 DEALER-context-swap pattern doesn't apply -- the actual failure is a startup race, addressed accordingly.

Fixes CI failures on master run 33438729348.

## Test plan

- [x] `venv314/bin/pytest` on all three affected tests locally (3x back-to-back stability check on the stress pair, all green)
- [ ] CI (`test:full` label applied)

## Sibling 3008.x PR

Same tests are also red on 3008.x since 2026-08-31 (verified in the prior investigation report). A sibling PR against 3008.x should mechanically port these commits, otherwise the next 3008.x -> master merge-forward will re-conflict.