### PR TITLE
Bump relenv to 0.22.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -461,7 +461,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -478,7 +478,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -508,7 +508,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -525,7 +525,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -546,7 +546,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -493,7 +493,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -510,7 +510,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -527,7 +527,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -467,7 +467,7 @@ jobs:
     with:
       cache-seed: ${{ needs.prepare-workflow.outputs.cache-seed }}
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       matrix: ${{ toJSON(fromJSON(needs.prepare-workflow.outputs.config)['onedir-matrix']) }}
@@ -485,7 +485,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "onedir"
@@ -507,7 +507,7 @@ jobs:
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}
-      relenv-version: "0.22.25"
+      relenv-version: "0.22.26"
       python-version: "3.11.16"
       ci-python-version: "3.14"
       source: "src"

--- a/changelog/70254.fixed.md
+++ b/changelog/70254.fixed.md
@@ -1,0 +1,2 @@
+* Relenv 0.22.26
+  - Update expat to 2.8.4

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,6 +1,6 @@
 nox_version: "2022.8.7"
 python_version: "3.11.16"
-relenv_version: "0.22.25"
+relenv_version: "0.22.26"
 release_branches:
   - "3006.x"
   - "3007.x"


### PR DESCRIPTION
Release includes:
- Update expat to 2.8.4

Regenerated .github/workflows/*.yml via the generate-workflows pre-commit hook.
