### PR TITLE
Upgrade gitpython

### DIFF
--- a/changelog/70263.security.md
+++ b/changelog/70263.security.md
@@ -1,0 +1,1 @@
+Bumped GitPython lower bound in `requirements/static/ci/{common,darwin}.txt` from `>=3.1.50` to `>=3.1.59` for CVE-2026-78676. The base pin and all lock files were already at `>=3.1.59` / `==3.1.59` (bf939d384b6), but the CI-static lower bounds were missed and permitted a fresh resolve to select a vulnerable 3.1.50-3.1.58.

--- a/requirements/static/ci/common.txt
+++ b/requirements/static/ci/common.txt
@@ -25,7 +25,7 @@ dnspython
 etcd3-py==0.1.6
 filelock>=3.19.1 ; python_version < '3.10'
 filelock>=3.29.1 ; python_version >= '3.10'
-gitpython>=3.1.50
+gitpython>=3.1.59
 google-auth==2.35.0; python_version == '3.9'
 jmespath>=1.1.0
 jsonschema

--- a/requirements/static/ci/darwin.txt
+++ b/requirements/static/ci/darwin.txt
@@ -3,4 +3,4 @@ pygit2>=1.19.2; python_version >= '3.11'
 yamllint
 mercurial>=7.2.2
 hglib
-gitpython>=3.1.50
+gitpython>=3.1.59


### PR DESCRIPTION
CVE-2026-78676

The base pin ``requirements/base.txt`` and every lock file under ``requirements/static/ci/py3.*/`` were already updated to ``>=3.1.59`` / ``==3.1.59`` in bf939d384b6 for CVE-2026-78676 (GitPython RCE via malformed config re-serialization corrupting a dormant multi-line quoted value into ``core.hooksPath``).

Two CI-static lower-bound files were missed by that bump:

- ``requirements/static/ci/common.txt``
- ``requirements/static/ci/darwin.txt``

Both still said ``gitpython>=3.1.50``, which permits vulnerable 3.1.50-3.1.58. The lock files are authoritative for installs, so this was not a live exposure, but any fresh resolve (regenerating a lock, or an out-of-lock install that consumes these constraint files directly) could select a vulnerable version.

Align them to ``>=3.1.59`` so the lower bound matches base.
