### PR TITLE
Add timeout to lspci shell-out in GPU grain collector

### DIFF
--- a/changelog/70251.fixed.md
+++ b/changelog/70251.fixed.md
@@ -1,0 +1,5 @@
+Add a 5-second timeout to the ``lspci`` shell-out in the GPU grain
+collector so a hung ``lspci`` (e.g. in a container without a live PCI
+bus) can no longer leak orphan child processes on every grains
+refresh. On timeout the grain returns empty (matching the
+``lspci``-not-found path) and logs a warning.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -297,7 +297,18 @@ def _linux_gpu_data():
 
     devs = []
     try:
-        lspci_out = __salt__["cmd.run"](f"{lspci} -vmm")
+        # Run lspci directly (not via cmd.run) with a short timeout so a
+        # hung lspci -- e.g. inside a container without a live PCI bus --
+        # cannot leak orphan child processes on every grains refresh.
+        # On timeout subprocess.run kills the child before re-raising.
+        proc = subprocess.run(
+            [lspci, "-vmm"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        lspci_out = proc.stdout
 
         cur_dev = {}
         error = False
@@ -325,6 +336,13 @@ def _linux_gpu_data():
                 "check that you have a valid shell configured and "
                 "permissions to run lspci command"
             )
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "The `lspci` command timed out while collecting GPU grains. "
+            "GPU grains will not be available. Set `enable_gpu_grains: "
+            "False` in the minion config to skip this collection entirely."
+        )
+        return {}
     except OSError:
         pass
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 import platform
 import socket
+import subprocess
 import sys
 import tempfile
 import textwrap
@@ -3680,7 +3681,7 @@ def test_linux_gpus(caplog):
     Test GPU detection on Linux systems
     """
 
-    def _cmd_side_effect(cmd):
+    def _cmd_side_effect(cmd, *args, **kwargs):
         ret = ""
         for device in devices:
             ret += textwrap.dedent(
@@ -3694,7 +3695,7 @@ def test_linux_gpus(caplog):
                                       NUMANode:	0"""
             ).format(*device)
             ret += "\n"
-        return ret.strip()
+        return subprocess.CompletedProcess(cmd, 0, stdout=ret.strip(), stderr="")
 
     devices = [
         [
@@ -3757,7 +3758,10 @@ def test_linux_gpus(caplog):
 
     with patch(
         "salt.utils.path.which", MagicMock(return_value="/usr/sbin/lspci")
-    ), patch.dict(core.__salt__, {"cmd.run": MagicMock(side_effect=_cmd_side_effect)}):
+    ), patch(
+        "salt.grains.core.subprocess.run",
+        MagicMock(side_effect=_cmd_side_effect),
+    ):
         ret = core._linux_gpu_data()["gpus"]
         count = 0
         for device in devices:
@@ -3769,7 +3773,7 @@ def test_linux_gpus(caplog):
 
     with patch(
         "salt.utils.path.which", MagicMock(return_value="/usr/sbin/lspci")
-    ), patch.dict(core.__salt__, {"cmd.run": MagicMock(side_effect=OSError)}):
+    ), patch("salt.grains.core.subprocess.run", MagicMock(side_effect=OSError)):
         ret = core._linux_gpu_data()
         assert ret == {"num_gpus": 0, "gpus": []}
 
@@ -3783,11 +3787,14 @@ def test_linux_gpus(caplog):
         Rev: c1
         NUMANode:	0"""
     )
+    bad_gpu_proc = subprocess.CompletedProcess(
+        ["/usr/sbin/lspci", "-vmm"], 0, stdout=bad_gpu_data, stderr=""
+    )
 
     with patch(
         "salt.utils.path.which", MagicMock(return_value="/usr/sbin/lspci")
-    ), patch.dict(
-        core.__salt__, {"cmd.run": MagicMock(return_value=bad_gpu_data)}
+    ), patch(
+        "salt.grains.core.subprocess.run", MagicMock(return_value=bad_gpu_proc)
     ), caplog.at_level(
         logging.WARN
     ):
@@ -3797,6 +3804,28 @@ def test_linux_gpus(caplog):
             "check that you have a valid shell configured and permissions "
             "to run lspci command" in caplog.messages
         )
+
+
+def test_linux_gpus_lspci_timeout(caplog):
+    """
+    If ``lspci`` hangs, the subprocess call must time out, kill the child,
+    log a warning, and return an empty grain (matching the behavior when
+    ``lspci`` is not installed). Regression for the orphan-lspci leak that
+    accumulates task_structs on every grains refresh.
+    """
+    timeout_exc = subprocess.TimeoutExpired(cmd=["/usr/sbin/lspci", "-vmm"], timeout=5)
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/usr/sbin/lspci")
+    ), patch(
+        "salt.grains.core.subprocess.run", MagicMock(side_effect=timeout_exc)
+    ), caplog.at_level(
+        logging.WARNING
+    ):
+        ret = core._linux_gpu_data()
+        assert ret == {}
+        assert any(
+            "lspci" in msg and "timed out" in msg for msg in caplog.messages
+        ), f"expected timeout warning in log; got: {caplog.messages!r}"
 
 
 def test_get_server_id():


### PR DESCRIPTION
The GPU grain collector shells out to lspci on every grains recomputation. Without a timeout, a hung lspci (e.g. inside a container without a live PCI bus) is never reaped and each recomputation leaks another orphan child, whose task_struct accumulates and manifests as an apparent minion memory leak.

Switch the shell-out to a direct subprocess.run call with a 5s timeout. On timeout, log a warning and return {} -- matching the existing lspci-not-found behavior. See changelog/70251.fixed.md.
