### PR TITLE
docs(sitemap): add git-derived lastmod to sitemap, and include in docs bundles uploaded to release assets

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -37,6 +37,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.14'

--- a/changelog/70241.added.md
+++ b/changelog/70241.added.md
@@ -1,0 +1,1 @@
+Added `<lastmod>` timestamps to the generated docs `sitemap.xml`, sourced from each page's git commit time (and, for autodoc pages, the newest commit among the Python modules that page documents). The docs build job's checkout now fetches full git history (via a blobless clone) since the timestamps cannot be computed from a shallow clone.

--- a/changelog/70241.removed.md
+++ b/changelog/70241.removed.md
@@ -1,0 +1,1 @@
+Removed the unused, broken `sitemap` target from `doc/Makefile`. It clobbered the extension list (dropping `saltdomain` and autodoc), hardcoded `html_baseurl` to `en/latest/`, and required `sphinx-sitemap`, which was in no requirements or lock file. The docs build now emits a sitemap directly as part of the regular HTML build.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean check_sphinx-build html dirhtml singlehtml pickle json htmlhelp qthelp devhelp latex latexpdf text man changes linkcheck linkcheck-audit sitemap doctest
+.PHONY: help clean check_sphinx-build html dirhtml singlehtml pickle json htmlhelp qthelp devhelp latex latexpdf text man changes linkcheck linkcheck-audit doctest
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -42,7 +42,6 @@ help:
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  linkcheck-audit  to run the wrapped audit (strips the catch-all ignore) and emit a CSV"
-	@echo "  sitemap    to build the HTML output with sphinx-sitemap and emit a sitemap.xml"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
@@ -181,13 +180,6 @@ linkcheck-audit:
 	    --csv doc/$(BUILDDIR)/linkcheck-audit/report.csv
 	@echo
 	@echo "Link audit complete; CSV report at $(BUILDDIR)/linkcheck-audit/report.csv."
-
-sitemap: check_sphinx-build
-	$(SPHINXBUILD) -b html -D extensions=sphinx_sitemap \
-	    -D html_baseurl=https://docs.saltproject.io/en/latest/ \
-	    $(ALLSPHINXOPTS) $(BUILDDIR)/sitemap
-	@echo
-	@echo "Sitemap generated under $(BUILDDIR)/sitemap/sitemap.xml."
 
 doctest: check_sphinx-build
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -397,7 +397,11 @@ docs_url_segment = os.environ.get("WEBSITE_RELEASE", major_version)
 html_baseurl = f"https://docs.saltproject.io/en/{docs_url_segment}/"
 sitemap_url_scheme = "{link}"  # segment already in html_baseurl
 sitemap_locales = [None]
-sitemap_show_lastmod = True  # max(rst commit time, autodoc'd .py commit times)
+sitemap_show_lastmod = not building_man_only  # max(rst commit time, autodoc'd .py commit times)
+# Skipped for man-only builds: sphinx-last-updated-by-git runs a git log against
+# every page's dependencies, and CI jobs that only build man pages (e.g. the
+# release-patch step in ci.yml) use a shallow checkout, which turns into a hard
+# "git.too_shallow" failure under -W. Man pages have no sitemap consumer anyway.
 sitemap_excludes = ["search.html", "genindex.html", "http-routingtable.html"]
 
 ### Latex options

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,6 +179,7 @@ extensions = [
     "salthttpanchors",
     "saltrepo",
     "myst_parser",
+    "sphinx_sitemap",
     #'saltautodoc', # Must be AFTER autodoc
 ]
 
@@ -388,6 +389,16 @@ html_last_updated_fmt = "%b %d, %Y"
 html_show_sourcelink = False
 html_show_sphinx = True
 html_show_copyright = True
+
+# Deployed URL segment: /en/<major>/ for release branches, /en/master/ for master.
+# WEBSITE_RELEASE is already set correctly by every builddocs job; major_version
+# (line 89) is the right default, which keeps this merge-forward safe with no per-branch edits.
+docs_url_segment = os.environ.get("WEBSITE_RELEASE", major_version)
+html_baseurl = f"https://docs.saltproject.io/en/{docs_url_segment}/"
+sitemap_url_scheme = "{link}"  # segment already in html_baseurl
+sitemap_locales = [None]
+sitemap_show_lastmod = True  # max(rst commit time, autodoc'd .py commit times)
+sitemap_excludes = ["search.html", "genindex.html", "http-routingtable.html"]
 
 ### Latex options
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,6 +2,7 @@
 """
 Sphinx documentation for Salt
 """
+
 import os
 import sys
 import urllib.parse
@@ -397,7 +398,9 @@ docs_url_segment = os.environ.get("WEBSITE_RELEASE", major_version)
 html_baseurl = f"https://docs.saltproject.io/en/{docs_url_segment}/"
 sitemap_url_scheme = "{link}"  # segment already in html_baseurl
 sitemap_locales = [None]
-sitemap_show_lastmod = not building_man_only  # max(rst commit time, autodoc'd .py commit times)
+sitemap_show_lastmod = (
+    not building_man_only
+)  # max(rst commit time, autodoc'd .py commit times)
 # Skipped for man-only builds: sphinx-last-updated-by-git runs a git log against
 # every page's dependencies, and CI jobs that only build man pages (e.g. the
 # release-patch step in ci.yml) use a shallow checkout, which turns into a hard

--- a/requirements/static/ci/docs.txt
+++ b/requirements/static/ci/docs.txt
@@ -5,6 +5,7 @@ myst-docutils[linkify]
 sphinxcontrib-httpdomain>=1.8.1,<2.0.0; python_version < '3.10'
 sphinxcontrib-httpdomain>=2.0.0; python_version >= '3.10'
 sphinxcontrib-spelling
+sphinx-sitemap>=2.9.0
 cherrypy
 jinja2
 pydata-sphinx-theme

--- a/requirements/static/ci/py3.10/docs.lock
+++ b/requirements/static/ci/py3.10/docs.lock
@@ -319,8 +319,13 @@ sphinx==7.0.1
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/static/ci/py3.11/docs.lock
+++ b/requirements/static/ci/py3.11/docs.lock
@@ -314,8 +314,13 @@ sphinx==7.0.1
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/static/ci/py3.12/docs.lock
+++ b/requirements/static/ci/py3.12/docs.lock
@@ -312,8 +312,13 @@ sphinx==9.1.0
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/requirements/static/ci/py3.13/docs.lock
+++ b/requirements/static/ci/py3.13/docs.lock
@@ -310,8 +310,13 @@ sphinx==9.1.0
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/requirements/static/ci/py3.14/docs.lock
+++ b/requirements/static/ci/py3.14/docs.lock
@@ -312,8 +312,13 @@ sphinx==9.1.0
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0

--- a/requirements/static/ci/py3.9/docs.lock
+++ b/requirements/static/ci/py3.9/docs.lock
@@ -323,8 +323,13 @@ sphinx==7.0.1
     # via
     #   -r requirements/static/ci/docs.txt
     #   pydata-sphinx-theme
+    #   sphinx-last-updated-by-git
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-spelling
+sphinx-last-updated-by-git==0.3.8
+    # via sphinx-sitemap
+sphinx-sitemap==2.9.0
+    # via -r requirements/static/ci/docs.txt
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
### What does this PR do?

Basic sitemap improvements across the docs to assist with AI agent or search engine crawlers for understanding when certain docs have last been updated.

sitemap index isn't currently generated/saved for each set of documentation. sitemaps are currently available for other subsets of docs:

- https://docs.saltproject.io/salt/user-guide/en/latest/sitemap.xml
- https://docs.saltproject.io/salt/install-guide/en/latest/sitemap.xml

But not for the salt reference docs:
- https://docs.saltproject.io/en/3006/sitemap.xml
- https://docs.saltproject.io/en/3008/sitemap.xml
- https://docs.saltproject.io/en/latest/sitemap.xml
- https://docs.saltproject.io/en/master/sitemap.xml

This is meant to go into 3006.x, then be merge-forwarded -> 3008.x -> master

Related efforts:
- https://github.com/saltstack/salt-user-guide/pull/14
- https://github.com/saltstack/salt-install-guide/pull/92

### What issues does this PR fix or reference?

- Fixes: #70241
- Related: #67954

### Previous Behavior

No sitemap is included in docs bundles in release assets.

### New Behavior

Generate sitemap in the docs bundle, and include last updated timestamps, so builddocs deployment includes sitemap data.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html

