### PR TITLE
Drop bullseye-EOL test workarounds now provided by salt-ci-containers

### DIFF
--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -32,58 +32,6 @@ from tests.support.runtests import RUNTIME_VARS
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _bullseye_eol_apt_bypass():
-    """
-    Debian 11 (bullseye) reached EOL on 2026-08-31 and its
-    ``debian-security`` InRelease signatures are no longer refreshed.
-    Any test that shells out to ``apt-get update`` -- directly, via
-    ``salt.modules.aptpkg``, or through a state that calls ``pkg.installed``
-    -- fails with ``Release file ... is expired`` and raises
-    ``CommandExecutionError``.
-
-    Drop an ``apt.conf.d`` snippet for the pytest session that disables
-    only the ``Valid-Until`` freshness check on bullseye. GPG signature
-    verification is untouched. Scoped to bullseye specifically so
-    Debian 12 (bookworm) and Debian 13 (trixie) continue to enforce
-    Valid-Until as a real security signal.
-
-    No-op on non-Debian, on non-bullseye Debian, and when we lack write
-    access to ``/etc/apt/apt.conf.d/`` (e.g. running unprivileged).
-    """
-    if not sys.platform.startswith("linux"):
-        yield
-        return
-    os_release = pathlib.Path("/etc/os-release")
-    if not os_release.is_file():
-        yield
-        return
-    codename = None
-    for line in os_release.read_text(encoding="utf-8").splitlines():
-        if line.startswith("VERSION_CODENAME="):
-            codename = line.split("=", 1)[1].strip().strip('"')
-            break
-    if codename != "bullseye":
-        yield
-        return
-    conf = pathlib.Path("/etc/apt/apt.conf.d/99-salt-tests-bullseye-eol")
-    try:
-        conf.write_text('Acquire::Check-Valid-Until "false";\n', encoding="utf-8")
-    except OSError:
-        # No root, or apt.conf.d unavailable. Nothing to do; tests that
-        # need apt on this host will fail loudly at their own callsite.
-        yield
-        return
-    log.info("Wrote %s to bypass expired bullseye InRelease", conf)
-    try:
-        yield
-    finally:
-        try:
-            conf.unlink()
-        except OSError:
-            pass
-
-
 @pytest.fixture(scope="session")
 def salt_auth_account_1_factory():
     return TestAccount(username="saltdev-auth-1")

--- a/tests/pytests/pkg/conftest.py
+++ b/tests/pytests/pkg/conftest.py
@@ -54,18 +54,7 @@ def _system_up_to_date(
     #    gpg_dest,
     # )
     if grains["os_family"] == "Debian":
-        # Debian 11 (bullseye) reached EOL on 2026-08-31 and its
-        # debian-security InRelease signatures are no longer refreshed,
-        # so a plain ``apt update`` returns 100 with "Release file ...
-        # is expired" and the fixture assert below fails. Scope the
-        # freshness-check bypass to bullseye ONLY -- Debian 12 (bookworm)
-        # and 13 (trixie) are still supported and their Valid-Until is
-        # a real security signal that must not be silenced.
-        # Gpg signature verification is unaffected either way.
-        apt_opts = ()
-        if str(grains.get("osmajorrelease", "")) == "11":
-            apt_opts = ("-o", "Acquire::Check-Valid-Until=false")
-        ret = shell.run("apt-get", "update", *apt_opts)
+        ret = shell.run("apt", "update")
         assert ret.returncode == 0
         env = os.environ.copy()
         env["DEBIAN_FRONTEND"] = "noninteractive"
@@ -84,14 +73,13 @@ def _system_up_to_date(
             "salt-ssh",
         )
         ret = shell.run(
-            "apt-get",
+            "apt",
             "upgrade",
             "-y",
             "-o",
             "DPkg::Options::=--force-confdef",
             "-o",
             "DPkg::Options::=--force-confold",
-            *apt_opts,
             env=env,
         )
         shell.run(


### PR DESCRIPTION
The `testing:debian-11` container image now bakes in the Debian 11 (bullseye) EOL apt fix directly (snapshot.debian.org sources pinned to `20260824T000000Z` plus `Acquire::Check-Valid-Until "false"` in `apt.conf.d`), landed via saltstack/salt-ci-containers#144. The test-suite-level workarounds this branch added while the container image was still broken are now redundant, so drop them:

- `tests/pytests/pkg/conftest.py` (reverts e281a249090 + 7f760958faf): The pkg-test bootstrap `_system_up_to_date` fixture no longer needs `-o Acquire::Check-Valid-Until=false` on Debian 11 -- the option is now set globally inside the container via apt.conf.d. Restore the original plain `apt update` / `apt upgrade` calls.

- `tests/pytests/conftest.py` (reverts 3633647bbe2): The session-scoped autouse fixture that dropped `/etc/apt/apt.conf.d/99-salt-tests-bullseye-eol` on bullseye hosts is redundant with the container-baked equivalent, so remove it.

The `after_start` docker-exec snippet added by 811042b1f10 to `tests/pytests/scenarios/compat/test_with_versions.py` is INTENTIONALLY KEPT: that test spawns
`ghcr.io/saltstack/salt-ci-containers/salt:{3002,3003,3004}` compat containers, which are pinned/immutable pre-built images that were NOT rebuilt by salt-ci-containers#144. Those containers still have expired bullseye InRelease baked in and still need the in-container apt fixup.