### PR TITLE
ci: drop debian-11 (EOL) from CI matrix

### DIFF
--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -59,16 +59,6 @@ test-salt-listing:
       arch: arm64
       container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
       enabled: true
-    - slug: debian-11
-      display_name: "Debian 11"
-      arch: x86_64
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
-      enabled: true
-    - slug: debian-11-arm64
-      display_name: "Debian 11 Arm64"
-      arch: arm64
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
-      enabled: false
     - slug: debian-12
       display_name: "Debian 12"
       arch: x86_64
@@ -199,18 +189,6 @@ test-salt-pkg-listing:
       pkg_type: rpm
       container: "ghcr.io/saltstack/salt-ci-containers/testing:amazonlinux-2023"
       enabled: false
-    - slug: debian-11-pkg
-      display_name: "Debian 11"
-      arch: x86_64
-      pkg_type: deb
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
-      enabled: false
-    - slug: debian-11-arm64-pkg
-      display_name: "Debian 11 Arm64"
-      arch: arm64
-      pkg_type: deb
-      container: "ghcr.io/saltstack/salt-ci-containers/testing:debian-11"
-      enabled: true
     - slug: debian-12-pkg
       display_name: "Debian 12"
       arch: x86_64


### PR DESCRIPTION
Debian 11 (bullseye) reached the end of its LTS window on 2026-08-31 (https://www.debian.org/releases/bullseye/). Its security suite is now frozen (the `Release` file's own `Date` field is stuck at that exact moment) and packages are becoming unreliable to fetch - this has been repeatedly breaking `salt-ci-containers`' `testing:debian-11` image build, which in turn blocks publication of every other image in the same run (the downstream `merge`/publish job needs every `build` matrix entry to succeed, regardless of `fail-fast: false`).

Salt's own published support policy already excludes this case: *"Debian stable, oldstable, and oldoldstable (if it is not EOL) versions."* Debian 11 is `oldoldstable` and is now EOL, so it's outside Salt's own supported list - the "Full" entry in the [supported-OS table](https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-supported-operating-systems.html) just hasn't caught up to that yet.

`debian-13` is already enabled in `cicd/shared-gh-workflows-context.yml` (x86_64 in the regular test matrix, arm64 in the pkg matrix), so Debian keeps CI coverage without further changes needed. Follows the same slug-swap precedent as `972e0d5` (Fedora 40 -> 43).

Companion PR in `salt-bootstrap`: saltstack/salt-bootstrap#2131